### PR TITLE
feat: add account settings page with 2FA setup UI

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -399,6 +399,13 @@ class TwoFactorDisableModel(BaseModel):
     password: str
 
 
+class ChangePasswordRequest(BaseModel):
+    """Request to change password while authenticated."""
+
+    current_password: str
+    new_password: str = Field(min_length=8, description="New password (minimum 8 characters)")
+
+
 class ChallengeResponse(BaseModel):
     """Response when login requires 2FA — contains a challenge token."""
 

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -27,6 +27,7 @@ from api.auth import (
 )
 from api.limiter import limiter
 from api.models import (
+    ChangePasswordRequest,
     LoginRequest,
     RegisterRequest,
     ResetConfirmModel,
@@ -326,6 +327,50 @@ async def reset_confirm(request: Request, body: ResetConfirmModel) -> JSONRespon
 
     logger.info("✅ Password reset completed", user_id=user_id)
     return JSONResponse(content={"message": "Password has been reset"})
+
+
+@router.post("/api/auth/change-password")
+@limiter.limit("5/minute")
+async def change_password(
+    request: Request,  # noqa: ARG001
+    current_user: Annotated[dict[str, Any], Depends(_require_user)],
+    body: ChangePasswordRequest,
+) -> JSONResponse:
+    """Change password for the currently authenticated user."""
+    if _pool is None or _redis is None or _config is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service not ready")
+
+    user_id = current_user.get("sub")
+
+    async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        await execute_sql(
+            cur,
+            "SELECT hashed_password FROM users WHERE id = %s::uuid",
+            (user_id,),
+        )
+        user = await cur.fetchone()
+
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    if not _verify_password(body.current_password, user["hashed_password"]):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect current password")
+
+    hashed_password = _hash_password(body.new_password)
+    now_ts = int(datetime.now(UTC).timestamp())
+
+    async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        await execute_sql(
+            cur,
+            "UPDATE users SET hashed_password = %s, password_changed_at = NOW(), updated_at = NOW() WHERE id = %s::uuid",
+            (hashed_password, user_id),
+        )
+
+    # Invalidate all existing sessions (same pattern as reset-confirm)
+    await _redis.setex(f"password_changed:{user_id}", _config.jwt_expire_minutes * 60, str(now_ts))
+
+    logger.info("✅ Password changed", user_id=user_id)
+    return JSONResponse(content={"message": "Password has been changed"})
 
 
 # ---------------------------------------------------------------------------

--- a/explore/__tests__/api-client.test.js
+++ b/explore/__tests__/api-client.test.js
@@ -1286,4 +1286,18 @@ describe('ApiClient', () => {
             expect(response.ok).toBe(false);
         });
     });
+
+    describe('changePassword', () => {
+        it('should send POST with auth header and credentials', async () => {
+            const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ message: 'Password has been changed' }) });
+            vi.stubGlobal('fetch', mockFetch);
+
+            const result = await window.apiClient.changePassword('token123', 'old', 'newpass123');
+            expect(result.ok).toBe(true);
+            expect(mockFetch).toHaveBeenCalledWith('/api/auth/change-password', expect.objectContaining({
+                method: 'POST',
+                headers: expect.objectContaining({ 'Authorization': 'Bearer token123' }),
+            }));
+        });
+    });
 });

--- a/explore/__tests__/app.test.js
+++ b/explore/__tests__/app.test.js
@@ -78,7 +78,7 @@ function setupAppDOM() {
         'zoomInBtn', 'zoomOutBtn', 'zoomResetBtn', 'fullscreenBtn',
         // Panes
         'explorePane', 'trendsPane', 'searchPane', 'insightsPane',
-        'collectionPane', 'wantlistPane', 'recommendationsPane', 'gapsPane',
+        'collectionPane', 'wantlistPane', 'recommendationsPane', 'gapsPane', 'settingsPane',
         // NLQ
         'nlqPanel', 'nlqInput', 'nlqSubmit', 'nlqStatus', 'nlqResult', 'nlqExamples',
         'searchAskToggle', 'searchModeBtn', 'askModeBtn',
@@ -113,7 +113,7 @@ function setupAppDOM() {
             el.value = '2025';
         }
         if (['explorePane', 'trendsPane', 'searchPane', 'insightsPane',
-             'collectionPane', 'wantlistPane', 'recommendationsPane', 'gapsPane'].includes(id)) {
+             'collectionPane', 'wantlistPane', 'recommendationsPane', 'gapsPane', 'settingsPane'].includes(id)) {
             el.className = 'pane';
         }
         document.body.appendChild(el);
@@ -188,6 +188,21 @@ function setupAppDOM() {
     const twoFactorRecoveryBtn = document.createElement('button');
     twoFactorRecoveryBtn.id = 'twoFactorRecoveryBtn';
     document.body.appendChild(twoFactorRecoveryBtn);
+
+    // Account settings button (inside a dropdown with x-data)
+    const userDropdownWrapper = document.createElement('div');
+    userDropdownWrapper.__x = { $data: { open: true } };
+    userDropdownWrapper.setAttribute('x-data', '');
+    const accountSettingsBtn = document.createElement('a');
+    accountSettingsBtn.id = 'accountSettingsBtn';
+    accountSettingsBtn.href = '#';
+    userDropdownWrapper.appendChild(accountSettingsBtn);
+    document.body.appendChild(userDropdownWrapper);
+
+    // Settings back button
+    const settingsBackBtn = document.createElement('button');
+    settingsBackBtn.id = 'settingsBackBtn';
+    document.body.appendChild(settingsBackBtn);
 }
 
 /**
@@ -305,6 +320,10 @@ function setupGlobalMocks() {
     };
 
     window.searchPane = { focus: vi.fn() };
+
+    window.settingsPane = {
+        init: vi.fn(),
+    };
 
     window.UserPanes = class {
         loadCollection = vi.fn();
@@ -1785,6 +1804,55 @@ describe('ExploreApp helper methods', () => {
             app._switchPane('credits');
 
             expect(window.creditsPanel.load).toHaveBeenCalled();
+        });
+
+        it('should call settingsPane.init when switching to settings', () => {
+            const app = new ExploreApp();
+            app._switchPane('settings');
+
+            expect(window.settingsPane.init).toHaveBeenCalled();
+        });
+    });
+
+    describe('Account settings button', () => {
+        it('should switch to settings pane on click', () => {
+            const app = new ExploreApp();
+            app._switchPane('explore');
+
+            document.getElementById('accountSettingsBtn').click();
+
+            expect(app.activePane).toBe('settings');
+            expect(window.settingsPane.init).toHaveBeenCalled();
+        });
+
+        it('should store previous pane for back navigation', () => {
+            const app = new ExploreApp();
+            app._switchPane('trends');
+
+            document.getElementById('accountSettingsBtn').click();
+
+            expect(app._previousPane).toBe('trends');
+        });
+    });
+
+    describe('Settings back button', () => {
+        it('should return to previous pane on click', () => {
+            const app = new ExploreApp();
+            app._switchPane('trends');
+            document.getElementById('accountSettingsBtn').click();
+
+            document.getElementById('settingsBackBtn').click();
+
+            expect(app.activePane).toBe('trends');
+        });
+
+        it('should default to explore pane when no previous pane', () => {
+            const app = new ExploreApp();
+            app._switchPane('settings');
+
+            document.getElementById('settingsBackBtn').click();
+
+            expect(app.activePane).toBe('explore');
         });
     });
 

--- a/explore/__tests__/auth.test.js
+++ b/explore/__tests__/auth.test.js
@@ -135,6 +135,19 @@ describe('AuthManager', () => {
         });
     });
 
+    describe('updateTotpEnabled', () => {
+        it('should update totp_enabled on user object', () => {
+            window.authManager.setUser({ id: 1, email: 'test@example.com', totp_enabled: false });
+            window.authManager.updateTotpEnabled(true);
+            expect(window.authManager.getUser().totp_enabled).toBe(true);
+        });
+
+        it('should be safe to call when no user is set', () => {
+            window.authManager.updateTotpEnabled(true);
+            expect(window.authManager.getUser()).toBeNull();
+        });
+    });
+
     describe('init', () => {
         it('should return false and stay logged out when no token', async () => {
             const result = await window.authManager.init();

--- a/explore/__tests__/settings.test.js
+++ b/explore/__tests__/settings.test.js
@@ -1,0 +1,676 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { loadScript } from './helpers.js';
+
+// Mock QRCode global
+globalThis.QRCode = vi.fn();
+QRCode.CorrectLevel = { M: 1 };
+
+function setupSettingsDOM() {
+    document.body.textContent = '';
+
+    // Profile elements
+    for (const id of ['settingsEmail', 'settingsCreatedAt', 'settingsDiscogsStatus']) {
+        const el = document.createElement('div');
+        el.id = id;
+        document.body.appendChild(el);
+    }
+
+    // Password form
+    for (const id of ['settingsCurrentPassword', 'settingsNewPassword', 'settingsConfirmPassword']) {
+        const inp = document.createElement('input');
+        inp.id = id;
+        inp.type = 'password';
+        document.body.appendChild(inp);
+    }
+
+    // Password messages
+    for (const id of ['passwordChangeError', 'passwordChangeSuccess']) {
+        const el = document.createElement('div');
+        el.id = id;
+        el.classList.add('hidden');
+        document.body.appendChild(el);
+    }
+
+    // Change password button
+    const btn = document.createElement('button');
+    btn.id = 'changePasswordBtn';
+    document.body.appendChild(btn);
+
+    // 2FA container
+    const twoFa = document.createElement('div');
+    twoFa.id = 'twoFactorContent';
+    document.body.appendChild(twoFa);
+}
+
+function setupMocks() {
+    window.authManager = {
+        getUser: vi.fn().mockReturnValue({ id: 1, email: 'user@test.com', totp_enabled: false }),
+        getDiscogsStatus: vi.fn().mockReturnValue(null),
+        getToken: vi.fn().mockReturnValue('test-token'),
+        updateTotpEnabled: vi.fn(),
+    };
+
+    window.apiClient = {
+        changePassword: vi.fn().mockResolvedValue({ ok: true }),
+        twoFactorSetup: vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ secret: 'JBSWY3DPEHPK3PXP', provisioning_uri: 'otpauth://totp/test' }),
+        }),
+        twoFactorConfirm: vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ recovery_codes: ['code1', 'code2', 'code3', 'code4'] }),
+        }),
+        twoFactorDisable: vi.fn().mockResolvedValue({ ok: true }),
+    };
+}
+
+describe('SettingsPane', () => {
+    beforeEach(() => {
+        delete globalThis.window;
+        globalThis.window = globalThis;
+        setupSettingsDOM();
+        setupMocks();
+        QRCode.mockClear();
+        loadScript('settings.js');
+    });
+
+    // ------------------------------------------------------------------ //
+    // Constructor
+    // ------------------------------------------------------------------ //
+
+    describe('constructor', () => {
+        it('should initialize with default state', () => {
+            const pane = window.settingsPane;
+            expect(pane._initialized).toBe(false);
+            expect(pane._twoFaState).toBe('disabled');
+            expect(pane._setupData).toBeNull();
+            expect(pane._recoveryCodes).toBeNull();
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // init
+    // ------------------------------------------------------------------ //
+
+    describe('init', () => {
+        it('should call _loadProfile and _renderTwoFaState', () => {
+            const pane = window.settingsPane;
+            const loadSpy = vi.spyOn(pane, '_loadProfile');
+            const renderSpy = vi.spyOn(pane, '_renderTwoFaState');
+
+            pane.init();
+
+            expect(loadSpy).toHaveBeenCalled();
+            expect(renderSpy).toHaveBeenCalled();
+        });
+
+        it('should bind events only once', () => {
+            const pane = window.settingsPane;
+            const bindSpy = vi.spyOn(pane, '_bindEvents');
+
+            pane.init();
+            expect(bindSpy).toHaveBeenCalledTimes(1);
+            expect(pane._initialized).toBe(true);
+
+            pane.init();
+            expect(bindSpy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // _loadProfile
+    // ------------------------------------------------------------------ //
+
+    describe('_loadProfile', () => {
+        it('should populate email', () => {
+            window.settingsPane.init();
+            expect(document.getElementById('settingsEmail').textContent).toBe('user@test.com');
+        });
+
+        it('should format created_at date', () => {
+            window.authManager.getUser.mockReturnValue({
+                id: 1, email: 'user@test.com', created_at: '2024-06-15T10:30:00Z', totp_enabled: false,
+            });
+            window.settingsPane.init();
+            const text = document.getElementById('settingsCreatedAt').textContent;
+            // Date should contain "June" and "2024" regardless of locale
+            expect(text).toContain('2024');
+        });
+
+        it('should show empty string when no created_at', () => {
+            window.authManager.getUser.mockReturnValue({ id: 1, email: 'user@test.com', totp_enabled: false });
+            window.settingsPane.init();
+            expect(document.getElementById('settingsCreatedAt').textContent).toBe('');
+        });
+
+        it('should show Discogs connected badge when connected', () => {
+            window.authManager.getDiscogsStatus.mockReturnValue({ connected: true, username: 'dj_test' });
+            window.settingsPane.init();
+            const el = document.getElementById('settingsDiscogsStatus');
+            const badge = el.querySelector('.twofa-badge-enabled');
+            expect(badge).not.toBeNull();
+            expect(badge.textContent).toBe('Connected');
+        });
+
+        it('should show Discogs username when available', () => {
+            window.authManager.getDiscogsStatus.mockReturnValue({ connected: true, username: 'dj_test' });
+            window.settingsPane.init();
+            const el = document.getElementById('settingsDiscogsStatus');
+            expect(el.textContent).toContain('dj_test');
+        });
+
+        it('should show "Not connected" when Discogs not connected', () => {
+            window.authManager.getDiscogsStatus.mockReturnValue(null);
+            window.settingsPane.init();
+            expect(document.getElementById('settingsDiscogsStatus').textContent).toBe('Not connected');
+        });
+
+        it('should derive totp_enabled = true as enabled state', () => {
+            window.authManager.getUser.mockReturnValue({ id: 1, email: 'user@test.com', totp_enabled: true });
+            window.settingsPane.init();
+            expect(window.settingsPane._twoFaState).toBe('enabled');
+        });
+
+        it('should derive totp_enabled = false as disabled state', () => {
+            window.authManager.getUser.mockReturnValue({ id: 1, email: 'user@test.com', totp_enabled: false });
+            window.settingsPane.init();
+            expect(window.settingsPane._twoFaState).toBe('disabled');
+        });
+
+        it('should return early when no user', () => {
+            window.authManager.getUser.mockReturnValue(null);
+            window.settingsPane.init();
+            expect(document.getElementById('settingsEmail').textContent).toBe('');
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // _handleChangePassword
+    // ------------------------------------------------------------------ //
+
+    describe('_handleChangePassword', () => {
+        it('should show error when current password is empty', async () => {
+            window.settingsPane.init();
+            document.getElementById('settingsCurrentPassword').value = '';
+
+            await window.settingsPane._handleChangePassword();
+
+            expect(document.getElementById('passwordChangeError').textContent).toBe('Current password is required');
+        });
+
+        it('should show error when new password is too short', async () => {
+            window.settingsPane.init();
+            document.getElementById('settingsCurrentPassword').value = 'oldpass';
+            document.getElementById('settingsNewPassword').value = 'short';
+            document.getElementById('settingsConfirmPassword').value = 'short';
+
+            await window.settingsPane._handleChangePassword();
+
+            expect(document.getElementById('passwordChangeError').textContent).toBe('New password must be at least 8 characters');
+        });
+
+        it('should show error when passwords do not match', async () => {
+            window.settingsPane.init();
+            document.getElementById('settingsCurrentPassword').value = 'oldpass';
+            document.getElementById('settingsNewPassword').value = 'newpassword1';
+            document.getElementById('settingsConfirmPassword').value = 'newpassword2';
+
+            await window.settingsPane._handleChangePassword();
+
+            expect(document.getElementById('passwordChangeError').textContent).toBe('Passwords do not match');
+        });
+
+        it('should show success and clear form on successful change', async () => {
+            window.settingsPane.init();
+            document.getElementById('settingsCurrentPassword').value = 'oldpass';
+            document.getElementById('settingsNewPassword').value = 'newpassword1';
+            document.getElementById('settingsConfirmPassword').value = 'newpassword1';
+
+            await window.settingsPane._handleChangePassword();
+
+            expect(document.getElementById('passwordChangeSuccess').textContent).toBe('Password changed successfully');
+            expect(document.getElementById('settingsCurrentPassword').value).toBe('');
+            expect(document.getElementById('settingsNewPassword').value).toBe('');
+            expect(document.getElementById('settingsConfirmPassword').value).toBe('');
+        });
+
+        it('should show API error detail on failure', async () => {
+            window.apiClient.changePassword.mockResolvedValue({
+                ok: false,
+                json: async () => ({ detail: 'Incorrect password' }),
+            });
+            window.settingsPane.init();
+            document.getElementById('settingsCurrentPassword').value = 'wrong';
+            document.getElementById('settingsNewPassword').value = 'newpassword1';
+            document.getElementById('settingsConfirmPassword').value = 'newpassword1';
+
+            await window.settingsPane._handleChangePassword();
+
+            expect(document.getElementById('passwordChangeError').textContent).toBe('Incorrect password');
+        });
+
+        it('should show generic error on API failure without detail', async () => {
+            window.apiClient.changePassword.mockResolvedValue({
+                ok: false,
+                json: async () => ({}),
+            });
+            window.settingsPane.init();
+            document.getElementById('settingsCurrentPassword').value = 'wrong';
+            document.getElementById('settingsNewPassword').value = 'newpassword1';
+            document.getElementById('settingsConfirmPassword').value = 'newpassword1';
+
+            await window.settingsPane._handleChangePassword();
+
+            expect(document.getElementById('passwordChangeError').textContent).toBe('Failed to change password');
+        });
+
+        it('should show network error on fetch failure', async () => {
+            window.apiClient.changePassword.mockRejectedValue(new Error('Network error'));
+            window.settingsPane.init();
+            document.getElementById('settingsCurrentPassword').value = 'old';
+            document.getElementById('settingsNewPassword').value = 'newpassword1';
+            document.getElementById('settingsConfirmPassword').value = 'newpassword1';
+
+            await window.settingsPane._handleChangePassword();
+
+            expect(document.getElementById('passwordChangeError').textContent).toBe('Network error — please try again');
+        });
+
+        it('should show error when not authenticated', async () => {
+            window.authManager.getToken.mockReturnValue(null);
+            window.settingsPane.init();
+            document.getElementById('settingsCurrentPassword').value = 'old';
+            document.getElementById('settingsNewPassword').value = 'newpassword1';
+            document.getElementById('settingsConfirmPassword').value = 'newpassword1';
+
+            await window.settingsPane._handleChangePassword();
+
+            expect(document.getElementById('passwordChangeError').textContent).toBe('Not authenticated');
+        });
+
+        it('should re-enable button after completion', async () => {
+            window.settingsPane.init();
+            document.getElementById('settingsCurrentPassword').value = 'old';
+            document.getElementById('settingsNewPassword').value = 'newpassword1';
+            document.getElementById('settingsConfirmPassword').value = 'newpassword1';
+
+            await window.settingsPane._handleChangePassword();
+
+            expect(document.getElementById('changePasswordBtn').disabled).toBe(false);
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // 2FA state: disabled
+    // ------------------------------------------------------------------ //
+
+    describe('2FA state: disabled', () => {
+        it('should render disabled badge and enable button', () => {
+            window.settingsPane.init();
+            const container = document.getElementById('twoFactorContent');
+            const badge = container.querySelector('.twofa-badge-disabled');
+            expect(badge).not.toBeNull();
+            expect(badge.textContent).toBe('Disabled');
+            expect(container.textContent).toContain('Enable 2FA');
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // 2FA state: enabled
+    // ------------------------------------------------------------------ //
+
+    describe('2FA state: enabled', () => {
+        it('should render enabled badge and disable button', () => {
+            window.authManager.getUser.mockReturnValue({ id: 1, email: 'user@test.com', totp_enabled: true });
+            window.settingsPane.init();
+            const container = document.getElementById('twoFactorContent');
+            const badge = container.querySelector('.twofa-badge-enabled');
+            expect(badge).not.toBeNull();
+            expect(badge.textContent).toBe('Enabled');
+            expect(container.textContent).toContain('Disable 2FA');
+        });
+
+        it('should transition to disableConfirm on disable button click', () => {
+            window.authManager.getUser.mockReturnValue({ id: 1, email: 'user@test.com', totp_enabled: true });
+            window.settingsPane.init();
+            const container = document.getElementById('twoFactorContent');
+            const disableBtn = container.querySelector('.btn-danger');
+            disableBtn.click();
+
+            expect(window.settingsPane._twoFaState).toBe('disableConfirm');
+            // Should now show the disable confirm UI
+            expect(container.textContent).toContain('Authenticator Code');
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // 2FA state: setup
+    // ------------------------------------------------------------------ //
+
+    describe('2FA state: setup', () => {
+        it('should render QR code, manual secret, and TOTP inputs after _startSetup', async () => {
+            window.settingsPane.init();
+
+            await window.settingsPane._startSetup();
+
+            const container = document.getElementById('twoFactorContent');
+            expect(QRCode).toHaveBeenCalled();
+            expect(container.textContent).toContain('JBSWY3DPEHPK3PXP');
+            expect(container.textContent).toContain('Verify & Enable');
+            expect(container.textContent).toContain('Cancel');
+        });
+
+        it('should show 6 TOTP input fields', async () => {
+            window.settingsPane.init();
+            await window.settingsPane._startSetup();
+
+            const inputs = document.querySelectorAll('[data-setup-totp]');
+            expect(inputs.length).toBe(6);
+        });
+
+        it('should cancel setup and return to disabled', async () => {
+            window.settingsPane.init();
+            await window.settingsPane._startSetup();
+
+            const container = document.getElementById('twoFactorContent');
+            const cancelBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'Cancel');
+            cancelBtn.click();
+
+            expect(window.settingsPane._twoFaState).toBe('disabled');
+            expect(window.settingsPane._setupData).toBeNull();
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // 2FA state: recovery
+    // ------------------------------------------------------------------ //
+
+    describe('2FA state: recovery', () => {
+        async function setupRecoveryState() {
+            window.settingsPane.init();
+            await window.settingsPane._startSetup();
+
+            // Fill TOTP inputs
+            const inputs = document.querySelectorAll('[data-setup-totp]');
+            '123456'.split('').forEach((d, i) => { inputs[i].value = d; });
+
+            await window.settingsPane._confirmSetup();
+        }
+
+        it('should render warning, codes grid, and buttons', async () => {
+            await setupRecoveryState();
+            const container = document.getElementById('twoFactorContent');
+            expect(container.textContent).toContain('Save these recovery codes');
+            expect(container.textContent).toContain('code1');
+            expect(container.textContent).toContain('code4');
+            expect(container.textContent).toContain('Copy Codes');
+            expect(container.textContent).toContain("I've Saved My Codes");
+        });
+
+        it('should call updateTotpEnabled(true) on confirm', async () => {
+            await setupRecoveryState();
+            expect(window.authManager.updateTotpEnabled).toHaveBeenCalledWith(true);
+        });
+
+        it('should transition to enabled when done button is clicked', async () => {
+            await setupRecoveryState();
+            const container = document.getElementById('twoFactorContent');
+            const doneBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent === "I've Saved My Codes");
+            doneBtn.click();
+
+            expect(window.settingsPane._twoFaState).toBe('enabled');
+            expect(window.settingsPane._recoveryCodes).toBeNull();
+        });
+
+        it('should copy codes when copy button is clicked', async () => {
+            const writeTextMock = vi.fn().mockResolvedValue(undefined);
+            navigator.clipboard = { writeText: writeTextMock };
+
+            await setupRecoveryState();
+            const container = document.getElementById('twoFactorContent');
+            const copyBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent.includes('Copy'));
+            copyBtn.click();
+
+            expect(writeTextMock).toHaveBeenCalledWith('code1\ncode2\ncode3\ncode4');
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // 2FA state: disableConfirm
+    // ------------------------------------------------------------------ //
+
+    describe('2FA state: disableConfirm', () => {
+        function enterDisableConfirm() {
+            window.authManager.getUser.mockReturnValue({ id: 1, email: 'user@test.com', totp_enabled: true });
+            window.settingsPane.init();
+            // Click disable button to enter disableConfirm state
+            const disableBtn = document.getElementById('twoFactorContent').querySelector('.btn-danger');
+            disableBtn.click();
+        }
+
+        it('should render TOTP inputs, password field, and buttons', () => {
+            enterDisableConfirm();
+            const container = document.getElementById('twoFactorContent');
+            expect(container.textContent).toContain('Authenticator Code');
+            expect(container.textContent).toContain('Password');
+            expect(document.getElementById('disableTotpPassword')).not.toBeNull();
+            expect(container.textContent).toContain('Disable 2FA');
+            expect(container.textContent).toContain('Cancel');
+        });
+
+        it('should cancel and return to enabled state', () => {
+            enterDisableConfirm();
+            const container = document.getElementById('twoFactorContent');
+            const cancelBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'Cancel');
+            cancelBtn.click();
+
+            expect(window.settingsPane._twoFaState).toBe('enabled');
+        });
+
+        it('should render 6 disable TOTP inputs', () => {
+            enterDisableConfirm();
+            const inputs = document.querySelectorAll('[data-disable-totp]');
+            expect(inputs.length).toBe(6);
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // _startSetup
+    // ------------------------------------------------------------------ //
+
+    describe('_startSetup', () => {
+        it('should transition to setup state on success', async () => {
+            window.settingsPane.init();
+            await window.settingsPane._startSetup();
+
+            expect(window.settingsPane._twoFaState).toBe('setup');
+            expect(window.settingsPane._setupData).toEqual({
+                secret: 'JBSWY3DPEHPK3PXP',
+                provisioning_uri: 'otpauth://totp/test',
+            });
+        });
+
+        it('should show error on API failure', async () => {
+            window.apiClient.twoFactorSetup.mockResolvedValue({
+                ok: false,
+                json: async () => ({ detail: 'Setup failed' }),
+            });
+            window.settingsPane.init();
+            await window.settingsPane._startSetup();
+
+            const container = document.getElementById('twoFactorContent');
+            expect(container.textContent).toContain('Setup failed');
+            expect(window.settingsPane._twoFaState).toBe('disabled');
+        });
+
+        it('should do nothing when not authenticated', async () => {
+            window.authManager.getToken.mockReturnValue(null);
+            window.settingsPane.init();
+            await window.settingsPane._startSetup();
+
+            expect(window.apiClient.twoFactorSetup).not.toHaveBeenCalled();
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // _confirmSetup
+    // ------------------------------------------------------------------ //
+
+    describe('_confirmSetup', () => {
+        async function enterSetupState() {
+            window.settingsPane.init();
+            await window.settingsPane._startSetup();
+        }
+
+        it('should transition to recovery on valid code', async () => {
+            await enterSetupState();
+            const inputs = document.querySelectorAll('[data-setup-totp]');
+            '123456'.split('').forEach((d, i) => { inputs[i].value = d; });
+
+            await window.settingsPane._confirmSetup();
+
+            expect(window.settingsPane._twoFaState).toBe('recovery');
+            expect(window.authManager.updateTotpEnabled).toHaveBeenCalledWith(true);
+        });
+
+        it('should show error on invalid code format', async () => {
+            await enterSetupState();
+            // Leave inputs empty
+
+            await window.settingsPane._confirmSetup();
+
+            expect(document.getElementById('setupTotpError').textContent).toBe('Please enter a 6-digit code');
+        });
+
+        it('should show API error on failure', async () => {
+            window.apiClient.twoFactorConfirm.mockResolvedValue({
+                ok: false,
+                json: async () => ({ detail: 'Wrong TOTP code' }),
+            });
+            await enterSetupState();
+            const inputs = document.querySelectorAll('[data-setup-totp]');
+            '123456'.split('').forEach((d, i) => { inputs[i].value = d; });
+
+            await window.settingsPane._confirmSetup();
+
+            expect(document.getElementById('setupTotpError').textContent).toBe('Wrong TOTP code');
+        });
+
+        it('should show network error on exception', async () => {
+            window.apiClient.twoFactorConfirm.mockRejectedValue(new Error('fail'));
+            await enterSetupState();
+            const inputs = document.querySelectorAll('[data-setup-totp]');
+            '123456'.split('').forEach((d, i) => { inputs[i].value = d; });
+
+            await window.settingsPane._confirmSetup();
+
+            expect(document.getElementById('setupTotpError').textContent).toBe('Network error — please try again');
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // _handleDisable
+    // ------------------------------------------------------------------ //
+
+    describe('_handleDisable', () => {
+        function enterDisableConfirm() {
+            window.authManager.getUser.mockReturnValue({ id: 1, email: 'user@test.com', totp_enabled: true });
+            window.settingsPane.init();
+            const disableBtn = document.getElementById('twoFactorContent').querySelector('.btn-danger');
+            disableBtn.click();
+        }
+
+        it('should transition to disabled on success', async () => {
+            enterDisableConfirm();
+            const inputs = document.querySelectorAll('[data-disable-totp]');
+            '654321'.split('').forEach((d, i) => { inputs[i].value = d; });
+            document.getElementById('disableTotpPassword').value = 'mypassword';
+
+            await window.settingsPane._handleDisable();
+
+            expect(window.settingsPane._twoFaState).toBe('disabled');
+            expect(window.authManager.updateTotpEnabled).toHaveBeenCalledWith(false);
+        });
+
+        it('should show error when password is missing', async () => {
+            enterDisableConfirm();
+            const inputs = document.querySelectorAll('[data-disable-totp]');
+            '654321'.split('').forEach((d, i) => { inputs[i].value = d; });
+            document.getElementById('disableTotpPassword').value = '';
+
+            await window.settingsPane._handleDisable();
+
+            expect(document.getElementById('disableTotpError').textContent).toBe('Password is required');
+        });
+
+        it('should show error when TOTP code is incomplete', async () => {
+            enterDisableConfirm();
+            document.getElementById('disableTotpPassword').value = 'mypassword';
+
+            await window.settingsPane._handleDisable();
+
+            expect(document.getElementById('disableTotpError').textContent).toBe('Please enter a 6-digit code');
+        });
+
+        it('should show API error on failure', async () => {
+            window.apiClient.twoFactorDisable.mockResolvedValue({
+                ok: false,
+                json: async () => ({ detail: 'Invalid TOTP code' }),
+            });
+            enterDisableConfirm();
+            const inputs = document.querySelectorAll('[data-disable-totp]');
+            '654321'.split('').forEach((d, i) => { inputs[i].value = d; });
+            document.getElementById('disableTotpPassword').value = 'pass';
+
+            await window.settingsPane._handleDisable();
+
+            expect(document.getElementById('disableTotpError').textContent).toBe('Invalid TOTP code');
+        });
+
+        it('should show network error on exception', async () => {
+            window.apiClient.twoFactorDisable.mockRejectedValue(new Error('fail'));
+            enterDisableConfirm();
+            const inputs = document.querySelectorAll('[data-disable-totp]');
+            '654321'.split('').forEach((d, i) => { inputs[i].value = d; });
+            document.getElementById('disableTotpPassword').value = 'pass';
+
+            await window.settingsPane._handleDisable();
+
+            expect(document.getElementById('disableTotpError').textContent).toBe('Network error — please try again');
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // TOTP helpers
+    // ------------------------------------------------------------------ //
+
+    describe('TOTP helpers', () => {
+        it('_collectTotpCode should return joined 6-digit string', async () => {
+            window.settingsPane.init();
+            await window.settingsPane._startSetup();
+
+            const inputs = document.querySelectorAll('[data-setup-totp]');
+            '789012'.split('').forEach((d, i) => { inputs[i].value = d; });
+
+            const code = window.settingsPane._collectTotpCode('setupTotp');
+            expect(code).toBe('789012');
+        });
+
+        it('_clearTotpInputs should clear all inputs', async () => {
+            window.settingsPane.init();
+            await window.settingsPane._startSetup();
+
+            const inputs = document.querySelectorAll('[data-setup-totp]');
+            '123456'.split('').forEach((d, i) => { inputs[i].value = d; });
+
+            window.settingsPane._clearTotpInputs('setupTotp');
+            inputs.forEach(inp => expect(inp.value).toBe(''));
+        });
+
+        it('_camelToKebab should convert camelCase to kebab-case', () => {
+            expect(window.settingsPane._camelToKebab('setupTotp')).toBe('setup-totp');
+            expect(window.settingsPane._camelToKebab('disableTotp')).toBe('disable-totp');
+            expect(window.settingsPane._camelToKebab('myLongName')).toBe('my-long-name');
+        });
+    });
+});

--- a/explore/static/css/styles.css
+++ b/explore/static/css/styles.css
@@ -2335,3 +2335,168 @@
         grid-template-columns: 1fr;
     }
 }
+
+/* ── Settings page ──────────────────────────────────────────────────────── */
+
+.settings-page {
+    max-width: 42rem;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+    overflow-y: auto;
+    height: 100%;
+}
+
+.settings-header {
+    margin-bottom: 1.5rem;
+}
+
+.settings-back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    color: var(--text-mid);
+    font-size: 0.875rem;
+    text-decoration: none;
+    margin-bottom: 0.5rem;
+    transition: color 0.15s;
+}
+
+.settings-back-link:hover {
+    color: var(--text-high);
+}
+
+.settings-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--text-high);
+}
+
+.settings-card {
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    background: var(--card-bg);
+    margin-bottom: 1rem;
+}
+
+.settings-card-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--border-color);
+    color: var(--text-high);
+}
+
+.settings-card-header h3 {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.settings-card-body {
+    padding: 1rem;
+}
+
+.settings-field {
+    display: flex;
+    align-items: baseline;
+    gap: 1rem;
+    padding: 0.375rem 0;
+}
+
+.settings-label {
+    font-size: 0.8125rem;
+    color: var(--text-mid);
+    min-width: 6rem;
+    flex-shrink: 0;
+}
+
+.settings-value {
+    font-size: 0.875rem;
+    color: var(--text-high);
+}
+
+/* 2FA status badges */
+.twofa-badge {
+    display: inline-block;
+    padding: 0.125rem 0.625rem;
+    border-radius: 0.75rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+.twofa-badge-enabled {
+    background: rgba(34, 197, 94, 0.15);
+    color: #22c55e;
+}
+
+.twofa-badge-disabled {
+    background: rgba(239, 68, 68, 0.15);
+    color: #ef4444;
+}
+
+/* 2FA setup — QR code container */
+.twofa-qr-container {
+    display: flex;
+    justify-content: center;
+    margin: 1rem 0;
+}
+
+.twofa-qr-container img,
+.twofa-qr-container canvas {
+    border-radius: 0.5rem;
+    background: white;
+    padding: 0.5rem;
+}
+
+/* 2FA setup — manual secret display */
+.twofa-manual-secret {
+    text-align: center;
+    font-size: 0.75rem;
+    color: var(--text-dim);
+    margin-bottom: 1rem;
+}
+
+.twofa-manual-secret code {
+    font-family: 'JetBrains Mono', monospace;
+    background: var(--inner-bg);
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+    letter-spacing: 0.1em;
+}
+
+/* 2FA setup — TOTP input group */
+.twofa-code-inputs {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+/* Recovery codes grid */
+.recovery-codes-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.375rem 1.5rem;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.875rem;
+    padding: 1rem;
+    background: var(--inner-bg);
+    border-radius: 0.5rem;
+    margin-bottom: 1rem;
+    color: var(--text-high);
+}
+
+/* Recovery codes warning banner */
+.recovery-warning {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    background: rgba(234, 179, 8, 0.1);
+    border: 1px solid rgba(234, 179, 8, 0.3);
+    border-radius: 0.5rem;
+    margin-bottom: 1rem;
+    font-size: 0.8125rem;
+    color: var(--text-high);
+}

--- a/explore/static/index.html
+++ b/explore/static/index.html
@@ -560,6 +560,9 @@ body {
                             <a class="hidden flex items-center px-3 py-1.5 text-sm text-text-mid hover:bg-bg-hover cursor-pointer" href="#" id="syncBtn">
                                 <span class="material-symbols-outlined mr-2" style="font-size:18px">sync</span>Sync Collection
                             </a>
+                            <a class="flex items-center px-3 py-1.5 text-sm text-text-mid hover:bg-bg-hover cursor-pointer" href="#" id="accountSettingsBtn">
+                                <span class="material-symbols-outlined mr-2" style="font-size:18px">settings</span>Account Settings
+                            </a>
                             <hr class="border-border-color my-1">
                             <a class="flex items-center px-3 py-1.5 text-sm text-accent-red hover:bg-bg-hover cursor-pointer" href="#" id="logoutBtn">
                                 <span class="material-symbols-outlined mr-2" style="font-size:18px">logout</span>Logout
@@ -1128,6 +1131,79 @@ body {
             </div>
         </div>
 
+        <!-- Settings pane — account management (no nav tab, activated from dropdown) -->
+        <div class="pane" id="settingsPane">
+            <div class="settings-page">
+                <div class="settings-header">
+                    <a href="#" class="settings-back-link" id="settingsBackBtn">
+                        <span class="material-symbols-outlined" style="font-size:18px">arrow_back</span>
+                        Back
+                    </a>
+                    <h2 class="settings-title">Account Settings</h2>
+                </div>
+
+                <!-- Profile Card -->
+                <div class="settings-card" id="settingsProfileCard">
+                    <div class="settings-card-header">
+                        <span class="material-symbols-outlined">person</span>
+                        <h3>Profile</h3>
+                    </div>
+                    <div class="settings-card-body">
+                        <div class="settings-field">
+                            <label class="settings-label">Email</label>
+                            <div class="settings-value" id="settingsEmail"></div>
+                        </div>
+                        <div class="settings-field">
+                            <label class="settings-label">Member since</label>
+                            <div class="settings-value" id="settingsCreatedAt"></div>
+                        </div>
+                        <div class="settings-field">
+                            <label class="settings-label">Discogs</label>
+                            <div class="settings-value" id="settingsDiscogsStatus"></div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Password Card -->
+                <div class="settings-card" id="settingsPasswordCard">
+                    <div class="settings-card-header">
+                        <span class="material-symbols-outlined">lock</span>
+                        <h3>Change Password</h3>
+                    </div>
+                    <div class="settings-card-body">
+                        <div class="mb-3">
+                            <label for="settingsCurrentPassword" class="settings-label">Current Password</label>
+                            <input type="password" class="form-input-dark" id="settingsCurrentPassword" autocomplete="current-password" placeholder="Enter current password">
+                        </div>
+                        <div class="mb-3">
+                            <label for="settingsNewPassword" class="settings-label">New Password</label>
+                            <input type="password" class="form-input-dark" id="settingsNewPassword" autocomplete="new-password" placeholder="Minimum 8 characters">
+                        </div>
+                        <div class="mb-3">
+                            <label for="settingsConfirmPassword" class="settings-label">Confirm New Password</label>
+                            <input type="password" class="form-input-dark" id="settingsConfirmPassword" autocomplete="new-password" placeholder="Repeat new password">
+                        </div>
+                        <div class="mb-2 min-h-[1.2rem] text-sm text-accent-red" id="passwordChangeError"></div>
+                        <div class="mb-2 min-h-[1.2rem] text-sm text-accent-green hidden" id="passwordChangeSuccess"></div>
+                        <button class="btn-primary" id="changePasswordBtn" type="button">
+                            <span class="material-symbols-outlined mr-1" style="font-size:18px">lock_reset</span>Change Password
+                        </button>
+                    </div>
+                </div>
+
+                <!-- Security Card (2FA) -->
+                <div class="settings-card" id="settingsSecurityCard">
+                    <div class="settings-card-header">
+                        <span class="material-symbols-outlined">shield</span>
+                        <h3>Two-Factor Authentication</h3>
+                    </div>
+                    <div class="settings-card-body" id="twoFactorContent">
+                        <!-- Populated dynamically by settings.js -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
     </div><!-- /.main-content -->
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js" integrity="sha512-CNgIRecGo7nphbeZ04Sc13ka07paqdeTu0WR1IM4kNcpmBAUSHSQX0FslNhTDadL4O5SAGapGt4FodqL8My0mA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
@@ -1144,6 +1220,7 @@ body {
     <script src="js/credits.js"></script>
     <script src="js/theme.js"></script>
     <script src="js/nlq.js"></script>
+    <script src="js/settings.js"></script>
     <script src="js/app.js"></script>
 </body>
 </html>

--- a/explore/static/js/api-client.js
+++ b/explore/static/js/api-client.js
@@ -264,6 +264,15 @@ class ApiClient {
         return response;
     }
 
+    async changePassword(token, currentPassword, newPassword) {
+        const response = await fetch('/api/auth/change-password', {
+            method: 'POST',
+            headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
+        });
+        return response;
+    }
+
     async getMe(token) {
         if (!token) return null;
         const response = await fetch('/api/auth/me', {

--- a/explore/static/js/app.js
+++ b/explore/static/js/app.js
@@ -543,6 +543,31 @@ class ExploreApp {
             this.userPanes.triggerSync();
         });
 
+        // Account Settings button
+        const accountSettingsBtn = document.getElementById('accountSettingsBtn');
+        if (accountSettingsBtn) {
+            accountSettingsBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                this._previousPane = this.activePane;
+                this._switchPane('settings');
+                // Close the dropdown
+                const dropdown = accountSettingsBtn.closest('[x-data]');
+                if (dropdown) {
+                    const data = _alpineData(dropdown);
+                    if (data) data.open = false;
+                }
+            });
+        }
+
+        // Settings back button
+        const settingsBackBtn = document.getElementById('settingsBackBtn');
+        if (settingsBackBtn) {
+            settingsBackBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                this._switchPane(this._previousPane || 'explore');
+            });
+        }
+
         // Collection / wantlist / recommendations refresh (delegated — buttons are rendered dynamically)
         document.getElementById('collectionPane')?.addEventListener('click', (e) => {
             if (e.target.closest('#collectionRefreshBtn')) {
@@ -886,6 +911,8 @@ class ExploreApp {
             window.genreTreeView.load();
         } else if (pane === 'credits' && window.creditsPanel) {
             window.creditsPanel.load();
+        } else if (pane === 'settings') {
+            window.settingsPane.init();
         }
     }
 

--- a/explore/static/js/auth.js
+++ b/explore/static/js/auth.js
@@ -73,6 +73,13 @@ class AuthManager {
         this._listeners.forEach(cb => cb(this.isLoggedIn()));
     }
 
+    /** Update totp_enabled flag without re-fetching from API. */
+    updateTotpEnabled(enabled) {
+        if (this._user) {
+            this._user.totp_enabled = enabled;
+        }
+    }
+
     /**
      * Initialise: if token in storage, validate it by calling /api/auth/me.
      * Returns true if the session is valid.

--- a/explore/static/js/settings.js
+++ b/explore/static/js/settings.js
@@ -1,0 +1,593 @@
+/**
+ * Settings pane controller — account management and 2FA state machine.
+ *
+ * 2FA states: disabled → setup → recovery → enabled
+ *                                enabled → disableConfirm → disabled
+ */
+class SettingsPane {
+    constructor() {
+        this._initialized = false;
+        this._twoFaState = 'disabled'; // disabled | setup | recovery | enabled | disableConfirm
+        this._setupData = null;        // { secret, provisioning_uri } from /api/auth/2fa/setup
+        this._recoveryCodes = null;    // string[] from /api/auth/2fa/confirm
+    }
+
+    /** Called when pane activates. Loads profile, renders 2FA, binds events once. */
+    init() {
+        this._loadProfile();
+        this._renderTwoFaState();
+
+        if (!this._initialized) {
+            this._bindEvents();
+            this._initialized = true;
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // Profile card
+    // ------------------------------------------------------------------ //
+
+    _loadProfile() {
+        const user = window.authManager.getUser();
+        if (!user) return;
+
+        const emailEl = document.getElementById('settingsEmail');
+        if (emailEl) emailEl.textContent = user.email || '';
+
+        const createdEl = document.getElementById('settingsCreatedAt');
+        if (createdEl) {
+            if (user.created_at) {
+                const d = new Date(user.created_at);
+                createdEl.textContent = d.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
+            } else {
+                createdEl.textContent = '';
+            }
+        }
+
+        const discogsEl = document.getElementById('settingsDiscogsStatus');
+        if (discogsEl) {
+            const status = window.authManager.getDiscogsStatus();
+            if (status && status.connected) {
+                discogsEl.textContent = '';
+                const badge = document.createElement('span');
+                badge.className = 'twofa-badge twofa-badge-enabled';
+                badge.textContent = 'Connected';
+                discogsEl.appendChild(badge);
+                if (status.username) {
+                    const username = document.createElement('span');
+                    username.className = 'ml-2 text-text-mid text-sm';
+                    username.textContent = status.username;
+                    discogsEl.appendChild(username);
+                }
+            } else {
+                discogsEl.textContent = 'Not connected';
+            }
+        }
+
+        // Derive initial 2FA state from user data
+        this._twoFaState = user.totp_enabled ? 'enabled' : 'disabled';
+    }
+
+    // ------------------------------------------------------------------ //
+    // Event binding
+    // ------------------------------------------------------------------ //
+
+    _bindEvents() {
+        const changeBtn = document.getElementById('changePasswordBtn');
+        if (changeBtn) {
+            changeBtn.addEventListener('click', () => this._handleChangePassword());
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // Change password
+    // ------------------------------------------------------------------ //
+
+    async _handleChangePassword() {
+        const currentPw = document.getElementById('settingsCurrentPassword');
+        const newPw = document.getElementById('settingsNewPassword');
+        const confirmPw = document.getElementById('settingsConfirmPassword');
+        const errorEl = document.getElementById('passwordChangeError');
+        const successEl = document.getElementById('passwordChangeSuccess');
+
+        errorEl.textContent = '';
+        successEl.textContent = '';
+        successEl.classList.add('hidden');
+
+        const current = currentPw.value;
+        const next = newPw.value;
+        const confirm = confirmPw.value;
+
+        if (!current) { errorEl.textContent = 'Current password is required'; return; }
+        if (!next || next.length < 8) { errorEl.textContent = 'New password must be at least 8 characters'; return; }
+        if (next !== confirm) { errorEl.textContent = 'Passwords do not match'; return; }
+
+        const token = window.authManager.getToken();
+        if (!token) { errorEl.textContent = 'Not authenticated'; return; }
+
+        const btn = document.getElementById('changePasswordBtn');
+        btn.disabled = true;
+
+        try {
+            const response = await window.apiClient.changePassword(token, current, next);
+            if (response.ok) {
+                successEl.textContent = 'Password changed successfully';
+                successEl.classList.remove('hidden');
+                currentPw.value = '';
+                newPw.value = '';
+                confirmPw.value = '';
+            } else {
+                const data = await response.json().catch(() => ({}));
+                errorEl.textContent = data.detail || 'Failed to change password';
+            }
+        } catch {
+            errorEl.textContent = 'Network error — please try again';
+        } finally {
+            btn.disabled = false;
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // 2FA state machine
+    // ------------------------------------------------------------------ //
+
+    _renderTwoFaState() {
+        const container = document.getElementById('twoFactorContent');
+        if (!container) return;
+        container.textContent = '';
+
+        switch (this._twoFaState) {
+            case 'disabled':       this._renderDisabledState(container); break;
+            case 'enabled':        this._renderEnabledState(container); break;
+            case 'setup':          this._renderSetupState(container); break;
+            case 'recovery':       this._renderRecoveryState(container); break;
+            case 'disableConfirm': this._renderDisableConfirmState(container); break;
+        }
+    }
+
+    // -- Disabled state ------------------------------------------------ //
+
+    _renderDisabledState(container) {
+        const row = document.createElement('div');
+        row.className = 'flex items-center justify-between';
+
+        const left = document.createElement('div');
+        const statusLabel = document.createElement('span');
+        statusLabel.className = 'text-sm text-text-mid mr-2';
+        statusLabel.textContent = 'Status:';
+        const badge = document.createElement('span');
+        badge.className = 'twofa-badge twofa-badge-disabled';
+        badge.textContent = 'Disabled';
+        left.appendChild(statusLabel);
+        left.appendChild(badge);
+
+        const btn = document.createElement('button');
+        btn.className = 'btn-primary';
+        btn.type = 'button';
+        const icon = document.createElement('span');
+        icon.className = 'material-symbols-outlined mr-1';
+        icon.style.fontSize = '18px';
+        icon.textContent = 'security';
+        btn.appendChild(icon);
+        btn.appendChild(document.createTextNode('Enable 2FA'));
+        btn.addEventListener('click', () => this._startSetup());
+
+        row.appendChild(left);
+        row.appendChild(btn);
+        container.appendChild(row);
+    }
+
+    // -- Enabled state ------------------------------------------------- //
+
+    _renderEnabledState(container) {
+        const row = document.createElement('div');
+        row.className = 'flex items-center justify-between';
+
+        const left = document.createElement('div');
+        const statusLabel = document.createElement('span');
+        statusLabel.className = 'text-sm text-text-mid mr-2';
+        statusLabel.textContent = 'Status:';
+        const badge = document.createElement('span');
+        badge.className = 'twofa-badge twofa-badge-enabled';
+        badge.textContent = 'Enabled';
+        left.appendChild(statusLabel);
+        left.appendChild(badge);
+
+        const btn = document.createElement('button');
+        btn.className = 'btn-danger';
+        btn.type = 'button';
+        const icon = document.createElement('span');
+        icon.className = 'material-symbols-outlined mr-1';
+        icon.style.fontSize = '18px';
+        icon.textContent = 'shield';
+        btn.appendChild(icon);
+        btn.appendChild(document.createTextNode('Disable 2FA'));
+        btn.addEventListener('click', () => {
+            this._twoFaState = 'disableConfirm';
+            this._renderTwoFaState();
+        });
+
+        row.appendChild(left);
+        row.appendChild(btn);
+        container.appendChild(row);
+    }
+
+    // -- Setup state --------------------------------------------------- //
+
+    _renderSetupState(container) {
+        if (!this._setupData) return;
+
+        // Instructions
+        const instructions = document.createElement('p');
+        instructions.className = 'text-sm text-text-mid mb-3';
+        instructions.textContent = 'Scan the QR code with your authenticator app, then enter the 6-digit code to verify.';
+        container.appendChild(instructions);
+
+        // QR code
+        const qrContainer = document.createElement('div');
+        qrContainer.className = 'twofa-qr-container';
+        container.appendChild(qrContainer);
+        /* global QRCode */
+        new QRCode(qrContainer, {
+            text: this._setupData.provisioning_uri,
+            width: 160,
+            height: 160,
+            colorDark: '#000000',
+            colorLight: '#ffffff',
+            correctLevel: QRCode.CorrectLevel.M,
+        });
+
+        // Manual secret
+        const manualDiv = document.createElement('div');
+        manualDiv.className = 'twofa-manual-secret';
+        const manualLabel = document.createElement('span');
+        manualLabel.textContent = 'Manual entry: ';
+        const codeEl = document.createElement('code');
+        codeEl.textContent = this._setupData.secret;
+        manualDiv.appendChild(manualLabel);
+        manualDiv.appendChild(codeEl);
+        container.appendChild(manualDiv);
+
+        // TOTP 6-digit inputs
+        const inputGroup = document.createElement('div');
+        inputGroup.className = 'twofa-code-inputs';
+        for (let i = 0; i < 6; i++) {
+            const inp = document.createElement('input');
+            inp.type = 'text';
+            inp.inputMode = 'numeric';
+            inp.maxLength = 1;
+            inp.className = 'form-input-dark text-center';
+            inp.style.width = '2.5rem';
+            inp.style.fontSize = '1.25rem';
+            inp.dataset.setupTotp = String(i);
+            inputGroup.appendChild(inp);
+        }
+        container.appendChild(inputGroup);
+        this._bindTotpInputs('setupTotp');
+
+        // Error
+        const errorEl = document.createElement('div');
+        errorEl.className = 'text-sm text-accent-red min-h-[1.2rem] mb-2';
+        errorEl.id = 'setupTotpError';
+        container.appendChild(errorEl);
+
+        // Buttons
+        const btnRow = document.createElement('div');
+        btnRow.className = 'flex gap-2';
+
+        const verifyBtn = document.createElement('button');
+        verifyBtn.className = 'btn-primary';
+        verifyBtn.type = 'button';
+        verifyBtn.textContent = 'Verify & Enable';
+        verifyBtn.addEventListener('click', () => this._confirmSetup());
+
+        const cancelBtn = document.createElement('button');
+        cancelBtn.className = 'btn-secondary';
+        cancelBtn.type = 'button';
+        cancelBtn.textContent = 'Cancel';
+        cancelBtn.addEventListener('click', () => {
+            this._setupData = null;
+            this._twoFaState = 'disabled';
+            this._renderTwoFaState();
+        });
+
+        btnRow.appendChild(verifyBtn);
+        btnRow.appendChild(cancelBtn);
+        container.appendChild(btnRow);
+    }
+
+    // -- Recovery state ------------------------------------------------ //
+
+    _renderRecoveryState(container) {
+        // Warning banner
+        const warning = document.createElement('div');
+        warning.className = 'recovery-warning';
+        const warnIcon = document.createElement('span');
+        warnIcon.className = 'material-symbols-outlined';
+        warnIcon.style.fontSize = '20px';
+        warnIcon.style.color = '#eab308';
+        warnIcon.textContent = 'warning';
+        const warnText = document.createElement('span');
+        warnText.textContent = 'Save these recovery codes in a secure location. Each code can only be used once. If you lose access to your authenticator app, you can use these codes to sign in.';
+        warning.appendChild(warnIcon);
+        warning.appendChild(warnText);
+        container.appendChild(warning);
+
+        // Codes grid
+        const grid = document.createElement('div');
+        grid.className = 'recovery-codes-grid';
+        if (this._recoveryCodes) {
+            for (const code of this._recoveryCodes) {
+                const cell = document.createElement('div');
+                cell.textContent = code;
+                grid.appendChild(cell);
+            }
+        }
+        container.appendChild(grid);
+
+        // Buttons
+        const btnRow = document.createElement('div');
+        btnRow.className = 'flex gap-2';
+
+        const copyBtn = document.createElement('button');
+        copyBtn.className = 'btn-secondary';
+        copyBtn.type = 'button';
+        const copyIcon = document.createElement('span');
+        copyIcon.className = 'material-symbols-outlined mr-1';
+        copyIcon.style.fontSize = '18px';
+        copyIcon.textContent = 'content_copy';
+        copyBtn.appendChild(copyIcon);
+        copyBtn.appendChild(document.createTextNode('Copy Codes'));
+        copyBtn.addEventListener('click', () => {
+            if (this._recoveryCodes) {
+                navigator.clipboard.writeText(this._recoveryCodes.join('\n')).then(() => {
+                    copyBtn.textContent = 'Copied!';
+                    setTimeout(() => {
+                        copyBtn.textContent = '';
+                        const icon2 = document.createElement('span');
+                        icon2.className = 'material-symbols-outlined mr-1';
+                        icon2.style.fontSize = '18px';
+                        icon2.textContent = 'content_copy';
+                        copyBtn.appendChild(icon2);
+                        copyBtn.appendChild(document.createTextNode('Copy Codes'));
+                    }, 2000);
+                });
+            }
+        });
+
+        const doneBtn = document.createElement('button');
+        doneBtn.className = 'btn-primary';
+        doneBtn.type = 'button';
+        doneBtn.textContent = "I've Saved My Codes";
+        doneBtn.addEventListener('click', () => {
+            this._recoveryCodes = null;
+            this._setupData = null;
+            this._twoFaState = 'enabled';
+            this._renderTwoFaState();
+        });
+
+        btnRow.appendChild(copyBtn);
+        btnRow.appendChild(doneBtn);
+        container.appendChild(btnRow);
+    }
+
+    // -- Disable confirm state ----------------------------------------- //
+
+    _renderDisableConfirmState(container) {
+        const instructions = document.createElement('p');
+        instructions.className = 'text-sm text-text-mid mb-3';
+        instructions.textContent = 'Enter your current TOTP code and password to disable two-factor authentication.';
+        container.appendChild(instructions);
+
+        // TOTP inputs
+        const label1 = document.createElement('label');
+        label1.className = 'settings-label mb-1 block';
+        label1.textContent = 'Authenticator Code';
+        container.appendChild(label1);
+
+        const inputGroup = document.createElement('div');
+        inputGroup.className = 'twofa-code-inputs';
+        for (let i = 0; i < 6; i++) {
+            const inp = document.createElement('input');
+            inp.type = 'text';
+            inp.inputMode = 'numeric';
+            inp.maxLength = 1;
+            inp.className = 'form-input-dark text-center';
+            inp.style.width = '2.5rem';
+            inp.style.fontSize = '1.25rem';
+            inp.dataset.disableTotp = String(i);
+            inputGroup.appendChild(inp);
+        }
+        container.appendChild(inputGroup);
+        this._bindTotpInputs('disableTotp');
+
+        // Password
+        const label2 = document.createElement('label');
+        label2.className = 'settings-label mb-1 block';
+        label2.textContent = 'Password';
+        container.appendChild(label2);
+
+        const pwInput = document.createElement('input');
+        pwInput.type = 'password';
+        pwInput.className = 'form-input-dark mb-3';
+        pwInput.id = 'disableTotpPassword';
+        pwInput.autocomplete = 'current-password';
+        pwInput.placeholder = 'Enter your password';
+        container.appendChild(pwInput);
+
+        // Error
+        const errorEl = document.createElement('div');
+        errorEl.className = 'text-sm text-accent-red min-h-[1.2rem] mb-2';
+        errorEl.id = 'disableTotpError';
+        container.appendChild(errorEl);
+
+        // Buttons
+        const btnRow = document.createElement('div');
+        btnRow.className = 'flex gap-2';
+
+        const confirmBtn = document.createElement('button');
+        confirmBtn.className = 'btn-danger';
+        confirmBtn.type = 'button';
+        confirmBtn.textContent = 'Disable 2FA';
+        confirmBtn.addEventListener('click', () => this._handleDisable());
+
+        const cancelBtn = document.createElement('button');
+        cancelBtn.className = 'btn-secondary';
+        cancelBtn.type = 'button';
+        cancelBtn.textContent = 'Cancel';
+        cancelBtn.addEventListener('click', () => {
+            this._twoFaState = 'enabled';
+            this._renderTwoFaState();
+        });
+
+        btnRow.appendChild(confirmBtn);
+        btnRow.appendChild(cancelBtn);
+        container.appendChild(btnRow);
+    }
+
+    // ------------------------------------------------------------------ //
+    // 2FA actions
+    // ------------------------------------------------------------------ //
+
+    async _startSetup() {
+        const token = window.authManager.getToken();
+        if (!token) return;
+
+        try {
+            const response = await window.apiClient.twoFactorSetup(token);
+            if (response.ok) {
+                this._setupData = await response.json();
+                this._twoFaState = 'setup';
+                this._renderTwoFaState();
+            } else {
+                const data = await response.json().catch(() => ({}));
+                // Show a temporary error in the container
+                const container = document.getElementById('twoFactorContent');
+                if (container) {
+                    const err = document.createElement('div');
+                    err.className = 'text-sm text-accent-red';
+                    err.textContent = data.detail || 'Failed to start 2FA setup';
+                    container.appendChild(err);
+                }
+            }
+        } catch {
+            // Network error — ignore silently, button remains clickable
+        }
+    }
+
+    async _confirmSetup() {
+        const code = this._collectTotpCode('setupTotp');
+        const errorEl = document.getElementById('setupTotpError');
+        if (!errorEl) return;
+        errorEl.textContent = '';
+
+        if (code.length !== 6 || !/^\d{6}$/.test(code)) {
+            errorEl.textContent = 'Please enter a 6-digit code';
+            return;
+        }
+
+        const token = window.authManager.getToken();
+        if (!token) { errorEl.textContent = 'Not authenticated'; return; }
+
+        try {
+            const response = await window.apiClient.twoFactorConfirm(token, code);
+            if (response.ok) {
+                const data = await response.json();
+                this._recoveryCodes = data.recovery_codes || [];
+                window.authManager.updateTotpEnabled(true);
+                this._twoFaState = 'recovery';
+                this._renderTwoFaState();
+            } else {
+                const data = await response.json().catch(() => ({}));
+                errorEl.textContent = data.detail || 'Invalid code';
+                this._clearTotpInputs('setupTotp');
+            }
+        } catch {
+            errorEl.textContent = 'Network error — please try again';
+        }
+    }
+
+    async _handleDisable() {
+        const code = this._collectTotpCode('disableTotp');
+        const password = document.getElementById('disableTotpPassword')?.value || '';
+        const errorEl = document.getElementById('disableTotpError');
+        if (!errorEl) return;
+        errorEl.textContent = '';
+
+        if (code.length !== 6 || !/^\d{6}$/.test(code)) {
+            errorEl.textContent = 'Please enter a 6-digit code';
+            return;
+        }
+        if (!password) {
+            errorEl.textContent = 'Password is required';
+            return;
+        }
+
+        const token = window.authManager.getToken();
+        if (!token) { errorEl.textContent = 'Not authenticated'; return; }
+
+        try {
+            const response = await window.apiClient.twoFactorDisable(token, code, password);
+            if (response.ok) {
+                window.authManager.updateTotpEnabled(false);
+                this._twoFaState = 'disabled';
+                this._renderTwoFaState();
+            } else {
+                const data = await response.json().catch(() => ({}));
+                errorEl.textContent = data.detail || 'Failed to disable 2FA';
+                this._clearTotpInputs('disableTotp');
+            }
+        } catch {
+            errorEl.textContent = 'Network error — please try again';
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // TOTP input helpers
+    // ------------------------------------------------------------------ //
+
+    _bindTotpInputs(dataAttr) {
+        const inputs = document.querySelectorAll(`[data-${this._camelToKebab(dataAttr)}]`);
+        inputs.forEach((input, idx) => {
+            input.addEventListener('input', () => {
+                // Accept only digits
+                input.value = input.value.replace(/\D/g, '').slice(0, 1);
+                if (input.value.length === 1 && idx < inputs.length - 1) {
+                    inputs[idx + 1].focus();
+                }
+            });
+            input.addEventListener('keydown', (e) => {
+                if (e.key === 'Backspace' && !input.value && idx > 0) {
+                    inputs[idx - 1].focus();
+                }
+            });
+            input.addEventListener('paste', (e) => {
+                e.preventDefault();
+                const paste = (e.clipboardData || window.clipboardData).getData('text').replace(/\D/g, '').slice(0, 6);
+                for (let i = 0; i < paste.length && i + idx < inputs.length; i++) {
+                    inputs[idx + i].value = paste[i];
+                }
+                const nextIdx = Math.min(idx + paste.length, inputs.length - 1);
+                inputs[nextIdx].focus();
+            });
+        });
+    }
+
+    _collectTotpCode(dataAttr) {
+        const inputs = document.querySelectorAll(`[data-${this._camelToKebab(dataAttr)}]`);
+        return Array.from(inputs).map(i => i.value).join('');
+    }
+
+    _clearTotpInputs(dataAttr) {
+        const inputs = document.querySelectorAll(`[data-${this._camelToKebab(dataAttr)}]`);
+        inputs.forEach(i => { i.value = ''; });
+        if (inputs.length > 0) inputs[0].focus();
+    }
+
+    /** Convert camelCase data attribute name to kebab-case for querySelector. */
+    _camelToKebab(str) {
+        return str.replace(/([A-Z])/g, '-$1').toLowerCase();
+    }
+}
+
+window.settingsPane = new SettingsPane();

--- a/tests/api/test_auth_router.py
+++ b/tests/api/test_auth_router.py
@@ -1121,3 +1121,84 @@ class TestTwoFactorRecoveryEdgeCases:
             },
         )
         assert response.status_code == 401
+
+
+class TestChangePassword:
+    """Tests for POST /api/auth/change-password."""
+
+    def test_change_password_success(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Happy path: correct current password, valid new password."""
+        mock_cur.fetchone = AsyncMock(return_value=make_sample_user_row())
+        response = test_client.post(
+            "/api/auth/change-password",
+            json={"current_password": "testpassword", "new_password": "newpassword123"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["message"] == "Password has been changed"
+        assert mock_cur.execute.call_count >= 2
+        mock_redis.setex.assert_called()
+        redis_call_args = mock_redis.setex.call_args
+        assert redis_call_args[0][0].startswith("password_changed:")
+
+    def test_change_password_wrong_current(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Wrong current password returns 401."""
+        mock_cur.fetchone = AsyncMock(return_value=make_sample_user_row())
+        response = test_client.post(
+            "/api/auth/change-password",
+            json={"current_password": "wrongpassword", "new_password": "newpassword123"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 401
+        assert "Incorrect" in response.json()["detail"]
+
+    def test_change_password_too_short(
+        self,
+        test_client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """New password shorter than 8 characters returns 422 (validation error)."""
+        response = test_client.post(
+            "/api/auth/change-password",
+            json={"current_password": "testpassword", "new_password": "short"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 422
+
+    def test_change_password_unauthenticated(
+        self,
+        test_client: TestClient,
+    ) -> None:
+        """No auth token returns 401."""
+        response = test_client.post(
+            "/api/auth/change-password",
+            json={"current_password": "testpassword", "new_password": "newpassword123"},
+        )
+        assert response.status_code == 401
+
+    def test_change_password_user_not_found(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """User not in DB returns 404."""
+        mock_cur.fetchone = AsyncMock(return_value=None)
+        response = test_client.post(
+            "/api/auth/change-password",
+            json={"current_password": "testpassword", "new_password": "newpassword123"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "User not found"


### PR DESCRIPTION
## Summary

- Add user account settings page accessible from the navbar user dropdown menu (#280, #281)
- **Profile card**: shows email, account creation date, Discogs connection status
- **Password card**: change password form with validation (current + new + confirm)
- **Security card**: full 2FA setup/disable lifecycle with 5-state state machine
- New `POST /api/auth/change-password` backend endpoint with rate limiting and session revocation

## 2FA Flow

The security card manages these states:
1. **Disabled** — "Enable 2FA" button
2. **Setup** — QR code + manual secret + 6-digit verification input
3. **Recovery codes** — one-time display with copy button
4. **Enabled** — "Disable 2FA" button
5. **Disable confirmation** — requires TOTP code + password

## Backend Changes

- `ChangePasswordRequest` model in `api/models.py`
- `POST /api/auth/change-password` endpoint in `api/routers/auth.py` — validates current password, hashes new password, revokes all sessions via Redis (same pattern as password reset)
- 5 new tests in `tests/api/test_auth_router.py`

## Frontend Changes

- New `settings.js` module — settings pane controller with 2FA state machine
- `changePassword()` method added to `api-client.js`
- `updateTotpEnabled()` method added to `auth.js`
- Settings pane HTML + "Account Settings" dropdown link in `index.html`
- Settings page and 2FA card styles in `styles.css`
- Settings pane integration in `app.js`

## Test plan

- [x] All 2749 Python unit tests pass
- [x] All 896 JS tests pass (Vitest)
- [x] Ruff + mypy clean
- [ ] Manual: Login, click user dropdown → Account Settings
- [ ] Manual: Verify profile card shows correct email and creation date
- [ ] Manual: Change password flow (correct current + valid new)
- [ ] Manual: Change password validation (wrong current, too short, mismatch)
- [ ] Manual: 2FA enable flow (QR scan → code entry → recovery codes → enabled state)
- [ ] Manual: 2FA disable flow (code + password → disabled state)

Closes #280, closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)