### PR TITLE
fix: wait for trends pane activation in Firefox E2E test

### DIFF
--- a/tests/explore/test_explore_ui.py
+++ b/tests/explore/test_explore_ui.py
@@ -346,6 +346,10 @@ class TestExploreSearchInteraction:
         trends_link = page.locator("[data-pane='trends']")
         trends_link.click()
 
+        # Wait for the pane to become active (Firefox can be slow to process the click)
+        trends_pane = page.locator("#trendsPane")
+        expect(trends_pane).to_have_class(re.compile(r"\bactive\b"), timeout=5000)
+
         placeholder = page.locator("#trendsPlaceholder")
         expect(placeholder).to_be_visible(timeout=5000)
 


### PR DESCRIPTION
## Summary
- Fixes flaky `test_trends_placeholder_visible` E2E test that fails only on Firefox
- The test clicks the trends tab then immediately checks placeholder visibility without waiting for Firefox to process the DOM update
- Adds an explicit wait for the `#trendsPane` to have the `active` class before asserting placeholder visibility, matching the pattern already used by `test_trends_pane_search`

## Test plan
- [ ] CI passes on all browsers (chromium, webkit, firefox)
- [ ] `test_trends_placeholder_visible` no longer flaky on Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)