### PR TITLE
security: encrypt Discogs consumer key/secret at rest

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -25,7 +25,7 @@ from slowapi.errors import RateLimitExceeded
 import structlog
 import uvicorn
 
-from api.auth import encrypt_oauth_token
+from api.auth import decrypt_oauth_token, encrypt_oauth_token
 from api.limiter import limiter
 from api.models import LoginRequest, RegisterRequest
 import api.routers.explore as _explore_router
@@ -495,6 +495,10 @@ async def authorize_discogs(
 
     consumer_key = await _get_app_config("discogs_consumer_key")
     consumer_secret = await _get_app_config("discogs_consumer_secret")
+    if consumer_key:
+        consumer_key = decrypt_oauth_token(consumer_key, _config.oauth_encryption_key)
+    if consumer_secret:
+        consumer_secret = decrypt_oauth_token(consumer_secret, _config.oauth_encryption_key)
 
     if not consumer_key or not consumer_secret:
         raise HTTPException(
@@ -551,6 +555,10 @@ async def verify_discogs(
 
     consumer_key = await _get_app_config("discogs_consumer_key")
     consumer_secret = await _get_app_config("discogs_consumer_secret")
+    if consumer_key:
+        consumer_key = decrypt_oauth_token(consumer_key, _config.oauth_encryption_key)
+    if consumer_secret:
+        consumer_secret = decrypt_oauth_token(consumer_secret, _config.oauth_encryption_key)
 
     if not consumer_key or not consumer_secret:
         raise HTTPException(

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -419,6 +419,9 @@ async def run_full_sync(
             await cur.execute("SELECT key, value FROM app_config WHERE key IN ('discogs_consumer_key', 'discogs_consumer_secret')")
             config_rows = await cur.fetchall()
             app_config = {row["key"]: row["value"] for row in config_rows}
+            for cred_key in ("discogs_consumer_key", "discogs_consumer_secret"):
+                if cred_key in app_config:
+                    app_config[cred_key] = decrypt_oauth_token(app_config[cred_key], oauth_encryption_key)
 
         if "discogs_consumer_key" not in app_config or "discogs_consumer_secret" not in app_config:
             raise ValueError("Discogs app credentials not configured in app_config table")


### PR DESCRIPTION
## Summary

- Applies Fernet symmetric encryption (same `OAUTH_ENCRYPTION_KEY` mechanism from #73) to `discogs_consumer_key` and `discogs_consumer_secret` stored in the `app_config` table
- `api/setup.py`: encrypt on write (`set_config`), decrypt before masking (`show_config`)
- `api/api.py`: decrypt after reading consumer key/secret for OAuth flows
- `api/syncer.py`: decrypt consumer key/secret after reading from `app_config`

## Migration

No data migration required — the existing plaintext fallback in `decrypt_oauth_token` handles already-stored plaintext values transparently.

## Test plan

- [ ] Existing tests guarded against ambient `OAUTH_ENCRYPTION_KEY`
- [ ] New tests for encrypted write path in `set_config`
- [ ] New tests for encrypted `show_config` display (masked output)
- [ ] CI passes

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)