### PR TITLE
perf: cache label-dna-compare, pre-warm search cache, increase search TTL

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -36,6 +36,7 @@ from api.auth import (
 import api.dependencies as _dependencies
 from api.limiter import limiter
 from api.models import LoginRequest, RegisterRequest
+from api.queries.search_queries import ALL_TYPES, execute_search
 import api.routers.collection as _collection_router
 import api.routers.explore as _explore_router
 import api.routers.insights as _insights_router
@@ -151,6 +152,28 @@ async def _get_current_user(
         ) from exc
 
 
+# Common search terms that produce high-cardinality FTS results (~9s for "Rock").
+# Pre-warming the Redis cache on startup ensures users never wait for cold cache.
+_PREWARM_SEARCH_TERMS = ["Rock", "Electronic", "Jazz", "Pop", "Punk", "Hip Hop", "Trance", "Blues", "Country", "Metal"]
+
+
+async def _prewarm_search_cache() -> None:  # pragma: no cover
+    """Pre-warm Redis search cache for common high-cardinality terms.
+
+    Runs as a background task after startup. Each term is searched with
+    default parameters, populating the Redis cache (1h TTL). Errors are
+    logged and swallowed — pre-warming is best-effort.
+    """
+    if not _pool or not _redis:
+        return
+    for term in _PREWARM_SEARCH_TERMS:
+        try:
+            await execute_search(_pool, _redis, term, ALL_TYPES, [], None, None, 20, 0)
+            logger.debug("🔥 Search cache pre-warmed", term=term)
+        except Exception:
+            logger.debug("⚠️ Search pre-warm failed", term=term)
+
+
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:  # pragma: no cover
     """Manage API service lifecycle."""
@@ -211,6 +234,10 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:  # pragma: no cover
         max_nodes=_config.snapshot_max_nodes,
     )
     logger.info("✅ API service ready", port=API_PORT)
+
+    # Pre-warm search cache for common high-cardinality terms in background.
+    # Store reference on app.state to prevent garbage collection (RUF006).
+    _app.state.prewarm_task = asyncio.create_task(_prewarm_search_cache())
 
     yield
 

--- a/api/queries/search_queries.py
+++ b/api/queries/search_queries.py
@@ -34,6 +34,10 @@ logger = structlog.get_logger(__name__)
 
 ALL_TYPES: list[str] = ["artist", "label", "master", "release"]
 
+# Search cache TTL (1 hour — longer than the old 5 min to reduce cold cache
+# frequency for high-cardinality terms like "Rock" that take ~9s to compute)
+_SEARCH_CACHE_TTL = 3600
+
 # Maps entity type → (table, name_field, has_year, has_genres)
 _ENTITY_CONFIG: dict[str, tuple[str, str, bool, bool]] = {
     "artist": ("artists", "name", False, False),
@@ -367,6 +371,6 @@ async def execute_search(
     }
 
     if redis is not None:
-        await redis.setex(key, 300, json.dumps(response))
+        await redis.setex(key, _SEARCH_CACHE_TTL, json.dumps(response))
 
     return response

--- a/api/routers/label_dna.py
+++ b/api/routers/label_dna.py
@@ -59,10 +59,20 @@ async def _build_dna(label_id: str) -> tuple[LabelDNA | None, str]:
 
     Returns (dna, reason) — reason is "ok", "not_found", or "too_few".
 
-    Uses ``get_label_full_profile`` to batch identity + genre + style +
-    decade into a single traversal (6 queries → 3), then fetches
-    active_years and formats in parallel.
+    Checks Redis cache first (same key as ``/api/label/{id}/dna``).
+    On miss, runs profile queries and caches the result so that
+    subsequent calls (e.g. from ``/api/label/dna/compare``) are instant.
     """
+    # Check cache first — reuses the same key as the /dna endpoint
+    cache_key = f"label-dna:{label_id}"
+    if _redis:
+        try:
+            cached = await _redis.get(cache_key)
+            if cached:
+                return LabelDNA(**json.loads(cached)), "ok"
+        except Exception:
+            logger.debug("⚠️ Label DNA _build_dna cache get failed", key=cache_key)
+
     profile = await get_label_full_profile(_neo4j_driver, label_id)
     if not profile:
         return None, "not_found"
@@ -97,7 +107,7 @@ async def _build_dna(label_id: str) -> tuple[LabelDNA | None, str]:
     decade_total = sum(d["count"] for d in decades)
     format_total = sum(f["count"] for f in formats)
 
-    return LabelDNA(
+    dna = LabelDNA(
         label_id=profile["label_id"],
         label_name=profile["label_name"],
         release_count=release_count,
@@ -110,7 +120,16 @@ async def _build_dna(label_id: str) -> tuple[LabelDNA | None, str]:
         styles=[StyleWeight(**s) for s in _add_percentages(styles, style_total)],
         formats=[FormatWeight(**f) for f in _add_percentages(formats, format_total)],
         decades=[DecadeCount(**d) for d in _add_percentages(decades, decade_total)],
-    ), "ok"
+    )
+
+    # Cache the result so compare and subsequent /dna calls are instant
+    if _redis:
+        try:
+            await _redis.setex(cache_key, _LABEL_DNA_CACHE_TTL, json.dumps(dna.model_dump(), default=str))
+        except Exception:
+            logger.debug("⚠️ Label DNA _build_dna cache set failed", key=cache_key)
+
+    return dna, "ok"
 
 
 @router.get("/api/label/{label_id}/dna")

--- a/tests/api/test_label_dna.py
+++ b/tests/api/test_label_dna.py
@@ -614,3 +614,92 @@ class TestLabelDnaCaching:
             response = test_client.get("/api/label/157/similar")
 
         assert response.status_code == 200
+
+
+class TestBuildDnaCaching:
+    """Tests for Redis caching inside _build_dna."""
+
+    def test_build_dna_cache_hit(self, test_client: TestClient, mock_redis: AsyncMock) -> None:
+        """_build_dna returns cached LabelDNA without running queries."""
+        from api.models import DecadeCount, FormatWeight, GenreWeight, LabelDNA, StyleWeight
+
+        dna = LabelDNA(
+            label_id="42",
+            label_name="ECM",
+            release_count=200,
+            artist_count=80,
+            artist_diversity=0.4,
+            active_years=[1970],
+            peak_decade=1970,
+            prolificacy=200.0,
+            genres=[GenreWeight(name="Jazz", count=200, percentage=100.0)],
+            styles=[StyleWeight(name="Avant", count=100, percentage=100.0)],
+            formats=[FormatWeight(name="Vinyl", count=100, percentage=100.0)],
+            decades=[DecadeCount(decade=1970, count=200, percentage=100.0)],
+        )
+        mock_redis.get = AsyncMock(return_value=json.dumps(dna.model_dump(), default=str))
+
+        response = test_client.get("/api/label/42/dna")
+        assert response.status_code == 200
+        assert response.json()["label_id"] == "42"
+
+    @patch("api.routers.label_dna.get_label_format_profile")
+    @patch("api.routers.label_dna.get_label_active_years")
+    @patch("api.routers.label_dna.get_label_full_profile")
+    def test_build_dna_cache_miss_stores(
+        self,
+        mock_full_profile: AsyncMock,
+        mock_active_years: AsyncMock,
+        mock_formats: AsyncMock,
+        test_client: TestClient,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """_build_dna caches computed DNA on miss."""
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_full_profile.return_value = {
+            "label_id": "42",
+            "label_name": "ECM",
+            "release_count": 200,
+            "artist_count": 80,
+            "genres": [{"name": "Jazz", "count": 200}],
+            "styles": [],
+            "decades": [{"decade": 1970, "count": 200}],
+        }
+        mock_active_years.return_value = [1970]
+        mock_formats.return_value = []
+
+        response = test_client.get("/api/label/42/dna")
+        assert response.status_code == 200
+        assert mock_redis.setex.call_count >= 1
+        cache_keys = [call[0][0] for call in mock_redis.setex.call_args_list]
+        assert "label-dna:42" in cache_keys
+
+    @patch("api.routers.label_dna.get_label_format_profile")
+    @patch("api.routers.label_dna.get_label_active_years")
+    @patch("api.routers.label_dna.get_label_full_profile")
+    def test_build_dna_cache_set_failure(
+        self,
+        mock_full_profile: AsyncMock,
+        mock_active_years: AsyncMock,
+        mock_formats: AsyncMock,
+        test_client: TestClient,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """_build_dna still returns DNA even if cache set fails."""
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.setex = AsyncMock(side_effect=Exception("write failed"))
+        mock_full_profile.return_value = {
+            "label_id": "42",
+            "label_name": "ECM",
+            "release_count": 200,
+            "artist_count": 80,
+            "genres": [],
+            "styles": [],
+            "decades": [],
+        }
+        mock_active_years.return_value = []
+        mock_formats.return_value = []
+
+        response = test_client.get("/api/label/42/dna")
+        assert response.status_code == 200
+        assert response.json()["label_id"] == "42"


### PR DESCRIPTION
## Summary

- **Cache `_build_dna` for label-dna-compare** (P1): `_build_dna` now reads/writes the Redis cache (same `label-dna:{id}` key as the `/dna` endpoint). The compare endpoint was doing 15.1s cold cache because it called `_build_dna` directly, bypassing Redis. Now it reuses cached DNA results. Expected: 15.1s → <1s when labels were previously queried.
- **Pre-warm search cache on startup** (P1): Fire-and-forget background task searches 10 common high-cardinality terms (Rock, Electronic, Jazz, Pop, Punk, Hip Hop, Trance, Blues, Country, Metal) on API startup, populating the Redis cache. Expected: search/Rock 9.09s → <5ms for users hitting warm cache.
- **Increase search cache TTL** (P1): From 300s (5 min) to 3600s (1 hour). Reduces cold cache frequency for common terms that take ~9s to compute.

Based on analysis in `perftest-results/optimization-analysis-v10.md`.

## Test plan

- [x] All 1888 tests pass (3 new for `_build_dna` caching)
- [x] All pre-commit hooks pass (ruff, mypy, bandit)
- [ ] Run perftest to verify label-dna-compare and search/Rock improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)