### PR TITLE
fix: handle NULL artist names in similar artist recommendations

### DIFF
--- a/api/queries/recommend_queries.py
+++ b/api/queries/recommend_queries.py
@@ -156,7 +156,7 @@ async def get_candidate_artists(driver: AsyncResilientNeo4jDriver, artist_id: st
     WITH a, collect(DISTINCT g.name) AS target_genres
     UNWIND target_genres AS genre_name
     MATCH (g2:Genre {name: genre_name})<-[:IS]-(r2:Release)-[:BY]->(a2:Artist)
-    WHERE a2 <> a
+    WHERE a2 <> a AND a2.name IS NOT NULL
     WITH a2, count(DISTINCT r2) AS shared_count
     WHERE shared_count >= $min_releases
     MATCH (r3:Release)-[:BY]->(a2)
@@ -197,6 +197,9 @@ def compute_similar_artists(
 
     results = []
     for candidate in candidates:
+        # Skip candidates with missing names (NULL in Neo4j)
+        if not candidate.get("artist_name"):
+            continue
         cand_vecs = {
             "genre": to_genre_vector(candidate.get("genres", [])),
             "style": to_genre_vector(candidate.get("styles", [])),

--- a/tests/api/test_recommend_queries.py
+++ b/tests/api/test_recommend_queries.py
@@ -189,6 +189,37 @@ class TestComputeSimilarArtists:
         results = compute_similar_artists(target, [], limit=10)
         assert results == []
 
+    def test_null_artist_name_excluded(self) -> None:
+        """Candidates with None artist_name are excluded to prevent validation errors.
+
+        Regression test: some Artist nodes in Neo4j have NULL names, which caused
+        pydantic ValidationError in SimilarArtist(artist_name=None). The Cypher
+        query now filters these out, but compute_similar_artists also skips them
+        as a defense-in-depth measure.
+        """
+        target = {
+            "genres": [{"name": "Rock", "count": 100}],
+            "styles": [],
+            "labels": [],
+            "collaborators": [],
+        }
+        candidates = [
+            self._make_candidate(artist_id="good", artist_name="Valid Artist"),
+            {
+                "artist_id": "bad",
+                "artist_name": None,
+                "release_count": 10,
+                "genres": [{"name": "Rock", "count": 10}],
+                "styles": [],
+                "labels": [],
+                "collaborators": [],
+            },
+        ]
+        results = compute_similar_artists(target, candidates, limit=10)
+        artist_ids = [r["artist_id"] for r in results]
+        assert "good" in artist_ids
+        assert "bad" not in artist_ids
+
     def test_zero_similarity_excluded(self) -> None:
         target = {
             "genres": [{"name": "Rock", "count": 100}],


### PR DESCRIPTION
## Summary
- Some Artist nodes in Neo4j have NULL `name` properties, causing a `pydantic ValidationError` when the `/api/recommend/similar/artist/{id}` endpoint constructs `SimilarArtist(artist_name=None)`
- Added `AND a2.name IS NOT NULL` filter to the candidate Cypher query to exclude nameless artists at the database level
- Added defense-in-depth check in `compute_similar_artists()` to skip candidates with missing names
- Added regression test covering the NULL name scenario

## Test plan
- [x] Existing tests pass (21/21 in `test_recommend_queries.py`)
- [x] New `test_null_artist_name_excluded` validates candidates with `None` artist_name are filtered out
- [ ] Manual verification: hit `/api/recommend/similar/artist/607257` — should return 200 instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)