### PR TITLE
feat(explore): add snapshot save/restore for shareable graph state

### DIFF
--- a/explore/models.py
+++ b/explore/models.py
@@ -1,0 +1,40 @@
+"""Pydantic models for the Explore service."""
+
+from pydantic import BaseModel, field_validator
+
+
+class SnapshotNode(BaseModel):
+    """A single node in a graph snapshot."""
+
+    id: str
+    type: str
+
+
+class SnapshotRequest(BaseModel):
+    """Request body for saving a graph snapshot."""
+
+    nodes: list[SnapshotNode]
+    center: SnapshotNode
+
+    @field_validator("nodes")
+    @classmethod
+    def nodes_not_empty(cls, v: list[SnapshotNode]) -> list[SnapshotNode]:
+        if not v:
+            raise ValueError("nodes must not be empty")
+        return v
+
+
+class SnapshotResponse(BaseModel):
+    """Response body after saving a graph snapshot."""
+
+    token: str
+    url: str
+    expires_at: str
+
+
+class SnapshotRestoreResponse(BaseModel):
+    """Response body when restoring a graph snapshot."""
+
+    nodes: list[SnapshotNode]
+    center: SnapshotNode
+    created_at: str

--- a/explore/snapshot_store.py
+++ b/explore/snapshot_store.py
@@ -1,0 +1,59 @@
+"""In-memory snapshot store with TTL eviction for graph state persistence."""
+
+from datetime import UTC, datetime, timedelta
+import os
+import secrets
+from typing import Any
+
+
+class SnapshotStore:
+    """Thread-safe in-memory store for graph snapshots with TTL eviction."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, dict[str, Any]] = {}
+        self._ttl_days: int = int(os.environ.get("SNAPSHOT_TTL_DAYS", "28"))
+        self._max_nodes: int = int(os.environ.get("SNAPSHOT_MAX_NODES", "100"))
+
+    @property
+    def ttl_days(self) -> int:
+        return self._ttl_days
+
+    @property
+    def max_nodes(self) -> int:
+        return self._max_nodes
+
+    def save(self, nodes: list[dict[str, Any]], center: dict[str, Any]) -> tuple[str, datetime]:
+        """Save a snapshot and return (token, expires_at)."""
+        self._evict_expired()
+        token = secrets.token_urlsafe(12)
+        now = datetime.now(UTC)
+        expires_at = now + timedelta(days=self._ttl_days)
+        self._store[token] = {
+            "nodes": nodes,
+            "center": center,
+            "created_at": now.isoformat(),
+            "expires_at": expires_at.isoformat(),
+        }
+        return token, expires_at
+
+    def load(self, token: str) -> dict[str, Any] | None:
+        """Load a snapshot by token, returning None if not found or expired."""
+        entry = self._store.get(token)
+        if entry is None:
+            return None
+        expires_at = datetime.fromisoformat(entry["expires_at"])
+        if datetime.now(UTC) > expires_at:
+            del self._store[token]
+            return None
+        return {
+            "nodes": entry["nodes"],
+            "center": entry["center"],
+            "created_at": entry["created_at"],
+        }
+
+    def _evict_expired(self) -> None:
+        """Remove all expired entries."""
+        now = datetime.now(UTC)
+        expired = [token for token, entry in self._store.items() if datetime.fromisoformat(entry["expires_at"]) < now]
+        for token in expired:
+            del self._store[token]

--- a/explore/static/css/styles.css
+++ b/explore/static/css/styles.css
@@ -368,6 +368,37 @@ body {
     stroke-opacity: 0.6;
 }
 
+/* Share toast notification */
+.share-toast {
+    display: none;
+    position: absolute;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: var(--accent-green);
+    color: #000;
+    font-weight: 600;
+    font-size: 14px;
+    padding: 8px 20px;
+    border-radius: 20px;
+    z-index: 20;
+    pointer-events: none;
+    white-space: nowrap;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+
+.share-toast.show {
+    display: block;
+    animation: toast-fade 2.5s ease forwards;
+}
+
+@keyframes toast-fade {
+    0%   { opacity: 0; transform: translateX(-50%) translateY(6px); }
+    15%  { opacity: 1; transform: translateX(-50%) translateY(0); }
+    75%  { opacity: 1; }
+    100% { opacity: 0; }
+}
+
 /* Responsive */
 @media (max-width: 768px) {
     .search-container {

--- a/explore/static/index.html
+++ b/explore/static/index.html
@@ -79,6 +79,12 @@
                     <button class="graph-control-btn" id="fullscreenBtn" title="Fullscreen">
                         <i class="fas fa-expand"></i>
                     </button>
+                    <button class="graph-control-btn" id="shareBtn" title="Share graph">
+                        <i class="fas fa-share-alt"></i>
+                    </button>
+                </div>
+                <div class="share-toast" id="shareToast">
+                    <span id="shareToastMsg">Link copied!</span>
                 </div>
                 <div class="loading-overlay" id="graphLoading">
                     <div class="spinner-border text-primary" role="status"></div>

--- a/explore/static/js/api-client.js
+++ b/explore/static/js/api-client.js
@@ -76,6 +76,33 @@ class ApiClient {
         if (!response.ok) return null;
         return response.json();
     }
+
+    /**
+     * Save a graph snapshot.
+     * @param {Array<{id: string, type: string}>} nodes - Node list
+     * @param {{id: string, type: string}} center - Center node
+     * @returns {Promise<Object|null>} Snapshot response with token and url
+     */
+    async saveSnapshot(nodes, center) {
+        const response = await fetch('/api/snapshot', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ nodes, center }),
+        });
+        if (!response.ok) return null;
+        return response.json();
+    }
+
+    /**
+     * Restore a graph snapshot by token.
+     * @param {string} token - Snapshot token
+     * @returns {Promise<Object|null>} Snapshot restore response
+     */
+    async restoreSnapshot(token) {
+        const response = await fetch(`/api/snapshot/${encodeURIComponent(token)}`);
+        if (!response.ok) return null;
+        return response.json();
+    }
 }
 
 // Global instance

--- a/explore/static/js/graph.js
+++ b/explore/static/js/graph.js
@@ -400,4 +400,57 @@ class GraphVisualization {
         }
         this.placeholder.classList.remove('hidden');
     }
+
+    /**
+     * Restore graph state from a snapshot node list and center.
+     * @param {Array<{id: string, type: string}>} snapshotNodes
+     * @param {{id: string, type: string}} center
+     */
+    restoreSnapshot(snapshotNodes, center) {
+        if (this.simulation) {
+            this.simulation.stop();
+            this.simulation = null;
+        }
+
+        this.placeholder.classList.add('hidden');
+        this.nodes = [];
+        this.links = [];
+        this.expandedCategories.clear();
+        this._pendingExpands = 0;
+
+        this.svg.call(this.zoom.transform, d3.zoomIdentity);
+
+        this.centerName = center.id;
+        this.centerType = center.type;
+
+        const width = this.container.clientWidth;
+        const height = this.container.clientHeight;
+
+        const centerNode = {
+            id: `snapshot-center-${center.id}`,
+            name: center.id,
+            type: center.type,
+            isCenter: true,
+            isCategory: false,
+            fx: width / 2,
+            fy: height / 2,
+        };
+        this.nodes.push(centerNode);
+
+        snapshotNodes.forEach(n => {
+            if (n.id === center.id && n.type === center.type) return;
+            const nodeId = `snapshot-${n.type}-${n.id}`;
+            this.nodes.push({
+                id: nodeId,
+                name: n.id,
+                type: n.type,
+                isCenter: false,
+                isCategory: false,
+                nodeId: n.id,
+            });
+            this.links.push({ source: centerNode.id, target: nodeId });
+        });
+
+        this._render();
+    }
 }

--- a/tests/explore/test_snapshot.py
+++ b/tests/explore/test_snapshot.py
@@ -1,0 +1,222 @@
+"""Tests for snapshot save/restore endpoints and SnapshotStore."""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from explore.snapshot_store import SnapshotStore
+
+
+# ---------------------------------------------------------------------------
+# SnapshotStore unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotStore:
+    """Tests for SnapshotStore."""
+
+    def test_save_returns_token_and_expiry(self) -> None:
+        store = SnapshotStore()
+        nodes = [{"id": "1", "type": "artist"}]
+        center = {"id": "1", "type": "artist"}
+        token, expires_at = store.save(nodes, center)
+        assert isinstance(token, str)
+        assert len(token) > 0
+        assert isinstance(expires_at, datetime)
+        assert expires_at > datetime.now(UTC)
+
+    def test_save_and_load_round_trip(self) -> None:
+        store = SnapshotStore()
+        nodes = [{"id": "1", "type": "artist"}, {"id": "2", "type": "release"}]
+        center = {"id": "1", "type": "artist"}
+        token, _ = store.save(nodes, center)
+        result = store.load(token)
+        assert result is not None
+        assert result["nodes"] == nodes
+        assert result["center"] == center
+        assert "created_at" in result
+
+    def test_load_unknown_token_returns_none(self) -> None:
+        store = SnapshotStore()
+        result = store.load("nonexistent_token")
+        assert result is None
+
+    def test_load_expired_token_returns_none(self) -> None:
+        store = SnapshotStore()
+        nodes = [{"id": "1", "type": "artist"}]
+        center = {"id": "1", "type": "artist"}
+        token, _ = store.save(nodes, center)
+
+        # Manually expire the entry
+        past = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+        store._store[token]["expires_at"] = past
+
+        result = store.load(token)
+        assert result is None
+        # Expired entry should be removed
+        assert token not in store._store
+
+    def test_ttl_days_from_env(self) -> None:
+        with patch.dict("os.environ", {"SNAPSHOT_TTL_DAYS": "7"}):
+            store = SnapshotStore()
+            assert store.ttl_days == 7
+
+    def test_max_nodes_from_env(self) -> None:
+        with patch.dict("os.environ", {"SNAPSHOT_MAX_NODES": "50"}):
+            store = SnapshotStore()
+            assert store.max_nodes == 50
+
+    def test_evict_expired_on_save(self) -> None:
+        store = SnapshotStore()
+        nodes = [{"id": "1", "type": "artist"}]
+        center = {"id": "1", "type": "artist"}
+
+        token1, _ = store.save(nodes, center)
+
+        # Manually expire the first entry
+        past = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+        store._store[token1]["expires_at"] = past
+
+        # Save a second entry — should trigger eviction of the first
+        store.save(nodes, center)
+        assert token1 not in store._store
+
+    def test_tokens_are_unique(self) -> None:
+        store = SnapshotStore()
+        nodes = [{"id": "1", "type": "artist"}]
+        center = {"id": "1", "type": "artist"}
+        tokens = {store.save(nodes, center)[0] for _ in range(20)}
+        assert len(tokens) == 20
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestSaveSnapshotEndpoint:
+    """Tests for POST /api/snapshot."""
+
+    def test_save_snapshot_success(self, test_client: TestClient) -> None:
+        payload = {
+            "nodes": [
+                {"id": "1", "type": "artist"},
+                {"id": "94", "type": "release"},
+            ],
+            "center": {"id": "1", "type": "artist"},
+        }
+        response = test_client.post("/api/snapshot", json=payload)
+        assert response.status_code == 201
+        data = response.json()
+        assert "token" in data
+        assert "url" in data
+        assert "expires_at" in data
+        assert data["url"] == f"/snapshot/{data['token']}"
+
+    def test_save_snapshot_exceeds_max_nodes(self, test_client: TestClient) -> None:
+        import explore.explore as explore_module
+
+        original_store = explore_module.snapshot_store
+        small_store = SnapshotStore()
+        small_store._max_nodes = 2
+        explore_module.snapshot_store = small_store
+
+        payload = {
+            "nodes": [
+                {"id": "1", "type": "artist"},
+                {"id": "2", "type": "release"},
+                {"id": "3", "type": "label"},
+            ],
+            "center": {"id": "1", "type": "artist"},
+        }
+        response = test_client.post("/api/snapshot", json=payload)
+        assert response.status_code == 422
+        data = response.json()
+        assert "error" in data
+
+        explore_module.snapshot_store = original_store
+
+    def test_save_snapshot_empty_nodes_rejected(self, test_client: TestClient) -> None:
+        payload = {
+            "nodes": [],
+            "center": {"id": "1", "type": "artist"},
+        }
+        response = test_client.post("/api/snapshot", json=payload)
+        assert response.status_code == 422
+
+    def test_save_snapshot_missing_center(self, test_client: TestClient) -> None:
+        payload = {
+            "nodes": [{"id": "1", "type": "artist"}],
+        }
+        response = test_client.post("/api/snapshot", json=payload)
+        assert response.status_code == 422
+
+    def test_save_snapshot_returns_valid_expiry(self, test_client: TestClient) -> None:
+        payload = {
+            "nodes": [{"id": "1", "type": "artist"}],
+            "center": {"id": "1", "type": "artist"},
+        }
+        before = datetime.now(UTC)
+        response = test_client.post("/api/snapshot", json=payload)
+        assert response.status_code == 201
+        data = response.json()
+        expires_at = datetime.fromisoformat(data["expires_at"])
+        # Should expire in the future (at least 27 days from now, allowing clock skew)
+        assert expires_at > before + timedelta(days=27)
+
+
+class TestRestoreSnapshotEndpoint:
+    """Tests for GET /api/snapshot/{token}."""
+
+    def test_restore_valid_snapshot(self, test_client: TestClient) -> None:
+        # First save a snapshot
+        payload: dict[str, Any] = {
+            "nodes": [
+                {"id": "1", "type": "artist"},
+                {"id": "94", "type": "release"},
+                {"id": "201", "type": "label"},
+            ],
+            "center": {"id": "1", "type": "artist"},
+        }
+        save_response = test_client.post("/api/snapshot", json=payload)
+        assert save_response.status_code == 201
+        token = save_response.json()["token"]
+
+        # Now restore it
+        restore_response = test_client.get(f"/api/snapshot/{token}")
+        assert restore_response.status_code == 200
+        data = restore_response.json()
+        assert "nodes" in data
+        assert "center" in data
+        assert "created_at" in data
+        assert len(data["nodes"]) == 3
+        assert data["center"]["id"] == "1"
+        assert data["center"]["type"] == "artist"
+
+    def test_restore_unknown_token_returns_404(self, test_client: TestClient) -> None:
+        response = test_client.get("/api/snapshot/unknowntoken123")
+        assert response.status_code == 404
+        data = response.json()
+        assert "error" in data
+
+    def test_restore_expired_token_returns_404(self, test_client: TestClient) -> None:
+        import explore.explore as explore_module
+
+        # Save a snapshot
+        payload: dict[str, Any] = {
+            "nodes": [{"id": "1", "type": "artist"}],
+            "center": {"id": "1", "type": "artist"},
+        }
+        save_response = test_client.post("/api/snapshot", json=payload)
+        assert save_response.status_code == 201
+        token = save_response.json()["token"]
+
+        # Manually expire it
+        past = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+        explore_module.snapshot_store._store[token]["expires_at"] = past
+
+        # Restore should return 404
+        restore_response = test_client.get(f"/api/snapshot/{token}")
+        assert restore_response.status_code == 404


### PR DESCRIPTION
## Summary

Addresses #51.

- Adds `POST /api/snapshot` and `GET /api/snapshot/{token}` endpoints to the Explore service, allowing users to persist and share the current graph view via a URL token
- Introduces `SnapshotStore` — an in-memory store with TTL eviction (default 28 days, configurable via `SNAPSHOT_TTL_DAYS`) and a node-count guard (default 100 nodes, configurable via `SNAPSHOT_MAX_NODES`)
- Adds a **Share** button to the graph toolbar; clicking it saves the current graph state, generates a `?snapshot=<token>` URL, and copies it to the clipboard with a toast notification
- On page load, if a `?snapshot=<token>` query param is present, the graph is restored directly from the snapshot instead of running a new search
- Adds Pydantic models (`SnapshotNode`, `SnapshotRequest`, `SnapshotResponse`, `SnapshotRestoreResponse`) in `explore/models.py` for request/response validation
- Adds `GraphVisualization.restoreSnapshot()` in `graph.js` to reconstruct the D3 force graph from a flat node list without re-querying Neo4j

## Changed files

| File | Change |
|---|---|
| `explore/explore.py` | New `POST /api/snapshot` and `GET /api/snapshot/{token}` endpoints |
| `explore/models.py` | New — Pydantic models for snapshot request/response |
| `explore/snapshot_store.py` | New — in-memory TTL store for graph snapshots |
| `explore/static/css/styles.css` | Share toast animation styles |
| `explore/static/index.html` | Share button + toast markup |
| `explore/static/js/api-client.js` | `saveSnapshot()` and `restoreSnapshot()` API methods |
| `explore/static/js/app.js` | Share handler, URL-based snapshot restore on load |
| `explore/static/js/graph.js` | `restoreSnapshot()` method for graph reconstruction |
| `tests/explore/test_snapshot.py` | New — 222-line test suite covering store and API endpoints |

## Test plan

- [x] `SnapshotStore` unit tests: save/load round-trip, unknown token, expired token eviction, env-var TTL/max-nodes, token uniqueness
- [x] `POST /api/snapshot`: success (201), too-many-nodes (422), empty nodes (422), missing center (422), expiry validity
- [x] `GET /api/snapshot/{token}`: valid restore, unknown token (404), expired token (404)
- [ ] Manual: open Explore, run a search, click Share, paste the copied URL in a new tab — graph should restore to the same state

🤖 Generated with [Claude Code](https://claude.com/claude-code)