### PR TITLE
fix: compute content hash post-filter for retroactive filter application

### DIFF
--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -17,7 +17,7 @@ use crate::message_queue::{MessagePublisher, MessageQueue};
 use crate::parser::XmlParser;
 use crate::rules::{CompiledRulesConfig, FlaggedRecordWriter, QualityReport, Severity, apply_filters, evaluate_rules, should_skip_record};
 use crate::state_marker::{PhaseStatus, ProcessingDecision, StateMarker};
-use crate::types::{DataMessage, DataType, ExtractionProgress};
+use crate::types::{DataMessage, DataType, ExtractionProgress, calculate_content_hash};
 
 /// Factory for creating MessagePublisher instances (enables DI for testing)
 #[cfg_attr(feature = "test-support", mockall::automock)]
@@ -605,6 +605,10 @@ pub async fn message_validator(
                 action.removed_count, action.field, data_type, message.id, action.removed_values, action.reason
             );
         }
+
+        // Compute content hash from post-filter data so consumers detect
+        // changes caused by filter updates, not just upstream XML/JSONL changes.
+        message.sha256 = calculate_content_hash(&message.data);
 
         let violations = evaluate_rules(&rules, data_type, &message.data);
         for violation in &violations {

--- a/extractor/src/jsonl_parser.rs
+++ b/extractor/src/jsonl_parser.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context, Result};
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
@@ -98,13 +97,6 @@ pub fn extract_external_links(url_rels: &[Value]) -> Vec<Value> {
         .collect()
 }
 
-/// Compute SHA-256 of the raw line string.
-fn hash_line(line: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(line.as_bytes());
-    hex::encode(hasher.finalize())
-}
-
 /// Find and return the Discogs numeric ID from a slice of url-rel objects.
 ///
 /// Scans `url_rels` for an entry with `"type": "discogs"` and extracts the
@@ -129,7 +121,7 @@ pub fn parse_mb_artist_line(line: &str) -> Result<DataMessage> {
     let v: Value = serde_json::from_str(line).context("Failed to parse artist JSONL line")?;
 
     let mbid = v["id"].as_str().unwrap_or("unknown").to_string();
-    let sha256 = hash_line(line);
+    let sha256 = String::new();
 
     let all_rels = v["relations"].as_array().map(|a| a.as_slice()).unwrap_or(&[]);
     let url_rels = extract_url_rels(all_rels);
@@ -171,7 +163,7 @@ pub fn parse_mb_label_line(line: &str) -> Result<DataMessage> {
     let v: Value = serde_json::from_str(line).context("Failed to parse label JSONL line")?;
 
     let mbid = v["id"].as_str().unwrap_or("unknown").to_string();
-    let sha256 = hash_line(line);
+    let sha256 = String::new();
 
     let all_rels = v["relations"].as_array().map(|a| a.as_slice()).unwrap_or(&[]);
     let url_rels = extract_url_rels(all_rels);
@@ -207,7 +199,7 @@ pub fn parse_mb_release_line(line: &str) -> Result<DataMessage> {
     let v: Value = serde_json::from_str(line).context("Failed to parse release JSONL line")?;
 
     let mbid = v["id"].as_str().unwrap_or("unknown").to_string();
-    let sha256 = hash_line(line);
+    let sha256 = String::new();
 
     let all_rels = v["relations"].as_array().map(|a| a.as_slice()).unwrap_or(&[]);
     let url_rels = extract_url_rels(all_rels);
@@ -238,7 +230,7 @@ pub fn parse_mb_release_group_line(line: &str) -> Result<DataMessage> {
     let v: Value = serde_json::from_str(line).context("Failed to parse release-group JSONL line")?;
 
     let mbid = v["id"].as_str().unwrap_or("unknown").to_string();
-    let sha256 = hash_line(line);
+    let sha256 = String::new();
 
     let all_rels = v["relations"].as_array().map(|a| a.as_slice()).unwrap_or(&[]);
     let url_rels = extract_url_rels(all_rels);

--- a/extractor/src/parser.rs
+++ b/extractor/src/parser.rs
@@ -3,7 +3,6 @@ use flate2::read::GzDecoder;
 use quick_xml::Reader;
 use quick_xml::events::Event;
 use serde_json::{Map, Value};
-use sha2::{Digest, Sha256};
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
@@ -171,13 +170,12 @@ impl XmlParser {
                         let record = ElementContext::with_attributes(&e).into_value();
                         if let Value::Object(ref obj) = record {
                             let id = obj.get("@id").or_else(|| obj.get("id")).and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
-                            let sha256 = calculate_record_hash(&record);
                             let raw_xml = if self.capture_raw_xml {
                                 Some(reconstruct_xml(target_element, &record))
                             } else {
                                 None
                             };
-                            let message = DataMessage { id, sha256, data: record.clone(), raw_xml };
+                            let message = DataMessage { id, sha256: String::new(), data: record.clone(), raw_xml };
 
                             if self.sender.send(message).await.is_err() {
                                 warn!("⚠️ Receiver dropped, stopping parsing");
@@ -224,13 +222,12 @@ impl XmlParser {
                                 }
 
                                 let final_value = Value::Object(final_obj);
-                                let sha256 = calculate_record_hash(&final_value);
                                 let raw_xml = if self.capture_raw_xml {
                                     Some(reconstruct_xml(target_element, &final_value))
                                 } else {
                                     None
                                 };
-                                let message = DataMessage { id: id.clone(), sha256, data: final_value, raw_xml };
+                                let message = DataMessage { id: id.clone(), sha256: String::new(), data: final_value, raw_xml };
 
                                 if self.sender.send(message).await.is_err() {
                                     warn!("⚠️ Receiver dropped, stopping parsing");
@@ -384,13 +381,6 @@ fn write_element<W: std::io::Write>(writer: &mut quick_xml::Writer<W>, name: &st
         _ => {}
     }
     Ok(())
-}
-
-fn calculate_record_hash(record: &Value) -> String {
-    let json_str = serde_json::to_string(record).unwrap_or_default();
-    let mut hasher = Sha256::new();
-    hasher.update(json_str.as_bytes());
-    hex::encode(hasher.finalize())
 }
 
 #[cfg(test)]

--- a/extractor/src/tests/jsonl_parser_tests.rs
+++ b/extractor/src/tests/jsonl_parser_tests.rs
@@ -141,7 +141,7 @@ fn test_parse_mb_artist_line_with_discogs() {
     assert_eq!(msg.data["area"], "London");
     assert_eq!(msg.data["begin_area"], "Liverpool");
     // sha256 should be non-empty
-    assert!(!msg.sha256.is_empty());
+    assert!(msg.sha256.is_empty(), "Parser should emit empty sha256; content hash is computed post-filter");
     // Check external links include wikipedia but not discogs
     let links = msg.data["external_links"].as_array().unwrap();
     assert_eq!(links.len(), 1);
@@ -258,7 +258,7 @@ fn test_parse_mb_release_group_line_with_discogs() {
     assert_eq!(msg.data["mb_type"], "Album");
     assert_eq!(msg.data["secondary_types"], serde_json::json!(["Compilation"]));
     assert_eq!(msg.data["first_release_date"], "1969-09-26");
-    assert!(!msg.sha256.is_empty());
+    assert!(msg.sha256.is_empty(), "Parser should emit empty sha256; content hash is computed post-filter");
     let links = msg.data["external_links"].as_array().unwrap();
     assert_eq!(links.len(), 1);
     assert_eq!(links[0]["service"], "wikipedia");

--- a/extractor/src/tests/parser_tests.rs
+++ b/extractor/src/tests/parser_tests.rs
@@ -330,27 +330,6 @@ fn test_element_context_add_child_to_existing_array() {
     assert_eq!(arr.len(), 3);
 }
 
-#[test]
-fn test_calculate_record_hash() {
-    let record = json!({"id": "123", "name": "Test"});
-    let hash1 = calculate_record_hash(&record);
-    let hash2 = calculate_record_hash(&record);
-
-    assert_eq!(hash1, hash2);
-    assert_eq!(hash1.len(), 64); // SHA256 hex string length
-}
-
-#[test]
-fn test_calculate_record_hash_different_records() {
-    let record1 = json!({"id": "123"});
-    let record2 = json!({"id": "456"});
-
-    let hash1 = calculate_record_hash(&record1);
-    let hash2 = calculate_record_hash(&record2);
-
-    assert_ne!(hash1, hash2);
-}
-
 #[tokio::test]
 async fn test_parse_master_with_artists() {
     let xml_content = r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -590,18 +569,6 @@ async fn test_parse_receiver_dropped() {
     assert!(result.is_ok());
     let count = result.unwrap();
     assert!(count < 100, "Should have stopped early due to dropped receiver, got {}", count);
-}
-
-#[test]
-fn test_calculate_record_hash_empty_value() {
-    let null_hash = calculate_record_hash(&Value::Null);
-    assert_eq!(null_hash.len(), 64);
-
-    let empty_obj_hash = calculate_record_hash(&Value::Object(Map::new()));
-    assert_eq!(empty_obj_hash.len(), 64);
-
-    // Null and empty object should produce different hashes
-    assert_ne!(null_hash, empty_obj_hash);
 }
 
 #[tokio::test]

--- a/extractor/src/tests/types_tests.rs
+++ b/extractor/src/tests/types_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serde_json::{Map, json};
 
 #[test]
 fn test_data_type_conversion() {
@@ -236,4 +237,37 @@ fn test_musicbrainz_types() {
     assert!(mb_types.contains(&DataType::Releases));
     // MusicBrainz does not have Masters
     assert!(!mb_types.contains(&DataType::Masters));
+}
+
+#[test]
+fn test_calculate_content_hash_deterministic() {
+    let record = json!({"id": "123", "name": "Test"});
+    let hash1 = calculate_content_hash(&record);
+    let hash2 = calculate_content_hash(&record);
+
+    assert_eq!(hash1, hash2);
+    assert_eq!(hash1.len(), 64); // SHA256 hex string length
+}
+
+#[test]
+fn test_calculate_content_hash_different_records() {
+    let record1 = json!({"id": "123"});
+    let record2 = json!({"id": "456"});
+
+    let hash1 = calculate_content_hash(&record1);
+    let hash2 = calculate_content_hash(&record2);
+
+    assert_ne!(hash1, hash2);
+}
+
+#[test]
+fn test_calculate_content_hash_empty_value() {
+    let null_hash = calculate_content_hash(&serde_json::Value::Null);
+    assert_eq!(null_hash.len(), 64);
+
+    let empty_obj_hash = calculate_content_hash(&serde_json::Value::Object(Map::new()));
+    assert_eq!(empty_obj_hash.len(), 64);
+
+    // Null and empty object should produce different hashes
+    assert_ne!(null_hash, empty_obj_hash);
 }

--- a/extractor/src/types.rs
+++ b/extractor/src/types.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::fmt;
 use std::str::FromStr;
 
@@ -138,6 +139,18 @@ pub enum Message {
     FileComplete(FileCompleteMessage),
     #[serde(rename = "extraction_complete")]
     ExtractionComplete(ExtractionCompleteMessage),
+}
+
+/// Compute SHA-256 hash of a JSON value's serialized form.
+///
+/// Used to produce a content hash from the post-filter data so that
+/// consumers can detect when the *consumer-facing* payload has changed,
+/// even if the upstream source (XML/JSONL) is identical.
+pub fn calculate_content_hash(data: &serde_json::Value) -> String {
+    let json_str = serde_json::to_string(data).unwrap_or_default();
+    let mut hasher = Sha256::new();
+    hasher.update(json_str.as_bytes());
+    hex::encode(hasher.finalize())
 }
 
 /// Data message containing a parsed record

--- a/extractor/tests/parser_test.rs
+++ b/extractor/tests/parser_test.rs
@@ -297,7 +297,9 @@ async fn test_parse_with_whitespace() {
 }
 
 #[tokio::test]
-async fn test_parse_hash_calculation() {
+async fn test_parser_emits_empty_hash() {
+    // The parser no longer computes hashes — that happens post-filter in
+    // message_validator.  Verify the parser outputs empty sha256 placeholders.
     let xml_content = r#"<?xml version="1.0" encoding="UTF-8"?>
 <artists>
     <artist id="1"><name>Artist 1</name></artist>
@@ -317,18 +319,12 @@ async fn test_parse_hash_calculation() {
 
     assert_eq!(count, 2);
 
-    // Collect messages
     let msg1 = receiver.recv().await.unwrap();
     let msg2 = receiver.recv().await.unwrap();
 
-    // Hashes should be different for different content
-    assert_ne!(msg1.sha256, msg2.sha256);
-
-    // Hashes should be non-empty and valid hex
-    assert_eq!(msg1.sha256.len(), 64); // SHA256 produces 64 hex chars
-    assert_eq!(msg2.sha256.len(), 64);
-    assert!(msg1.sha256.chars().all(|c| c.is_ascii_hexdigit()));
-    assert!(msg2.sha256.chars().all(|c| c.is_ascii_hexdigit()));
+    // Parser emits empty sha256; content hash is computed post-filter
+    assert!(msg1.sha256.is_empty());
+    assert!(msg2.sha256.is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Moves SHA-256 hash computation from parsers (pre-filter) to `message_validator` (post-filter) so the hash reflects consumer-facing data after extraction rules are applied
- Adds shared `calculate_content_hash()` in `types.rs`, removes duplicated hash functions from `parser.rs` (`calculate_record_hash`) and `jsonl_parser.rs` (`hash_line`)
- On next extraction run, all records will get new hashes, triggering full consumer re-processing with current filter rules applied retroactively

Closes #291

## Test plan

- [x] All extractor unit tests pass (types, parser, jsonl_parser)
- [x] All extractor integration tests pass (parser_test, rules_integration_test)
- [x] `cargo clippy` clean (no new warnings)
- [ ] Verify on next extraction that consumers re-process all records due to hash changes
- [ ] Confirm filtered fields (e.g., `year=0 → null`) are applied to previously-skipped records

🤖 Generated with [Claude Code](https://claude.ai/claude-code)