### PR TITLE
fix: dashboard UI bugs, extraction analysis response, and Brevo link tracking

### DIFF
--- a/api/notifications.py
+++ b/api/notifications.py
@@ -67,6 +67,9 @@ class BrevoNotificationChannel:
                     email=self._sender_email,
                 ),
                 to=[SendTransacEmailRequestToItem(email=email)],
+                # Disable Brevo link tracking so the reset URL is delivered
+                # as-is rather than wrapped in a tracking redirect.
+                headers={"X-Mailin-Track-Links": "0", "X-Mailin-Track": "0"},
             )
             logger.info("📧 Password reset email sent", email=email)
         except Exception:

--- a/api/routers/extraction_analysis.py
+++ b/api/routers/extraction_analysis.py
@@ -153,23 +153,43 @@ def _load_state_marker(data_root: Path, version: str, source: str) -> dict[str, 
 
 
 def _build_violation_summary(violations: list[dict[str, Any]]) -> dict[str, Any]:
-    """Aggregate violations by severity, entity type, and rule."""
+    """Aggregate violations by severity, entity type, and rule.
+
+    Returns a dict with:
+    - total: int
+    - by_severity: {severity: count}
+    - by_entity: {entity_type: {total, errors, warnings}}
+    - by_rule: [{rule, entity_type, severity, count}]
+    """
     by_severity: dict[str, int] = {}
-    by_entity_type: dict[str, int] = {}
-    by_rule: dict[str, int] = {}
+    # entity → {total, errors, warnings}
+    by_entity: dict[str, dict[str, int]] = {}
+    # (rule, entity_type, severity) → count
+    rule_key_counts: dict[tuple[str, str, str], int] = {}
 
     for v in violations:
         severity: str = v.get("severity", "unknown")
         entity_type: str = v.get("entity_type", "unknown")
         rule: str = v.get("rule", "unknown")
+
         by_severity[severity] = by_severity.get(severity, 0) + 1
-        by_entity_type[entity_type] = by_entity_type.get(entity_type, 0) + 1
-        by_rule[rule] = by_rule.get(rule, 0) + 1
+
+        entity_entry = by_entity.setdefault(entity_type, {"total": 0, "errors": 0, "warnings": 0})
+        entity_entry["total"] += 1
+        if severity == "error":
+            entity_entry["errors"] += 1
+        elif severity == "warning":
+            entity_entry["warnings"] += 1
+
+        key = (rule, entity_type, severity)
+        rule_key_counts[key] = rule_key_counts.get(key, 0) + 1
+
+    by_rule = [{"rule": rule, "entity_type": et, "severity": sev, "count": count} for (rule, et, sev), count in sorted(rule_key_counts.items())]
 
     return {
         "total": len(violations),
         "by_severity": by_severity,
-        "by_entity_type": by_entity_type,
+        "by_entity": by_entity,
         "by_rule": by_rule,
     }
 
@@ -242,15 +262,24 @@ async def get_summary(
     flagged_version_dir = data_root / "flagged" / version
 
     violations = _read_violations(flagged_version_dir)
-    pipeline_status = _load_state_marker(data_root, version, source)
+    raw_state = _load_state_marker(data_root, version, source)
     summary = _build_violation_summary(violations)
+
+    # Extract phase statuses from the state marker for the frontend.
+    # The raw marker has nested objects for each phase; the dashboard
+    # expects {phase_name: status_string}.
+    pipeline_status: dict[str, str] = {}
+    if raw_state:
+        for key, value in raw_state.items():
+            if key.endswith("_phase") and isinstance(value, dict):
+                pipeline_status[key] = value.get("status", "unknown")
 
     return JSONResponse(
         content={
             "version": version,
             "source": source,
             "pipeline_status": pipeline_status,
-            "violation_summary": summary,
+            **summary,
         }
     )
 

--- a/dashboard/static/admin.html
+++ b/dashboard/static/admin.html
@@ -119,7 +119,7 @@
         }
 
         /* Extraction Analysis sub-view toggle buttons */
-        .ea-view-btn { color: var(--text-dim); background: transparent; border: 1px solid var(--border-color); cursor: pointer; }
+        .ea-view-btn { color: var(--text-dim); background: transparent; border: 1px solid var(--border-color); cursor: pointer; display: inline-flex; align-items: center; gap: 0.25rem; }
         .ea-view-btn:hover { color: var(--text-high); }
         .ea-view-btn.active { background: var(--purple-accent); color: #fff; border-color: var(--purple-accent); }
 
@@ -479,11 +479,11 @@
                             <!-- Node counts -->
                             <div>
                                 <p class="text-[10px] font-bold uppercase tracking-wider t-muted mb-2">Node Counts by Label</p>
-                                <table class="w-full text-xs">
+                                <table class="text-xs" style="min-width:280px">
                                     <thead>
                                         <tr class="text-[10px] t-muted uppercase font-bold tracking-wider border-b b-theme">
-                                            <th class="text-left py-1.5 pr-4">Label</th>
-                                            <th class="text-right py-1.5">Count</th>
+                                            <th class="text-left py-1.5 pr-8">Label</th>
+                                            <th class="text-right py-1.5 w-28">Count</th>
                                         </tr>
                                     </thead>
                                     <tbody id="neo4j-nodes-body">
@@ -494,11 +494,11 @@
                             <!-- Relationship counts -->
                             <div>
                                 <p class="text-[10px] font-bold uppercase tracking-wider t-muted mb-2">Relationship Counts by Type</p>
-                                <table class="w-full text-xs">
+                                <table class="text-xs" style="min-width:280px">
                                     <thead>
                                         <tr class="text-[10px] t-muted uppercase font-bold tracking-wider border-b b-theme">
-                                            <th class="text-left py-1.5 pr-4">Type</th>
-                                            <th class="text-right py-1.5">Count</th>
+                                            <th class="text-left py-1.5 pr-8">Type</th>
+                                            <th class="text-right py-1.5 w-28">Count</th>
                                         </tr>
                                     </thead>
                                     <tbody id="neo4j-rels-body">

--- a/dashboard/static/admin.js
+++ b/dashboard/static/admin.js
@@ -25,6 +25,11 @@ function _esc(str) {
     return div.innerHTML;
 }
 
+// Helper: shorten queue names by stripping the common "discogsography-" prefix
+function _shortQueueName(name) {
+    return name.replace(/^discogsography-/, '');
+}
+
 // Helper: create a table row with a single "no data" cell spanning colSpan columns
 function _emptyRow(colSpan, message) {
     const tr = document.createElement('tr');
@@ -654,7 +659,7 @@ class AdminDashboard {
 
             const data = await response.json();
             this._renderNeo4j(data.neo4j || {});
-            this._renderPostgres(data.postgres || {});
+            this._renderPostgres(data.postgresql || {});
             this._renderRedis(data.redis || {});
         } catch {
             this._showInlineError(errorEl, errorMsgEl, 'Failed to load storage data');
@@ -671,7 +676,13 @@ class AdminDashboard {
             badge.textContent = neo4j.status || '—';
         }
 
-        if (neo4j.status !== 'ok') return;
+        if (neo4j.status !== 'ok') {
+            const nodesTbody = document.getElementById('neo4j-nodes-body');
+            if (nodesTbody) nodesTbody.replaceChildren(_emptyRow(2, neo4j.status === 'error' ? 'Connection error' : 'No data'));
+            const relsTbody = document.getElementById('neo4j-rels-body');
+            if (relsTbody) relsTbody.replaceChildren(_emptyRow(2, neo4j.status === 'error' ? 'Connection error' : 'No data'));
+            return;
+        }
 
         // Node counts
         const nodesTbody = document.getElementById('neo4j-nodes-body');
@@ -758,7 +769,12 @@ class AdminDashboard {
             badge.textContent = postgres.status || '—';
         }
 
-        if (postgres.status !== 'ok') return;
+        if (postgres.status !== 'ok') {
+            // Clear the "Loading..." placeholder when status is not ok
+            const tbody = document.getElementById('postgres-tables-body');
+            if (tbody) tbody.replaceChildren(_emptyRow(4, postgres.status === 'error' ? 'Connection error' : 'No data'));
+            return;
+        }
 
         const dbSizeEl = document.getElementById('postgres-db-size');
         if (dbSizeEl && postgres.total_size) {
@@ -918,8 +934,8 @@ class AdminDashboard {
             this.renderQueueSummaryTiles(normalized);
             this.renderQueueDepthChart(normalized);
             this.renderDlqGrid(normalized);
-        } catch {
-            this._showInlineError(errorEl, errorMsgEl, 'Failed to load queue history');
+        } catch (err) {
+            this._showInlineError(errorEl, errorMsgEl, `Failed to load queue history: ${err.message || err}`);
         } finally {
             if (loadingEl) loadingEl.style.display = 'none';
         }
@@ -1005,7 +1021,7 @@ class AdminDashboard {
         const datasets = queues.map((q, i) => {
             const pts = q.data_points || [];
             return {
-                label: q.queue_name || `Queue ${i + 1}`,
+                label: _shortQueueName(q.queue_name || `Queue ${i + 1}`),
                 data: pts.map(p => ({ x: p.timestamp, y: p.messages_ready || 0 })),
                 borderColor: QUEUE_CHART_COLORS[i % QUEUE_CHART_COLORS.length],
                 backgroundColor: QUEUE_CHART_COLORS[i % QUEUE_CHART_COLORS.length] + '20',
@@ -1080,7 +1096,7 @@ class AdminDashboard {
 
             const name = document.createElement('p');
             name.className = 'text-[10px] font-bold uppercase tracking-wider t-muted mb-1 truncate';
-            name.textContent = q.queue_name || '\u2014';
+            name.textContent = _shortQueueName(q.queue_name || '\u2014');
             name.title = q.queue_name || '';
 
             const row = document.createElement('div');
@@ -1129,8 +1145,8 @@ class AdminDashboard {
             this.renderServiceCards(normalized);
             this.renderResponseTimeChart(normalized);
             this.renderEndpointsTable(normalized);
-        } catch {
-            this._showInlineError(errorEl, errorMsgEl, 'Failed to load health history');
+        } catch (err) {
+            this._showInlineError(errorEl, errorMsgEl, `Failed to load health history: ${err.message || err}`);
         } finally {
             if (loadingEl) loadingEl.style.display = 'none';
         }

--- a/tests/api/test_extraction_analysis.py
+++ b/tests/api/test_extraction_analysis.py
@@ -190,15 +190,18 @@ class TestSummaryEndpoint:
         data = resp.json()
         assert data["version"] == "20260101"
         assert data["source"] == "discogs"
-        assert data["pipeline_status"] is None  # no state marker
+        assert data["pipeline_status"] == {}  # no state marker
 
-        vs = data["violation_summary"]
-        assert vs["total"] == 3
-        assert vs["by_severity"]["warning"] == 2
-        assert vs["by_severity"]["error"] == 1
-        assert vs["by_entity_type"]["artists"] == 3
-        assert vs["by_rule"]["year-out-of-range"] == 2
-        assert vs["by_rule"]["missing-field"] == 1
+        assert data["total"] == 3
+        assert data["by_severity"]["warning"] == 2
+        assert data["by_severity"]["error"] == 1
+        assert data["by_entity"]["artists"]["total"] == 3
+        assert data["by_entity"]["artists"]["errors"] == 1
+        assert data["by_entity"]["artists"]["warnings"] == 2
+        # by_rule is now an array of {rule, entity_type, severity, count}
+        rules = {(r["rule"], r["severity"]): r["count"] for r in data["by_rule"]}
+        assert rules[("year-out-of-range", "warning")] == 2
+        assert rules[("missing-field", "error")] == 1
 
     def test_summary_with_pipeline_status(self, test_client: TestClient, tmp_path: Path) -> None:
         """Returns pipeline_status when a state marker file exists."""
@@ -216,7 +219,7 @@ class TestSummaryEndpoint:
         assert resp.status_code == 200
         data = resp.json()
         assert data["pipeline_status"] is not None
-        assert data["pipeline_status"]["download_phase"]["status"] == "completed"
+        assert data["pipeline_status"]["download_phase"] == "completed"
 
     def test_summary_musicbrainz_version(self, test_client: TestClient, tmp_path: Path) -> None:
         """Returns summary for a musicbrainz version."""
@@ -259,7 +262,7 @@ class TestSummaryEndpoint:
         assert resp.status_code == 200
         data = resp.json()
         # Only 2 valid lines should be counted
-        assert data["violation_summary"]["total"] == 2
+        assert data["total"] == 2
 
     def test_summary_entity_type_injected(self, test_client: TestClient, tmp_path: Path) -> None:
         """Each violation has entity_type added from directory name."""
@@ -281,7 +284,7 @@ class TestSummaryEndpoint:
             )
 
         assert resp.status_code == 200
-        assert resp.json()["violation_summary"]["by_entity_type"]["releases"] == 1
+        assert resp.json()["by_entity"]["releases"]["total"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -887,7 +890,7 @@ class TestReadViolationsEdgeCases:
 
         assert resp.status_code == 200
         # The junk file must not inflate the violation count
-        assert resp.json()["violation_summary"]["total"] == 1
+        assert resp.json()["total"] == 1
 
     def test_skips_entity_dirs_without_violations_jsonl(self, test_client: TestClient, tmp_path: Path) -> None:
         """_read_violations skips entity dirs that have no violations.jsonl (line 122)."""
@@ -907,7 +910,7 @@ class TestReadViolationsEdgeCases:
 
         assert resp.status_code == 200
         # Only the artists violation should be counted
-        assert resp.json()["violation_summary"]["total"] == 1
+        assert resp.json()["total"] == 1
 
     def test_skips_empty_lines_in_jsonl(self, test_client: TestClient, tmp_path: Path) -> None:
         """_read_violations skips blank lines in violations.jsonl (line 127)."""
@@ -930,7 +933,7 @@ class TestReadViolationsEdgeCases:
 
         assert resp.status_code == 200
         # Empty lines must be skipped; only 2 real records
-        assert resp.json()["violation_summary"]["total"] == 2
+        assert resp.json()["total"] == 2
 
 
 class TestLoadStateMarkerCorrupt:
@@ -949,8 +952,8 @@ class TestLoadStateMarkerCorrupt:
             )
 
         assert resp.status_code == 200
-        # pipeline_status must be None when state marker is corrupt
-        assert resp.json()["pipeline_status"] is None
+        # pipeline_status must be empty when state marker is corrupt
+        assert resp.json()["pipeline_status"] == {}
 
 
 class TestLoadRecordFilesErrors:

--- a/tests/api/test_notifications.py
+++ b/tests/api/test_notifications.py
@@ -59,6 +59,9 @@ class TestBrevoNotificationChannel:
         assert call_kwargs.kwargs["sender"].email == "noreply@test.com"
         assert call_kwargs.kwargs["sender"].name == "Test Sender"
         assert call_kwargs.kwargs["to"][0].email == "user@example.com"
+        # Verify link tracking is disabled for password reset emails
+        assert call_kwargs.kwargs["headers"]["X-Mailin-Track-Links"] == "0"
+        assert call_kwargs.kwargs["headers"]["X-Mailin-Track"] == "0"
 
     @pytest.mark.asyncio
     async def test_send_password_reset_swallows_api_error(self) -> None:


### PR DESCRIPTION
## Summary

- Fix multiple dashboard admin panel UI bugs (PostgreSQL storage, extraction analysis, queue charts, table formatting)
- Restructure extraction analysis API response to match frontend expectations
- Disable Brevo link tracking on password reset emails

## Dashboard admin fixes

| Bug | Root Cause | Fix |
|---|---|---|
| PostgreSQL storage shows "Loading..." forever | API returns key `"postgresql"` but frontend reads `data.postgres` | Changed to `data.postgresql` |
| Extraction analysis shows `[OBJECT OBJECT]` for pipeline phases | State marker phases are nested objects, `String(obj)` = `[object Object]` | API now extracts `{phase: status_string}` from nested objects |
| Extraction analysis shows "No violation data" / "No violations found" | Frontend reads `summary.by_entity`/`summary.by_rule` but API nested them under `violation_summary` with incompatible format | API now returns `by_entity` (with `{total, errors, warnings}`) and `by_rule` (as array of `{rule, entity_type, severity, count}`) at top level |
| Neo4j/PostgreSQL tables stuck on "Loading..." when status != ok | Render functions returned early without clearing placeholder | Now shows "Connection error" or "No data" |
| Queue chart legend labels overflow | Full queue names like `discogsography-discogs-graphinator-artists` | Strip `discogsography-` prefix |
| Neo4j table columns too spread out | `w-full` on 2-column table | Removed `w-full`, added `min-width` and fixed count column width |
| Extraction analysis tab icons misaligned | `.ea-view-btn` didn't flex-align icon + text | Added `display: inline-flex; align-items: center` |
| Queue/health history error messages unhelpful | Catch blocks swallowed error details | Now includes `err.message` in display |

## API fixes

- **Brevo link tracking**: Password reset emails had their URLs wrapped in Brevo tracking redirects (e.g., `https://baiidbae.r.af.d.sendibt2.com/tr/cl/...`), making them look suspicious. Added `X-Mailin-Track-Links: 0` and `X-Mailin-Track: 0` headers to disable tracking on password reset emails.

## Test plan

- [x] `tests/api/test_extraction_analysis.py` — 60 tests pass (updated assertions for new response format)
- [x] `tests/api/test_notifications.py` — 5 tests pass (added assertion for tracking headers)
- [x] `tests/dashboard/` — 161 tests pass (excluding browser UI test)
- [x] Ruff lint + format pass
- [x] Mypy passes
- [ ] Manual verification of dashboard admin panel UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)