### PR TITLE
test: improve coverage for explore, API, and insights

### DIFF
--- a/explore/__tests__/graph.test.js
+++ b/explore/__tests__/graph.test.js
@@ -540,4 +540,233 @@ describe('GraphVisualization', () => {
             expect(window.apiClient.expand).not.toHaveBeenCalled();
         });
     });
+
+    describe('_loadMoreCategory', () => {
+        it('should load more children and update category label', async () => {
+            graph._categoryMeta.set('cat-releases', {
+                parentName: 'Radiohead', parentType: 'artist',
+                category: 'releases', offset: 30, limit: 30, total: 50,
+            });
+            graph.nodes.push({
+                id: 'cat-releases', displayName: 'Releases', name: 'Releases (30)',
+                isCategory: true, isCenter: false,
+            });
+            graph.nodes.push({
+                id: 'load-more-cat-releases', categoryId: 'cat-releases', isLoadMore: true,
+            });
+            graph.links.push({ source: 'cat-releases', target: 'load-more-cat-releases' });
+
+            window.apiClient.expand.mockResolvedValue({
+                children: [{ id: '31', name: 'Album 31', type: 'release' }],
+                total: 50, limit: 30, has_more: true, offset: 30,
+            });
+
+            const loadMoreNode = graph.nodes.find(n => n.id === 'load-more-cat-releases');
+            await graph._loadMoreCategory(loadMoreNode);
+
+            expect(graph.nodes.find(n => n.id === 'child-release-31')).toBeDefined();
+        });
+
+        it('should return early when no meta exists', async () => {
+            await graph._loadMoreCategory({ id: 'load-more-unknown', categoryId: 'unknown' });
+            expect(window.apiClient.expand).not.toHaveBeenCalled();
+        });
+
+        it('should not add load-more when has_more is false', async () => {
+            graph._categoryMeta.set('cat-test', {
+                parentName: 'Test', parentType: 'artist',
+                category: 'releases', offset: 30, limit: 30, total: 31,
+            });
+            graph.nodes.push({ id: 'cat-test', displayName: 'Releases', name: 'Releases (30)', isCategory: true, isCenter: false });
+
+            window.apiClient.expand.mockResolvedValue({
+                children: [{ id: '31', name: 'Album 31', type: 'release' }],
+                total: 31, limit: 30, has_more: false, offset: 30,
+            });
+
+            await graph._loadMoreCategory({ id: 'load-more-cat-test', categoryId: 'cat-test' });
+
+            const loadMoreNodes = graph.nodes.filter(n => n.isLoadMore);
+            expect(loadMoreNodes).toHaveLength(0);
+        });
+    });
+
+    describe('setCompareYears', () => {
+        it('should set compare mode state', async () => {
+            graph.centerName = 'Radiohead';
+            graph.centerType = 'artist';
+            await graph.setCompareYears(1995, 2005);
+            expect(graph.compareMode).toBe(true);
+            expect(graph.compareYearA).toBe(1995);
+            expect(graph.compareYearB).toBe(2005);
+        });
+
+        it('should return early if no center set', async () => {
+            graph.centerName = null;
+            graph.centerType = null;
+            await graph.setCompareYears(1990, 2000);
+            expect(window.apiClient.expand).not.toHaveBeenCalled();
+        });
+
+        it('should return early if no categories', async () => {
+            graph.centerName = 'Radiohead';
+            graph.centerType = 'artist';
+            await graph.setCompareYears(1990, 2000);
+            expect(window.apiClient.expand).not.toHaveBeenCalled();
+        });
+
+        it('should clear beforeYear', async () => {
+            graph.beforeYear = 1990;
+            graph.centerName = 'Radiohead';
+            graph.centerType = 'artist';
+            await graph.setCompareYears(1990, 2000);
+            expect(graph.beforeYear).toBeNull();
+        });
+    });
+
+    describe('_fetchComparisonData', () => {
+        it('should mark nodes as only_a, only_b, or both', async () => {
+            graph.compareYearA = 1990;
+            graph.compareYearB = 2000;
+            graph.nodes.push({
+                id: 'cat-releases', displayName: 'Releases', name: 'Releases',
+                isCategory: true, isCenter: false, count: 5,
+            });
+
+            window.apiClient.expand
+                .mockResolvedValueOnce({
+                    children: [
+                        { id: '1', name: 'A Only', type: 'release' },
+                        { id: '2', name: 'Both', type: 'release' },
+                    ],
+                    total: 2, limit: 30, has_more: false,
+                })
+                .mockResolvedValueOnce({
+                    children: [
+                        { id: '2', name: 'Both', type: 'release' },
+                        { id: '3', name: 'B Only', type: 'release' },
+                    ],
+                    total: 2, limit: 30, has_more: false,
+                });
+
+            graph._pendingExpands = 1;
+            await graph._fetchComparisonData('cat-releases', 'Radiohead', 'artist', 'releases');
+
+            const aOnly = graph.nodes.find(n => n.id === 'child-release-1');
+            const both = graph.nodes.find(n => n.id === 'child-release-2');
+            const bOnly = graph.nodes.find(n => n.id === 'child-release-3');
+
+            expect(aOnly.compareStatus).toBe('only_a');
+            expect(both.compareStatus).toBe('both');
+            expect(bOnly.compareStatus).toBe('only_b');
+        });
+
+        it('should show toast on fetch error', async () => {
+            graph.compareYearA = 1990;
+            graph.compareYearB = 2000;
+
+            window.apiClient.expand.mockRejectedValue(new Error('fail'));
+
+            graph._pendingExpands = 1;
+            await graph._fetchComparisonData('cat-releases', 'Radiohead', 'artist', 'releases');
+
+            const toast = document.getElementById('shareToast');
+            expect(toast.classList.contains('show')).toBe(true);
+        });
+    });
+
+    describe('toggleFullscreen', () => {
+        it('should toggle fullscreen class', () => {
+            expect(graph.container.classList.contains('fullscreen')).toBe(false);
+            graph.toggleFullscreen();
+            expect(graph.container.classList.contains('fullscreen')).toBe(true);
+            graph.toggleFullscreen();
+            expect(graph.container.classList.contains('fullscreen')).toBe(false);
+        });
+    });
+
+    describe('zoomIn / zoomOut / zoomReset', () => {
+        it('zoomIn should call zoom.scaleBy', () => {
+            graph.zoomIn();
+            // zoom methods are called via D3 transition chain
+        });
+
+        it('zoomOut should call zoom.scaleBy', () => {
+            graph.zoomOut();
+        });
+
+        it('zoomReset should call zoom.transform', () => {
+            graph.zoomReset();
+        });
+    });
+
+    describe('_onResize', () => {
+        it('should update SVG dimensions', () => {
+            graph._onResize();
+            // Should not throw even without a simulation
+        });
+
+        it('should restart simulation when running', () => {
+            const mockSim = {
+                force: vi.fn().mockReturnThis(),
+                alpha: vi.fn().mockReturnThis(),
+                restart: vi.fn(),
+            };
+            graph.simulation = mockSim;
+            graph._onResize();
+            expect(mockSim.alpha).toHaveBeenCalledWith(0.3);
+            expect(mockSim.restart).toHaveBeenCalled();
+        });
+    });
+
+    describe('_expandCategoryFiltered', () => {
+        it('should re-expand category with new before_year', async () => {
+            graph.beforeYear = 1990;
+            graph.nodes.push({
+                id: 'cat-releases', displayName: 'Releases', name: 'Releases (10)',
+                isCategory: true, isCenter: false, count: 10,
+            });
+
+            window.apiClient.expand.mockResolvedValue({
+                children: [{ id: '1', name: 'Album 1', type: 'release' }],
+                total: 1, limit: 30, has_more: false,
+            });
+
+            graph._pendingExpands = 1;
+            await graph._expandCategoryFiltered('cat-releases', 'Radiohead', 'artist', 'releases');
+
+            expect(window.apiClient.expand).toHaveBeenCalledWith('Radiohead', 'artist', 'releases', 30, 0, 1990);
+            expect(graph.nodes.find(n => n.id === 'child-release-1')).toBeDefined();
+            const catNode = graph.nodes.find(n => n.id === 'cat-releases');
+            expect(catNode.name).toBe('Releases (1)');
+        });
+    });
+
+    describe('setBeforeYear with categories', () => {
+        it('should re-fetch categories with year filter', async () => {
+            graph.centerName = 'Radiohead';
+            graph.centerType = 'artist';
+
+            // Set up existing category
+            graph.nodes.push(
+                { id: 'center-1', isCenter: true, isCategory: false, name: 'Radiohead', type: 'artist' },
+                { id: 'cat-releases', isCategory: true, isCenter: false, displayName: 'Releases', name: 'Releases (5)', count: 5 },
+            );
+            graph.links.push({ source: 'center-1', target: 'cat-releases' });
+            graph._categoryMeta.set('cat-releases', {
+                parentName: 'Radiohead', parentType: 'artist',
+                category: 'releases', offset: 5, limit: 30, total: 5,
+            });
+
+            window.apiClient.expand.mockResolvedValue({
+                children: [{ id: '1', name: 'Album 1', type: 'release' }],
+                total: 1, limit: 30, has_more: false,
+            });
+
+            await graph.setBeforeYear(1990);
+
+            expect(window.apiClient.expand).toHaveBeenCalledWith('Radiohead', 'artist', 'releases', 30, 0, 1990);
+            expect(graph.beforeYear).toBe(1990);
+        });
+    });
 });

--- a/explore/__tests__/insights.test.js
+++ b/explore/__tests__/insights.test.js
@@ -160,4 +160,330 @@ describe('InsightsPanel', () => {
             expect(table.querySelector('table')).not.toBeNull();
         });
     });
+
+    describe('_showEmpty', () => {
+        it('should hide content and show placeholder', () => {
+            const content = document.getElementById('insightsContent');
+            const placeholder = document.getElementById('insightsPlaceholder');
+            content.classList.remove('hidden');
+            placeholder.classList.add('hidden');
+
+            window.insightsPanel._showEmpty();
+
+            expect(content.classList.contains('hidden')).toBe(true);
+            expect(placeholder.classList.contains('hidden')).toBe(false);
+        });
+    });
+
+    describe('_renderTopArtists', () => {
+        it('should render a table with artist data', () => {
+            const el = document.getElementById('insightsTopArtists');
+            window.insightsPanel._renderTopArtists({
+                items: [
+                    { rank: 1, artist_name: 'Radiohead', edge_count: 100 },
+                    { rank: 2, artist_name: 'Bjork', edge_count: 80 },
+                ],
+            });
+
+            expect(el.querySelector('table')).not.toBeNull();
+            expect(el.querySelectorAll('tbody tr')).toHaveLength(2);
+        });
+
+        it('should show "No data" when items are empty', () => {
+            const el = document.getElementById('insightsTopArtists');
+            window.insightsPanel._renderTopArtists({ items: [] });
+            expect(el.textContent).toContain('No data available yet');
+        });
+
+        it('should show "No data" when data is null', () => {
+            const el = document.getElementById('insightsTopArtists');
+            window.insightsPanel._renderTopArtists(null);
+            expect(el.textContent).toContain('No data available yet');
+        });
+
+        it('should do nothing when element is missing', () => {
+            document.getElementById('insightsTopArtists').remove();
+            expect(() => window.insightsPanel._renderTopArtists({ items: [] })).not.toThrow();
+        });
+
+        it('should render header columns', () => {
+            const el = document.getElementById('insightsTopArtists');
+            window.insightsPanel._renderTopArtists({
+                items: [{ rank: 1, artist_name: 'Test', edge_count: 50 }],
+            });
+            const headers = el.querySelectorAll('th');
+            expect(headers).toHaveLength(3);
+            expect(headers[0].textContent).toBe('#');
+            expect(headers[1].textContent).toBe('Artist');
+            expect(headers[2].textContent).toBe('Connections');
+        });
+    });
+
+    describe('_renderThisMonth', () => {
+        it('should render anniversary groups', () => {
+            const el = document.getElementById('insightsThisMonth');
+            window.insightsPanel._renderThisMonth({
+                items: [
+                    { anniversary: 25, title: 'OK Computer', artist_name: 'Radiohead', release_year: 1997 },
+                    { anniversary: 25, title: 'Homogenic', artist_name: 'Bjork', release_year: 1997 },
+                    { anniversary: 50, title: 'Abbey Road', artist_name: 'The Beatles', release_year: 1969 },
+                ],
+            });
+            const groups = el.querySelectorAll('.insights-anniversary-group');
+            expect(groups).toHaveLength(2);
+            expect(groups[0].querySelector('h4').textContent).toBe('25 Years Ago');
+        });
+
+        it('should show empty message when no items', () => {
+            const el = document.getElementById('insightsThisMonth');
+            window.insightsPanel._renderThisMonth({ items: [] });
+            expect(el.textContent).toContain('No anniversaries this month');
+        });
+
+        it('should show empty message when null', () => {
+            const el = document.getElementById('insightsThisMonth');
+            window.insightsPanel._renderThisMonth(null);
+            expect(el.textContent).toContain('No anniversaries this month');
+        });
+
+        it('should do nothing when element is missing', () => {
+            document.getElementById('insightsThisMonth').remove();
+            expect(() => window.insightsPanel._renderThisMonth({ items: [] })).not.toThrow();
+        });
+
+        it('should show "Unknown Artist" when artist_name is null', () => {
+            const el = document.getElementById('insightsThisMonth');
+            window.insightsPanel._renderThisMonth({
+                items: [{ anniversary: 10, title: 'Album', artist_name: null, release_year: 2000 }],
+            });
+            expect(el.querySelector('.insights-anniversary-artist').textContent).toBe('Unknown Artist');
+        });
+    });
+
+    describe('_renderDataCompleteness', () => {
+        it('should render completeness bars', () => {
+            const el = document.getElementById('insightsCompleteness');
+            window.insightsPanel._renderDataCompleteness({
+                items: [
+                    { entity_type: 'releases', completeness_pct: 89.5, total_count: 15000000 },
+                    { entity_type: 'artists', completeness_pct: 95.2, total_count: 8000000 },
+                ],
+            });
+            expect(el.querySelectorAll('.insights-completeness-row')).toHaveLength(2);
+        });
+
+        it('should capitalize entity type', () => {
+            const el = document.getElementById('insightsCompleteness');
+            window.insightsPanel._renderDataCompleteness({
+                items: [{ entity_type: 'releases', completeness_pct: 89.5, total_count: 100 }],
+            });
+            expect(el.querySelector('.insights-completeness-label').textContent).toBe('Releases');
+        });
+
+        it('should cap bar width at 100%', () => {
+            const el = document.getElementById('insightsCompleteness');
+            window.insightsPanel._renderDataCompleteness({
+                items: [{ entity_type: 'test', completeness_pct: 120, total_count: 50 }],
+            });
+            expect(el.querySelector('.insights-completeness-bar').style.width).toBe('100%');
+        });
+
+        it('should show empty message when no items', () => {
+            const el = document.getElementById('insightsCompleteness');
+            window.insightsPanel._renderDataCompleteness({ items: [] });
+            expect(el.textContent).toContain('No completeness data available');
+        });
+
+        it('should show empty message when null', () => {
+            const el = document.getElementById('insightsCompleteness');
+            window.insightsPanel._renderDataCompleteness(null);
+            expect(el.textContent).toContain('No completeness data available');
+        });
+
+        it('should do nothing when element is missing', () => {
+            document.getElementById('insightsCompleteness').remove();
+            expect(() => window.insightsPanel._renderDataCompleteness({ items: [] })).not.toThrow();
+        });
+    });
+
+    describe('_renderStatus', () => {
+        it('should render healthy status when all completed', () => {
+            const el = document.getElementById('insightsStatus');
+            window.insightsPanel._renderStatus({
+                statuses: [
+                    { insight_type: 'top_artists', status: 'completed', last_computed: '2026-01-01T00:00:00Z' },
+                ],
+            });
+            const dot = el.querySelector('.insights-status-dot');
+            expect(dot.className).toContain('healthy');
+            expect(dot.textContent).toBe('All healthy');
+        });
+
+        it('should render warning status when some have issues', () => {
+            const el = document.getElementById('insightsStatus');
+            window.insightsPanel._renderStatus({
+                statuses: [
+                    { insight_type: 'a', status: 'completed', last_computed: '2026-01-01T00:00:00Z' },
+                    { insight_type: 'b', status: 'error', last_computed: '2026-01-01T00:00:00Z' },
+                ],
+            });
+            const dot = el.querySelector('.insights-status-dot');
+            expect(dot.className).toContain('warning');
+            expect(dot.textContent).toBe('Issues detected');
+        });
+
+        it('should treat never_run as healthy', () => {
+            const el = document.getElementById('insightsStatus');
+            window.insightsPanel._renderStatus({
+                statuses: [{ insight_type: 'a', status: 'never_run', last_computed: null }],
+            });
+            expect(el.querySelector('.insights-status-dot').className).toContain('healthy');
+        });
+
+        it('should clear element when no statuses', () => {
+            const el = document.getElementById('insightsStatus');
+            el.textContent = 'old';
+            window.insightsPanel._renderStatus({ statuses: [] });
+            expect(el.textContent).toBe('');
+        });
+
+        it('should clear element when data is null', () => {
+            const el = document.getElementById('insightsStatus');
+            el.textContent = 'old';
+            window.insightsPanel._renderStatus(null);
+            expect(el.textContent).toBe('');
+        });
+
+        it('should do nothing when element is missing', () => {
+            document.getElementById('insightsStatus').remove();
+            expect(() => window.insightsPanel._renderStatus({ statuses: [] })).not.toThrow();
+        });
+    });
+
+    describe('_loadGenreTrends', () => {
+        it('should update selected genre', async () => {
+            window.apiClient = {
+                getInsightsGenreTrends: vi.fn().mockResolvedValue({ trends: [] }),
+            };
+            await window.insightsPanel._loadGenreTrends('Jazz');
+            expect(window.insightsPanel._selectedGenre).toBe('Jazz');
+        });
+
+        it('should toggle active class on genre chips', async () => {
+            const chip1 = document.createElement('div');
+            chip1.className = 'insights-genre-chip';
+            chip1.dataset.genre = 'Rock';
+            const chip2 = document.createElement('div');
+            chip2.className = 'insights-genre-chip active';
+            chip2.dataset.genre = 'Jazz';
+            document.body.append(chip1, chip2);
+
+            window.apiClient = {
+                getInsightsGenreTrends: vi.fn().mockResolvedValue({ trends: [] }),
+            };
+            await window.insightsPanel._loadGenreTrends('Rock');
+            expect(chip1.classList.contains('active')).toBe(true);
+            expect(chip2.classList.contains('active')).toBe(false);
+        });
+    });
+
+    describe('_renderGenreTrends', () => {
+        it('should call Plotly.newPlot with trend data', () => {
+            const el = document.getElementById('insightsGenreChart');
+            window.insightsPanel._renderGenreTrends({
+                genre: 'Rock',
+                trends: [
+                    { decade: 1970, release_count: 1000 },
+                    { decade: 1980, release_count: 2000 },
+                ],
+            });
+            expect(Plotly.newPlot).toHaveBeenCalled();
+        });
+
+        it('should show "No trend data" when trends are empty', () => {
+            const el = document.getElementById('insightsGenreChart');
+            window.insightsPanel._renderGenreTrends({ trends: [] });
+            expect(el.textContent).toContain('No trend data for this genre');
+        });
+
+        it('should show "No trend data" when null', () => {
+            const el = document.getElementById('insightsGenreChart');
+            window.insightsPanel._renderGenreTrends(null);
+            expect(el.textContent).toContain('No trend data for this genre');
+        });
+
+        it('should do nothing when element is missing', () => {
+            document.getElementById('insightsGenreChart').remove();
+            expect(() => window.insightsPanel._renderGenreTrends({ trends: [] })).not.toThrow();
+        });
+    });
+
+    describe('_checkForUpdates', () => {
+        it('should reload when timestamps have changed', async () => {
+            window.insightsPanel._lastComputedAt = new Map([['top_artists', '2026-01-01']]);
+            window.apiClient = {
+                getInsightsStatus: vi.fn().mockResolvedValue({
+                    statuses: [{ insight_type: 'top_artists', last_computed: '2026-01-02' }],
+                }),
+                getInsightsTopArtists: vi.fn().mockResolvedValue(null),
+                getInsightsThisMonth: vi.fn().mockResolvedValue(null),
+                getInsightsDataCompleteness: vi.fn().mockResolvedValue(null),
+            };
+            await window.insightsPanel._checkForUpdates();
+            expect(window.insightsPanel._lastComputedAt.get('top_artists')).toBe('2026-01-02');
+        });
+
+        it('should not reload when timestamps unchanged', async () => {
+            window.insightsPanel._lastComputedAt = new Map([['top_artists', '2026-01-01']]);
+            const loadSpy = vi.spyOn(window.insightsPanel, 'load');
+            window.apiClient = {
+                getInsightsStatus: vi.fn().mockResolvedValue({
+                    statuses: [{ insight_type: 'top_artists', last_computed: '2026-01-01' }],
+                }),
+            };
+            await window.insightsPanel._checkForUpdates();
+            expect(loadSpy).not.toHaveBeenCalled();
+            loadSpy.mockRestore();
+        });
+
+        it('should skip on API error', async () => {
+            window.apiClient = {
+                getInsightsStatus: vi.fn().mockRejectedValue(new Error('fail')),
+            };
+            await window.insightsPanel._checkForUpdates();
+        });
+
+        it('should skip when status returns null', async () => {
+            window.apiClient = {
+                getInsightsStatus: vi.fn().mockResolvedValue(null),
+            };
+            await window.insightsPanel._checkForUpdates();
+        });
+    });
+
+    describe('load error handling', () => {
+        it('should show empty state on API error', async () => {
+            window.apiClient = {
+                getInsightsTopArtists: vi.fn().mockRejectedValue(new Error('fail')),
+                getInsightsThisMonth: vi.fn().mockRejectedValue(new Error('fail')),
+                getInsightsDataCompleteness: vi.fn().mockRejectedValue(new Error('fail')),
+                getInsightsStatus: vi.fn().mockRejectedValue(new Error('fail')),
+            };
+            await window.insightsPanel.load();
+            const content = document.getElementById('insightsContent');
+            expect(content.classList.contains('hidden')).toBe(true);
+        });
+
+        it('should remove loading state after error', async () => {
+            window.apiClient = {
+                getInsightsTopArtists: vi.fn().mockRejectedValue(new Error('fail')),
+                getInsightsThisMonth: vi.fn().mockRejectedValue(new Error('fail')),
+                getInsightsDataCompleteness: vi.fn().mockRejectedValue(new Error('fail')),
+                getInsightsStatus: vi.fn().mockRejectedValue(new Error('fail')),
+            };
+            await window.insightsPanel.load();
+            const loading = document.getElementById('insightsLoading');
+            expect(loading.classList.contains('active')).toBe(false);
+        });
+    });
 });

--- a/explore/__tests__/user-panes.test.js
+++ b/explore/__tests__/user-panes.test.js
@@ -611,4 +611,234 @@ describe('UserPanes', () => {
             expect(wrap.querySelector('.pane-pagination')).not.toBeNull();
         });
     });
+
+    describe('loadCollectionStats', () => {
+        it('should return early when no token', async () => {
+            window.authManager.getToken.mockReturnValue(null);
+            await userPanes.loadCollectionStats();
+            expect(window.apiClient.getUserCollectionStats).not.toHaveBeenCalled();
+        });
+
+        it('should call getUserCollectionStats with token', async () => {
+            window.apiClient.getUserCollectionStats.mockResolvedValue({
+                total_releases: 100, unique_artists: 50, unique_labels: 20, average_rating: 3.5,
+            });
+            await userPanes.loadCollectionStats();
+            expect(window.apiClient.getUserCollectionStats).toHaveBeenCalledWith('test-token');
+        });
+
+        it('should render stats when data returned', async () => {
+            window.apiClient.getUserCollectionStats.mockResolvedValue({
+                total_releases: 100, unique_artists: 50, unique_labels: 20, average_rating: 3.5,
+            });
+            await userPanes.loadCollectionStats();
+            const el = document.getElementById('collectionStats');
+            expect(el.querySelectorAll('.stat-card').length).toBe(4);
+        });
+    });
+
+    describe('startDiscogsOAuth', () => {
+        beforeEach(() => {
+            globalThis.Alpine = { store: vi.fn().mockReturnValue({ discogsOpen: false }) };
+        });
+
+        it('should return early when no token', async () => {
+            window.authManager.getToken.mockReturnValue(null);
+            await userPanes.startDiscogsOAuth();
+            expect(window.apiClient.authorizeDiscogs).not.toHaveBeenCalled();
+        });
+
+        it('should call authorizeDiscogs with token', async () => {
+            window.apiClient.authorizeDiscogs.mockResolvedValue({
+                authorize_url: 'https://discogs.com/oauth', state: 'abc',
+            });
+            const origOpen = window.open;
+            window.open = vi.fn();
+            await userPanes.startDiscogsOAuth();
+            expect(window.apiClient.authorizeDiscogs).toHaveBeenCalledWith('test-token');
+            window.open = origOpen;
+        });
+
+        it('should store OAuth state', async () => {
+            window.apiClient.authorizeDiscogs.mockResolvedValue({
+                authorize_url: 'https://discogs.com/oauth', state: 'test-state',
+            });
+            window.open = vi.fn();
+            await userPanes.startDiscogsOAuth();
+            expect(userPanes._discogsOAuthState).toBe('test-state');
+        });
+
+        it('should alert when API returns null', async () => {
+            window.apiClient.authorizeDiscogs.mockResolvedValue(null);
+            window.alert = vi.fn();
+            await userPanes.startDiscogsOAuth();
+            expect(window.alert).toHaveBeenCalled();
+            expect(userPanes._discogsOAuthState).toBeNull();
+        });
+    });
+
+    describe('submitDiscogsVerifier', () => {
+        beforeEach(() => {
+            globalThis.Alpine = { store: vi.fn().mockReturnValue({ discogsOpen: false }) };
+        });
+
+        it('should show error when verifier is empty', async () => {
+            const input = document.getElementById('discogsVerifierInput');
+            input.value = '';
+            await userPanes.submitDiscogsVerifier();
+            const errorEl = document.getElementById('discogsVerifierError');
+            expect(errorEl.textContent).toContain('Please enter');
+        });
+
+        it('should show error when no OAuth state', async () => {
+            const input = document.getElementById('discogsVerifierInput');
+            input.value = 'verifier-code';
+            userPanes._discogsOAuthState = null;
+            await userPanes.submitDiscogsVerifier();
+            const errorEl = document.getElementById('discogsVerifierError');
+            expect(errorEl.textContent).toContain('Session expired');
+        });
+
+        it('should call verifyDiscogs and update status on success', async () => {
+            const input = document.getElementById('discogsVerifierInput');
+            input.value = 'verifier-code';
+            userPanes._discogsOAuthState = 'test-state';
+            window.apiClient.verifyDiscogs.mockResolvedValue({ connected: true });
+            window.apiClient.getDiscogsStatus.mockResolvedValue({ connected: true });
+            await userPanes.submitDiscogsVerifier();
+            expect(window.apiClient.verifyDiscogs).toHaveBeenCalledWith('test-token', 'test-state', 'verifier-code');
+            expect(window.authManager.setDiscogsStatus).toHaveBeenCalledWith({ connected: true });
+        });
+
+        it('should show error on verification failure', async () => {
+            const input = document.getElementById('discogsVerifierInput');
+            input.value = 'bad-code';
+            userPanes._discogsOAuthState = 'test-state';
+            window.apiClient.verifyDiscogs.mockResolvedValue({ connected: false });
+            await userPanes.submitDiscogsVerifier();
+            const errorEl = document.getElementById('discogsVerifierError');
+            expect(errorEl.textContent).toContain('Verification failed');
+        });
+    });
+
+    describe('disconnectDiscogs', () => {
+        it('should return early when no token', async () => {
+            window.authManager.getToken.mockReturnValue(null);
+            await userPanes.disconnectDiscogs();
+            expect(window.apiClient.revokeDiscogs).not.toHaveBeenCalled();
+        });
+
+        it('should call revokeDiscogs when confirmed', async () => {
+            window.confirm = vi.fn().mockReturnValue(true);
+            await userPanes.disconnectDiscogs();
+            expect(window.apiClient.revokeDiscogs).toHaveBeenCalledWith('test-token');
+            expect(window.authManager.setDiscogsStatus).toHaveBeenCalledWith({ connected: false });
+        });
+
+        it('should not call revokeDiscogs when cancelled', async () => {
+            window.confirm = vi.fn().mockReturnValue(false);
+            await userPanes.disconnectDiscogs();
+            expect(window.apiClient.revokeDiscogs).not.toHaveBeenCalled();
+        });
+
+        it('should clear taste cache after disconnect', async () => {
+            window.confirm = vi.fn().mockReturnValue(true);
+            userPanes._tasteCache = { some: 'data' };
+            await userPanes.disconnectDiscogs();
+            expect(userPanes._tasteCache).toBeNull();
+        });
+    });
+
+    describe('loadGapAnalysis', () => {
+        it('should return early when no token', async () => {
+            window.authManager.getToken.mockReturnValue(null);
+            await userPanes.loadGapAnalysis('artist', '123');
+            expect(window.apiClient.getCollectionGaps).not.toHaveBeenCalled();
+        });
+
+        it('should call getCollectionGaps with params', async () => {
+            window.apiClient.getCollectionGaps.mockResolvedValue({
+                entity: { name: 'Test', type: 'artist' },
+                owned_count: 5, total_count: 10, missing: [],
+                pagination: { total: 5, offset: 0, limit: 50 },
+            });
+            await userPanes.loadGapAnalysis('artist', '123');
+            expect(window.apiClient.getCollectionGaps).toHaveBeenCalled();
+        });
+
+        it('should render empty state when API returns null', async () => {
+            window.apiClient.getCollectionGaps.mockResolvedValue(null);
+            await userPanes.loadGapAnalysis('artist', '123');
+            const body = document.getElementById('gapsBody');
+            expect(body.querySelector('.user-pane-empty')).not.toBeNull();
+        });
+
+        it('should reset offset when reset=true', async () => {
+            userPanes._gapOffset = 50;
+            window.apiClient.getCollectionGaps.mockResolvedValue(null);
+            await userPanes.loadGapAnalysis('artist', '123', true);
+            expect(userPanes._gapOffset).toBe(0);
+        });
+
+        it('should show gaps pane', async () => {
+            window.apiClient.getCollectionGaps.mockResolvedValue(null);
+            await userPanes.loadGapAnalysis('artist', '123');
+            const gapsPane = document.getElementById('gapsPane');
+            expect(gapsPane.classList.contains('active')).toBe(true);
+        });
+    });
+
+    describe('_downloadTasteCard', () => {
+        it('should return early when no token', async () => {
+            window.authManager.getToken.mockReturnValue(null);
+            const btn = document.createElement('button');
+            await userPanes._downloadTasteCard(btn);
+            expect(window.apiClient.getTasteCard).not.toHaveBeenCalled();
+        });
+
+        it('should show downloading state on button', async () => {
+            window.apiClient.getTasteCard.mockResolvedValue(null);
+            const btn = document.createElement('button');
+            btn.textContent = 'Download Taste Card';
+
+            // Use a flag to check state during execution
+            let textDuringCall = null;
+            window.apiClient.getTasteCard.mockImplementation(async () => {
+                textDuringCall = btn.textContent;
+                return null;
+            });
+
+            await userPanes._downloadTasteCard(btn);
+            expect(textDuringCall).toBe('Downloading...');
+        });
+
+        it('should show failure message when blob is null', async () => {
+            vi.useFakeTimers();
+            window.apiClient.getTasteCard.mockResolvedValue(null);
+            const btn = document.createElement('button');
+            await userPanes._downloadTasteCard(btn);
+            expect(btn.textContent).toBe('Download failed');
+            vi.useRealTimers();
+        });
+
+        it('should trigger download when blob is returned', async () => {
+            const blob = new Blob(['<svg></svg>'], { type: 'image/svg+xml' });
+            window.apiClient.getTasteCard.mockResolvedValue(blob);
+            globalThis.URL.createObjectURL = vi.fn().mockReturnValue('blob:test');
+            globalThis.URL.revokeObjectURL = vi.fn();
+
+            const btn = document.createElement('button');
+            const clickSpy = vi.fn();
+            const origCreateElement = document.createElement.bind(document);
+            vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+                const el = origCreateElement(tag);
+                if (tag === 'a') el.click = clickSpy;
+                return el;
+            });
+
+            await userPanes._downloadTasteCard(btn);
+            expect(clickSpy).toHaveBeenCalled();
+            document.createElement.mockRestore();
+        });
+    });
 });

--- a/tests/api/test_dependencies.py
+++ b/tests/api/test_dependencies.py
@@ -1,0 +1,150 @@
+"""Tests for FastAPI dependency functions."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from api.dependencies import configure, get_optional_user, require_user
+
+
+# Use a known JWT secret for tests
+TEST_SECRET = "test-jwt-secret-for-unit-tests"
+
+
+def _make_credentials(token: str) -> MagicMock:
+    """Create a mock HTTPAuthorizationCredentials."""
+    creds = MagicMock()
+    creds.credentials = token
+    return creds
+
+
+def _make_valid_token(secret: str = TEST_SECRET) -> str:
+    """Create a valid HS256 JWT for testing."""
+    import base64
+    import hashlib
+    import hmac
+    import json
+
+    def b64url(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+    header = b64url(json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode())
+    body = b64url(json.dumps({"sub": "user-1", "email": "test@example.com", "exp": 9_999_999_999}, separators=(",", ":")).encode())
+    signing_input = f"{header}.{body}".encode("ascii")
+    sig = b64url(hmac.new(secret.encode("utf-8"), signing_input, hashlib.sha256).digest())
+    return f"{header}.{body}.{sig}"
+
+
+class TestConfigure:
+    def test_sets_jwt_secret(self) -> None:
+        configure(TEST_SECRET)
+        # Verify it took effect by using require_user with a valid token
+        # (just verify configure doesn't raise)
+
+    def test_sets_none_secret(self) -> None:
+        configure(None)
+
+
+class TestGetOptionalUser:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_credentials(self) -> None:
+        configure(TEST_SECRET)
+        result = await get_optional_user(None)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_secret(self) -> None:
+        configure(None)
+        creds = _make_credentials("some-token")
+        result = await get_optional_user(creds)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_payload_for_valid_token(self) -> None:
+        configure(TEST_SECRET)
+        token = _make_valid_token()
+        creds = _make_credentials(token)
+        result = await get_optional_user(creds)
+        assert result is not None
+        assert result["sub"] == "user-1"
+        assert result["email"] == "test@example.com"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_invalid_token(self) -> None:
+        configure(TEST_SECRET)
+        creds = _make_credentials("invalid.token.here")
+        result = await get_optional_user(creds)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_wrong_secret(self) -> None:
+        configure(TEST_SECRET)
+        token = _make_valid_token(secret="wrong-secret-key-for-testing-1234")  # noqa: S106
+        creds = _make_credentials(token)
+        result = await get_optional_user(creds)
+        assert result is None
+
+
+class TestRequireUser:
+    @pytest.mark.asyncio
+    async def test_raises_503_when_no_secret(self) -> None:
+        configure(None)
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await require_user(MagicMock())
+        assert exc_info.value.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_raises_401_when_no_credentials(self) -> None:
+        configure(TEST_SECRET)
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await require_user(None)
+        assert exc_info.value.status_code == 401
+        assert "Authentication required" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_returns_payload_for_valid_token(self) -> None:
+        configure(TEST_SECRET)
+        token = _make_valid_token()
+        creds = _make_credentials(token)
+        result = await require_user(creds)
+        assert result["sub"] == "user-1"
+
+    @pytest.mark.asyncio
+    async def test_raises_401_for_invalid_token(self) -> None:
+        configure(TEST_SECRET)
+        from fastapi import HTTPException
+
+        creds = _make_credentials("bad.token.value")
+        with pytest.raises(HTTPException) as exc_info:
+            await require_user(creds)
+        assert exc_info.value.status_code == 401
+        assert "Invalid or expired token" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_raises_401_for_expired_token(self) -> None:
+        """Test with an expired JWT (exp in the past)."""
+        import base64
+        import hashlib
+        import hmac
+        import json
+
+        configure(TEST_SECRET)
+        from fastapi import HTTPException
+
+        def b64url(data: bytes) -> str:
+            return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+        header = b64url(json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode())
+        body = b64url(json.dumps({"sub": "user-1", "exp": 1000000000}, separators=(",", ":")).encode())
+        signing_input = f"{header}.{body}".encode("ascii")
+        sig = b64url(hmac.new(TEST_SECRET.encode("utf-8"), signing_input, hashlib.sha256).digest())
+        expired_token = f"{header}.{body}.{sig}"
+
+        creds = _make_credentials(expired_token)
+        with pytest.raises(HTTPException) as exc_info:
+            await require_user(creds)
+        assert exc_info.value.status_code == 401

--- a/tests/api/test_insights_pg_queries.py
+++ b/tests/api/test_insights_pg_queries.py
@@ -1,0 +1,174 @@
+"""Tests for insights PostgreSQL queries."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.queries.insights_pg_queries import (
+    _ALLOWED_TABLES,
+    _COMPLETENESS_FIELDS,
+    _COUNT_QUERIES,
+    _FIELD_QUERIES,
+    query_data_completeness,
+)
+
+
+class TestConstants:
+    def test_allowed_tables_are_expected(self) -> None:
+        assert frozenset({"artists", "labels", "masters", "releases"}) == _ALLOWED_TABLES
+
+    def test_count_queries_are_built_for_each_table(self) -> None:
+        for table in _ALLOWED_TABLES:
+            assert table in _COUNT_QUERIES
+            assert _COUNT_QUERIES[table] == f"SELECT count(*) FROM {table}"  # noqa: S608
+
+    def test_field_queries_built_for_completeness_fields(self) -> None:
+        for table, fields in _COMPLETENESS_FIELDS.items():
+            assert table in _FIELD_QUERIES
+            for field_name, _jsonb_key in fields:
+                assert field_name in _FIELD_QUERIES[table]
+
+    def test_completeness_fields_cover_all_entity_types(self) -> None:
+        assert set(_COMPLETENESS_FIELDS.keys()) == {"artists", "labels", "masters", "releases"}
+
+    def test_releases_has_most_fields(self) -> None:
+        assert len(_COMPLETENESS_FIELDS["releases"]) == 4
+        field_names = [f[0] for f in _COMPLETENESS_FIELDS["releases"]]
+        assert "with_year" in field_names
+        assert "with_country" in field_names
+        assert "with_genre" in field_names
+        assert "with_image" in field_names
+
+
+def _make_mock_pool(count_result: int = 100, field_result: int = 80) -> MagicMock:
+    """Create a mock pool that returns configurable counts."""
+    call_count = 0
+
+    async def mock_execute(query: str, *args: Any) -> None:
+        pass
+
+    async def mock_fetchall() -> list[tuple[int]]:
+        nonlocal call_count
+        call_count += 1
+        # First call per entity is the total count, subsequent are field counts
+        return [(count_result,)] if call_count % 2 == 1 else [(field_result,)]
+
+    mock_cursor = AsyncMock()
+    mock_cursor.execute = AsyncMock(side_effect=mock_execute)
+    mock_cursor.fetchall = AsyncMock(side_effect=mock_fetchall)
+    mock_cursor.__aenter__ = AsyncMock(return_value=mock_cursor)
+    mock_cursor.__aexit__ = AsyncMock(return_value=False)
+
+    mock_conn = AsyncMock()
+    mock_conn.cursor = MagicMock(return_value=mock_cursor)
+    mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+    pool = MagicMock()
+    pool.connection = MagicMock(return_value=mock_conn)
+    return pool
+
+
+def _make_pool_with_sequence(sequence: list[list[tuple[int]]]) -> MagicMock:
+    """Create a mock pool that returns results in order from the sequence list."""
+    idx = 0
+
+    async def mock_fetchall() -> list[tuple[int]]:
+        nonlocal idx
+        result = sequence[idx] if idx < len(sequence) else []
+        idx += 1
+        return result
+
+    mock_cursor = AsyncMock()
+    mock_cursor.execute = AsyncMock()
+    mock_cursor.fetchall = AsyncMock(side_effect=mock_fetchall)
+    mock_cursor.__aenter__ = AsyncMock(return_value=mock_cursor)
+    mock_cursor.__aexit__ = AsyncMock(return_value=False)
+
+    mock_conn = AsyncMock()
+    mock_conn.cursor = MagicMock(return_value=mock_cursor)
+    mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+    pool = MagicMock()
+    pool.connection = MagicMock(return_value=mock_conn)
+    return pool
+
+
+class TestQueryDataCompleteness:
+    @pytest.mark.asyncio
+    async def test_returns_results_for_all_entity_types(self) -> None:
+        # Build sequence: for each entity type, first call is total, then field counts
+        sequence: list[list[tuple[int]]] = []
+        for _table, fields in _COMPLETENESS_FIELDS.items():
+            sequence.append([(1000,)])  # total count
+            for _ in fields:
+                sequence.append([(800,)])  # field count
+
+        pool = _make_pool_with_sequence(sequence)
+        results = await query_data_completeness(pool)
+
+        assert len(results) == 4
+        entity_types = {r["entity_type"] for r in results}
+        assert entity_types == {"artists", "labels", "masters", "releases"}
+
+    @pytest.mark.asyncio
+    async def test_calculates_completeness_percentage(self) -> None:
+        # artists has 1 field (with_image), so completeness = 80/100 * 100 = 80%
+        sequence: list[list[tuple[int]]] = []
+        for _table, fields in _COMPLETENESS_FIELDS.items():
+            sequence.append([(100,)])  # total
+            for _ in fields:
+                sequence.append([(80,)])  # field count
+
+        pool = _make_pool_with_sequence(sequence)
+        results = await query_data_completeness(pool)
+
+        # All should have completeness_pct = 80.0 (80/100 * 100)
+        for result in results:
+            assert result["completeness_pct"] == 80.0
+
+    @pytest.mark.asyncio
+    async def test_zero_total_count_returns_zero_completeness(self) -> None:
+        # All tables return 0 total
+        sequence: list[list[tuple[int]]] = []
+        for _table, _fields in _COMPLETENESS_FIELDS.items():
+            sequence.append([(0,)])  # total count = 0, no field queries needed
+
+        pool = _make_pool_with_sequence(sequence)
+        results = await query_data_completeness(pool)
+
+        for result in results:
+            assert result["total_count"] == 0
+            assert result["completeness_pct"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_empty_fetchall_returns_zero_count(self) -> None:
+        # All fetchall return empty list
+        sequence: list[list[tuple[int]]] = []
+        for _table, _fields in _COMPLETENESS_FIELDS.items():
+            sequence.append([])  # empty result for total count
+
+        pool = _make_pool_with_sequence(sequence)
+        results = await query_data_completeness(pool)
+
+        for result in results:
+            assert result["total_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_result_contains_expected_fields(self) -> None:
+        sequence: list[list[tuple[int]]] = []
+        for _table, fields in _COMPLETENESS_FIELDS.items():
+            sequence.append([(100,)])
+            for _ in fields:
+                sequence.append([(50,)])
+
+        pool = _make_pool_with_sequence(sequence)
+        results = await query_data_completeness(pool)
+
+        for result in results:
+            assert "entity_type" in result
+            assert "total_count" in result
+            assert "completeness_pct" in result
+            assert "with_image" in result

--- a/tests/api/test_limiter.py
+++ b/tests/api/test_limiter.py
@@ -1,0 +1,16 @@
+"""Tests for rate limiter singleton."""
+
+from api.limiter import limiter
+
+
+class TestLimiter:
+    def test_limiter_is_importable(self) -> None:
+        assert limiter is not None
+
+    def test_limiter_has_key_func(self) -> None:
+        assert limiter._key_func is not None
+
+    def test_limiter_is_singleton(self) -> None:
+        from api.limiter import limiter as limiter2
+
+        assert limiter is limiter2

--- a/tests/api/test_similarity.py
+++ b/tests/api/test_similarity.py
@@ -1,0 +1,73 @@
+"""Tests for cosine similarity utilities."""
+
+from api.queries.similarity import cosine_similarity, to_genre_vector
+
+
+class TestToGenreVector:
+    def test_converts_genre_list_to_percentages(self) -> None:
+        genres = [
+            {"name": "Rock", "count": 60},
+            {"name": "Jazz", "count": 40},
+        ]
+        result = to_genre_vector(genres)
+        assert result == {"Rock": 0.6, "Jazz": 0.4}
+
+    def test_returns_empty_dict_when_total_is_zero(self) -> None:
+        genres = [{"name": "Rock", "count": 0}, {"name": "Jazz", "count": 0}]
+        assert to_genre_vector(genres) == {}
+
+    def test_returns_empty_dict_for_empty_list(self) -> None:
+        assert to_genre_vector([]) == {}
+
+    def test_single_genre_returns_1_point_0(self) -> None:
+        genres = [{"name": "Electronic", "count": 100}]
+        result = to_genre_vector(genres)
+        assert result == {"Electronic": 1.0}
+
+    def test_handles_many_genres(self) -> None:
+        genres = [
+            {"name": "Rock", "count": 10},
+            {"name": "Jazz", "count": 20},
+            {"name": "Pop", "count": 30},
+            {"name": "Metal", "count": 40},
+        ]
+        result = to_genre_vector(genres)
+        assert abs(sum(result.values()) - 1.0) < 1e-9
+
+
+class TestCosineSimilarity:
+    def test_identical_vectors_return_1(self) -> None:
+        vec = {"Rock": 0.5, "Jazz": 0.5}
+        assert abs(cosine_similarity(vec, vec) - 1.0) < 1e-9
+
+    def test_orthogonal_vectors_return_0(self) -> None:
+        vec_a = {"Rock": 1.0}
+        vec_b = {"Jazz": 1.0}
+        assert cosine_similarity(vec_a, vec_b) == 0.0
+
+    def test_empty_vec_a_returns_0(self) -> None:
+        assert cosine_similarity({}, {"Rock": 1.0}) == 0.0
+
+    def test_empty_vec_b_returns_0(self) -> None:
+        assert cosine_similarity({"Rock": 1.0}, {}) == 0.0
+
+    def test_both_empty_returns_0(self) -> None:
+        assert cosine_similarity({}, {}) == 0.0
+
+    def test_partial_overlap(self) -> None:
+        vec_a = {"Rock": 0.6, "Jazz": 0.4}
+        vec_b = {"Rock": 0.8, "Electronic": 0.2}
+        result = cosine_similarity(vec_a, vec_b)
+        assert 0.0 < result < 1.0
+
+    def test_known_value(self) -> None:
+        # vec_a = (3, 4), vec_b = (4, 3) => dot=24, |a|=5, |b|=5 => 24/25
+        vec_a = {"x": 3.0, "y": 4.0}
+        vec_b = {"x": 4.0, "y": 3.0}
+        expected = 24.0 / 25.0
+        assert abs(cosine_similarity(vec_a, vec_b) - expected) < 1e-9
+
+    def test_zero_magnitude_vec_returns_0(self) -> None:
+        vec_a = {"Rock": 0.0}
+        vec_b = {"Rock": 1.0}
+        assert cosine_similarity(vec_a, vec_b) == 0.0

--- a/tests/insights/test_log_computation.py
+++ b/tests/insights/test_log_computation.py
@@ -1,0 +1,102 @@
+"""Tests for the _log_computation helper in insights.computations."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from insights.computations import _log_computation
+
+
+def _make_mock_pool() -> AsyncMock:
+    """Create a mock pool for logging."""
+    mock_cursor = AsyncMock()
+    mock_cursor.execute = AsyncMock()
+    mock_cursor.__aenter__ = AsyncMock(return_value=mock_cursor)
+    mock_cursor.__aexit__ = AsyncMock(return_value=False)
+
+    mock_conn = AsyncMock()
+    mock_conn.cursor = MagicMock(return_value=mock_cursor)
+    mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+    pool = AsyncMock()
+    pool.connection = MagicMock(return_value=mock_conn)
+    return pool
+
+
+class TestLogComputation:
+    @pytest.mark.asyncio
+    async def test_inserts_completed_log_entry(self) -> None:
+        pool = _make_mock_pool()
+        started_at = datetime.now(UTC)
+
+        await _log_computation(pool, "artist_centrality", "completed", started_at, rows_affected=10)
+
+        cursor = pool.connection.return_value.__aenter__.return_value.cursor.return_value.__aenter__.return_value
+        cursor.execute.assert_called_once()
+        call_args = cursor.execute.call_args
+        assert "INSERT INTO insights.computation_log" in call_args[0][0]
+        params = call_args[0][1]
+        assert params[0] == "artist_centrality"
+        assert params[1] == "completed"
+        assert params[4] == 10
+        assert params[6] is None  # error_message
+
+    @pytest.mark.asyncio
+    async def test_inserts_failed_log_entry_with_error(self) -> None:
+        pool = _make_mock_pool()
+        started_at = datetime.now(UTC)
+
+        await _log_computation(
+            pool,
+            "genre_trends",
+            "failed",
+            started_at,
+            rows_affected=0,
+            error_message="DB connection lost",
+        )
+
+        cursor = pool.connection.return_value.__aenter__.return_value.cursor.return_value.__aenter__.return_value
+        params = cursor.execute.call_args[0][1]
+        assert params[0] == "genre_trends"
+        assert params[1] == "failed"
+        assert params[4] == 0
+        assert params[6] == "DB connection lost"
+
+    @pytest.mark.asyncio
+    async def test_calculates_positive_duration(self) -> None:
+        pool = _make_mock_pool()
+        # Use a started_at slightly in the past
+        started_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+
+        await _log_computation(pool, "test_type", "completed", started_at)
+
+        cursor = pool.connection.return_value.__aenter__.return_value.cursor.return_value.__aenter__.return_value
+        params = cursor.execute.call_args[0][1]
+        duration_ms = params[5]
+        assert duration_ms > 0
+
+    @pytest.mark.asyncio
+    async def test_default_rows_affected_is_zero(self) -> None:
+        pool = _make_mock_pool()
+        started_at = datetime.now(UTC)
+
+        await _log_computation(pool, "test_type", "completed", started_at)
+
+        cursor = pool.connection.return_value.__aenter__.return_value.cursor.return_value.__aenter__.return_value
+        params = cursor.execute.call_args[0][1]
+        assert params[4] == 0
+
+    @pytest.mark.asyncio
+    async def test_passes_started_at_and_completed_at(self) -> None:
+        pool = _make_mock_pool()
+        started_at = datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
+
+        await _log_computation(pool, "test_type", "completed", started_at)
+
+        cursor = pool.connection.return_value.__aenter__.return_value.cursor.return_value.__aenter__.return_value
+        params = cursor.execute.call_args[0][1]
+        assert params[2] == started_at  # started_at
+        assert isinstance(params[3], datetime)  # completed_at
+        assert params[3] >= started_at


### PR DESCRIPTION
## Summary
- Add **76 new JavaScript tests** for explore frontend (insights.js, user-panes.js, graph.js) covering rendering methods, OAuth flow, gap analysis, comparison mode, and error handling
- Add **43 new Python tests** for 4 previously untested API modules (`similarity.py`, `dependencies.py`, `insights_pg_queries.py`, `limiter.py`) and the insights `_log_computation` helper
- JS test count: 296 → 372 (+76)
- Python test count: 1534 → 1577 (+43)

## Test plan
- [x] All 372 JavaScript tests pass (`npx vitest run`)
- [x] All 1577 Python tests pass (`uv run pytest`)
- [x] Ruff linting passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)