### PR TITLE
fix: pass required genre param to insights/genre-trends perftest

### DIFF
--- a/tests/perftest/run_perftest.py
+++ b/tests/perftest/run_perftest.py
@@ -275,7 +275,6 @@ def build_test_plan(
         ("explore/year-range", f"{base}/api/explore/year-range", None),
         ("explore/genre-emergence", f"{base}/api/explore/genre-emergence", {"before_year": "2025"}),
         ("insights/top-artists", f"{base}/api/insights/top-artists", None),
-        ("insights/genre-trends", f"{base}/api/insights/genre-trends", None),
         ("insights/label-longevity", f"{base}/api/insights/label-longevity", None),
         ("insights/this-month", f"{base}/api/insights/this-month", None),
         ("insights/data-completeness", f"{base}/api/insights/data-completeness", None),
@@ -283,6 +282,16 @@ def build_test_plan(
     ]
     for name, url, params in static_endpoints:
         tests.append({"name": name, "url": url, "params": params})
+
+    # --- Insights genre trends (per genre) ---
+    for genre_name in config.get("genres", []):
+        tests.append(
+            {
+                "name": f"insights/genre-trends/{genre_name}",
+                "url": f"{base}/api/insights/genre-trends",
+                "params": {"genre": genre_name},
+            }
+        )
 
     # --- Autocomplete (per entity type + name) ---
     for entity_type, entities in [


### PR DESCRIPTION
## Summary
- The `/api/insights/genre-trends` endpoint requires a `genre` query parameter, but the perftest listed it as a static (no-params) endpoint, causing a **422 Unprocessable Entity**
- Moved it from the static endpoint list to a new per-genre loop that iterates over the `genres` list from `config.yaml` (e.g., Electronic, Rock)

## Container review
- All 7 `discogsography-*` containers are healthy
- The only other error was a transient `ReadTimeout` in the insights scheduler on initial startup (data-completeness computation timed out calling the API service before it was ready) — self-recovers on next cycle, not a code bug

## Test plan
- [ ] Run `tests/perftest/run_perftest.py` and verify `insights/genre-trends/Electronic` and `insights/genre-trends/Rock` return 200 instead of 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)