### PR TITLE
fix: update callers and tests for async context manager session()

### DIFF
--- a/api/queries/neo4j_queries.py
+++ b/api/queries/neo4j_queries.py
@@ -42,14 +42,14 @@ def _build_autocomplete_query(query: str) -> str:
 
 async def _run_query(driver: AsyncResilientNeo4jDriver, cypher: str, **params: Any) -> list[dict[str, Any]]:
     """Execute a Cypher query and return all results as a list of dicts."""
-    async with await driver.session() as session:
+    async with driver.session() as session:
         result = await session.run(cypher, params)
         return [dict(record) async for record in result]
 
 
 async def _run_single(driver: AsyncResilientNeo4jDriver, cypher: str, **params: Any) -> dict[str, Any] | None:
     """Execute a Cypher query and return a single result, or None if not found."""
-    async with await driver.session() as session:
+    async with driver.session() as session:
         result = await session.run(cypher, params)
         record = await result.single()
         return dict(record) if record else None
@@ -57,7 +57,7 @@ async def _run_single(driver: AsyncResilientNeo4jDriver, cypher: str, **params: 
 
 async def _run_count(driver: AsyncResilientNeo4jDriver, cypher: str, **params: Any) -> int:
     """Execute a count Cypher query and return the integer result."""
-    async with await driver.session() as session:
+    async with driver.session() as session:
         result = await session.run(cypher, params)
         record = await result.single()
         return int(record["total"]) if record else 0

--- a/api/queries/taste_queries.py
+++ b/api/queries/taste_queries.py
@@ -12,14 +12,14 @@ from common import AsyncResilientNeo4jDriver
 
 async def _run_query(driver: AsyncResilientNeo4jDriver, cypher: str, **params: Any) -> list[dict[str, Any]]:
     """Execute a Cypher query and return all results as a list of dicts."""
-    async with await driver.session() as session:
+    async with driver.session() as session:
         result = await session.run(cypher, params)
         return [dict(record) async for record in result]
 
 
 async def _run_count(driver: AsyncResilientNeo4jDriver, cypher: str, **params: Any) -> int:
     """Execute a count Cypher query and return the integer result."""
-    async with await driver.session() as session:
+    async with driver.session() as session:
         result = await session.run(cypher, params)
         record = await result.single()
         return int(record["total"]) if record else 0

--- a/api/queries/user_queries.py
+++ b/api/queries/user_queries.py
@@ -18,14 +18,14 @@ from common import AsyncResilientNeo4jDriver
 
 async def _run_query(driver: AsyncResilientNeo4jDriver, cypher: str, **params: Any) -> list[dict[str, Any]]:
     """Execute a Cypher query and return all results as a list of dicts."""
-    async with await driver.session() as session:
+    async with driver.session() as session:
         result = await session.run(cypher, params)
         return [dict(record) async for record in result]
 
 
 async def _run_count(driver: AsyncResilientNeo4jDriver, cypher: str, **params: Any) -> int:
     """Execute a count Cypher query and return the integer result."""
-    async with await driver.session() as session:
+    async with driver.session() as session:
         result = await session.run(cypher, params)
         record = await result.single()
         return int(record["total"]) if record else 0

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -207,7 +207,7 @@ async def sync_collection(
             ]
 
             if neo4j_releases:
-                async with await neo4j_driver.session() as session:
+                async with neo4j_driver.session() as session:
                     await session.run(
                         cypher,
                         {
@@ -368,7 +368,7 @@ async def sync_wantlist(
             ]
 
             if neo4j_wants:
-                async with await neo4j_driver.session() as session:
+                async with neo4j_driver.session() as session:
                     await session.run(
                         cypher,
                         {

--- a/common/neo4j_resilient.py
+++ b/common/neo4j_resilient.py
@@ -1,10 +1,10 @@
 """Resilient Neo4j connection management with circuit breaker and retry logic."""
 
 import asyncio
-import logging
-import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+import logging
+import time
 from typing import Any
 
 from neo4j import AsyncGraphDatabase, GraphDatabase

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -368,7 +368,7 @@ class DashboardApp:
         # Check Neo4j
         try:
             if self.neo4j_driver:
-                async with await self.neo4j_driver.session() as session:
+                async with self.neo4j_driver.session() as session:
                     result = await session.run("CALL dbms.components() YIELD name, versions")
                     await result.single()  # Consume result
 

--- a/graphinator/batch_processor.py
+++ b/graphinator/batch_processor.py
@@ -365,7 +365,7 @@ class Neo4jBatchProcessor:
         existing_hashes: dict[str, str] = {}
 
         # First, check which artists need updates (by hash)
-        async with await self.driver.session(database="neo4j") as session:
+        async with self.driver.session(database="neo4j") as session:
             # Get all IDs and their hashes
             ids = [msg.data.get("id") for msg in messages if msg.data.get("id")]
             if ids:
@@ -391,7 +391,7 @@ class Neo4jBatchProcessor:
             return
 
         # Process artists in a single transaction
-        async with await self.driver.session(database="neo4j") as session:
+        async with self.driver.session(database="neo4j") as session:
 
             async def batch_write(tx: Any) -> None:
                 # Create/update all artist nodes
@@ -483,7 +483,7 @@ class Neo4jBatchProcessor:
         labels_to_process = []
         existing_hashes: dict[str, str] = {}
 
-        async with await self.driver.session(database="neo4j") as session:
+        async with self.driver.session(database="neo4j") as session:
             ids = [msg.data.get("id") for msg in messages if msg.data.get("id")]
             if ids:
                 result = await session.run(
@@ -506,7 +506,7 @@ class Neo4jBatchProcessor:
             logger.debug("🔄 All labels in batch already up to date")
             return
 
-        async with await self.driver.session(database="neo4j") as session:
+        async with self.driver.session(database="neo4j") as session:
 
             async def batch_write(tx: Any) -> None:
                 # Create/update all label nodes
@@ -572,7 +572,7 @@ class Neo4jBatchProcessor:
         masters_to_process = []
         existing_hashes: dict[str, str] = {}
 
-        async with await self.driver.session(database="neo4j") as session:
+        async with self.driver.session(database="neo4j") as session:
             ids = [msg.data.get("id") for msg in messages if msg.data.get("id")]
             if ids:
                 result = await session.run(
@@ -595,7 +595,7 @@ class Neo4jBatchProcessor:
             logger.debug("🔄 All masters in batch already up to date")
             return
 
-        async with await self.driver.session(database="neo4j") as session:
+        async with self.driver.session(database="neo4j") as session:
 
             async def batch_write(tx: Any) -> None:
                 # Create/update all master nodes
@@ -711,7 +711,7 @@ class Neo4jBatchProcessor:
         releases_to_process = []
         existing_hashes: dict[str, str] = {}
 
-        async with await self.driver.session(database="neo4j") as session:
+        async with self.driver.session(database="neo4j") as session:
             ids = [msg.data.get("id") for msg in messages if msg.data.get("id")]
             if ids:
                 result = await session.run(
@@ -736,7 +736,7 @@ class Neo4jBatchProcessor:
             logger.debug("🔄 All releases in batch already up to date")
             return
 
-        async with await self.driver.session(database="neo4j") as session:
+        async with self.driver.session(database="neo4j") as session:
 
             async def batch_write(tx: Any) -> None:
                 # Create/update all release nodes

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -518,7 +518,7 @@ async def cleanup_stub_nodes(data_type: str) -> None:
         return
 
     try:
-        async with await graph.session(database="neo4j") as session:
+        async with graph.session(database="neo4j") as session:
             result = await session.run(
                 f"MATCH (n:{label}) WHERE n.sha256 IS NULL "
                 "DETACH DELETE n "
@@ -889,7 +889,7 @@ def make_message_handler(
             if graph is None:
                 raise RuntimeError("Neo4j driver not initialized")
 
-            async with await graph.session(database="neo4j") as session:
+            async with graph.session(database="neo4j") as session:
 
                 def tx_fn(tx: Any) -> bool:
                     return bool(process_fn(tx, record))
@@ -1124,7 +1124,7 @@ async def main() -> None:
 
     # Test Neo4j connectivity using async operations
     try:
-        async with await graph.session(database="neo4j") as session:
+        async with graph.session(database="neo4j") as session:
             result = await session.run("RETURN 1 as test")
             await result.single()
             logger.info("✅ Neo4j connectivity verified (async)")

--- a/schema-init/neo4j_schema.py
+++ b/schema-init/neo4j_schema.py
@@ -127,7 +127,7 @@ async def create_neo4j_schema(driver: Any) -> int:
     success_count = 0
     failure_count = 0
 
-    async with await driver.session(database="neo4j") as session:
+    async with driver.session(database="neo4j") as session:
         for name, cypher in SCHEMA_STATEMENTS:
             try:
                 await session.run(cypher)

--- a/schema-init/schema_init.py
+++ b/schema-init/schema_init.py
@@ -131,7 +131,7 @@ async def _init_neo4j() -> bool:
         )
 
         # Verify connectivity first
-        async with await driver.session(database="neo4j") as session:
+        async with driver.session(database="neo4j") as session:
             result = await session.run("RETURN 1 AS health")
             await result.single()
         logger.info("✅ Neo4j connectivity verified")

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -103,18 +103,13 @@ def mock_redis() -> AsyncMock:
 @pytest.fixture
 def mock_neo4j() -> MagicMock:
     """Mock AsyncResilientNeo4jDriver."""
-    from typing import Any
-
     driver = MagicMock()
     mock_session = AsyncMock()
     mock_session.__aenter__ = AsyncMock(return_value=mock_session)
     mock_session.__aexit__ = AsyncMock(return_value=False)
     mock_session.run = AsyncMock()
 
-    async def _session_factory(*_args: Any, **_kwargs: Any) -> Any:
-        return mock_session
-
-    driver.session = MagicMock(side_effect=_session_factory)
+    driver.session = MagicMock(return_value=mock_session)
     driver.close = AsyncMock()
     return driver
 

--- a/tests/api/test_gap_queries.py
+++ b/tests/api/test_gap_queries.py
@@ -58,10 +58,7 @@ def _make_driver_with_results(results: list[_MockResult]) -> MagicMock:
 
     driver = MagicMock()
 
-    async def _session_factory(*_a: Any, **_kw: Any) -> Any:
-        return mock_session
-
-    driver.session = MagicMock(side_effect=_session_factory)
+    driver.session = MagicMock(return_value=mock_session)
     return driver
 
 

--- a/tests/api/test_label_dna.py
+++ b/tests/api/test_label_dna.py
@@ -54,11 +54,7 @@ class TestLabelDnaEndpoint:
 
     def test_label_not_found(self, test_client: TestClient, mock_neo4j: MagicMock) -> None:
         session = _make_mock_session(single_return=None)
-
-        async def _session(*_a: Any, **_k: Any) -> Any:
-            return session
-
-        mock_neo4j.session = MagicMock(side_effect=_session)
+        mock_neo4j.session = MagicMock(return_value=session)
         response = test_client.get("/api/label/99999/dna")
         assert response.status_code == 404
 
@@ -66,11 +62,7 @@ class TestLabelDnaEndpoint:
         # First call returns identity with < 5 releases, second call also returns identity
         identity = {"label_id": "1", "label_name": "Tiny Label", "release_count": 3, "artist_count": 2}
         session = _make_mock_session(single_return=identity)
-
-        async def _session_factory(*_a: Any, **_k: Any) -> Any:
-            return session
-
-        mock_neo4j.session = MagicMock(side_effect=_session_factory)
+        mock_neo4j.session = MagicMock(return_value=session)
         response = test_client.get("/api/label/1/dna")
         assert response.status_code == 422
         assert "fewer than" in response.json()["error"]
@@ -123,11 +115,7 @@ class TestSimilarLabelsEndpoint:
 
     def test_label_not_found(self, test_client: TestClient, mock_neo4j: MagicMock) -> None:
         session = _make_mock_session(single_return=None)
-
-        async def _session(*_a: Any, **_k: Any) -> Any:
-            return session
-
-        mock_neo4j.session = MagicMock(side_effect=_session)
+        mock_neo4j.session = MagicMock(return_value=session)
         response = test_client.get("/api/label/99999/similar")
         assert response.status_code == 404
 

--- a/tests/api/test_neo4j_queries.py
+++ b/tests/api/test_neo4j_queries.py
@@ -57,10 +57,7 @@ def _make_driver(records: list[dict[str, Any]] | None = None, single: dict[str, 
 
     driver = MagicMock()
 
-    async def _session_factory(*_args: Any, **_kwargs: Any) -> Any:
-        return mock_session
-
-    driver.session = MagicMock(side_effect=_session_factory)
+    driver.session = MagicMock(return_value=mock_session)
     return driver
 
 
@@ -78,11 +75,7 @@ def _make_driver_with_side_effects(results: list[_MockResult]) -> MagicMock:
     mock_session.run = AsyncMock(side_effect=_run_side_effect)
 
     driver = MagicMock()
-
-    async def _session_factory(*_args: Any, **_kwargs: Any) -> Any:
-        return mock_session
-
-    driver.session = MagicMock(side_effect=_session_factory)
+    driver.session = MagicMock(return_value=mock_session)
     return driver
 
 
@@ -593,10 +586,7 @@ def _make_capturing_driver(total: int = 10) -> tuple[MagicMock, list[str], list[
 
     driver: MagicMock = MagicMock()
 
-    async def session_factory(*_args: Any, **_kwargs: Any) -> Any:
-        return mock_session
-
-    driver.session = MagicMock(side_effect=session_factory)
+    driver.session = MagicMock(return_value=mock_session)
     return driver, captured_cypher, captured_params
 
 
@@ -781,10 +771,7 @@ class TestExpandBeforeYear:
 
         driver = MagicMock()
 
-        async def _session_factory(*_args: Any, **_kwargs: Any) -> Any:
-            return mock_session
-
-        driver.session = MagicMock(side_effect=_session_factory)
+        driver.session = MagicMock(return_value=mock_session)
         return driver, calls
 
     @pytest.mark.asyncio
@@ -987,7 +974,7 @@ class TestFindShortestPath:
         mock_result = AsyncMock()
         mock_result.single = AsyncMock(return_value=mock_record)
         mock_session.run = AsyncMock(return_value=mock_result)
-        mock_driver.session = AsyncMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock()))
+        mock_driver.session = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock()))
 
         result = await find_shortest_path(mock_driver, "1", "2", max_depth=10)
 
@@ -1005,7 +992,7 @@ class TestFindShortestPath:
         mock_result = AsyncMock()
         mock_result.single = AsyncMock(return_value=None)
         mock_session.run = AsyncMock(return_value=mock_result)
-        mock_driver.session = AsyncMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock()))
+        mock_driver.session = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock()))
 
         result = await find_shortest_path(mock_driver, "1", "999", max_depth=10)
 
@@ -1025,7 +1012,7 @@ class TestFindShortestPath:
         mock_result = AsyncMock()
         mock_result.single = AsyncMock(return_value=mock_record)
         mock_session.run = AsyncMock(return_value=mock_result)
-        mock_driver.session = AsyncMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock()))
+        mock_driver.session = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock()))
 
         result = await find_shortest_path(mock_driver, "1", "1", max_depth=10)
 
@@ -1049,7 +1036,7 @@ class TestYearRangeQuery:
         mock_result = AsyncMock()
         mock_result.single = AsyncMock(return_value={"min_year": 1950, "max_year": 2025})
         mock_session.run = AsyncMock(return_value=mock_result)
-        mock_driver.session = AsyncMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock()))
+        mock_driver.session = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock()))
 
         result = await get_year_range(mock_driver)
         assert result == {"min_year": 1950, "max_year": 2025}
@@ -1063,7 +1050,7 @@ class TestYearRangeQuery:
         mock_result = AsyncMock()
         mock_result.single = AsyncMock(return_value=None)
         mock_session.run = AsyncMock(return_value=mock_result)
-        mock_driver.session = AsyncMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock()))
+        mock_driver.session = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock()))
 
         result = await get_year_range(mock_driver)
         assert result is None

--- a/tests/api/test_syncer.py
+++ b/tests/api/test_syncer.py
@@ -117,10 +117,7 @@ def mock_neo4j() -> MagicMock:
     mock_session.__aexit__ = AsyncMock(return_value=False)
     mock_session.run = AsyncMock()
 
-    async def _session_factory(*_a: object, **_kw: object) -> AsyncMock:
-        return mock_session
-
-    driver.session = MagicMock(side_effect=_session_factory)
+    driver.session = MagicMock(return_value=mock_session)
     driver._mock_session = mock_session
     return driver
 

--- a/tests/api/test_taste_queries.py
+++ b/tests/api/test_taste_queries.py
@@ -58,10 +58,7 @@ def _make_driver_with_results(results: list[_MockResult]) -> MagicMock:
 
     driver = MagicMock()
 
-    async def _session_factory(*_a: Any, **_kw: Any) -> Any:
-        return mock_session
-
-    driver.session = MagicMock(side_effect=_session_factory)
+    driver.session = MagicMock(return_value=mock_session)
     return driver
 
 

--- a/tests/api/test_user_queries.py
+++ b/tests/api/test_user_queries.py
@@ -58,10 +58,7 @@ def _make_driver_with_results(results: list[_MockResult]) -> MagicMock:
 
     driver = MagicMock()
 
-    async def _session_factory(*_a: Any, **_kw: Any) -> Any:
-        return mock_session
-
-    driver.session = MagicMock(side_effect=_session_factory)
+    driver.session = MagicMock(return_value=mock_session)
     return driver
 
 

--- a/tests/common/test_neo4j_resilient.py
+++ b/tests/common/test_neo4j_resilient.py
@@ -205,9 +205,8 @@ class TestAsyncResilientNeo4jDriver:
         # Mock get_connection to return the mock driver directly
         resilient_driver.get_connection = AsyncMock(return_value=mock_async_driver)
 
-        _session = await resilient_driver.session(database="neo4j")
-
-        mock_async_driver.session.assert_called_once_with(database="neo4j")
+        async with resilient_driver.session(database="neo4j") as _session:
+            mock_async_driver.session.assert_called_once_with(database="neo4j")
 
     @pytest.mark.asyncio
     @patch("common.neo4j_resilient.AsyncGraphDatabase")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,16 +35,12 @@ def mock_neo4j_driver() -> MagicMock:
     mock_session = AsyncMock()
 
     # Configure async context manager for session
+    # session() is an @asynccontextmanager, so it returns an async context manager directly
     mock_context_manager = AsyncMock()
     mock_context_manager.__aenter__ = AsyncMock(return_value=mock_session)
     mock_context_manager.__aexit__ = AsyncMock(return_value=None)
 
-    # For async with await graph.session() pattern:
-    # session() should return an awaitable that returns the context manager
-    async def mock_session_factory(*_args: Any, **_kwargs: Any) -> Any:
-        return mock_context_manager
-
-    mock_driver.session = MagicMock(side_effect=mock_session_factory)
+    mock_driver.session = MagicMock(return_value=mock_context_manager)
 
     # Setup mock returns
     mock_session.execute_write = AsyncMock(return_value=True)

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -3,7 +3,7 @@
 import asyncio
 from datetime import UTC, datetime
 from typing import Any
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from fastapi.testclient import TestClient
 import httpx
@@ -702,7 +702,7 @@ class TestDashboardAppDataCollection:
             mock_neo4j_session.__aenter__ = AsyncMock(return_value=mock_neo4j_session)
             mock_neo4j_session.__aexit__ = AsyncMock(return_value=None)
 
-            app.neo4j_driver.session = AsyncMock(return_value=mock_neo4j_session)
+            app.neo4j_driver.session = MagicMock(return_value=mock_neo4j_session)
 
             databases = await app.get_database_info()
 
@@ -891,7 +891,7 @@ class TestDashboardAppDataCollection:
             app.postgres_conn = mock_postgres_conn
 
             # Mock Neo4j session failure
-            app.neo4j_driver.session.side_effect = Exception("Neo4j connection failed")
+            app.neo4j_driver.session = MagicMock(side_effect=Exception("Neo4j connection failed"))
 
             databases = await app.get_database_info()
 

--- a/tests/graphinator/test_batch_processor.py
+++ b/tests/graphinator/test_batch_processor.py
@@ -26,8 +26,8 @@ def create_async_session_mock() -> tuple[MagicMock, AsyncMock]:
     mock_session_context.__aexit__.return_value = None
 
     mock_driver = MagicMock()
-    # driver.session() is an async method that returns an async context manager
-    mock_driver.session = AsyncMock(return_value=mock_session_context)
+    # driver.session() is an @asynccontextmanager, returns context manager directly
+    mock_driver.session = MagicMock(return_value=mock_session_context)
 
     return mock_driver, mock_session
 

--- a/tests/graphinator/test_batch_processor_integration.py
+++ b/tests/graphinator/test_batch_processor_integration.py
@@ -21,8 +21,7 @@ def realistic_async_driver():
     """Create a realistic async Neo4j driver mock.
 
     This mock accurately represents the async behavior of AsyncResilientNeo4jDriver:
-    - driver.session() is an async method (returns awaitable)
-    - The awaitable returns an async context manager
+    - driver.session() is an @asynccontextmanager (returns async context manager directly)
     - session.run() is async
     - Results support async iteration
     """
@@ -36,8 +35,8 @@ def realistic_async_driver():
 
     # Create driver
     mock_driver = MagicMock()
-    # CRITICAL: session() must be async and return the context manager
-    mock_driver.session = AsyncMock(return_value=mock_session_context)
+    # CRITICAL: session() returns an async context manager directly (not awaitable)
+    mock_driver.session = MagicMock(return_value=mock_session_context)
 
     return mock_driver, mock_session
 
@@ -52,7 +51,7 @@ class TestAsyncDriverIntegration:
         This test would have caught the bug where we used:
             with self.driver.session() as session:  # WRONG - not async
         instead of:
-            async with await self.driver.session() as session:  # CORRECT
+            async with self.driver.session() as session:  # CORRECT
         """
         mock_driver, mock_session = realistic_async_driver
 
@@ -302,7 +301,7 @@ class TestAsyncErrorConditions:
         await processor._flush_queue("artists")
 
         # Verify context manager exit was called
-        session_context = await mock_driver.session()
+        session_context = mock_driver.session()
         session_context.__aexit__.assert_called()
 
     @pytest.mark.asyncio

--- a/tests/graphinator/test_graphinator.py
+++ b/tests/graphinator/test_graphinator.py
@@ -32,7 +32,7 @@ class TestOnArtistMessage:
         mock_message.body = json.dumps(sample_artist_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         # Mock transaction to indicate new artist
@@ -62,7 +62,7 @@ class TestOnArtistMessage:
         mock_message.body = json.dumps(sample_artist_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         # Mock transaction to return existing hash
@@ -211,7 +211,7 @@ class TestOnLabelMessage:
         mock_message.body = json.dumps(sample_label_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
         mock_session.execute_write = AsyncMock(return_value=True)
 
@@ -244,7 +244,7 @@ class TestOnMasterMessage:
         mock_message.body = json.dumps(sample_master_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
         mock_session.execute_write = AsyncMock(return_value=True)
 
@@ -266,7 +266,7 @@ class TestOnReleaseMessage:
         mock_message.body = json.dumps(sample_release_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
         mock_session.execute_write = AsyncMock(return_value=True)
 
@@ -365,11 +365,8 @@ class TestMain:
         mock_context_manager.__aenter__ = AsyncMock(return_value=mock_session)
         mock_context_manager.__aexit__ = AsyncMock(return_value=None)
 
-        # session() returns an awaitable that returns the context manager
-        async def mock_session_factory(*_args, **_kwargs):
-            return mock_context_manager
-
-        mock_neo4j_instance.session = MagicMock(side_effect=mock_session_factory)
+        # session() is an @asynccontextmanager, returns context manager directly
+        mock_neo4j_instance.session = MagicMock(return_value=mock_context_manager)
 
         # Mock the connectivity test
         mock_result = AsyncMock()
@@ -467,10 +464,7 @@ class TestMain:
         mock_context_manager.__aenter__ = AsyncMock(return_value=mock_session)
         mock_context_manager.__aexit__ = AsyncMock(return_value=None)
 
-        async def mock_session_factory(*_args, **_kwargs):
-            return mock_context_manager
-
-        mock_neo4j_instance.session = MagicMock(side_effect=mock_session_factory)
+        mock_neo4j_instance.session = MagicMock(return_value=mock_context_manager)
 
         # Make AMQP connection fail
         mock_rabbitmq_class.side_effect = Exception("Cannot connect to AMQP")
@@ -872,7 +866,7 @@ class TestCheckFileCompletion:
         mock_session = AsyncMock()
         mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
-        mock_driver.session.return_value = mock_session_ctx
+        mock_driver.session = MagicMock(return_value=mock_session_ctx)
 
         mock_result = AsyncMock()
         mock_record = {"deleted": 5}
@@ -911,7 +905,7 @@ class TestCleanupStubNodes:
         mock_session = AsyncMock()
         mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
-        mock_driver.session.return_value = mock_session_ctx
+        mock_driver.session = MagicMock(return_value=mock_session_ctx)
 
         mock_result = AsyncMock()
         mock_result.single = AsyncMock(return_value={"deleted": 17138})
@@ -1124,7 +1118,7 @@ class TestLabelTransactionLogic:
         mock_message.body = json.dumps(sample_label_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         # Create a mock transaction function that will be called
@@ -1165,7 +1159,7 @@ class TestLabelTransactionLogic:
         mock_message.body = json.dumps(label_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
@@ -1207,7 +1201,7 @@ class TestLabelTransactionLogic:
         mock_message.body = json.dumps(label_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
@@ -1245,7 +1239,7 @@ class TestLabelTransactionLogic:
         mock_message.body = json.dumps(label_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
@@ -1277,7 +1271,7 @@ class TestMasterTransactionLogic:
         mock_message.body = json.dumps(sample_master_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
@@ -1317,7 +1311,7 @@ class TestMasterTransactionLogic:
         mock_message.body = json.dumps(master_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
@@ -1360,7 +1354,7 @@ class TestMasterTransactionLogic:
         mock_message.body = json.dumps(master_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
@@ -1392,7 +1386,7 @@ class TestReleaseTransactionLogic:
         mock_message.body = json.dumps(sample_release_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
@@ -1433,7 +1427,7 @@ class TestReleaseTransactionLogic:
         mock_message.body = json.dumps(release_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
@@ -1478,7 +1472,7 @@ class TestReleaseTransactionLogic:
         mock_message.body = json.dumps(release_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
@@ -1514,7 +1508,7 @@ class TestReleaseTransactionLogic:
         mock_message.body = json.dumps(release_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
@@ -1563,8 +1557,8 @@ class TestMasterMessageErrorHandling:
         # Mock Neo4j driver to raise ServiceUnavailable
         mock_driver = MagicMock()
         mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(side_effect=ServiceUnavailable("Neo4j down"))
-        mock_session.__exit__ = MagicMock()
+        mock_session.__aenter__ = AsyncMock(side_effect=ServiceUnavailable("Neo4j down"))
+        mock_session.__aexit__ = AsyncMock()
         mock_driver.session.return_value = mock_session
 
         # Process message
@@ -1599,8 +1593,8 @@ class TestMasterMessageErrorHandling:
 
         # Make session() return a context manager
         mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(return_value=mock_session_context)
-        mock_session.__exit__ = MagicMock(return_value=None)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session_context)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
 
         mock_driver.session.return_value = mock_session
 
@@ -1626,8 +1620,8 @@ class TestMasterMessageErrorHandling:
         # Mock Neo4j driver to raise ServiceUnavailable
         mock_driver = MagicMock()
         mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(side_effect=ServiceUnavailable("Neo4j down"))
-        mock_session.__exit__ = MagicMock()
+        mock_session.__aenter__ = AsyncMock(side_effect=ServiceUnavailable("Neo4j down"))
+        mock_session.__aexit__ = AsyncMock()
         mock_driver.session.return_value = mock_session
 
         # Process message - should not raise exception
@@ -1820,7 +1814,7 @@ class TestBatchModeIntegration:
         mock_batch_processor = AsyncMock()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
         mock_session.execute_write.return_value = True
 
@@ -1856,7 +1850,7 @@ class TestArtistTransactionEdgeCases:
         mock_message.body = json.dumps(artist_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
@@ -1892,7 +1886,7 @@ class TestArtistTransactionEdgeCases:
         mock_message.body = json.dumps(artist_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
@@ -1927,7 +1921,7 @@ class TestArtistTransactionEdgeCases:
         mock_message.body = json.dumps(artist_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
@@ -1958,8 +1952,8 @@ class TestArtistTransactionEdgeCases:
 
         mock_driver = MagicMock()
         mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(side_effect=SessionExpired("Session expired"))
-        mock_session.__exit__ = MagicMock()
+        mock_session.__aenter__ = AsyncMock(side_effect=SessionExpired("Session expired"))
+        mock_session.__aexit__ = AsyncMock()
         mock_driver.session.return_value = mock_session
 
         with patch("graphinator.graphinator.graph", mock_driver):
@@ -2004,7 +1998,7 @@ class TestLabelTransactionEdgeCases:
         mock_message.body = json.dumps(label_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
@@ -2039,7 +2033,7 @@ class TestLabelTransactionEdgeCases:
         mock_message.body = json.dumps(label_data).encode()
 
         # Get the mock session from the fixture's async context manager
-        mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
@@ -2082,8 +2076,8 @@ class TestReleaseMessageErrorHandling:
         # Mock Neo4j driver to raise ServiceUnavailable
         mock_driver = MagicMock()
         mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(side_effect=ServiceUnavailable("Neo4j down"))
-        mock_session.__exit__ = MagicMock()
+        mock_session.__aenter__ = AsyncMock(side_effect=ServiceUnavailable("Neo4j down"))
+        mock_session.__aexit__ = AsyncMock()
         mock_driver.session.return_value = mock_session
 
         # Process message
@@ -2118,8 +2112,8 @@ class TestReleaseMessageErrorHandling:
 
         # Make session() return a context manager
         mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(return_value=mock_session_context)
-        mock_session.__exit__ = MagicMock(return_value=None)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session_context)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
 
         mock_driver.session.return_value = mock_session
 
@@ -2150,8 +2144,8 @@ class TestReleaseMessageErrorHandling:
         # Mock Neo4j driver to raise ServiceUnavailable
         mock_driver = MagicMock()
         mock_session = MagicMock()
-        mock_session.__enter__ = MagicMock(side_effect=ServiceUnavailable("Neo4j down"))
-        mock_session.__exit__ = MagicMock()
+        mock_session.__aenter__ = AsyncMock(side_effect=ServiceUnavailable("Neo4j down"))
+        mock_session.__aexit__ = AsyncMock()
         mock_driver.session.return_value = mock_session
 
         # Process message - should not raise exception
@@ -2728,7 +2722,7 @@ class TestMainNeo4jFailure:
         mock_neo4j_instance = MagicMock()
         mock_neo4j_class.return_value = mock_neo4j_instance
 
-        async def failing_session(*_args: Any, **_kwargs: Any) -> Any:
+        def failing_session(*_args: Any, **_kwargs: Any) -> Any:
             raise Exception("Neo4j connection refused")
 
         mock_neo4j_instance.session = MagicMock(side_effect=failing_session)
@@ -2783,7 +2777,7 @@ class TestMainBatchProcessorFlushError:
 
         call_index = 0
 
-        async def mock_session_factory(*_args: Any, **_kwargs: Any) -> Any:
+        def mock_session_factory(*_args: Any, **_kwargs: Any) -> Any:
             nonlocal call_index
             call_index += 1
             mock_session = AsyncMock()
@@ -2904,7 +2898,7 @@ class TestMainNeo4jCloseError:
 
         call_index = 0
 
-        async def mock_session_factory(*_args: Any, **_kwargs: Any) -> Any:
+        def mock_session_factory(*_args: Any, **_kwargs: Any) -> Any:
             nonlocal call_index
             call_index += 1
             mock_session = AsyncMock()
@@ -3029,7 +3023,7 @@ class TestMainAmqpConnectionNone:
 
         call_index = 0
 
-        async def mock_session_factory(*_args: Any, **_kwargs: Any) -> Any:
+        def mock_session_factory(*_args: Any, **_kwargs: Any) -> Any:
             nonlocal call_index
             call_index += 1
             mock_session = AsyncMock()
@@ -3447,7 +3441,7 @@ class TestProgressIntervalLog:
             mock_message = AsyncMock(spec=AbstractIncomingMessage)
             mock_message.body = json.dumps(sample_artist_data).encode()
 
-            mock_context_manager = await mock_neo4j_driver.session(database="neo4j")
+            mock_context_manager = mock_neo4j_driver.session(database="neo4j")
             mock_session = await mock_context_manager.__aenter__()
             mock_session.execute_write = AsyncMock(return_value=True)
 
@@ -3636,10 +3630,7 @@ class TestMainAmqpRetryExhausted:
         mock_cm.__aenter__ = AsyncMock(return_value=mock_session)
         mock_cm.__aexit__ = AsyncMock(return_value=None)
 
-        async def mock_session_factory(*_args: Any, **_kwargs: Any) -> Any:
-            return mock_cm
-
-        mock_neo4j_instance.session = MagicMock(side_effect=mock_session_factory)
+        mock_neo4j_instance.session = MagicMock(return_value=mock_cm)
 
         # RabbitMQ constructor succeeds, but connect() always raises
         mock_rabbitmq_instance = MagicMock()

--- a/tests/schema-init/test_neo4j_schema.py
+++ b/tests/schema-init/test_neo4j_schema.py
@@ -10,14 +10,14 @@ from neo4j_schema import SCHEMA_STATEMENTS, create_neo4j_schema
 
 @pytest.fixture
 def mock_driver() -> MagicMock:
-    """Mock AsyncResilientNeo4jDriver whose session() is a coroutine."""
+    """Mock AsyncResilientNeo4jDriver whose session() is an @asynccontextmanager."""
     driver = MagicMock()
     mock_session = AsyncMock()
     mock_session.__aenter__ = AsyncMock(return_value=mock_session)
     mock_session.__aexit__ = AsyncMock(return_value=False)
     mock_session.run = AsyncMock()
-    # session() is an async method on AsyncResilientNeo4jDriver
-    driver.session = AsyncMock(return_value=mock_session)
+    # session() is an @asynccontextmanager, returns context manager directly
+    driver.session = MagicMock(return_value=mock_session)
     return driver
 
 
@@ -97,7 +97,7 @@ class TestCreateNeo4jSchema:
     async def test_runs_all_schema_statements(self, mock_driver: MagicMock) -> None:
         await create_neo4j_schema(mock_driver)
 
-        mock_driver.session.assert_awaited_once_with(database="neo4j")
+        mock_driver.session.assert_called_once_with(database="neo4j")
         session = mock_driver.session.return_value
         assert session.run.await_count == len(SCHEMA_STATEMENTS)
 

--- a/tests/schema-init/test_schema_init.py
+++ b/tests/schema-init/test_schema_init.py
@@ -208,7 +208,7 @@ class TestInitNeo4j:
         mock_result = AsyncMock()
         mock_result.single = AsyncMock(return_value={"health": 1})
         mock_session.run = AsyncMock(return_value=mock_result)
-        driver.session = AsyncMock(return_value=mock_session)
+        driver.session = MagicMock(return_value=mock_session)
         driver.close = AsyncMock()
         return driver
 

--- a/tests/test_batch_performance.py
+++ b/tests/test_batch_performance.py
@@ -27,7 +27,7 @@ class TestGraphinatorBatchPerformance:
         session_context.__aenter__.return_value = session
         session_context.__aexit__.return_value = None
 
-        driver.session = AsyncMock(return_value=session_context)
+        driver.session = MagicMock(return_value=session_context)
 
         # Mock transaction execution
         async def mock_execute_write(func):
@@ -392,7 +392,7 @@ class TestPerformanceRegression:
         session_context.__aenter__.return_value = session
         session_context.__aexit__.return_value = None
 
-        mock_driver.session = AsyncMock(return_value=session_context)
+        mock_driver.session = MagicMock(return_value=session_context)
 
         async def mock_execute_write(func):
             tx = AsyncMock()


### PR DESCRIPTION
## Summary
- Remove `await` from all `async with await driver.session()` calls (14 mypy errors), since `session()` is now an `@asynccontextmanager` that returns an async context manager directly
- Fix ruff import ordering in `common/neo4j_resilient.py`
- Update all test mocks from coroutine-based `side_effect` pattern to direct `return_value` pattern matching the new session() signature

## Test plan
- [x] mypy passes with 0 errors (was 14 on main)
- [x] ruff passes clean
- [x] All 1760 tests pass
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)