### PR TITLE
fix: dashboard UI polish and logging noise reduction

### DIFF
--- a/api/routers/extraction_analysis.py
+++ b/api/routers/extraction_analysis.py
@@ -199,9 +199,7 @@ def _build_violation_summary(violations: list[dict[str, Any]]) -> dict[str, Any]
 _MAX_RECORD_FILE_BYTES = 512 * 1024  # 512 KiB
 
 
-def _load_record_files(
-    flagged_dir: Path, entity_type: str, record_id: str
-) -> tuple[str | None, dict[str, Any] | None, bool]:
+def _load_record_files(flagged_dir: Path, entity_type: str, record_id: str) -> tuple[str | None, dict[str, Any] | None, bool]:
     """Load raw XML and parsed JSON for a record from its flagged entity directory.
 
     Returns (raw_xml, parsed_json, truncated) where either content value may be None
@@ -232,7 +230,11 @@ def _load_record_files(
             size = json_path.stat().st_size
             if size > _MAX_RECORD_FILE_BYTES:
                 raw_json_text = json_path.read_bytes()[:_MAX_RECORD_FILE_BYTES].decode("utf-8", errors="replace")
-                parsed_json = {"_truncated": True, "_message": f"File is {size / 1024 / 1024:.1f} MB, too large to display", "_preview": raw_json_text[:4096]}
+                parsed_json = {
+                    "_truncated": True,
+                    "_message": f"File is {size / 1024 / 1024:.1f} MB, too large to display",
+                    "_preview": raw_json_text[:4096],
+                }
                 truncated = True
             else:
                 parsed_json = json.loads(json_path.read_text(encoding="utf-8"))

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -31,6 +31,9 @@ from common import (
 from dashboard.admin_proxy import configure as configure_admin_proxy, router as admin_router
 
 
+# Suppress per-request httpx INFO logs (health checks every 2s are too noisy)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
 logger = logging.getLogger(__name__)
 
 # CORS origins configurable via environment variable (comma-separated list)
@@ -218,13 +221,26 @@ class DashboardApp:
 
     async def collect_metrics_loop(self) -> None:
         """Continuously collect metrics in the background."""
+        cycle_count = 0
         while True:
             try:
                 metrics = await self.collect_all_metrics()
                 self.latest_metrics = metrics
+                cycle_count += 1
 
                 # Broadcast to all connected websockets
                 await self.broadcast_metrics(metrics)
+
+                # Log a summary every 50 cycles (~100s) instead of every request
+                if cycle_count % 50 == 0:
+                    pipeline_names = list(metrics.pipelines.keys()) if metrics.pipelines else []
+                    ws_count = len(self.websocket_connections)
+                    logger.info(
+                        "📊 Metrics collection summary: cycles=%d, pipelines=%s, websocket_clients=%d",
+                        cycle_count,
+                        pipeline_names,
+                        ws_count,
+                    )
 
                 await asyncio.sleep(2)  # Update every 2 seconds
 

--- a/dashboard/static/admin.html
+++ b/dashboard/static/admin.html
@@ -263,7 +263,7 @@
         </header>
 
         <!-- Tab Navigation -->
-        <nav class="flex items-center gap-2 mb-6 dashboard-card p-2" style="width:fit-content">
+        <nav class="flex items-center gap-2 mb-6 dashboard-card p-2 overflow-x-auto">
             <button class="tab-btn active" data-tab="extractions" id="tab-btn-extractions">
                 <span class="material-symbols-outlined text-sm">rocket_launch</span> Extractions
             </button>
@@ -465,7 +465,7 @@
                 </div>
 
                 <!-- Neo4j collapsible -->
-                <div class="mb-4 border b-theme rounded-lg overflow-hidden">
+                <div class="mb-6 border b-theme rounded-lg overflow-hidden">
                     <div class="collapsible-header flex items-center justify-between px-4 py-3 bg-inner" data-target="storage-neo4j-body">
                         <div class="flex items-center gap-3">
                             <span class="material-symbols-outlined text-sm t-dim">graph_3</span>
@@ -476,35 +476,37 @@
                     </div>
                     <div class="collapsible-body" id="storage-neo4j-body">
                         <div class="p-4 space-y-4">
-                            <!-- Node counts -->
-                            <div>
-                                <p class="text-[10px] font-bold uppercase tracking-wider t-muted mb-2">Node Counts by Label</p>
-                                <table class="text-xs" style="min-width:280px">
-                                    <thead>
-                                        <tr class="text-[10px] t-muted uppercase font-bold tracking-wider border-b b-theme">
-                                            <th class="text-left py-1.5 pr-8">Label</th>
-                                            <th class="text-right py-1.5 w-28">Count</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody id="neo4j-nodes-body">
-                                        <tr><td colspan="2" class="py-3 text-center t-muted">Loading...</td></tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                            <!-- Relationship counts -->
-                            <div>
-                                <p class="text-[10px] font-bold uppercase tracking-wider t-muted mb-2">Relationship Counts by Type</p>
-                                <table class="text-xs" style="min-width:280px">
-                                    <thead>
-                                        <tr class="text-[10px] t-muted uppercase font-bold tracking-wider border-b b-theme">
-                                            <th class="text-left py-1.5 pr-8">Type</th>
-                                            <th class="text-right py-1.5 w-28">Count</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody id="neo4j-rels-body">
-                                        <tr><td colspan="2" class="py-3 text-center t-muted">Loading...</td></tr>
-                                    </tbody>
-                                </table>
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                                <!-- Node counts -->
+                                <div>
+                                    <p class="text-[10px] font-bold uppercase tracking-wider t-muted mb-2">Node Counts by Label</p>
+                                    <table class="text-xs" style="min-width:280px">
+                                        <thead>
+                                            <tr class="text-[10px] t-muted uppercase font-bold tracking-wider border-b b-theme">
+                                                <th class="text-left py-1.5 pr-8">Label</th>
+                                                <th class="text-right py-1.5 w-28">Count</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody id="neo4j-nodes-body">
+                                            <tr><td colspan="2" class="py-3 text-center t-muted">Loading...</td></tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                                <!-- Relationship counts -->
+                                <div>
+                                    <p class="text-[10px] font-bold uppercase tracking-wider t-muted mb-2">Relationship Counts by Type</p>
+                                    <table class="text-xs" style="min-width:280px">
+                                        <thead>
+                                            <tr class="text-[10px] t-muted uppercase font-bold tracking-wider border-b b-theme">
+                                                <th class="text-left py-1.5 pr-8">Type</th>
+                                                <th class="text-right py-1.5 w-28">Count</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody id="neo4j-rels-body">
+                                            <tr><td colspan="2" class="py-3 text-center t-muted">Loading...</td></tr>
+                                        </tbody>
+                                    </table>
+                                </div>
                             </div>
                             <!-- Store sizes -->
                             <div id="neo4j-store-sizes"></div>
@@ -513,7 +515,7 @@
                 </div>
 
                 <!-- PostgreSQL collapsible -->
-                <div class="mb-4 border b-theme rounded-lg overflow-hidden">
+                <div class="mb-6 border b-theme rounded-lg overflow-hidden">
                     <div class="collapsible-header flex items-center justify-between px-4 py-3 bg-inner" data-target="storage-postgres-body">
                         <div class="flex items-center gap-3">
                             <span class="material-symbols-outlined text-sm t-dim">table_chart</span>
@@ -634,8 +636,8 @@
                 <!-- Queue Depth Chart -->
                 <div class="mb-6">
                     <p class="text-[10px] font-bold uppercase tracking-wider t-muted mb-3">Queue Depth Over Time</p>
-                    <div class="bg-inner rounded-lg border b-theme p-4">
-                        <div id="queue-chart-legend" class="flex flex-wrap gap-3 mb-3 text-[10px] t-muted"></div>
+                    <div class="bg-inner rounded-lg border b-theme p-4 overflow-hidden">
+                        <div id="queue-chart-legend" class="flex flex-wrap gap-x-3 gap-y-1 mb-3 text-[10px] t-muted max-h-20 overflow-y-auto"></div>
                         <canvas id="queue-depth-chart" height="280"></canvas>
                     </div>
                 </div>
@@ -869,6 +871,56 @@
                     </div>
                 </section>
 
+                <!-- Violations detail table (shown when View is clicked) -->
+                <section id="ea-violations-detail" class="dashboard-card p-6 space-y-4" style="display:none">
+                    <div class="flex items-center justify-between border-b b-theme pb-3">
+                        <h3 class="text-sm font-semibold flex items-center gap-2">
+                            <span class="material-symbols-outlined text-sm t-dim">list_alt</span>
+                            Violations — <span id="ea-vd-rule" class="mono t-dim text-xs"></span>
+                            <span id="ea-vd-entity" class="text-xs t-muted"></span>
+                        </h3>
+                        <div class="flex items-center gap-3">
+                            <label class="text-[10px] t-dim font-bold uppercase tracking-wider">
+                                Page size
+                                <select id="ea-vd-page-size" class="ml-1 text-xs bg-transparent border b-theme rounded px-2 py-0.5 t-high">
+                                    <option value="50">50</option>
+                                    <option value="100">100</option>
+                                    <option value="200">200</option>
+                                </select>
+                            </label>
+                            <button id="ea-vd-close" class="t-dim hover:t-high transition-colors text-xs font-bold uppercase tracking-wider flex items-center gap-1">
+                                <span class="material-symbols-outlined text-sm">close</span> Close
+                            </button>
+                        </div>
+                    </div>
+                    <div class="overflow-x-auto">
+                        <table class="w-full text-xs">
+                            <thead>
+                                <tr class="text-[10px] t-muted uppercase font-bold tracking-wider border-b b-theme">
+                                    <th class="text-left py-2 px-2">Record ID</th>
+                                    <th class="text-left py-2 px-2">Rule</th>
+                                    <th class="text-left py-2 px-2">Severity</th>
+                                    <th class="text-left py-2 px-2">Field</th>
+                                    <th class="text-left py-2 px-2">Value</th>
+                                    <th class="text-right py-2 px-2">Detail</th>
+                                </tr>
+                            </thead>
+                            <tbody id="ea-vd-tbody">
+                                <tr><td colspan="6" class="py-6 text-center t-muted">Loading...</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!-- Pagination -->
+                    <div class="flex items-center justify-between">
+                        <span id="ea-vd-info" class="text-xs t-muted"></span>
+                        <div class="flex items-center gap-2">
+                            <button id="ea-vd-prev" class="text-xs px-3 py-1 rounded border b-theme t-dim hover:t-high disabled:opacity-40" disabled>Prev</button>
+                            <span id="ea-vd-page-label" class="text-xs mono t-dim"></span>
+                            <button id="ea-vd-next" class="text-xs px-3 py-1 rounded border b-theme t-dim hover:t-high disabled:opacity-40" disabled>Next</button>
+                        </div>
+                    </div>
+                </section>
+
             </div><!-- /ea-view-report -->
 
             <!-- ── Sub-view: Version Comparison ────────────────────── -->
@@ -940,9 +992,9 @@
         <!-- ============================================================
              RECORD DETAIL MODAL
              ============================================================ -->
-        <div id="ea-modal" class="fixed inset-0 z-50 flex items-center justify-center" style="display:none; background:rgba(0,0,0,0.5)">
-            <div class="dashboard-card p-6 w-full max-w-5xl max-h-[90vh] flex flex-col gap-4 overflow-y-auto">
-                <div class="flex items-center justify-between border-b b-theme pb-3">
+        <div id="ea-modal" class="fixed inset-0 z-50 flex items-center justify-center p-6" style="display:none; background:rgba(0,0,0,0.5)">
+            <div class="dashboard-card p-6 w-full max-w-5xl max-h-[90vh] flex flex-col gap-4 overflow-hidden">
+                <div class="flex items-center justify-between border-b b-theme pb-3 flex-shrink-0">
                     <h3 class="text-sm font-semibold flex items-center gap-2">
                         <span class="material-symbols-outlined text-sm t-dim">data_object</span>
                         Record Detail — <span id="ea-modal-record-id" class="mono t-dim text-xs"></span>
@@ -951,19 +1003,21 @@
                         <span class="material-symbols-outlined">close</span>
                     </button>
                 </div>
-                <div class="grid grid-cols-2 gap-4">
-                    <div class="space-y-1">
-                        <p class="text-[10px] font-bold uppercase tracking-wider t-muted">Raw XML</p>
-                        <pre id="ea-modal-xml" class="mono text-xs bg-inner border b-theme rounded p-3 overflow-auto t-mid" style="max-height:350px;white-space:pre-wrap;word-break:break-all"></pre>
+                <div class="flex-1 overflow-y-auto space-y-4 min-h-0">
+                    <div class="grid grid-cols-2 gap-4">
+                        <div class="space-y-1 min-w-0">
+                            <p class="text-[10px] font-bold uppercase tracking-wider t-muted">Raw XML</p>
+                            <pre id="ea-modal-xml" class="mono text-xs bg-inner border b-theme rounded p-3 overflow-auto t-mid" style="max-height:50vh;white-space:pre-wrap;word-break:break-all"></pre>
+                        </div>
+                        <div class="space-y-1 min-w-0">
+                            <p class="text-[10px] font-bold uppercase tracking-wider t-muted">Parsed JSON</p>
+                            <pre id="ea-modal-json" class="mono text-xs bg-inner border b-theme rounded p-3 overflow-auto t-mid" style="max-height:50vh;white-space:pre-wrap;word-break:break-all"></pre>
+                        </div>
                     </div>
-                    <div class="space-y-1">
-                        <p class="text-[10px] font-bold uppercase tracking-wider t-muted">Parsed JSON</p>
-                        <pre id="ea-modal-json" class="mono text-xs bg-inner border b-theme rounded p-3 overflow-auto t-mid" style="max-height:350px;white-space:pre-wrap;word-break:break-all"></pre>
+                    <div class="space-y-2">
+                        <p class="text-[10px] font-bold uppercase tracking-wider t-muted">Violations</p>
+                        <ul id="ea-modal-violations" class="space-y-1 text-xs"></ul>
                     </div>
-                </div>
-                <div class="space-y-2">
-                    <p class="text-[10px] font-bold uppercase tracking-wider t-muted">Violations</p>
-                    <ul id="ea-modal-violations" class="space-y-1 text-xs"></ul>
                 </div>
             </div>
         </div><!-- /ea-modal -->

--- a/dashboard/static/admin.js
+++ b/dashboard/static/admin.js
@@ -52,6 +52,9 @@ class AdminDashboard {
         this._eaVersions = [];
         this._eaSelectedRecords = new Map();
         this._eaParsingErrors = null;
+        this._eaVdRule = '';
+        this._eaVdEntityType = '';
+        this._eaVdPage = 1;
         this.initTheme();
         this.bindEvents();
         if (this.token) {
@@ -258,6 +261,25 @@ class AdminDashboard {
         if (eaModalClose) eaModalClose.addEventListener('click', () => {
             const modal = document.getElementById('ea-modal');
             if (modal) modal.style.display = 'none';
+        });
+
+        // Violations detail pagination
+        const eaVdClose = document.getElementById('ea-vd-close');
+        if (eaVdClose) eaVdClose.addEventListener('click', () => {
+            const section = document.getElementById('ea-violations-detail');
+            if (section) section.style.display = 'none';
+        });
+        const eaVdPrev = document.getElementById('ea-vd-prev');
+        if (eaVdPrev) eaVdPrev.addEventListener('click', () => {
+            if (this._eaVdPage > 1) { this._eaVdPage--; this._eaLoadViolationsPage(); }
+        });
+        const eaVdNext = document.getElementById('ea-vd-next');
+        if (eaVdNext) eaVdNext.addEventListener('click', () => {
+            this._eaVdPage++; this._eaLoadViolationsPage();
+        });
+        const eaVdPageSize = document.getElementById('ea-vd-page-size');
+        if (eaVdPageSize) eaVdPageSize.addEventListener('change', () => {
+            this._eaVdPage = 1; this._eaLoadViolationsPage();
         });
     }
 
@@ -1490,6 +1512,27 @@ class AdminDashboard {
         return svg;
     }
 
+    static _prettyPrintXml(xml) {
+        let formatted = '';
+        let indent = 0;
+        const parts = xml.replace(/>\s*</g, '><').split(/(<[^>]+>)/);
+        for (const part of parts) {
+            if (!part.trim()) continue;
+            if (part.startsWith('</')) {
+                indent = Math.max(0, indent - 1);
+                formatted += '  '.repeat(indent) + part + '\n';
+            } else if (part.startsWith('<') && !part.startsWith('<?') && !part.endsWith('/>') && !part.startsWith('<!')) {
+                formatted += '  '.repeat(indent) + part + '\n';
+                indent++;
+            } else if (part.endsWith('/>')) {
+                formatted += '  '.repeat(indent) + part + '\n';
+            } else {
+                formatted += '  '.repeat(indent) + part + '\n';
+            }
+        }
+        return formatted.trim();
+    }
+
     // ─── Audit Log ───────────────────────────────────────────────────────────
 
     async fetchAuditLog() {
@@ -1849,26 +1892,114 @@ class AdminDashboard {
     }
 
     async _eaShowViolationsForRule(rule, entityType) {
+        this._eaVdRule = rule;
+        this._eaVdEntityType = entityType;
+        this._eaVdPage = 1;
+        await this._eaLoadViolationsPage();
+    }
+
+    async _eaLoadViolationsPage() {
         const sel = document.getElementById('ea-version-select');
         const version = sel ? sel.value : '';
         if (!version) return;
+
+        const section = document.getElementById('ea-violations-detail');
+        if (!section) return;
+        section.style.display = '';
+        section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+        const ruleEl = document.getElementById('ea-vd-rule');
+        if (ruleEl) ruleEl.textContent = this._eaVdRule;
+        const entityEl = document.getElementById('ea-vd-entity');
+        if (entityEl) entityEl.textContent = this._eaVdEntityType ? `(${this._eaVdEntityType})` : '';
+
+        const pageSizeEl = document.getElementById('ea-vd-page-size');
+        const pageSize = pageSizeEl ? parseInt(pageSizeEl.value, 10) : 50;
+
+        const params = new URLSearchParams({
+            rule: this._eaVdRule,
+            page: String(this._eaVdPage),
+            page_size: String(pageSize),
+        });
+        if (this._eaVdEntityType) params.set('entity_type', this._eaVdEntityType);
+
+        const tbody = document.getElementById('ea-vd-tbody');
+        if (tbody) tbody.replaceChildren(_emptyRow(6, 'Loading...'));
+
         try {
-            const params = new URLSearchParams({ rule, page_size: '1' });
-            if (entityType) params.set('entity_type', entityType);
             const resp = await this.authFetch(
                 `/admin/api/extraction-analysis/${encodeURIComponent(version)}/violations?${params}`,
             );
-            if (!resp.ok) return;
+            if (!resp.ok) {
+                if (tbody) tbody.replaceChildren(_emptyRow(6, 'Failed to load violations.'));
+                return;
+            }
             const data = await resp.json();
             const violations = data.violations || [];
-            if (violations.length > 0) {
-                const firstRecordId = violations[0].record_id;
-                if (firstRecordId) {
-                    await this._eaShowRecordDetail(version, firstRecordId);
-                }
+            const pagination = data.pagination || {};
+
+            if (violations.length === 0) {
+                if (tbody) tbody.replaceChildren(_emptyRow(6, 'No violations found.'));
+            } else if (tbody) {
+                const rows = violations.map(v => {
+                    const tr = document.createElement('tr');
+                    tr.className = 'border-b b-row';
+
+                    const tdId = document.createElement('td');
+                    tdId.className = 'py-2 px-2 mono t-mid';
+                    tdId.textContent = v.record_id || '—';
+
+                    const tdRule = document.createElement('td');
+                    tdRule.className = 'py-2 px-2 mono t-dim';
+                    tdRule.textContent = v.rule || '—';
+
+                    const tdSev = document.createElement('td');
+                    tdSev.className = 'py-2 px-2';
+                    const sevBadge = document.createElement('span');
+                    const sevClass = v.severity === 'error' ? 'badge-error' : v.severity === 'warning' ? 'badge-running' : 'badge-idle';
+                    sevBadge.className = `text-[10px] px-1.5 py-0.5 rounded uppercase font-bold ${sevClass}`;
+                    sevBadge.textContent = v.severity || 'info';
+                    tdSev.appendChild(sevBadge);
+
+                    const tdField = document.createElement('td');
+                    tdField.className = 'py-2 px-2 mono t-dim';
+                    tdField.textContent = v.field || '—';
+
+                    const tdValue = document.createElement('td');
+                    tdValue.className = 'py-2 px-2 mono t-dim';
+                    tdValue.textContent = v.field_value || '—';
+
+                    const tdDetail = document.createElement('td');
+                    tdDetail.className = 'py-2 px-2 text-right';
+                    const detailBtn = document.createElement('button');
+                    detailBtn.className = 'text-[10px] px-2 py-0.5 rounded border b-theme t-dim hover:t-high';
+                    detailBtn.textContent = 'View';
+                    detailBtn.addEventListener('click', () => this._eaShowRecordDetail(version, v.record_id));
+                    tdDetail.appendChild(detailBtn);
+
+                    tr.append(tdId, tdRule, tdSev, tdField, tdValue, tdDetail);
+                    return tr;
+                });
+                tbody.replaceChildren(...rows);
             }
+
+            // Update pagination controls
+            const infoEl = document.getElementById('ea-vd-info');
+            if (infoEl) {
+                const start = ((pagination.page || 1) - 1) * (pagination.page_size || pageSize) + 1;
+                const end = Math.min(start + violations.length - 1, pagination.total_items || 0);
+                infoEl.textContent = `${start}–${end} of ${(pagination.total_items || 0).toLocaleString()}`;
+            }
+
+            const labelEl = document.getElementById('ea-vd-page-label');
+            if (labelEl) labelEl.textContent = `${pagination.page || 1} / ${pagination.total_pages || 1}`;
+
+            const prevBtn = document.getElementById('ea-vd-prev');
+            const nextBtn = document.getElementById('ea-vd-next');
+            if (prevBtn) prevBtn.disabled = (pagination.page || 1) <= 1;
+            if (nextBtn) nextBtn.disabled = (pagination.page || 1) >= (pagination.total_pages || 1);
         } catch {
-            // Silently fail
+            if (tbody) tbody.replaceChildren(_emptyRow(6, 'Error loading violations.'));
         }
     }
 
@@ -1886,7 +2017,7 @@ class AdminDashboard {
             if (recordIdEl) recordIdEl.textContent = recordId;
 
             const xmlEl = document.getElementById('ea-modal-xml');
-            if (xmlEl) xmlEl.textContent = data.raw_xml || '(none)';
+            if (xmlEl) xmlEl.textContent = data.raw_xml ? AdminDashboard._prettyPrintXml(data.raw_xml) : '(none)';
 
             const jsonEl = document.getElementById('ea-modal-json');
             if (jsonEl) {

--- a/tests/api/test_extraction_analysis.py
+++ b/tests/api/test_extraction_analysis.py
@@ -1002,6 +1002,34 @@ class TestLoadRecordFilesErrors:
         assert resp.json()["parsed_json"] is None
 
 
+class TestLoadRecordFilesTruncation:
+    def test_oversized_json_returns_truncation_marker(self, test_client: TestClient, tmp_path: Path) -> None:
+        """Oversized JSON file returns _truncated dict instead of parsed content."""
+        import api.routers.extraction_analysis as ea
+
+        violations = [{"record_id": "77", "rule": "missing-field", "severity": "error", "field": "title"}]
+        entity_dir = tmp_path / "flagged" / "20260101" / "artists"
+        entity_dir.mkdir(parents=True)
+        (entity_dir / "violations.jsonl").write_text(json.dumps(violations[0]) + "\n")
+
+        # Create a JSON file larger than _MAX_RECORD_FILE_BYTES (512 KiB)
+        large_json = json.dumps({"data": "x" * (600 * 1024)})
+        (entity_dir / "77.json").write_text(large_json)
+
+        with patch.object(ea, "_discogs_data_root", tmp_path), patch.object(ea, "_musicbrainz_data_root", None):
+            resp = test_client.get(
+                "/api/admin/extraction-analysis/20260101/violations/77",
+                headers=_admin_auth_headers(),
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["parsed_json"]["_truncated"] is True
+        assert "too large" in data["parsed_json"]["_message"]
+        assert "_preview" in data["parsed_json"]
+        assert data["truncated"] is True
+
+
 class TestViolationDetailNotFound:
     def test_version_not_found_returns_404(self, test_client: TestClient, tmp_path: Path) -> None:
         """violation_detail returns 404 when version directory does not exist (line 319)."""

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -275,6 +275,40 @@ class TestDashboardAppMetrics:
                 assert app.latest_metrics == mock_metrics
 
     @pytest.mark.asyncio
+    async def test_collect_metrics_loop_logs_summary_every_50_cycles(self) -> None:
+        """Test that a summary is logged every 50 cycles."""
+        mock_config = Mock()
+
+        with patch("dashboard.dashboard.get_config", return_value=mock_config):
+            app = DashboardApp()
+
+            mock_metrics = Mock()
+            mock_metrics.pipelines = {"discogs": Mock(), "musicbrainz": Mock()}
+
+            call_count = 0
+
+            async def mock_collect() -> SystemMetrics:
+                nonlocal call_count
+                call_count += 1
+                if call_count > 50:
+                    raise asyncio.CancelledError()
+                return mock_metrics
+
+            with (
+                patch.object(app, "collect_all_metrics", side_effect=mock_collect),
+                patch.object(app, "broadcast_metrics", new_callable=AsyncMock),
+                patch("asyncio.sleep", new_callable=AsyncMock),
+                patch("dashboard.dashboard.logger") as mock_logger,
+            ):
+                await app.collect_metrics_loop()
+
+                # After 50 successful cycles, the summary log should fire once
+                mock_logger.info.assert_called_once()
+                log_args = mock_logger.info.call_args
+                assert "Metrics collection summary" in log_args[0][0]
+                assert log_args[0][1] == 50  # cycle_count
+
+    @pytest.mark.asyncio
     async def test_collect_metrics_loop_error_handling(self) -> None:
         """Test error handling in metrics collection loop."""
         mock_config = Mock()


### PR DESCRIPTION
## Summary
- **Nav bar** now spans full content width instead of `fit-content`
- **Neo4j tables** (node counts + relationship counts) placed side-by-side on wider screens
- **Storage collapsibles** given more vertical breathing room (`mb-4` -> `mb-6`)
- **Queue chart legend** constrained to container with scrollable overflow
- **Record detail modal** properly contained — scrollable body, no content spill
- **XML pretty-printed** in record detail modal (indented tag formatting)
- **"View" button** now opens a paginated violations table (50/100/200 page sizes) with prev/next navigation, instead of showing a single sample record
- **httpx logs suppressed** at INFO level (health checks every 2s were flooding logs); summary logged every 50 cycles (~100s) instead

## Test plan
- [x] All 161 dashboard tests pass
- [x] All extraction analysis API tests pass
- [x] `ruff check` and `mypy` clean
- [ ] Manually verify UI changes in browser: nav width, storage layout, queue chart, violations table pagination, XML formatting, modal scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)