### PR TITLE
ci: skip heavy jobs when only markdown files change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,59 @@ permissions:
   packages: write
 
 jobs:
+  # ============================================================================
+  # CHANGE DETECTION - Determines if only documentation files were modified
+  # ============================================================================
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code-changed: ${{ steps.filter.outputs.code-changed }}
+    steps:
+      - name: 🔀 Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: 🔍 Detect changed file types
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          # Always run full pipeline for scheduled builds and manual dispatches
+          if [[ "$EVENT_NAME" == "schedule" ]] || \
+             [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "code-changed=true" >> "$GITHUB_OUTPUT"
+            echo "⚙️ Scheduled/manual build — running full pipeline"
+            exit 0
+          fi
+
+          # Get changed files compared to base
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          else
+            CHANGED_FILES=$(git diff --name-only "$BEFORE_SHA" "$HEAD_SHA")
+          fi
+
+          echo "📝 Changed files:"
+          echo "$CHANGED_FILES"
+
+          # Check if any non-markdown files were changed
+          NON_MD_FILES=$(echo "$CHANGED_FILES" | grep -v '\.md$' || true)
+
+          if [[ -z "$NON_MD_FILES" ]]; then
+            echo "code-changed=false" >> "$GITHUB_OUTPUT"
+            echo "📄 Only markdown files changed — skipping tests, security, and docker jobs"
+          else
+            echo "code-changed=true" >> "$GITHUB_OUTPUT"
+            echo "💻 Code changes detected — running full pipeline"
+          fi
+
   list-sub-projects:
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.code-changed == 'true'
     uses: ./.github/workflows/list-sub-projects.yml
 
   run-code-quality:
@@ -32,7 +84,8 @@ jobs:
     secrets: inherit
 
   run-security:
-    needs: [run-code-quality]
+    needs: [detect-changes, run-code-quality]
+    if: needs.detect-changes.outputs.code-changed == 'true'
     uses: ./.github/workflows/security.yml
     secrets: inherit
     permissions:
@@ -40,12 +93,14 @@ jobs:
       security-events: write # Required for SARIF uploads to GitHub Security tab
 
   run-docker-compose-validate:
-    needs: [run-code-quality]
+    needs: [detect-changes, run-code-quality]
+    if: needs.detect-changes.outputs.code-changed == 'true'
     uses: ./.github/workflows/docker-compose-validate.yml
     secrets: inherit
 
   run-docker-validate:
-    needs: [list-sub-projects, run-code-quality]
+    needs: [list-sub-projects, detect-changes, run-code-quality]
+    if: needs.detect-changes.outputs.code-changed == 'true'
     uses: ./.github/workflows/docker-validate.yml
     secrets: inherit
     with:
@@ -54,7 +109,8 @@ jobs:
   # Test workflow runs all service tests in parallel
   # Each service has its own job that runs independently
   run-tests:
-    needs: [run-code-quality]
+    needs: [detect-changes, run-code-quality]
+    if: needs.detect-changes.outputs.code-changed == 'true'
     uses: ./.github/workflows/test.yml
     secrets: inherit
     permissions:
@@ -63,7 +119,8 @@ jobs:
       statuses: write  # Required for coverage status creation (only used on PRs)
 
   run-e2e-tests:
-    needs: [run-code-quality]
+    needs: [detect-changes, run-code-quality]
+    if: needs.detect-changes.outputs.code-changed == 'true'
     uses: ./.github/workflows/e2e-test.yml
     secrets: inherit
     permissions:
@@ -77,6 +134,7 @@ jobs:
   aggregate-results:
     runs-on: ubuntu-latest
     needs:
+      - detect-changes
       - run-code-quality
       - run-tests
       - run-e2e-tests
@@ -87,8 +145,11 @@ jobs:
 
     steps:
       - name: 📊 Check all pipeline results
+        env:
+          CODE_CHANGED: ${{ needs.detect-changes.outputs.code-changed }}
         run: |
           echo "Pipeline Results Summary:"
+          echo "  Code Changed:            $CODE_CHANGED"
           echo "  Code Quality:            ${{ needs.run-code-quality.result }}"
           echo "  Tests:                   ${{ needs.run-tests.result }}"
           echo "  E2E Tests:               ${{ needs.run-e2e-tests.result }}"
@@ -96,8 +157,21 @@ jobs:
           echo "  Docker Compose Validate: ${{ needs.run-docker-compose-validate.result }}"
           echo "  Docker Validate:         ${{ needs.run-docker-validate.result }}"
 
-          if [[ "${{ needs.run-code-quality.result }}" == "failure" ]] || \
-             [[ "${{ needs.run-tests.result }}" == "failure" ]] || \
+          # Code quality must always pass
+          if [[ "${{ needs.run-code-quality.result }}" == "failure" ]]; then
+            echo "❌ Code quality failed"
+            exit 1
+          fi
+
+          # For docs-only changes, skipped jobs are expected
+          if [[ "$CODE_CHANGED" == "false" ]]; then
+            echo "📄 Docs-only change — skipped jobs are expected"
+            echo "✅ All required pipeline workflows passed!"
+            exit 0
+          fi
+
+          # For code changes, all jobs must pass (not fail)
+          if [[ "${{ needs.run-tests.result }}" == "failure" ]] || \
              [[ "${{ needs.run-e2e-tests.result }}" == "failure" ]] || \
              [[ "${{ needs.run-security.result }}" == "failure" ]] || \
              [[ "${{ needs.run-docker-compose-validate.result }}" == "failure" ]] || \
@@ -110,7 +184,8 @@ jobs:
 
   build-discogsography:
     # Wait for aggregate-results (which ensures all quality gates pass) before building
-    needs: [list-sub-projects, aggregate-results]
+    needs: [list-sub-projects, detect-changes, aggregate-results]
+    if: needs.detect-changes.outputs.code-changed == 'true'
 
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Summary
- Adds a `detect-changes` job that identifies whether only `.md` files were modified
- When docs-only: runs only `code-quality`, skips tests, security, docker validation, e2e, and image builds
- Scheduled (`cron`) and manual (`workflow_dispatch`) builds always run the full pipeline
- `aggregate-results` updated to treat skipped jobs as expected for docs-only changes

## Test plan
- [ ] Push a PR with only markdown changes — verify only `detect-changes` + `code-quality` + `aggregate-results` run
- [ ] Push a PR with code changes — verify full pipeline runs as before
- [ ] Verify `aggregate-results` passes for docs-only PRs (skipped jobs not treated as failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)