### PR TITLE
fix: align prompt-context API with dashboard frontend request shape

### DIFF
--- a/api/routers/extraction_analysis.py
+++ b/api/routers/extraction_analysis.py
@@ -12,7 +12,6 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 import structlog
-import yaml
 
 from api.dependencies import require_admin
 
@@ -39,9 +38,13 @@ _PARSING_ERROR_CACHE_TTL: float = 300.0  # 5 minutes
 # ---------------------------------------------------------------------------
 
 
-class PromptContextRequest(BaseModel):
-    record_ids: list[str] = Field(..., min_length=1, max_length=20)
+class _RuleSelection(BaseModel):
     rule: str = Field(..., pattern=r"^[a-zA-Z0-9_-]+$")
+    entity_type: str = Field(..., pattern=r"^[a-z-]+$")
+
+
+class PromptContextRequest(BaseModel):
+    rules: list[_RuleSelection] = Field(..., min_length=1, max_length=20)
 
 
 def configure(discogs_root: str | Path | None = None, musicbrainz_root: str | Path | None = None) -> None:
@@ -583,11 +586,8 @@ async def get_prompt_context(
     body: PromptContextRequest,
     _admin: Annotated[dict[str, Any], Depends(require_admin)],
 ) -> JSONResponse:
-    """Assemble structured context for AI prompts — violations, raw XML, and parsed JSON for a set of records."""
+    """Assemble structured context for AI prompts — violations and sample records grouped by rule+entity_type."""
     _validate_version(version)
-
-    for rid in body.record_ids:
-        _validate_record_id(rid)
 
     location = _find_version_root(version)
     if location is None:
@@ -596,51 +596,42 @@ async def get_prompt_context(
     data_root, _source = location
     flagged_version_dir = data_root / "flagged" / version
 
-    # Load rule definition from extraction-rules.yaml if present
-    rule_definition: dict[str, Any] | None = None
-    rules_yaml_path = data_root / "extraction-rules.yaml"
-    if rules_yaml_path.is_file():
-        try:
-            rules_data = yaml.safe_load(rules_yaml_path.read_text(encoding="utf-8"))
-            if isinstance(rules_data, dict):
-                for rule_entry in rules_data.get("rules", []):
-                    if isinstance(rule_entry, dict) and rule_entry.get("id") == body.rule:
-                        rule_definition = rule_entry
-                        break
-        except Exception:
-            logger.warning("⚠️ Could not load extraction-rules.yaml", path=str(rules_yaml_path))
-
     all_violations = _read_violations(flagged_version_dir)
 
-    records: list[dict[str, Any]] = []
-    for rid in body.record_ids:
-        matching = [v for v in all_violations if v.get("record_id") == rid and v.get("rule") == body.rule]
-        if not matching:
-            continue
-        violation = matching[0]
-        entity_type: str = violation.get("entity_type", "unknown")
-        raw_xml, parsed_json = _load_record_files(flagged_version_dir, entity_type, rid)
-        records.append(
+    max_samples = 5
+    contexts: list[dict[str, Any]] = []
+    for sel in body.rules:
+        matching = [v for v in all_violations if v.get("rule") == sel.rule and v.get("entity_type") == sel.entity_type]
+        severity = matching[0].get("severity", "unknown") if matching else "unknown"
+
+        sample_records: list[dict[str, Any]] = []
+        seen_ids: set[str] = set()
+        for v in matching:
+            rid = v.get("record_id", "")
+            if rid in seen_ids:
+                continue
+            seen_ids.add(rid)
+            raw_xml, parsed_json = _load_record_files(flagged_version_dir, sel.entity_type, rid)
+            record_violations = [m for m in matching if m.get("record_id") == rid]
+            sample_records.append(
+                {
+                    "record_id": rid,
+                    "violations": [{"rule": m.get("rule", ""), "message": m.get("message", m.get("field", ""))} for m in record_violations],
+                    "raw_xml": raw_xml,
+                    "parsed_json": parsed_json,
+                }
+            )
+            if len(sample_records) >= max_samples:
+                break
+
+        contexts.append(
             {
-                "record_id": rid,
-                "entity_type": entity_type,
-                "violation": {
-                    "field": violation.get("field", ""),
-                    "field_value": violation.get("field_value", ""),
-                },
-                "raw_xml": raw_xml,
-                "parsed_json": parsed_json,
+                "rule": sel.rule,
+                "entity_type": sel.entity_type,
+                "severity": severity,
+                "total_violations": len(matching),
+                "sample_records": sample_records,
             }
         )
 
-    return JSONResponse(
-        content={
-            "rule": body.rule,
-            "rule_definition": rule_definition,
-            "records": records,
-            "extractor_context": {
-                "parser_file": "extractor/src/xml_parser.rs",
-                "rules_file": "extractor/extraction-rules.yaml",
-            },
-        }
-    )
+    return JSONResponse(content={"contexts": contexts})

--- a/tests/api/test_extraction_analysis.py
+++ b/tests/api/test_extraction_analysis.py
@@ -684,7 +684,7 @@ class TestPromptContextEndpoint:
         """Returns 401 without a valid token."""
         resp = test_client.post(
             "/api/admin/extraction-analysis/20260101/prompt-context",
-            json={"record_ids": ["1"], "rule": "year-out-of-range"},
+            json={"rules": [{"rule": "year-out-of-range", "entity_type": "artists"}]},
         )
         assert resp.status_code == 401
 
@@ -695,13 +695,13 @@ class TestPromptContextEndpoint:
         with patch.object(ea, "_discogs_data_root", tmp_path), patch.object(ea, "_musicbrainz_data_root", None):
             resp = test_client.post(
                 "/api/admin/extraction-analysis/99990101/prompt-context",
-                json={"record_ids": ["1"], "rule": "year-out-of-range"},
+                json={"rules": [{"rule": "year-out-of-range", "entity_type": "artists"}]},
                 headers=_admin_auth_headers(),
             )
         assert resp.status_code == 404
 
-    def test_validation_rejects_empty_record_ids(self, test_client: TestClient, tmp_path: Path) -> None:
-        """Returns 422 when record_ids is empty."""
+    def test_validation_rejects_empty_rules(self, test_client: TestClient, tmp_path: Path) -> None:
+        """Returns 422 when rules list is empty."""
         import api.routers.extraction_analysis as ea
 
         _make_flagged_version(tmp_path)
@@ -709,13 +709,13 @@ class TestPromptContextEndpoint:
         with patch.object(ea, "_discogs_data_root", tmp_path), patch.object(ea, "_musicbrainz_data_root", None):
             resp = test_client.post(
                 "/api/admin/extraction-analysis/20260101/prompt-context",
-                json={"record_ids": [], "rule": "year-out-of-range"},
+                json={"rules": []},
                 headers=_admin_auth_headers(),
             )
         assert resp.status_code == 422
 
     def test_prompt_context_with_records(self, test_client: TestClient, tmp_path: Path) -> None:
-        """Returns records with violation, raw_xml, and parsed_json."""
+        """Returns contexts grouped by rule with sample records."""
         import api.routers.extraction_analysis as ea
 
         _make_flagged_version(tmp_path)
@@ -723,44 +723,24 @@ class TestPromptContextEndpoint:
         with patch.object(ea, "_discogs_data_root", tmp_path), patch.object(ea, "_musicbrainz_data_root", None):
             resp = test_client.post(
                 "/api/admin/extraction-analysis/20260101/prompt-context",
-                json={"record_ids": ["1", "2"], "rule": "year-out-of-range"},
+                json={"rules": [{"rule": "year-out-of-range", "entity_type": "artists"}]},
                 headers=_admin_auth_headers(),
             )
 
         assert resp.status_code == 200
         data = resp.json()
-        assert data["rule"] == "year-out-of-range"
-        assert data["extractor_context"]["parser_file"] == "extractor/src/xml_parser.rs"
-        assert data["extractor_context"]["rules_file"] == "extractor/extraction-rules.yaml"
-        assert len(data["records"]) == 2
-        record_ids = {r["record_id"] for r in data["records"]}
+        assert len(data["contexts"]) == 1
+        ctx = data["contexts"][0]
+        assert ctx["rule"] == "year-out-of-range"
+        assert ctx["entity_type"] == "artists"
+        assert ctx["severity"] == "warning"
+        assert ctx["total_violations"] == 2
+        record_ids = {r["record_id"] for r in ctx["sample_records"]}
         assert "1" in record_ids
         assert "2" in record_ids
 
-    def test_prompt_context_rule_definition_loaded(self, test_client: TestClient, tmp_path: Path) -> None:
-        """Loads rule definition from extraction-rules.yaml when present."""
-        import api.routers.extraction_analysis as ea
-
-        _make_flagged_version(tmp_path)
-        (tmp_path / "extraction-rules.yaml").write_text(
-            "rules:\n  - id: year-out-of-range\n    description: Year is out of valid range\n    severity: warning\n"
-        )
-
-        with patch.object(ea, "_discogs_data_root", tmp_path), patch.object(ea, "_musicbrainz_data_root", None):
-            resp = test_client.post(
-                "/api/admin/extraction-analysis/20260101/prompt-context",
-                json={"record_ids": ["1"], "rule": "year-out-of-range"},
-                headers=_admin_auth_headers(),
-            )
-
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["rule_definition"] is not None
-        assert data["rule_definition"]["id"] == "year-out-of-range"
-        assert data["rule_definition"]["description"] == "Year is out of valid range"
-
-    def test_prompt_context_rule_definition_null_when_missing(self, test_client: TestClient, tmp_path: Path) -> None:
-        """Returns null rule_definition when extraction-rules.yaml is absent."""
+    def test_prompt_context_multiple_rules(self, test_client: TestClient, tmp_path: Path) -> None:
+        """Returns separate contexts when multiple rules are selected."""
         import api.routers.extraction_analysis as ea
 
         _make_flagged_version(tmp_path)
@@ -768,16 +748,23 @@ class TestPromptContextEndpoint:
         with patch.object(ea, "_discogs_data_root", tmp_path), patch.object(ea, "_musicbrainz_data_root", None):
             resp = test_client.post(
                 "/api/admin/extraction-analysis/20260101/prompt-context",
-                json={"record_ids": ["1"], "rule": "year-out-of-range"},
+                json={
+                    "rules": [
+                        {"rule": "year-out-of-range", "entity_type": "artists"},
+                        {"rule": "missing-field", "entity_type": "artists"},
+                    ]
+                },
                 headers=_admin_auth_headers(),
             )
 
         assert resp.status_code == 200
         data = resp.json()
-        assert data["rule_definition"] is None
+        assert len(data["contexts"]) == 2
+        rules = {ctx["rule"] for ctx in data["contexts"]}
+        assert rules == {"year-out-of-range", "missing-field"}
 
-    def test_prompt_context_skips_unmatched_records(self, test_client: TestClient, tmp_path: Path) -> None:
-        """Skips record_ids that have no violations for the given rule."""
+    def test_prompt_context_no_matching_violations(self, test_client: TestClient, tmp_path: Path) -> None:
+        """Returns empty sample_records when no violations match the rule+entity_type."""
         import api.routers.extraction_analysis as ea
 
         _make_flagged_version(tmp_path)
@@ -785,33 +772,15 @@ class TestPromptContextEndpoint:
         with patch.object(ea, "_discogs_data_root", tmp_path), patch.object(ea, "_musicbrainz_data_root", None):
             resp = test_client.post(
                 "/api/admin/extraction-analysis/20260101/prompt-context",
-                json={"record_ids": ["3", "9999"], "rule": "year-out-of-range"},
+                json={"rules": [{"rule": "nonexistent-rule", "entity_type": "artists"}]},
                 headers=_admin_auth_headers(),
             )
 
         assert resp.status_code == 200
         data = resp.json()
-        # Record 3 has missing-field rule, not year-out-of-range; 9999 doesn't exist
-        assert data["records"] == []
-
-    def test_prompt_context_corrupt_yaml_still_returns_200(self, test_client: TestClient, tmp_path: Path) -> None:
-        """Returns 200 with null rule_definition when extraction-rules.yaml is corrupt (line 610-611)."""
-        import api.routers.extraction_analysis as ea
-
-        _make_flagged_version(tmp_path)
-        # Write a corrupt YAML file that will raise an exception during load
-        (tmp_path / "extraction-rules.yaml").write_bytes(b"\x00\xff\xfe invalid yaml \x80\x81")
-
-        with patch.object(ea, "_discogs_data_root", tmp_path), patch.object(ea, "_musicbrainz_data_root", None):
-            resp = test_client.post(
-                "/api/admin/extraction-analysis/20260101/prompt-context",
-                json={"record_ids": ["1"], "rule": "year-out-of-range"},
-                headers=_admin_auth_headers(),
-            )
-
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["rule_definition"] is None
+        assert len(data["contexts"]) == 1
+        assert data["contexts"][0]["total_violations"] == 0
+        assert data["contexts"][0]["sample_records"] == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The dashboard sends `{ rules: [{rule, entity_type}] }` but the API expected `{ record_ids: [...], rule: "..." }`, causing a 422 Unprocessable Content error when generating extraction analysis prompts
- Updated `PromptContextRequest` Pydantic model and endpoint to accept the frontend's shape and return `{ contexts: [...] }` with per-rule groupings and sample records
- Updated tests to match the new request/response contract

## Test plan
- [x] `just test-api` — all extraction analysis tests pass
- [x] Dashboard proxy tests pass
- [x] Linting (`ruff check`) and type checking (`mypy`) pass
- [ ] Manually verify prompt generation in the dashboard extraction analysis tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)