### PR TITLE
feat: community have/want enrichment for release rarity scoring

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -255,7 +255,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:  # pragma: no cover
     _label_dna_router.configure(_neo4j, _redis)
     _recommend_router.configure(_neo4j, jwt_secret_for_neo4j, _redis)
     _search_router.configure(_pool, _redis)
-    _insights_compute_router.configure(_neo4j, _pool, _redis)
+    _insights_compute_router.configure(_neo4j, _pool, _redis, _config)
     _admin_router.configure(_pool, _redis, _config, neo4j_driver=_neo4j)
     _musicbrainz_router.configure(_pool, _neo4j)
     _network_router.configure(_neo4j, _redis)

--- a/api/queries/rarity_queries.py
+++ b/api/queries/rarity_queries.py
@@ -385,7 +385,8 @@ async def get_rarity_for_release(pool: Any, release_id: int) -> dict[str, Any] |
             """
             SELECT release_id, title, artist_name, year, rarity_score, tier,
                    hidden_gem_score, pressing_scarcity, label_catalog,
-                   format_rarity, temporal_scarcity, graph_isolation
+                   format_rarity, temporal_scarcity, graph_isolation,
+                   collection_prevalence
             FROM insights.release_rarity
             WHERE release_id = %s
             """,

--- a/api/queries/rarity_queries.py
+++ b/api/queries/rarity_queries.py
@@ -170,11 +170,12 @@ def compute_rarity_tier(score: float) -> str:
 # ── Neo4j batch signal queries ──────────────────────────────────────
 
 
-async def fetch_all_rarity_signals(driver: Any) -> list[dict[str, Any]]:
+async def fetch_all_rarity_signals(driver: Any, pool: Any = None) -> list[dict[str, Any]]:
     """Fetch all rarity signals from Neo4j and compute scores.
 
     Executes 8 batch Cypher queries (5 signal queries + 3 quality queries),
     joins by release_id, and computes composite rarity + hidden gem scores.
+    Optionally fetches community counts (have/want) from PostgreSQL when pool is provided.
 
     Returns a list of dicts ready for PostgreSQL insertion.
     """
@@ -275,6 +276,18 @@ async def fetch_all_rarity_signals(driver: Any) -> list[dict[str, Any]]:
         formats=len(format_rows),
     )
 
+    # 9. Community counts from PostgreSQL (if pool available)
+    community_map: dict[str, tuple[int, int]] = {}
+    if pool is not None:
+        try:
+            async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+                await cur.execute("SELECT release_id, have_count, want_count FROM insights.community_counts")
+                community_rows = await cur.fetchall()
+            community_map = {str(r["release_id"]): (r["have_count"], r["want_count"]) for r in community_rows}
+            logger.info("📊 Community counts loaded", count=len(community_map))
+        except Exception:
+            logger.warning("⚠️ Failed to load community counts, using neutral fallback")
+
     # Build lookup dicts keyed by release_id
     label_map = {r["release_id"]: r["label_catalog_size"] for r in label_rows}
     format_map = {r["release_id"]: r["formats"] for r in format_rows}
@@ -313,12 +326,16 @@ async def fetch_all_rarity_signals(driver: Any) -> list[dict[str, Any]]:
 
         isolation_score = compute_graph_isolation_score(degree_map.get(rid, 0))
 
+        have, want = community_map.get(rid, (None, None))
+        prevalence_score = compute_collection_prevalence_score(have, want or 0) if have is not None else 50.0  # neutral fallback
+
         rarity_score = (
             SIGNAL_WEIGHTS["pressing_scarcity"] * pressing_score
             + SIGNAL_WEIGHTS["label_catalog"] * label_score
             + SIGNAL_WEIGHTS["format_rarity"] * fmt_score
             + SIGNAL_WEIGHTS["temporal_scarcity"] * temporal_score
             + SIGNAL_WEIGHTS["graph_isolation"] * isolation_score
+            + SIGNAL_WEIGHTS["collection_prevalence"] * prevalence_score
         )
 
         tier = compute_rarity_tier(rarity_score)
@@ -350,6 +367,7 @@ async def fetch_all_rarity_signals(driver: Any) -> list[dict[str, Any]]:
                 "format_rarity": fmt_score,
                 "temporal_scarcity": temporal_score,
                 "graph_isolation": isolation_score,
+                "collection_prevalence": prevalence_score,
             }
         )
 

--- a/api/queries/rarity_queries.py
+++ b/api/queries/rarity_queries.py
@@ -1,7 +1,7 @@
 """Rarity scoring queries and computation logic.
 
-Computes a 5-signal rarity index (0-100) for releases using Neo4j graph data,
-and provides PostgreSQL lookup functions for precomputed scores.
+Computes a 6-signal rarity index (0-100) for releases using Neo4j graph data
+and PostgreSQL community counts, and provides lookup functions for precomputed scores.
 
 Graph model:
   (Release)-[:BY]->(Artist)
@@ -286,7 +286,7 @@ async def fetch_all_rarity_signals(driver: Any, pool: Any = None) -> list[dict[s
             community_map = {str(r["release_id"]): (r["have_count"], r["want_count"]) for r in community_rows}
             logger.info("📊 Community counts loaded", count=len(community_map))
         except Exception:
-            logger.warning("⚠️ Failed to load community counts, using neutral fallback")
+            logger.warning("⚠️ Failed to load community counts, using neutral fallback", exc_info=True)
 
     # Build lookup dicts keyed by release_id
     label_map = {r["release_id"]: r["label_catalog_size"] for r in label_rows}

--- a/api/queries/rarity_queries.py
+++ b/api/queries/rarity_queries.py
@@ -27,11 +27,12 @@ logger = structlog.get_logger(__name__)
 # ── Signal weights (must sum to 1.0) ────────────────────────────────
 
 SIGNAL_WEIGHTS: dict[str, float] = {
-    "pressing_scarcity": 0.30,
-    "label_catalog": 0.15,
-    "format_rarity": 0.15,
+    "pressing_scarcity": 0.25,
+    "label_catalog": 0.10,
+    "format_rarity": 0.10,
     "temporal_scarcity": 0.20,
-    "graph_isolation": 0.20,
+    "graph_isolation": 0.15,
+    "collection_prevalence": 0.20,
 }
 
 # ── Format rarity lookup ────────────────────────────────────────────
@@ -131,6 +132,31 @@ def compute_graph_isolation_score(degree: int) -> float:
     if degree <= 12:
         return 30.0
     return 10.0
+
+
+def compute_collection_prevalence_score(have_count: int, want_count: int) -> float:
+    """Score based on community ownership rarity (inverse of prevalence).
+
+    Uses log-scale thresholds since community counts follow power-law distribution.
+    Want > have adds a +5 bonus (capped at 100) indicating scarcity pressure.
+    """
+    if have_count <= 0:
+        base = 95.0
+    elif have_count <= 10:
+        base = 85.0
+    elif have_count <= 100:
+        base = 70.0
+    elif have_count <= 1000:
+        base = 50.0
+    elif have_count <= 10000:
+        base = 25.0
+    else:
+        base = 10.0
+
+    if want_count > have_count:
+        base = min(100.0, base + 5.0)
+
+    return base
 
 
 def compute_rarity_tier(score: float) -> str:

--- a/api/routers/insights_compute.py
+++ b/api/routers/insights_compute.py
@@ -4,13 +4,17 @@ Exposes raw Neo4j and PostgreSQL query results as JSON so the insights
 service can fetch data over HTTP instead of importing query modules directly.
 """
 
+import asyncio
 import json
 from typing import Any
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
+import httpx
+from psycopg.rows import dict_row
 import structlog
 
+from api.auth import decrypt_oauth_token, get_oauth_encryption_key
 from api.limiter import limiter
 from api.queries.insights_neo4j_queries import (
     query_artist_centrality,
@@ -20,6 +24,7 @@ from api.queries.insights_neo4j_queries import (
 )
 from api.queries.insights_pg_queries import query_data_completeness
 from api.queries.rarity_queries import fetch_all_rarity_signals
+from api.syncer import DISCOGS_API_BASE, MAX_RATE_LIMIT_RETRIES, _auth_header
 
 
 logger = structlog.get_logger(__name__)
@@ -29,17 +34,22 @@ router = APIRouter(prefix="/api/internal/insights", tags=["insights-compute"])
 _neo4j: Any = None
 _pool: Any = None
 _redis: Any = None
+_config: Any = None
+
+_ENRICHMENT_DELAY_SECONDS = 1.0  # 1 req/sec to stay under 60 req/min
+_STALENESS_DAYS = 7
 
 # Cache TTL for data-completeness (6 hours — full table scans are very expensive)
 _COMPLETENESS_CACHE_TTL = 21600
 
 
-def configure(neo4j: Any, pool: Any, redis: Any = None) -> None:
+def configure(neo4j: Any, pool: Any, redis: Any = None, config: Any = None) -> None:
     """Configure the insights compute router with database connections."""
-    global _neo4j, _pool, _redis
+    global _neo4j, _pool, _redis, _config
     _neo4j = neo4j
     _pool = pool
     _redis = redis
+    _config = config
 
 
 @router.get("/artist-centrality")
@@ -131,3 +141,159 @@ async def rarity_scores(request: Request) -> JSONResponse:  # noqa: ARG001
         return JSONResponse(content={"error": "Service not ready"}, status_code=503)
     results = await fetch_all_rarity_signals(_neo4j, _pool)
     return JSONResponse(content={"items": results})
+
+
+async def _enrich_community_counts(
+    pool: Any,
+    neo4j: Any,
+    encryption_key: str | None,
+) -> dict[str, Any]:
+    """Fetch community have/want counts from Discogs API for releases in user collections."""
+    # 1. Find releases needing enrichment (new or stale)
+    async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            """
+            SELECT DISTINCT release_id FROM (
+                SELECT release_id FROM user_collections
+                UNION
+                SELECT release_id FROM user_wantlists
+            ) AS combined
+            WHERE release_id NOT IN (
+                SELECT release_id FROM insights.community_counts
+                WHERE fetched_at > NOW() - INTERVAL '%s days'
+            )
+            """,
+            (_STALENESS_DAYS,),
+        )
+        rows = await cur.fetchall()
+        release_ids = [r["release_id"] for r in rows]
+
+    if not release_ids:
+        logger.info("📊 No releases need community enrichment")
+        return {"enriched": 0, "skipped": 0, "errors": 0}
+
+    logger.info("📊 Releases needing community enrichment", count=len(release_ids))
+
+    # 2. Get OAuth credentials (any user with valid Discogs OAuth)
+    async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            """
+            SELECT ot.access_token, ot.access_secret, ot.provider_username
+            FROM oauth_tokens ot
+            WHERE ot.provider = 'discogs'
+            LIMIT 1
+            """
+        )
+        token = await cur.fetchone()
+
+        if not token:
+            logger.warning("⚠️ No Discogs OAuth credentials for community enrichment")
+            return {"enriched": 0, "skipped": len(release_ids), "errors": 0, "error": "no_credentials"}
+
+        access_token = decrypt_oauth_token(token["access_token"], encryption_key)
+        access_secret = decrypt_oauth_token(token["access_secret"], encryption_key)
+
+        await cur.execute("SELECT key, value FROM app_config WHERE key IN ('discogs_consumer_key', 'discogs_consumer_secret')")
+        config_rows = await cur.fetchall()
+        app_config = {r["key"]: r["value"] for r in config_rows}
+        if "discogs_consumer_key" not in app_config or "discogs_consumer_secret" not in app_config:
+            logger.warning("⚠️ Discogs app credentials not configured")
+            return {"enriched": 0, "skipped": len(release_ids), "errors": 0, "error": "no_credentials"}
+        consumer_key = decrypt_oauth_token(app_config["discogs_consumer_key"], encryption_key)
+        consumer_secret = decrypt_oauth_token(app_config["discogs_consumer_secret"], encryption_key)
+
+    # 3. Fetch community counts from Discogs API
+    enriched = 0
+    errors = 0
+    batch: list[dict[str, Any]] = []
+    rate_limit_retries = 0
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        for release_id in release_ids:
+            url = f"{DISCOGS_API_BASE}/releases/{release_id}"
+            auth = _auth_header(
+                "GET",
+                url,
+                consumer_key,
+                consumer_secret,
+                access_token,
+                access_secret,
+            )
+            headers = {
+                "Authorization": auth,
+                "User-Agent": "discogsography/1.0 +https://github.com/SimplicityGuy/discogsography",
+                "Accept": "application/json",
+            }
+
+            response = await client.get(url, headers=headers)
+
+            if response.status_code == 429:
+                rate_limit_retries += 1
+                if rate_limit_retries > MAX_RATE_LIMIT_RETRIES:
+                    logger.error("❌ Rate limit retries exhausted during enrichment")
+                    break
+                logger.warning("⚠️ Rate limited, waiting 60s...", retry=rate_limit_retries)
+                await asyncio.sleep(60)
+                continue
+
+            rate_limit_retries = 0
+
+            if response.status_code != 200:
+                logger.warning("⚠️ Discogs API error for release", release_id=release_id, status=response.status_code)
+                errors += 1
+                await asyncio.sleep(_ENRICHMENT_DELAY_SECONDS)
+                continue
+
+            data = response.json()
+            community = data.get("community", {})
+            have = community.get("have", 0)
+            want = community.get("want", 0)
+
+            # Upsert to PostgreSQL
+            async with pool.connection() as conn, conn.cursor() as cur:
+                await cur.execute(
+                    """
+                    INSERT INTO insights.community_counts (release_id, have_count, want_count, fetched_at)
+                    VALUES (%s, %s, %s, NOW())
+                    ON CONFLICT (release_id) DO UPDATE SET
+                        have_count = EXCLUDED.have_count,
+                        want_count = EXCLUDED.want_count,
+                        fetched_at = NOW()
+                    """,
+                    (release_id, have, want),
+                )
+
+            batch.append({"release_id": release_id, "have": have, "want": want})
+            enriched += 1
+            await asyncio.sleep(_ENRICHMENT_DELAY_SECONDS)
+
+    # 4. Batch update Neo4j Release nodes
+    if batch and neo4j is not None:
+        cypher = """
+        UNWIND $batch AS item
+        MATCH (r:Release {id: toString(item.release_id)})
+        SET r.community_have = item.have,
+            r.community_want = item.want
+        """
+        try:
+            async with neo4j.session() as session:
+                result = await session.run(cypher, {"batch": batch})
+                await result.consume()
+            logger.info("✅ Neo4j Release nodes updated with community counts", count=len(batch))
+        except Exception as e:
+            logger.error("❌ Failed to update Neo4j community counts", error=str(e))
+
+    logger.info("✅ Community enrichment complete", enriched=enriched, errors=errors)
+    return {"enriched": enriched, "skipped": len(release_ids) - enriched - errors, "errors": errors}
+
+
+@router.get("/community-enrichment")
+@limiter.limit("1/minute")
+async def community_enrichment(request: Request) -> JSONResponse:  # noqa: ARG001
+    """Enrich releases in user collections with Discogs community have/want counts."""
+    if not _pool:
+        return JSONResponse(content={"error": "Service not ready"}, status_code=503)
+
+    encryption_key = get_oauth_encryption_key(_config.encryption_master_key) if _config else None
+    result = await _enrich_community_counts(_pool, _neo4j, encryption_key)
+    return JSONResponse(content=result)

--- a/api/routers/insights_compute.py
+++ b/api/routers/insights_compute.py
@@ -129,5 +129,5 @@ async def rarity_scores(request: Request) -> JSONResponse:  # noqa: ARG001
     """Return computed rarity scores for all releases from Neo4j."""
     if not _neo4j:
         return JSONResponse(content={"error": "Service not ready"}, status_code=503)
-    results = await fetch_all_rarity_signals(_neo4j)
+    results = await fetch_all_rarity_signals(_neo4j, _pool)
     return JSONResponse(content={"items": results})

--- a/api/routers/insights_compute.py
+++ b/api/routers/insights_compute.py
@@ -160,7 +160,7 @@ async def _enrich_community_counts(
             ) AS combined
             WHERE release_id NOT IN (
                 SELECT release_id FROM insights.community_counts
-                WHERE fetched_at > NOW() - INTERVAL '%s days'
+                WHERE fetched_at > NOW() - make_interval(days => %s)
             )
             """,
             (_STALENESS_DAYS,),
@@ -208,8 +208,12 @@ async def _enrich_community_counts(
     batch: list[dict[str, Any]] = []
     rate_limit_retries = 0
 
+    exhausted = False
     async with httpx.AsyncClient(timeout=30.0) as client:
         for release_id in release_ids:
+            if exhausted:
+                break
+
             url = f"{DISCOGS_API_BASE}/releases/{release_id}"
             auth = _auth_header(
                 "GET",
@@ -225,18 +229,25 @@ async def _enrich_community_counts(
                 "Accept": "application/json",
             }
 
-            response = await client.get(url, headers=headers)
+            # Retry loop for rate limiting — ensures the same release is retried
+            while True:
+                response = await client.get(url, headers=headers)
 
-            if response.status_code == 429:
-                rate_limit_retries += 1
-                if rate_limit_retries > MAX_RATE_LIMIT_RETRIES:
-                    logger.error("❌ Rate limit retries exhausted during enrichment")
-                    break
-                logger.warning("⚠️ Rate limited, waiting 60s...", retry=rate_limit_retries)
-                await asyncio.sleep(60)
-                continue
+                if response.status_code == 429:
+                    rate_limit_retries += 1
+                    if rate_limit_retries > MAX_RATE_LIMIT_RETRIES:
+                        logger.error("❌ Rate limit retries exhausted during enrichment")
+                        exhausted = True
+                        break
+                    logger.warning("⚠️ Rate limited, waiting 60s...", retry=rate_limit_retries)
+                    await asyncio.sleep(60)
+                    continue
 
-            rate_limit_retries = 0
+                rate_limit_retries = 0
+                break  # Got a non-429 response
+
+            if exhausted:
+                break
 
             if response.status_code != 200:
                 logger.warning("⚠️ Discogs API error for release", release_id=release_id, status=response.status_code)

--- a/docs/superpowers/plans/2026-04-11-community-enrichment-rarity.md
+++ b/docs/superpowers/plans/2026-04-11-community-enrichment-rarity.md
@@ -1,0 +1,1192 @@
+# Community Have/Want Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a 6th "collection prevalence" rarity signal by fetching Discogs community have/want counts for releases in user collections, storing in PostgreSQL + Neo4j, and integrating into the rarity scoring engine.
+
+**Architecture:** New enrichment endpoint in the API service fetches community counts from the Discogs REST API (rate-limited, OAuth-authenticated), stores them in `insights.community_counts` (PostgreSQL) and as Release node properties (Neo4j). The existing rarity computation pipeline is extended with a 6th signal that reads these counts.
+
+**Tech Stack:** Python 3.13+, FastAPI, httpx, psycopg, neo4j async driver, pytest
+
+---
+
+### Task 1: Add PostgreSQL schema for community_counts table
+
+**Files:**
+- Modify: `schema-init/postgres_schema.py:430-443` (insert new table + index after release_rarity indexes, before computation_log)
+- Modify: `schema-init/postgres_schema.py:415-429` (add column to release_rarity table)
+
+- [ ] **Step 1: Add `insights.community_counts` table to `_INSIGHTS_TABLES`**
+
+In `schema-init/postgres_schema.py`, after the `idx_release_rarity_gem` entry (line ~443) and before the `insights.computation_log table` entry (line ~445), insert:
+
+```python
+    (
+        "insights.community_counts table",
+        """
+        CREATE TABLE IF NOT EXISTS insights.community_counts (
+            release_id      BIGINT PRIMARY KEY,
+            have_count      INTEGER NOT NULL DEFAULT 0,
+            want_count      INTEGER NOT NULL DEFAULT 0,
+            fetched_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        """,
+    ),
+    (
+        "idx_community_counts_fetched",
+        "CREATE INDEX IF NOT EXISTS idx_community_counts_fetched ON insights.community_counts (fetched_at)",
+    ),
+```
+
+- [ ] **Step 2: Add `collection_prevalence` column to `insights.release_rarity` table definition**
+
+In the `insights.release_rarity table` CREATE TABLE statement (line ~415-429), add `collection_prevalence REAL` after `graph_isolation REAL`:
+
+```python
+        CREATE TABLE IF NOT EXISTS insights.release_rarity (
+            release_id      BIGINT PRIMARY KEY,
+            title           TEXT,
+            artist_name     TEXT,
+            year            INTEGER,
+            rarity_score    REAL NOT NULL,
+            tier            TEXT NOT NULL,
+            hidden_gem_score REAL,
+            pressing_scarcity REAL,
+            label_catalog   REAL,
+            format_rarity   REAL,
+            temporal_scarcity REAL,
+            graph_isolation REAL,
+            collection_prevalence REAL,
+            computed_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+```
+
+- [ ] **Step 3: Add migration for existing databases**
+
+Since the schema uses `CREATE TABLE IF NOT EXISTS` and existing databases already have the `release_rarity` table without the new column, add an `ALTER TABLE` entry at the end of the insights section (after `idx_genre_trends_genre`, before `_MUSICBRAINZ_TABLES`):
+
+```python
+    (
+        "insights.release_rarity add collection_prevalence",
+        "ALTER TABLE insights.release_rarity ADD COLUMN IF NOT EXISTS collection_prevalence REAL",
+    ),
+```
+
+- [ ] **Step 4: Run schema-init tests**
+
+Run: `cd /Users/Robert/Code/public/discogsography/.claude/worktrees/206-customer-rarity && uv run pytest tests/schema-init/ -v`
+Expected: All existing tests pass (schema entries are validated for syntax)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add schema-init/postgres_schema.py
+git commit -m "feat(schema): add community_counts table and collection_prevalence column (#206)"
+```
+
+---
+
+### Task 2: Add collection prevalence scoring function and update weights
+
+**Files:**
+- Modify: `api/queries/rarity_queries.py:29-35` (update SIGNAL_WEIGHTS)
+- Modify: `api/queries/rarity_queries.py:123-133` (add new scoring function after compute_graph_isolation_score)
+- Test: `tests/api/test_rarity_queries.py`
+
+- [ ] **Step 1: Write failing tests for the new scoring function**
+
+In `tests/api/test_rarity_queries.py`, add after the `TestGraphIsolationScore` class (line ~133) and update the import:
+
+```python
+from api.queries.rarity_queries import (
+    SIGNAL_WEIGHTS,
+    compute_collection_prevalence_score,
+    compute_format_rarity_score,
+    compute_graph_isolation_score,
+    compute_label_catalog_score,
+    compute_pressing_scarcity_score,
+    compute_rarity_tier,
+    compute_temporal_scarcity_score,
+    fetch_all_rarity_signals,
+    get_rarity_by_artist,
+    get_rarity_by_label,
+    get_rarity_for_release,
+    get_rarity_hidden_gems,
+    get_rarity_leaderboard,
+)
+
+
+class TestCollectionPrevalenceScore:
+    def test_zero_have(self) -> None:
+        assert compute_collection_prevalence_score(0, 0) == 95.0
+
+    def test_very_few_have(self) -> None:
+        assert compute_collection_prevalence_score(5, 0) == 85.0
+
+    def test_few_have(self) -> None:
+        assert compute_collection_prevalence_score(50, 0) == 70.0
+
+    def test_moderate_have(self) -> None:
+        assert compute_collection_prevalence_score(500, 0) == 50.0
+
+    def test_many_have(self) -> None:
+        assert compute_collection_prevalence_score(5000, 0) == 25.0
+
+    def test_mass_market(self) -> None:
+        assert compute_collection_prevalence_score(50000, 0) == 10.0
+
+    def test_boundary_1_inclusive(self) -> None:
+        assert compute_collection_prevalence_score(1, 0) == 85.0
+
+    def test_boundary_10_inclusive(self) -> None:
+        assert compute_collection_prevalence_score(10, 0) == 85.0
+
+    def test_boundary_11(self) -> None:
+        assert compute_collection_prevalence_score(11, 0) == 70.0
+
+    def test_boundary_100_inclusive(self) -> None:
+        assert compute_collection_prevalence_score(100, 0) == 70.0
+
+    def test_boundary_101(self) -> None:
+        assert compute_collection_prevalence_score(101, 0) == 50.0
+
+    def test_boundary_1000_inclusive(self) -> None:
+        assert compute_collection_prevalence_score(1000, 0) == 50.0
+
+    def test_boundary_1001(self) -> None:
+        assert compute_collection_prevalence_score(1001, 0) == 25.0
+
+    def test_boundary_10000_inclusive(self) -> None:
+        assert compute_collection_prevalence_score(10000, 0) == 25.0
+
+    def test_boundary_10001(self) -> None:
+        assert compute_collection_prevalence_score(10001, 0) == 10.0
+
+    def test_want_bonus_applied(self) -> None:
+        # have=50, want=100 -> base 70.0 + 5.0 bonus = 75.0
+        assert compute_collection_prevalence_score(50, 100) == 75.0
+
+    def test_want_bonus_not_applied_when_want_lte_have(self) -> None:
+        assert compute_collection_prevalence_score(50, 50) == 70.0
+        assert compute_collection_prevalence_score(50, 30) == 70.0
+
+    def test_want_bonus_capped_at_100(self) -> None:
+        # have=0 -> base 95.0 + 5.0 = 100.0, not 105.0
+        assert compute_collection_prevalence_score(0, 10) == 100.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/Robert/Code/public/discogsography/.claude/worktrees/206-customer-rarity && uv run pytest tests/api/test_rarity_queries.py::TestCollectionPrevalenceScore -v`
+Expected: FAIL with `ImportError: cannot import name 'compute_collection_prevalence_score'`
+
+- [ ] **Step 3: Implement the scoring function**
+
+In `api/queries/rarity_queries.py`, after `compute_graph_isolation_score` (line ~133), add:
+
+```python
+def compute_collection_prevalence_score(have_count: int, want_count: int) -> float:
+    """Score based on community ownership rarity (inverse of prevalence).
+
+    Uses log-scale thresholds since community counts follow power-law distribution.
+    Want > have adds a +5 bonus (capped at 100) indicating scarcity pressure.
+    """
+    if have_count <= 0:
+        base = 95.0
+    elif have_count <= 10:
+        base = 85.0
+    elif have_count <= 100:
+        base = 70.0
+    elif have_count <= 1000:
+        base = 50.0
+    elif have_count <= 10000:
+        base = 25.0
+    else:
+        base = 10.0
+
+    if want_count > have_count:
+        base = min(100.0, base + 5.0)
+
+    return base
+```
+
+- [ ] **Step 4: Update SIGNAL_WEIGHTS**
+
+In `api/queries/rarity_queries.py`, replace the `SIGNAL_WEIGHTS` dict (lines 29-35):
+
+```python
+SIGNAL_WEIGHTS: dict[str, float] = {
+    "pressing_scarcity": 0.25,
+    "label_catalog": 0.10,
+    "format_rarity": 0.10,
+    "temporal_scarcity": 0.20,
+    "graph_isolation": 0.15,
+    "collection_prevalence": 0.20,
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/Robert/Code/public/discogsography/.claude/worktrees/206-customer-rarity && uv run pytest tests/api/test_rarity_queries.py::TestCollectionPrevalenceScore tests/api/test_rarity_queries.py::TestSignalWeights -v`
+Expected: All PASS (weights still sum to 1.0)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/queries/rarity_queries.py tests/api/test_rarity_queries.py
+git commit -m "feat(rarity): add collection_prevalence scoring function and update weights (#206)"
+```
+
+---
+
+### Task 3: Integrate collection prevalence into fetch_all_rarity_signals
+
+**Files:**
+- Modify: `api/queries/rarity_queries.py:147-331` (update fetch_all_rarity_signals to accept pool, query community_counts, compute 6th signal)
+- Test: `tests/api/test_rarity_queries.py`
+
+- [ ] **Step 1: Update the test for fetch_all_rarity_signals to include community data**
+
+In `tests/api/test_rarity_queries.py`, update `TestFetchAllRaritySignals.test_computes_scores_for_releases` — add a mock for the PostgreSQL community counts query. The function will now take both `driver` and `pool`:
+
+```python
+class TestFetchAllRaritySignals:
+    @pytest.mark.asyncio
+    async def test_computes_scores_for_releases(self) -> None:
+        """Test end-to-end signal fetch and scoring."""
+        mock_driver = MagicMock()
+
+        pressing_data = [{"release_id": "1", "pressing_count": 1, "title": "R1", "artist_name": "A1", "year": 1970}]
+        label_data = [{"release_id": "1", "label_catalog_size": 20}]
+        format_data = [{"release_id": "1", "formats": ["LP", "Flexi-disc"]}]
+        temporal_data = [{"release_id": "1", "year": 1970, "latest_sibling_year": None}]
+        degree_data = [{"release_id": "1", "degree": 3}]
+        artist_degree_data = [{"release_id": "1", "artist_max_degree": 500}]
+        label_size_data = [{"release_id": "1", "label_max_catalog": 2000}]
+        genre_count_data = [{"release_id": "1", "genre_max_release_count": 50000}]
+
+        # Mock PostgreSQL pool for community counts
+        mock_cur = AsyncMock()
+        mock_cur.fetchall = AsyncMock(return_value=[
+            {"release_id": 1, "have_count": 50, "want_count": 10},
+        ])
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool = MagicMock()
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+
+        with patch("api.queries.rarity_queries.run_query") as mock_run:
+            mock_run.side_effect = [
+                pressing_data,
+                label_data,
+                format_data,
+                temporal_data,
+                degree_data,
+                artist_degree_data,
+                label_size_data,
+                genre_count_data,
+            ]
+
+            results = await fetch_all_rarity_signals(mock_driver, mock_pool)
+
+        assert len(results) == 1
+        r = results[0]
+        assert r["release_id"] == "1"
+        assert 0 <= r["rarity_score"] <= 100
+        assert r["tier"] in ("common", "uncommon", "scarce", "rare", "ultra-rare")
+        assert r["pressing_scarcity"] == 100.0  # 1 pressing
+        assert r["format_rarity"] == 95.0  # Flexi-disc max
+        assert r["collection_prevalence"] == 70.0  # have=50, want<have -> no bonus
+        assert "hidden_gem_score" in r
+
+    @pytest.mark.asyncio
+    async def test_handles_zero_quality_signals(self) -> None:
+        """Test that releases with zero quality signals get hidden_gem_score of 0."""
+        mock_driver = MagicMock()
+
+        pressing_data = [{"release_id": "1", "pressing_count": 1, "title": "R1", "artist_name": "A1", "year": 1970}]
+        label_data = [{"release_id": "1", "label_catalog_size": 5}]
+        format_data = [{"release_id": "1", "formats": ["LP"]}]
+        temporal_data = [{"release_id": "1", "year": 1970, "latest_sibling_year": None}]
+        degree_data = [{"release_id": "1", "degree": 2}]
+        artist_degree_data = [{"release_id": "1", "artist_max_degree": 0}]
+        label_size_data = [{"release_id": "1", "label_max_catalog": 0}]
+        genre_count_data = [{"release_id": "1", "genre_max_release_count": 0}]
+
+        # Mock pool with no community data
+        mock_cur = AsyncMock()
+        mock_cur.fetchall = AsyncMock(return_value=[])
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool = MagicMock()
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+
+        with patch("api.queries.rarity_queries.run_query") as mock_run:
+            mock_run.side_effect = [
+                pressing_data,
+                label_data,
+                format_data,
+                temporal_data,
+                degree_data,
+                artist_degree_data,
+                label_size_data,
+                genre_count_data,
+            ]
+            results = await fetch_all_rarity_signals(mock_driver, mock_pool)
+
+        assert len(results) == 1
+        assert results[0]["hidden_gem_score"] == 0.0
+        assert results[0]["collection_prevalence"] == 50.0  # neutral fallback
+
+    @pytest.mark.asyncio
+    async def test_fallback_when_no_pool(self) -> None:
+        """Test that passing pool=None uses neutral fallback for all releases."""
+        mock_driver = MagicMock()
+
+        pressing_data = [{"release_id": "1", "pressing_count": 1, "title": "R1", "artist_name": "A1", "year": 1970}]
+        label_data = [{"release_id": "1", "label_catalog_size": 20}]
+        format_data = [{"release_id": "1", "formats": ["LP"]}]
+        temporal_data = [{"release_id": "1", "year": 1970, "latest_sibling_year": None}]
+        degree_data = [{"release_id": "1", "degree": 3}]
+        artist_degree_data = [{"release_id": "1", "artist_max_degree": 500}]
+        label_size_data = [{"release_id": "1", "label_max_catalog": 2000}]
+        genre_count_data = [{"release_id": "1", "genre_max_release_count": 50000}]
+
+        with patch("api.queries.rarity_queries.run_query") as mock_run:
+            mock_run.side_effect = [
+                pressing_data, label_data, format_data, temporal_data,
+                degree_data, artist_degree_data, label_size_data, genre_count_data,
+            ]
+            results = await fetch_all_rarity_signals(mock_driver, None)
+
+        assert len(results) == 1
+        assert results[0]["collection_prevalence"] == 50.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/Robert/Code/public/discogsography/.claude/worktrees/206-customer-rarity && uv run pytest tests/api/test_rarity_queries.py::TestFetchAllRaritySignals -v`
+Expected: FAIL (function signature mismatch or missing `collection_prevalence` key)
+
+- [ ] **Step 3: Update `fetch_all_rarity_signals` to accept pool and integrate community counts**
+
+In `api/queries/rarity_queries.py`, update the function signature and body:
+
+```python
+async def fetch_all_rarity_signals(driver: Any, pool: Any = None) -> list[dict[str, Any]]:
+    """Fetch all rarity signals from Neo4j and compute scores.
+
+    Executes 8 batch Cypher queries (5 signal queries + 3 quality queries),
+    optionally fetches community counts from PostgreSQL,
+    joins by release_id, and computes composite rarity + hidden gem scores.
+
+    Returns a list of dicts ready for PostgreSQL insertion.
+    """
+```
+
+After the 8 Neo4j queries and their `asyncio.gather` (line ~243), add the PostgreSQL community counts fetch:
+
+```python
+    # 9. Community counts from PostgreSQL (if pool available)
+    community_map: dict[str, tuple[int, int]] = {}
+    if pool is not None:
+        try:
+            async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+                await cur.execute(
+                    "SELECT release_id, have_count, want_count FROM insights.community_counts"
+                )
+                community_rows = await cur.fetchall()
+            community_map = {
+                str(r["release_id"]): (r["have_count"], r["want_count"])
+                for r in community_rows
+            }
+            logger.info("📊 Community counts loaded", count=len(community_map))
+        except Exception:
+            logger.warning("⚠️ Failed to load community counts, using neutral fallback")
+```
+
+In the scoring loop, after `isolation_score` (line ~288), add:
+
+```python
+        have, want = community_map.get(rid, (None, None))
+        if have is not None:
+            prevalence_score = compute_collection_prevalence_score(have, want or 0)
+        else:
+            prevalence_score = 50.0  # neutral fallback
+```
+
+Update the weighted sum (lines ~290-296):
+
+```python
+        rarity_score = (
+            SIGNAL_WEIGHTS["pressing_scarcity"] * pressing_score
+            + SIGNAL_WEIGHTS["label_catalog"] * label_score
+            + SIGNAL_WEIGHTS["format_rarity"] * fmt_score
+            + SIGNAL_WEIGHTS["temporal_scarcity"] * temporal_score
+            + SIGNAL_WEIGHTS["graph_isolation"] * isolation_score
+            + SIGNAL_WEIGHTS["collection_prevalence"] * prevalence_score
+        )
+```
+
+Add `collection_prevalence` to the result dict (after `"graph_isolation": isolation_score,`):
+
+```python
+                "collection_prevalence": prevalence_score,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/Robert/Code/public/discogsography/.claude/worktrees/206-customer-rarity && uv run pytest tests/api/test_rarity_queries.py::TestFetchAllRaritySignals -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/queries/rarity_queries.py tests/api/test_rarity_queries.py
+git commit -m "feat(rarity): integrate collection_prevalence into signal computation (#206)"
+```
+
+---
+
+### Task 4: Update call sites for fetch_all_rarity_signals
+
+**Files:**
+- Modify: `api/routers/insights_compute.py:126-133` (pass pool to fetch_all_rarity_signals)
+- Modify: `api/queries/rarity_queries.py:337-351` (update get_rarity_for_release SELECT)
+
+- [ ] **Step 1: Update the internal rarity-scores endpoint to pass pool**
+
+In `api/routers/insights_compute.py`, update the `rarity_scores` endpoint (line ~132):
+
+```python
+@router.get("/rarity-scores")
+@limiter.limit("5/minute")
+async def rarity_scores(request: Request) -> JSONResponse:  # noqa: ARG001
+    """Return computed rarity scores for all releases from Neo4j."""
+    if not _neo4j:
+        return JSONResponse(content={"error": "Service not ready"}, status_code=503)
+    results = await fetch_all_rarity_signals(_neo4j, _pool)
+    return JSONResponse(content={"items": results})
+```
+
+- [ ] **Step 2: Update `get_rarity_for_release` SELECT to include collection_prevalence**
+
+In `api/queries/rarity_queries.py`, update the SQL in `get_rarity_for_release` (line ~342-346):
+
+```python
+        await cur.execute(
+            """
+            SELECT release_id, title, artist_name, year, rarity_score, tier,
+                   hidden_gem_score, pressing_scarcity, label_catalog,
+                   format_rarity, temporal_scarcity, graph_isolation,
+                   collection_prevalence
+            FROM insights.release_rarity
+            WHERE release_id = %s
+            """,
+            (release_id,),
+        )
+```
+
+- [ ] **Step 3: Run the full rarity test suite**
+
+Run: `cd /Users/Robert/Code/public/discogsography/.claude/worktrees/206-customer-rarity && uv run pytest tests/api/test_rarity_queries.py -v`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/routers/insights_compute.py api/queries/rarity_queries.py
+git commit -m "feat(rarity): update call sites to pass pool and select collection_prevalence (#206)"
+```
+
+---
+
+### Task 5: Update insights computation pipeline to store collection_prevalence
+
+**Files:**
+- Modify: `insights/computations.py:305-353` (update INSERT in compute_and_store_rarity)
+- Modify: `insights/insights.py:296-339` (update SELECT in release_rarity endpoint)
+- Modify: `insights/insights.py:424-454` (add community_enrichment to status endpoint)
+- Test: `tests/insights/test_rarity_computation.py`
+
+- [ ] **Step 1: Update mock data in test_rarity_computation.py**
+
+In `tests/insights/test_rarity_computation.py`, update `_MOCK_RARITY_ITEMS` (line ~31) to include the new column:
+
+```python
+_MOCK_RARITY_ITEMS = [
+    {
+        "release_id": "1",
+        "title": "Test Release",
+        "artist_name": "Test Artist",
+        "year": 1970,
+        "rarity_score": 85.0,
+        "tier": "ultra-rare",
+        "hidden_gem_score": 60.0,
+        "pressing_scarcity": 100.0,
+        "label_catalog": 75.0,
+        "format_rarity": 95.0,
+        "temporal_scarcity": 80.0,
+        "graph_isolation": 70.0,
+        "collection_prevalence": 85.0,
+    }
+]
+```
+
+- [ ] **Step 2: Update `compute_and_store_rarity` INSERT statement**
+
+In `insights/computations.py`, update the INSERT in `compute_and_store_rarity` (lines ~322-343):
+
+```python
+                for row in results:
+                    await cursor.execute(
+                        """
+                            INSERT INTO insights.release_rarity
+                                (release_id, title, artist_name, year, rarity_score, tier,
+                                 hidden_gem_score, pressing_scarcity, label_catalog,
+                                 format_rarity, temporal_scarcity, graph_isolation,
+                                 collection_prevalence)
+                            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                            """,
+                        (
+                            row["release_id"],
+                            row.get("title", ""),
+                            row.get("artist_name", ""),
+                            row.get("year"),
+                            row["rarity_score"],
+                            row["tier"],
+                            row.get("hidden_gem_score"),
+                            row.get("pressing_scarcity"),
+                            row.get("label_catalog"),
+                            row.get("format_rarity"),
+                            row.get("temporal_scarcity"),
+                            row.get("graph_isolation"),
+                            row.get("collection_prevalence"),
+                        ),
+                    )
+```
+
+- [ ] **Step 3: Update the insights release-rarity read endpoint**
+
+In `insights/insights.py`, update the SELECT in the `release_rarity` endpoint (lines ~310-313) to include `collection_prevalence`:
+
+```python
+        await cursor.execute(
+            "SELECT release_id, title, artist_name, year, rarity_score, tier, "
+            "hidden_gem_score, pressing_scarcity, label_catalog, "
+            "format_rarity, temporal_scarcity, graph_isolation, "
+            "collection_prevalence "
+            "FROM insights.release_rarity ORDER BY rarity_score DESC LIMIT %s",
+            (limit,),
+        )
+```
+
+And update the item dict (lines ~319-333) to include `collection_prevalence`:
+
+```python
+    items = [
+        {
+            "release_id": r[0],
+            "title": r[1],
+            "artist_name": r[2],
+            "year": r[3],
+            "rarity_score": r[4],
+            "tier": r[5],
+            "hidden_gem_score": r[6],
+            "pressing_scarcity": r[7],
+            "label_catalog": r[8],
+            "format_rarity": r[9],
+            "temporal_scarcity": r[10],
+            "graph_isolation": r[11],
+            "collection_prevalence": r[12],
+        }
+        for r in rows
+    ]
+```
+
+- [ ] **Step 4: Add `community_enrichment` to the status endpoint insight_types list**
+
+In `insights/insights.py`, update the `insight_types` list in `computation_status` (line ~429):
+
+```python
+    insight_types = [
+        "artist_centrality", "genre_trends", "label_longevity",
+        "anniversaries", "data_completeness", "community_enrichment",
+        "release_rarity",
+    ]
+```
+
+- [ ] **Step 5: Run insights tests**
+
+Run: `cd /Users/Robert/Code/public/discogsography/.claude/worktrees/206-customer-rarity && uv run pytest tests/insights/test_rarity_computation.py -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add insights/computations.py insights/insights.py tests/insights/test_rarity_computation.py
+git commit -m "feat(insights): update pipeline to store and serve collection_prevalence (#206)"
+```
+
+---
+
+### Task 6: Add community enrichment endpoint
+
+**Files:**
+- Modify: `api/routers/insights_compute.py` (add community-enrichment endpoint)
+- Create: `tests/api/test_community_enrichment.py`
+
+- [ ] **Step 1: Write tests for the enrichment endpoint**
+
+Create `tests/api/test_community_enrichment.py`:
+
+```python
+"""Tests for community have/want enrichment endpoint."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from api.routers import insights_compute
+
+
+def _make_mock_pool(community_rows=None, oauth_row=None, app_config_rows=None,
+                     collection_release_ids=None):
+    """Create mock pool with configurable query responses."""
+    mock_cur = AsyncMock()
+
+    # Track which query is being executed to return the right response
+    call_count = 0
+    execute_calls = []
+
+    async def mock_execute(sql, params=None):
+        nonlocal call_count
+        execute_calls.append((sql, params))
+        call_count += 1
+
+    mock_cur.execute = mock_execute
+    mock_cur.executemany = AsyncMock()
+
+    responses = []
+    if collection_release_ids is not None:
+        responses.append(collection_release_ids)
+    if oauth_row is not None:
+        responses.append(oauth_row)
+    if app_config_rows is not None:
+        responses.append(app_config_rows)
+
+    fetchall_idx = 0
+    async def mock_fetchall():
+        nonlocal fetchall_idx
+        if fetchall_idx < len(responses):
+            result = responses[fetchall_idx]
+            fetchall_idx += 1
+            return result
+        return []
+
+    fetchone_idx = 0
+    async def mock_fetchone():
+        nonlocal fetchone_idx
+        if oauth_row and fetchone_idx == 0:
+            fetchone_idx += 1
+            return oauth_row
+        return None
+
+    mock_cur.fetchall = mock_fetchall
+    mock_cur.fetchone = mock_fetchone
+    mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+    mock_cur.__aexit__ = AsyncMock(return_value=False)
+
+    mock_conn = AsyncMock()
+    mock_conn.cursor = MagicMock(return_value=mock_cur)
+    mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+    mock_pool = MagicMock()
+    mock_pool.connection = MagicMock(return_value=mock_conn)
+    return mock_pool
+
+
+class TestEnrichReleasesFromDiscogs:
+    @pytest.mark.asyncio
+    async def test_no_releases_to_enrich(self) -> None:
+        """When no releases need enrichment, return 0."""
+        from api.routers.insights_compute import _enrich_community_counts
+
+        mock_pool = MagicMock()
+        mock_cur = AsyncMock()
+        mock_cur.fetchall = AsyncMock(return_value=[])  # no releases
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+
+        result = await _enrich_community_counts(mock_pool, None, None)
+        assert result["enriched"] == 0
+
+    @pytest.mark.asyncio
+    async def test_no_oauth_credentials(self) -> None:
+        """When no OAuth credentials found, skip enrichment."""
+        from api.routers.insights_compute import _enrich_community_counts
+
+        mock_pool = MagicMock()
+        mock_cur = AsyncMock()
+        # First call: releases needing enrichment
+        # Second call: no OAuth token
+        call_count = 0
+        async def mock_fetchall():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [{"release_id": 123}]
+            return []  # no app config
+
+        mock_cur.fetchall = mock_fetchall
+        mock_cur.fetchone = AsyncMock(return_value=None)  # no OAuth token
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+
+        result = await _enrich_community_counts(mock_pool, None, None)
+        assert result["enriched"] == 0
+        assert result["error"] == "no_credentials"
+
+    @pytest.mark.asyncio
+    async def test_successful_enrichment(self) -> None:
+        """Successful fetch stores counts in PG and Neo4j."""
+        from api.routers.insights_compute import _enrich_community_counts
+
+        mock_pool = MagicMock()
+        mock_cur = AsyncMock()
+
+        call_count = 0
+        async def mock_fetchall():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [{"release_id": 123}]  # releases to enrich
+            if call_count == 2:
+                return [  # app config
+                    {"key": "discogs_consumer_key", "value": "ck"},
+                    {"key": "discogs_consumer_secret", "value": "cs"},
+                ]
+            return []
+
+        mock_cur.fetchall = mock_fetchall
+        mock_cur.fetchone = AsyncMock(return_value={
+            "access_token": "at", "access_secret": "as",
+            "provider_username": "testuser",
+        })
+        mock_cur.execute = AsyncMock()
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+
+        # Mock Neo4j
+        mock_neo4j_result = AsyncMock()
+        mock_neo4j_result.consume = AsyncMock()
+        mock_neo4j_session = AsyncMock()
+        mock_neo4j_session.run = AsyncMock(return_value=mock_neo4j_result)
+        mock_neo4j_session.__aenter__ = AsyncMock(return_value=mock_neo4j_session)
+        mock_neo4j_session.__aexit__ = AsyncMock(return_value=False)
+        mock_neo4j = MagicMock()
+        mock_neo4j.session = MagicMock(return_value=mock_neo4j_session)
+
+        # Mock Discogs API response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "community": {"have": 42, "want": 7},
+        }
+
+        with (
+            patch("api.routers.insights_compute.decrypt_oauth_token", side_effect=lambda v, _k: v),
+            patch("api.routers.insights_compute._auth_header", return_value="OAuth ..."),
+            patch("httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await _enrich_community_counts(
+                mock_pool, mock_neo4j, None,
+            )
+
+        assert result["enriched"] == 1
+        assert result["errors"] == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/Robert/Code/public/discogsography/.claude/worktrees/206-customer-rarity && uv run pytest tests/api/test_community_enrichment.py -v`
+Expected: FAIL with `ImportError: cannot import name '_enrich_community_counts'`
+
+- [ ] **Step 3: Implement the enrichment function**
+
+In `api/routers/insights_compute.py`, add the necessary imports at the top:
+
+```python
+import asyncio
+from typing import Any
+
+import httpx
+
+from api.auth import decrypt_oauth_token, get_oauth_encryption_key
+from api.syncer import _auth_header, DISCOGS_API_BASE, MAX_RATE_LIMIT_RETRIES
+from common.query_debug import execute_sql
+```
+
+Add the `_enrich_community_counts` function and the endpoint after the existing endpoints:
+
+```python
+_ENRICHMENT_DELAY_SECONDS = 1.0  # 1 req/sec to stay under 60 req/min
+_STALENESS_DAYS = 7
+
+
+async def _enrich_community_counts(
+    pool: Any,
+    neo4j: Any,
+    encryption_key: str | None,
+) -> dict[str, Any]:
+    """Fetch community have/want counts from Discogs API for releases in user collections.
+
+    Returns a dict with enriched/skipped/errors counts.
+    """
+    from psycopg.rows import dict_row
+
+    # 1. Find releases needing enrichment (new or stale)
+    async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            """
+            SELECT DISTINCT release_id FROM (
+                SELECT release_id FROM user_collections
+                UNION
+                SELECT release_id FROM user_wantlists
+            ) AS combined
+            WHERE release_id NOT IN (
+                SELECT release_id FROM insights.community_counts
+                WHERE fetched_at > NOW() - INTERVAL '%s days'
+            )
+            """,
+            (_STALENESS_DAYS,),
+        )
+        rows = await cur.fetchall()
+        release_ids = [r["release_id"] for r in rows]
+
+    if not release_ids:
+        logger.info("📊 No releases need community enrichment")
+        return {"enriched": 0, "skipped": 0, "errors": 0}
+
+    logger.info("📊 Releases needing community enrichment", count=len(release_ids))
+
+    # 2. Get OAuth credentials (any user with valid Discogs OAuth)
+    async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            """
+            SELECT ot.access_token, ot.access_secret, ot.provider_username
+            FROM oauth_tokens ot
+            WHERE ot.provider = 'discogs'
+            LIMIT 1
+            """
+        )
+        token = await cur.fetchone()
+
+        if not token:
+            logger.warning("⚠️ No Discogs OAuth credentials for community enrichment")
+            return {"enriched": 0, "skipped": len(release_ids), "errors": 0, "error": "no_credentials"}
+
+        access_token = decrypt_oauth_token(token["access_token"], encryption_key)
+        access_secret = decrypt_oauth_token(token["access_secret"], encryption_key)
+
+        await cur.execute(
+            "SELECT key, value FROM app_config WHERE key IN ('discogs_consumer_key', 'discogs_consumer_secret')"
+        )
+        config_rows = await cur.fetchall()
+        app_config = {r["key"]: r["value"] for r in config_rows}
+        if "discogs_consumer_key" not in app_config or "discogs_consumer_secret" not in app_config:
+            logger.warning("⚠️ Discogs app credentials not configured")
+            return {"enriched": 0, "skipped": len(release_ids), "errors": 0, "error": "no_credentials"}
+        consumer_key = decrypt_oauth_token(app_config["discogs_consumer_key"], encryption_key)
+        consumer_secret = decrypt_oauth_token(app_config["discogs_consumer_secret"], encryption_key)
+
+    # 3. Fetch community counts from Discogs API
+    enriched = 0
+    errors = 0
+    batch: list[dict[str, Any]] = []
+    rate_limit_retries = 0
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        for release_id in release_ids:
+            url = f"{DISCOGS_API_BASE}/releases/{release_id}"
+            auth = _auth_header(
+                "GET", url, consumer_key, consumer_secret,
+                access_token, access_secret,
+            )
+            headers = {
+                "Authorization": auth,
+                "User-Agent": "discogsography/1.0 +https://github.com/SimplicityGuy/discogsography",
+                "Accept": "application/json",
+            }
+
+            response = await client.get(url, headers=headers)
+
+            if response.status_code == 429:
+                rate_limit_retries += 1
+                if rate_limit_retries > MAX_RATE_LIMIT_RETRIES:
+                    logger.error("❌ Rate limit retries exhausted during enrichment")
+                    break
+                logger.warning("⚠️ Rate limited, waiting 60s...", retry=rate_limit_retries)
+                await asyncio.sleep(60)
+                continue
+
+            rate_limit_retries = 0
+
+            if response.status_code != 200:
+                logger.warning("⚠️ Discogs API error for release", release_id=release_id, status=response.status_code)
+                errors += 1
+                await asyncio.sleep(_ENRICHMENT_DELAY_SECONDS)
+                continue
+
+            data = response.json()
+            community = data.get("community", {})
+            have = community.get("have", 0)
+            want = community.get("want", 0)
+
+            # Upsert to PostgreSQL
+            async with pool.connection() as conn, conn.cursor() as cur:
+                await cur.execute(
+                    """
+                    INSERT INTO insights.community_counts (release_id, have_count, want_count, fetched_at)
+                    VALUES (%s, %s, %s, NOW())
+                    ON CONFLICT (release_id) DO UPDATE SET
+                        have_count = EXCLUDED.have_count,
+                        want_count = EXCLUDED.want_count,
+                        fetched_at = NOW()
+                    """,
+                    (release_id, have, want),
+                )
+
+            batch.append({"release_id": release_id, "have": have, "want": want})
+            enriched += 1
+            await asyncio.sleep(_ENRICHMENT_DELAY_SECONDS)
+
+    # 4. Batch update Neo4j Release nodes
+    if batch and neo4j is not None:
+        cypher = """
+        UNWIND $batch AS item
+        MATCH (r:Release {id: toString(item.release_id)})
+        SET r.community_have = item.have,
+            r.community_want = item.want
+        """
+        try:
+            async with neo4j.session() as session:
+                result = await session.run(cypher, {"batch": batch})
+                await result.consume()
+            logger.info("✅ Neo4j Release nodes updated with community counts", count=len(batch))
+        except Exception as e:
+            logger.error("❌ Failed to update Neo4j community counts", error=str(e))
+
+    logger.info("✅ Community enrichment complete", enriched=enriched, errors=errors)
+    return {"enriched": enriched, "skipped": len(release_ids) - enriched - errors, "errors": errors}
+```
+
+- [ ] **Step 4: Add the HTTP endpoint**
+
+In `api/routers/insights_compute.py`, add after the existing endpoints:
+
+```python
+# Module-level config reference (set by configure())
+_config: Any = None
+
+
+@router.get("/community-enrichment")
+@limiter.limit("1/minute")
+async def community_enrichment(request: Request) -> JSONResponse:  # noqa: ARG001
+    """Enrich releases in user collections with Discogs community have/want counts."""
+    if not _pool:
+        return JSONResponse(content={"error": "Service not ready"}, status_code=503)
+
+    encryption_key = get_oauth_encryption_key(_config.encryption_master_key) if _config else None
+    result = await _enrich_community_counts(_pool, _neo4j, encryption_key)
+    return JSONResponse(content=result)
+```
+
+- [ ] **Step 5: Update `configure()` to accept and store config**
+
+In `api/routers/insights_compute.py`, update the `configure` function:
+
+```python
+def configure(neo4j: Any, pool: Any, redis: Any = None, config: Any = None) -> None:
+    """Configure the insights compute router with database connections."""
+    global _neo4j, _pool, _redis, _config
+    _neo4j = neo4j
+    _pool = pool
+    _redis = redis
+    _config = config
+```
+
+- [ ] **Step 6: Update the configure call site in api.py**
+
+In `api/api.py`, update line ~258:
+
+```python
+    _insights_compute_router.configure(_neo4j, _pool, _redis, _config)
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `cd /Users/Robert/Code/public/discogsography/.claude/worktrees/206-customer-rarity && uv run pytest tests/api/test_community_enrichment.py -v`
+Expected: All PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add api/routers/insights_compute.py api/api.py tests/api/test_community_enrichment.py
+git commit -m "feat(enrichment): add community have/want enrichment endpoint (#206)"
+```
+
+---
+
+### Task 7: Add enrichment to insights computation pipeline
+
+**Files:**
+- Modify: `insights/computations.py:356-388` (add community_enrichment to run_all_computations, before release_rarity)
+
+- [ ] **Step 1: Add `compute_and_store_community_enrichment` function**
+
+In `insights/computations.py`, add before `compute_and_store_rarity` (line ~305):
+
+```python
+async def compute_and_store_community_enrichment(client: httpx.AsyncClient, pool: Any) -> int:
+    """Trigger community enrichment via the API internal endpoint."""
+    started_at = datetime.now(UTC)
+    try:
+        results = await _fetch_from_api(client, "/api/internal/insights/community-enrichment", timeout=3600.0)
+        enriched = results.get("enriched", 0) if isinstance(results, dict) else 0
+        logger.info("📊 Community enrichment complete", enriched=enriched)
+        await _log_computation(pool, "community_enrichment", "completed", started_at, enriched)
+        return enriched
+    except Exception as e:
+        logger.error("❌ Community enrichment failed", error=str(e))
+        try:
+            await _log_computation(pool, "community_enrichment", "failed", started_at, error_message=str(e))
+        except Exception as log_err:
+            logger.warning("⚠️ Failed to log computation error", error=str(log_err))
+        raise
+```
+
+Note: The `_fetch_from_api` function returns `data.get("items", [])` by default, but the community-enrichment endpoint returns a flat dict, not `{"items": [...]}`. We need to handle this — update the function to handle the response format:
+
+Actually, looking at this more carefully, `_fetch_from_api` always returns `data.get("items", [])` which would return `[]` for the community enrichment response. Instead, make a direct call:
+
+```python
+async def compute_and_store_community_enrichment(client: httpx.AsyncClient, pool: Any) -> int:
+    """Trigger community enrichment via the API internal endpoint."""
+    started_at = datetime.now(UTC)
+    try:
+        response = await client.get("/api/internal/insights/community-enrichment", timeout=3600.0)
+        response.raise_for_status()
+        data: dict[str, Any] = response.json()
+        enriched = data.get("enriched", 0)
+        logger.info("📊 Community enrichment complete", enriched=enriched)
+        await _log_computation(pool, "community_enrichment", "completed", started_at, enriched)
+        return enriched
+    except Exception as e:
+        logger.error("❌ Community enrichment failed", error=str(e))
+        try:
+            await _log_computation(pool, "community_enrichment", "failed", started_at, error_message=str(e))
+        except Exception as log_err:
+            logger.warning("⚠️ Failed to log computation error", error=str(log_err))
+        raise
+```
+
+- [ ] **Step 2: Add to `run_all_computations` — before release_rarity**
+
+In `insights/computations.py`, update the `computations` list in `run_all_computations` (lines ~367-377). Insert community_enrichment before release_rarity:
+
+```python
+    computations: list[tuple[str, Callable[[], Coroutine[Any, Any, int]]]] = [
+        ("artist_centrality", lambda: compute_and_store_artist_centrality(client, pool)),
+        ("genre_trends", lambda: compute_and_store_genre_trends(client, pool)),
+        ("label_longevity", lambda: compute_and_store_label_longevity(client, pool)),
+        (
+            "anniversaries",
+            lambda: compute_and_store_anniversaries(client, pool, milestone_years=milestone_years),
+        ),
+        ("data_completeness", lambda: compute_and_store_data_completeness(client, pool)),
+        ("community_enrichment", lambda: compute_and_store_community_enrichment(client, pool)),
+        ("release_rarity", lambda: compute_and_store_rarity(client, pool)),
+    ]
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd /Users/Robert/Code/public/discogsography/.claude/worktrees/206-customer-rarity && uv run pytest tests/insights/ -v`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add insights/computations.py
+git commit -m "feat(insights): add community enrichment to computation pipeline (#206)"
+```
+
+---
+
+### Task 8: Run full test suite and lint
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full Python test suite**
+
+Run: `cd /Users/Robert/Code/public/discogsography/.claude/worktrees/206-customer-rarity && uv run pytest tests/api/test_rarity_queries.py tests/api/test_community_enrichment.py tests/insights/test_rarity_computation.py -v`
+Expected: All PASS
+
+- [ ] **Step 2: Run type checking**
+
+Run: `cd /Users/Robert/Code/public/discogsography/.claude/worktrees/206-customer-rarity && uv run mypy api/queries/rarity_queries.py api/routers/insights_compute.py insights/computations.py insights/insights.py schema-init/postgres_schema.py`
+Expected: No errors (or only pre-existing ones)
+
+- [ ] **Step 3: Run linter**
+
+Run: `cd /Users/Robert/Code/public/discogsography/.claude/worktrees/206-customer-rarity && uv run ruff check api/queries/rarity_queries.py api/routers/insights_compute.py insights/computations.py insights/insights.py schema-init/postgres_schema.py`
+Expected: No errors
+
+- [ ] **Step 4: Run formatter**
+
+Run: `cd /Users/Robert/Code/public/discogsography/.claude/worktrees/206-customer-rarity && uv run ruff format api/queries/rarity_queries.py api/routers/insights_compute.py insights/computations.py insights/insights.py schema-init/postgres_schema.py`
+
+- [ ] **Step 5: Run the broader test suite to check for regressions**
+
+Run: `cd /Users/Robert/Code/public/discogsography/.claude/worktrees/206-customer-rarity && just test`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit any formatting changes**
+
+```bash
+git add -A
+git commit -m "chore: format and lint fixes (#206)"
+```

--- a/docs/superpowers/specs/2026-04-11-community-enrichment-rarity-design.md
+++ b/docs/superpowers/specs/2026-04-11-community-enrichment-rarity-design.md
@@ -1,0 +1,171 @@
+# Community Have/Want Enrichment for Release Rarity Scoring
+
+**Issue:** #206
+**Date:** 2026-04-11
+**Status:** Approved
+
+## Overview
+
+Add a 6th rarity signal — **collection prevalence** — by fetching `community.have` and `community.want` counts from the Discogs REST API for releases in user collections/wantlists. These global counts reflect how many Discogs users worldwide own or want a release, providing the strongest real-world scarcity signal.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Enrichment scope | Collection-first | Only enrich releases in synced user collections/wantlists. Manageable scope, serves active users. Unenriched releases get a neutral fallback score (50.0). |
+| Storage | PostgreSQL + Neo4j mirror | PostgreSQL `insights.community_counts` as source of truth. Neo4j Release nodes get `community_have`/`community_want` properties for query convenience. |
+| Process location | API internal endpoint | Fits existing insights architecture. API already has OAuth, DB connections, rate limiting patterns. Triggered by insights scheduler before rarity computation. |
+
+## Data Flow
+
+```mermaid
+sequenceDiagram
+    participant S as Insights Scheduler
+    participant A as API Internal Endpoint
+    participant D as Discogs REST API
+    participant P as PostgreSQL
+    participant N as Neo4j
+
+    S->>A: GET /api/internal/insights/community-enrichment
+    A->>P: Query releases needing enrichment (new or stale >7d)
+    A->>P: Fetch any valid OAuth credentials
+    loop For each release (1 req/sec)
+        A->>D: GET /releases/{id} (OAuth 1.0a)
+        D-->>A: {community: {have: N, want: M}}
+        A->>P: UPSERT insights.community_counts
+    end
+    A->>N: Batch SET r.community_have, r.community_want
+    A-->>S: {enriched: N, skipped: M, errors: E}
+    S->>A: GET /api/internal/insights/rarity-scores
+    Note over A: fetch_all_rarity_signals() now includes<br/>collection_prevalence from community_counts
+```
+
+## Storage Schema
+
+### PostgreSQL — new table
+
+```sql
+CREATE TABLE IF NOT EXISTS insights.community_counts (
+    release_id   BIGINT PRIMARY KEY,
+    have_count   INTEGER NOT NULL DEFAULT 0,
+    want_count   INTEGER NOT NULL DEFAULT 0,
+    fetched_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_community_counts_fetched
+    ON insights.community_counts (fetched_at);
+```
+
+### PostgreSQL — extend `insights.release_rarity`
+
+Add column: `collection_prevalence REAL`
+
+### Neo4j — Release node properties
+
+Add `community_have` (integer) and `community_want` (integer) properties to Release nodes during enrichment via batch Cypher update.
+
+## Scoring Function
+
+`compute_collection_prevalence_score(have_count, want_count) -> float`
+
+Score is inversely proportional to how many people have the release, using log-scale thresholds (community counts follow a power-law distribution):
+
+| have_count | Base Score | Interpretation |
+|---|---|---|
+| 0 | 95.0 | Almost nobody has it |
+| 1-10 | 85.0 | Extremely scarce |
+| 11-100 | 70.0 | Hard to find |
+| 101-1000 | 50.0 | Moderate availability |
+| 1001-10000 | 25.0 | Widely available |
+| 10000+ | 10.0 | Mass market |
+
+**Want bonus:** If `want_count > have_count`, add +5.0 to the score (capped at 100.0). High want relative to have indicates desirability/scarcity pressure.
+
+**Fallback:** Releases without community data get 50.0 (neutral).
+
+## Updated Signal Weights
+
+```python
+SIGNAL_WEIGHTS = {
+    "pressing_scarcity": 0.25,       # was 0.30
+    "label_catalog": 0.10,           # was 0.15
+    "format_rarity": 0.10,           # was 0.15
+    "temporal_scarcity": 0.20,       # unchanged
+    "graph_isolation": 0.15,         # was 0.20
+    "collection_prevalence": 0.20,   # NEW
+}
+```
+
+Rationale: Collection prevalence is the strongest real-world rarity signal, matching temporal scarcity's weight. Pressing scarcity stays highest as the most graph-reliable signal. Label catalog and format rarity absorb reductions as the least discriminating signals.
+
+## Enrichment Process Details
+
+### Release selection
+
+Query PostgreSQL for distinct `release_id` values from `user_collections` and `user_wantlists` that either:
+- Don't exist in `insights.community_counts`, or
+- Have `fetched_at` older than 7 days
+
+### OAuth credentials
+
+Pick any user with valid Discogs OAuth credentials from `oauth_tokens`. Community counts are public data — any authenticated user can read them. If no credentials are available, the endpoint returns early with `{"enriched": 0, "skipped": N, "error": "no_credentials"}`.
+
+### Rate limiting
+
+- 1 request per second (SYNC_DELAY_SECONDS = 1.0) to stay under 60 req/min
+- On 429 response: wait 60 seconds, retry up to 5 times (same pattern as `syncer.py`)
+- On non-200/non-429: log error, skip release, continue
+
+### Staleness
+
+Counts older than 7 days are refreshed on the next enrichment run. The `fetched_at` timestamp is updated on each successful fetch.
+
+## API & Pipeline Changes
+
+### New internal endpoint
+
+`GET /api/internal/insights/community-enrichment` in `api/routers/insights_compute.py`:
+- Rate limited to 1/minute (long-running operation)
+- Runs the enrichment process described above
+- Returns `{"enriched": N, "skipped": M, "errors": E}`
+
+### Updated `fetch_all_rarity_signals()`
+
+- Add `pool` parameter (PostgreSQL) alongside existing `driver` parameter (Neo4j)
+- After the 8 existing Neo4j queries, query `insights.community_counts` for have/want counts
+- Build a `community_map` lookup dict
+- Compute `collection_prevalence` score for each release
+- Include in weighted sum and result dict
+
+### Updated `compute_and_store_rarity()`
+
+- INSERT statement adds the `collection_prevalence` column
+
+### Updated public API
+
+- `get_rarity_for_release()` SELECT query includes `collection_prevalence`
+- `_format_breakdown()` automatically includes the new signal (iterates `SIGNAL_WEIGHTS`)
+
+### Insights scheduler ordering
+
+Enrichment runs before rarity computation so freshly fetched counts are available for scoring.
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `api/queries/rarity_queries.py` | Add `compute_collection_prevalence_score()`, update weights, update `fetch_all_rarity_signals()` to accept pool and query community counts, update `get_rarity_for_release()` SELECT |
+| `api/routers/insights_compute.py` | Add `community-enrichment` endpoint with enrichment logic |
+| `api/routers/rarity.py` | No changes needed (breakdown auto-includes new signal) |
+| `schema-init/postgres_schema.py` | Add `insights.community_counts` table, add `collection_prevalence` column to `insights.release_rarity` |
+| `insights/computations.py` | Update `compute_and_store_rarity()` INSERT to include `collection_prevalence`, add `compute_and_store_community_enrichment()`, update scheduler ordering |
+| `tests/api/test_rarity_queries.py` | Add `TestCollectionPrevalenceScore`, update `TestFetchAllRaritySignals` |
+| `tests/api/test_community_enrichment.py` | New file: enrichment endpoint tests |
+| `tests/insights/test_rarity_computation.py` | Update mock data with `collection_prevalence` |
+
+## Testing Strategy
+
+**Unit tests for scoring function:** Each threshold bucket, want>have bonus, 100 cap, neutral fallback.
+
+**Unit tests for enrichment logic:** Release selection (new + stale), Discogs API response parsing, 429 backoff, PostgreSQL upsert, Neo4j property update, no-credentials handling.
+
+**Updated integration tests:** `TestFetchAllRaritySignals` with 9th data source (PostgreSQL community counts), `TestSignalWeights` (automatically passes), mock data updated with `collection_prevalence` column.

--- a/insights/computations.py
+++ b/insights/computations.py
@@ -323,8 +323,9 @@ async def compute_and_store_rarity(client: httpx.AsyncClient, pool: Any) -> int:
                             INSERT INTO insights.release_rarity
                                 (release_id, title, artist_name, year, rarity_score, tier,
                                  hidden_gem_score, pressing_scarcity, label_catalog,
-                                 format_rarity, temporal_scarcity, graph_isolation)
-                            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                                 format_rarity, temporal_scarcity, graph_isolation,
+                                 collection_prevalence)
+                            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                             """,
                         (
                             row["release_id"],
@@ -339,6 +340,7 @@ async def compute_and_store_rarity(client: httpx.AsyncClient, pool: Any) -> int:
                             row.get("format_rarity"),
                             row.get("temporal_scarcity"),
                             row.get("graph_isolation"),
+                            row.get("collection_prevalence"),
                         ),
                     )
         logger.info("💾 Release rarity scores stored", count=len(results))

--- a/insights/computations.py
+++ b/insights/computations.py
@@ -302,6 +302,26 @@ async def compute_and_store_data_completeness(client: httpx.AsyncClient, pool: A
         raise
 
 
+async def compute_and_store_community_enrichment(client: httpx.AsyncClient, pool: Any) -> int:
+    """Trigger community enrichment via the API internal endpoint."""
+    started_at = datetime.now(UTC)
+    try:
+        response = await client.get("/api/internal/insights/community-enrichment", timeout=3600.0)
+        response.raise_for_status()
+        data: dict[str, Any] = response.json()
+        enriched = int(data.get("enriched", 0))
+        logger.info("📊 Community enrichment complete", enriched=enriched)
+        await _log_computation(pool, "community_enrichment", "completed", started_at, enriched)
+        return enriched
+    except Exception as e:
+        logger.error("❌ Community enrichment failed", error=str(e))
+        try:
+            await _log_computation(pool, "community_enrichment", "failed", started_at, error_message=str(e))
+        except Exception as log_err:
+            logger.warning("⚠️ Failed to log computation error", error=str(log_err))
+        raise
+
+
 async def compute_and_store_rarity(client: httpx.AsyncClient, pool: Any) -> int:
     """Compute release rarity scores and store results."""
     started_at = datetime.now(UTC)
@@ -375,6 +395,7 @@ async def run_all_computations(
             lambda: compute_and_store_anniversaries(client, pool, milestone_years=milestone_years),
         ),
         ("data_completeness", lambda: compute_and_store_data_completeness(client, pool)),
+        ("community_enrichment", lambda: compute_and_store_community_enrichment(client, pool)),
         ("release_rarity", lambda: compute_and_store_rarity(client, pool)),
     ]
 

--- a/insights/insights.py
+++ b/insights/insights.py
@@ -310,7 +310,8 @@ async def release_rarity(limit: int = Query(50, ge=1, le=500)) -> JSONResponse:
         await cursor.execute(
             "SELECT release_id, title, artist_name, year, rarity_score, tier, "
             "hidden_gem_score, pressing_scarcity, label_catalog, "
-            "format_rarity, temporal_scarcity, graph_isolation "
+            "format_rarity, temporal_scarcity, graph_isolation, "
+            "collection_prevalence "
             "FROM insights.release_rarity ORDER BY rarity_score DESC LIMIT %s",
             (limit,),
         )
@@ -330,6 +331,7 @@ async def release_rarity(limit: int = Query(50, ge=1, le=500)) -> JSONResponse:
             "format_rarity": r[9],
             "temporal_scarcity": r[10],
             "graph_isolation": r[11],
+            "collection_prevalence": r[12],
         }
         for r in rows
     ]
@@ -426,7 +428,15 @@ async def computation_status() -> JSONResponse:
     if not _pool:
         return JSONResponse(content={"error": "Service not ready"}, status_code=503)
 
-    insight_types = ["artist_centrality", "genre_trends", "label_longevity", "anniversaries", "data_completeness", "release_rarity"]
+    insight_types = [
+        "artist_centrality",
+        "genre_trends",
+        "label_longevity",
+        "anniversaries",
+        "data_completeness",
+        "community_enrichment",
+        "release_rarity",
+    ]
     statuses: list[dict[str, Any]] = []
 
     async with _pool.connection() as conn, conn.cursor() as cursor:

--- a/schema-init/postgres_schema.py
+++ b/schema-init/postgres_schema.py
@@ -425,6 +425,7 @@ _INSIGHTS_TABLES: list[tuple[str, str]] = [
             format_rarity   REAL,
             temporal_scarcity REAL,
             graph_isolation REAL,
+            collection_prevalence REAL,
             computed_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
         )
         """,
@@ -440,6 +441,21 @@ _INSIGHTS_TABLES: list[tuple[str, str]] = [
     (
         "idx_release_rarity_gem",
         "CREATE INDEX IF NOT EXISTS idx_release_rarity_gem ON insights.release_rarity (hidden_gem_score DESC NULLS LAST)",
+    ),
+    (
+        "insights.community_counts table",
+        """
+        CREATE TABLE IF NOT EXISTS insights.community_counts (
+            release_id      BIGINT PRIMARY KEY,
+            have_count      INTEGER NOT NULL DEFAULT 0,
+            want_count      INTEGER NOT NULL DEFAULT 0,
+            fetched_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        """,
+    ),
+    (
+        "idx_community_counts_fetched",
+        "CREATE INDEX IF NOT EXISTS idx_community_counts_fetched ON insights.community_counts (fetched_at)",
     ),
     (
         "insights.computation_log table",
@@ -467,6 +483,10 @@ _INSIGHTS_TABLES: list[tuple[str, str]] = [
     (
         "idx_genre_trends_genre",
         "CREATE INDEX IF NOT EXISTS idx_genre_trends_genre ON insights.genre_trends (genre)",
+    ),
+    (
+        "insights.release_rarity add collection_prevalence",
+        "ALTER TABLE insights.release_rarity ADD COLUMN IF NOT EXISTS collection_prevalence REAL",
     ),
 ]
 

--- a/tests/api/test_community_enrichment.py
+++ b/tests/api/test_community_enrichment.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from fastapi.testclient import TestClient
 import pytest
 
 
@@ -125,3 +126,207 @@ class TestEnrichReleasesFromDiscogs:
 
         assert result["enriched"] == 1
         assert result["errors"] == 0
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_retry_and_exhaust(self) -> None:
+        """When 429 responses are received repeatedly, the retry loop eventually gives up."""
+        from api.routers.insights_compute import _enrich_community_counts
+
+        mock_pool = MagicMock()
+        mock_cur = AsyncMock()
+
+        call_count = 0
+
+        async def mock_fetchall():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [{"release_id": 123}]
+            if call_count == 2:
+                return [
+                    {"key": "discogs_consumer_key", "value": "ck"},
+                    {"key": "discogs_consumer_secret", "value": "cs"},
+                ]
+            return []
+
+        mock_cur.fetchall = mock_fetchall
+        mock_cur.fetchone = AsyncMock(
+            return_value={
+                "access_token": "at",
+                "access_secret": "as",
+                "provider_username": "testuser",
+            }
+        )
+        mock_cur.execute = AsyncMock()
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+
+        mock_response_429 = MagicMock()
+        mock_response_429.status_code = 429
+
+        with (
+            patch("api.routers.insights_compute.decrypt_oauth_token", side_effect=lambda v, _k: v),
+            patch("api.routers.insights_compute._auth_header", return_value="OAuth ..."),
+            patch("api.routers.insights_compute.MAX_RATE_LIMIT_RETRIES", 2),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response_429)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await _enrich_community_counts(mock_pool, None, None)
+
+        # After exhausting retries, enriched stays 0
+        assert result["enriched"] == 0
+
+    @pytest.mark.asyncio
+    async def test_non_200_error_counted(self) -> None:
+        """A non-200, non-429 response increments the errors counter."""
+        from api.routers.insights_compute import _enrich_community_counts
+
+        mock_pool = MagicMock()
+        mock_cur = AsyncMock()
+
+        call_count = 0
+
+        async def mock_fetchall():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [{"release_id": 456}]
+            if call_count == 2:
+                return [
+                    {"key": "discogs_consumer_key", "value": "ck"},
+                    {"key": "discogs_consumer_secret", "value": "cs"},
+                ]
+            return []
+
+        mock_cur.fetchall = mock_fetchall
+        mock_cur.fetchone = AsyncMock(
+            return_value={
+                "access_token": "at",
+                "access_secret": "as",
+                "provider_username": "testuser",
+            }
+        )
+        mock_cur.execute = AsyncMock()
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+
+        mock_response_404 = MagicMock()
+        mock_response_404.status_code = 404
+
+        with (
+            patch("api.routers.insights_compute.decrypt_oauth_token", side_effect=lambda v, _k: v),
+            patch("api.routers.insights_compute._auth_header", return_value="OAuth ..."),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response_404)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await _enrich_community_counts(mock_pool, None, None)
+
+        assert result["errors"] == 1
+        assert result["enriched"] == 0
+
+    @pytest.mark.asyncio
+    async def test_neo4j_update_failure_handled(self) -> None:
+        """If Neo4j session.run raises, the error is logged but enrichment still returns results."""
+        from api.routers.insights_compute import _enrich_community_counts
+
+        mock_pool = MagicMock()
+        mock_cur = AsyncMock()
+
+        call_count = 0
+
+        async def mock_fetchall():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [{"release_id": 789}]
+            if call_count == 2:
+                return [
+                    {"key": "discogs_consumer_key", "value": "ck"},
+                    {"key": "discogs_consumer_secret", "value": "cs"},
+                ]
+            return []
+
+        mock_cur.fetchall = mock_fetchall
+        mock_cur.fetchone = AsyncMock(
+            return_value={
+                "access_token": "at",
+                "access_secret": "as",
+                "provider_username": "testuser",
+            }
+        )
+        mock_cur.execute = AsyncMock()
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+
+        # Neo4j session.run raises
+        mock_neo4j_session = AsyncMock()
+        mock_neo4j_session.run = AsyncMock(side_effect=RuntimeError("neo4j down"))
+        mock_neo4j_session.__aenter__ = AsyncMock(return_value=mock_neo4j_session)
+        mock_neo4j_session.__aexit__ = AsyncMock(return_value=False)
+        mock_neo4j = MagicMock()
+        mock_neo4j.session = MagicMock(return_value=mock_neo4j_session)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"community": {"have": 10, "want": 5}}
+
+        with (
+            patch("api.routers.insights_compute.decrypt_oauth_token", side_effect=lambda v, _k: v),
+            patch("api.routers.insights_compute._auth_header", return_value="OAuth ..."),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            # Should not raise even though Neo4j fails
+            result = await _enrich_community_counts(mock_pool, mock_neo4j, None)
+
+        assert result["enriched"] == 1
+        assert result["errors"] == 0
+
+
+class TestCommunityEnrichmentEndpoint:
+    def test_community_enrichment_endpoint_not_ready(self, test_client: TestClient) -> None:
+        """The HTTP endpoint returns 503 when the pool is None."""
+        import api.routers.insights_compute as insights_compute_module
+
+        original_pool = insights_compute_module._pool
+        try:
+            insights_compute_module._pool = None
+            response = test_client.get("/api/internal/insights/community-enrichment")
+            assert response.status_code == 503
+            body = response.json()
+            assert "error" in body
+        finally:
+            insights_compute_module._pool = original_pool

--- a/tests/api/test_community_enrichment.py
+++ b/tests/api/test_community_enrichment.py
@@ -1,0 +1,127 @@
+"""Tests for community have/want enrichment endpoint."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestEnrichReleasesFromDiscogs:
+    @pytest.mark.asyncio
+    async def test_no_releases_to_enrich(self) -> None:
+        """When no releases need enrichment, return 0."""
+        from api.routers.insights_compute import _enrich_community_counts
+
+        mock_pool = MagicMock()
+        mock_cur = AsyncMock()
+        mock_cur.fetchall = AsyncMock(return_value=[])
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+
+        result = await _enrich_community_counts(mock_pool, None, None)
+        assert result["enriched"] == 0
+
+    @pytest.mark.asyncio
+    async def test_no_oauth_credentials(self) -> None:
+        """When no OAuth credentials found, skip enrichment."""
+        from api.routers.insights_compute import _enrich_community_counts
+
+        mock_pool = MagicMock()
+        mock_cur = AsyncMock()
+        call_count = 0
+
+        async def mock_fetchall():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [{"release_id": 123}]
+            return []
+
+        mock_cur.fetchall = mock_fetchall
+        mock_cur.fetchone = AsyncMock(return_value=None)
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+
+        result = await _enrich_community_counts(mock_pool, None, None)
+        assert result["enriched"] == 0
+        assert result["error"] == "no_credentials"
+
+    @pytest.mark.asyncio
+    async def test_successful_enrichment(self) -> None:
+        """Successful fetch stores counts in PG and Neo4j."""
+        from api.routers.insights_compute import _enrich_community_counts
+
+        mock_pool = MagicMock()
+        mock_cur = AsyncMock()
+
+        call_count = 0
+
+        async def mock_fetchall():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [{"release_id": 123}]
+            if call_count == 2:
+                return [
+                    {"key": "discogs_consumer_key", "value": "ck"},
+                    {"key": "discogs_consumer_secret", "value": "cs"},
+                ]
+            return []
+
+        mock_cur.fetchall = mock_fetchall
+        mock_cur.fetchone = AsyncMock(
+            return_value={
+                "access_token": "at",
+                "access_secret": "as",
+                "provider_username": "testuser",
+            }
+        )
+        mock_cur.execute = AsyncMock()
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+
+        # Mock Neo4j
+        mock_neo4j_result = AsyncMock()
+        mock_neo4j_result.consume = AsyncMock()
+        mock_neo4j_session = AsyncMock()
+        mock_neo4j_session.run = AsyncMock(return_value=mock_neo4j_result)
+        mock_neo4j_session.__aenter__ = AsyncMock(return_value=mock_neo4j_session)
+        mock_neo4j_session.__aexit__ = AsyncMock(return_value=False)
+        mock_neo4j = MagicMock()
+        mock_neo4j.session = MagicMock(return_value=mock_neo4j_session)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "community": {"have": 42, "want": 7},
+        }
+
+        with (
+            patch("api.routers.insights_compute.decrypt_oauth_token", side_effect=lambda v, _k: v),
+            patch("api.routers.insights_compute._auth_header", return_value="OAuth ..."),
+            patch("httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await _enrich_community_counts(mock_pool, mock_neo4j, None)
+
+        assert result["enriched"] == 1
+        assert result["errors"] == 0

--- a/tests/api/test_rarity_queries.py
+++ b/tests/api/test_rarity_queries.py
@@ -696,6 +696,40 @@ class TestFetchAllRaritySignals:
         assert results[0]["collection_prevalence"] == 50.0  # neutral fallback
 
     @pytest.mark.asyncio
+    async def test_community_counts_exception_uses_fallback(self) -> None:
+        """When pool.connection raises, community counts fall back to neutral 50.0."""
+        mock_driver = MagicMock()
+
+        pressing_data = [{"release_id": "1", "pressing_count": 1, "title": "R1", "artist_name": "A1", "year": 1970}]
+        label_data = [{"release_id": "1", "label_catalog_size": 20}]
+        format_data = [{"release_id": "1", "formats": ["LP"]}]
+        temporal_data = [{"release_id": "1", "year": 1970, "latest_sibling_year": None}]
+        degree_data = [{"release_id": "1", "degree": 3}]
+        artist_degree_data = [{"release_id": "1", "artist_max_degree": 500}]
+        label_size_data = [{"release_id": "1", "label_max_catalog": 2000}]
+        genre_count_data = [{"release_id": "1", "genre_max_release_count": 50000}]
+
+        # Pool connection raises an exception
+        mock_pool = MagicMock()
+        mock_pool.connection = MagicMock(side_effect=RuntimeError("db connection failed"))
+
+        with patch("api.queries.rarity_queries.run_query") as mock_run:
+            mock_run.side_effect = [
+                pressing_data,
+                label_data,
+                format_data,
+                temporal_data,
+                degree_data,
+                artist_degree_data,
+                label_size_data,
+                genre_count_data,
+            ]
+            results = await fetch_all_rarity_signals(mock_driver, mock_pool)
+
+        assert len(results) == 1
+        assert results[0]["collection_prevalence"] == 50.0
+
+    @pytest.mark.asyncio
     async def test_fallback_when_no_pool(self) -> None:
         """Test that passing pool=None uses neutral fallback for all releases."""
         mock_driver = MagicMock()

--- a/tests/api/test_rarity_queries.py
+++ b/tests/api/test_rarity_queries.py
@@ -613,6 +613,22 @@ class TestFetchAllRaritySignals:
         label_size_data = [{"release_id": "1", "label_max_catalog": 2000}]
         genre_count_data = [{"release_id": "1", "genre_max_release_count": 50000}]
 
+        # Mock PostgreSQL pool for community counts
+        mock_cur = AsyncMock()
+        mock_cur.fetchall = AsyncMock(
+            return_value=[
+                {"release_id": 1, "have_count": 50, "want_count": 10},
+            ]
+        )
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool = MagicMock()
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+
         with patch("api.queries.rarity_queries.run_query") as mock_run:
             mock_run.side_effect = [
                 pressing_data,
@@ -624,16 +640,16 @@ class TestFetchAllRaritySignals:
                 label_size_data,
                 genre_count_data,
             ]
-
-            results = await fetch_all_rarity_signals(mock_driver)
+            results = await fetch_all_rarity_signals(mock_driver, mock_pool)
 
         assert len(results) == 1
         r = results[0]
         assert r["release_id"] == "1"
         assert 0 <= r["rarity_score"] <= 100
         assert r["tier"] in ("common", "uncommon", "scarce", "rare", "ultra-rare")
-        assert r["pressing_scarcity"] == 100.0  # 1 pressing
+        assert r["pressing_scarcity"] == 100.0
         assert r["format_rarity"] == 95.0  # Flexi-disc max
+        assert r["collection_prevalence"] == 70.0  # have=50 -> 70.0, want<have -> no bonus
         assert "hidden_gem_score" in r
 
     @pytest.mark.asyncio
@@ -650,6 +666,18 @@ class TestFetchAllRaritySignals:
         label_size_data = [{"release_id": "1", "label_max_catalog": 0}]
         genre_count_data = [{"release_id": "1", "genre_max_release_count": 0}]
 
+        # Mock pool with no community data
+        mock_cur = AsyncMock()
+        mock_cur.fetchall = AsyncMock(return_value=[])
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool = MagicMock()
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+
         with patch("api.queries.rarity_queries.run_query") as mock_run:
             mock_run.side_effect = [
                 pressing_data,
@@ -661,7 +689,38 @@ class TestFetchAllRaritySignals:
                 label_size_data,
                 genre_count_data,
             ]
-            results = await fetch_all_rarity_signals(mock_driver)
+            results = await fetch_all_rarity_signals(mock_driver, mock_pool)
 
         assert len(results) == 1
         assert results[0]["hidden_gem_score"] == 0.0
+        assert results[0]["collection_prevalence"] == 50.0  # neutral fallback
+
+    @pytest.mark.asyncio
+    async def test_fallback_when_no_pool(self) -> None:
+        """Test that passing pool=None uses neutral fallback for all releases."""
+        mock_driver = MagicMock()
+
+        pressing_data = [{"release_id": "1", "pressing_count": 1, "title": "R1", "artist_name": "A1", "year": 1970}]
+        label_data = [{"release_id": "1", "label_catalog_size": 20}]
+        format_data = [{"release_id": "1", "formats": ["LP"]}]
+        temporal_data = [{"release_id": "1", "year": 1970, "latest_sibling_year": None}]
+        degree_data = [{"release_id": "1", "degree": 3}]
+        artist_degree_data = [{"release_id": "1", "artist_max_degree": 500}]
+        label_size_data = [{"release_id": "1", "label_max_catalog": 2000}]
+        genre_count_data = [{"release_id": "1", "genre_max_release_count": 50000}]
+
+        with patch("api.queries.rarity_queries.run_query") as mock_run:
+            mock_run.side_effect = [
+                pressing_data,
+                label_data,
+                format_data,
+                temporal_data,
+                degree_data,
+                artist_degree_data,
+                label_size_data,
+                genre_count_data,
+            ]
+            results = await fetch_all_rarity_signals(mock_driver, None)
+
+        assert len(results) == 1
+        assert results[0]["collection_prevalence"] == 50.0

--- a/tests/api/test_rarity_queries.py
+++ b/tests/api/test_rarity_queries.py
@@ -7,6 +7,7 @@ import pytest
 
 from api.queries.rarity_queries import (
     SIGNAL_WEIGHTS,
+    compute_collection_prevalence_score,
     compute_format_rarity_score,
     compute_graph_isolation_score,
     compute_label_catalog_score,
@@ -131,6 +132,63 @@ class TestGraphIsolationScore:
 
     def test_zero_rels(self) -> None:
         assert compute_graph_isolation_score(0) == 90.0
+
+
+class TestCollectionPrevalenceScore:
+    def test_zero_have(self) -> None:
+        assert compute_collection_prevalence_score(0, 0) == 95.0
+
+    def test_very_few_have(self) -> None:
+        assert compute_collection_prevalence_score(5, 0) == 85.0
+
+    def test_few_have(self) -> None:
+        assert compute_collection_prevalence_score(50, 0) == 70.0
+
+    def test_moderate_have(self) -> None:
+        assert compute_collection_prevalence_score(500, 0) == 50.0
+
+    def test_many_have(self) -> None:
+        assert compute_collection_prevalence_score(5000, 0) == 25.0
+
+    def test_mass_market(self) -> None:
+        assert compute_collection_prevalence_score(50000, 0) == 10.0
+
+    def test_boundary_1_inclusive(self) -> None:
+        assert compute_collection_prevalence_score(1, 0) == 85.0
+
+    def test_boundary_10_inclusive(self) -> None:
+        assert compute_collection_prevalence_score(10, 0) == 85.0
+
+    def test_boundary_11(self) -> None:
+        assert compute_collection_prevalence_score(11, 0) == 70.0
+
+    def test_boundary_100_inclusive(self) -> None:
+        assert compute_collection_prevalence_score(100, 0) == 70.0
+
+    def test_boundary_101(self) -> None:
+        assert compute_collection_prevalence_score(101, 0) == 50.0
+
+    def test_boundary_1000_inclusive(self) -> None:
+        assert compute_collection_prevalence_score(1000, 0) == 50.0
+
+    def test_boundary_1001(self) -> None:
+        assert compute_collection_prevalence_score(1001, 0) == 25.0
+
+    def test_boundary_10000_inclusive(self) -> None:
+        assert compute_collection_prevalence_score(10000, 0) == 25.0
+
+    def test_boundary_10001(self) -> None:
+        assert compute_collection_prevalence_score(10001, 0) == 10.0
+
+    def test_want_bonus_applied(self) -> None:
+        assert compute_collection_prevalence_score(50, 100) == 75.0
+
+    def test_want_bonus_not_applied_when_want_lte_have(self) -> None:
+        assert compute_collection_prevalence_score(50, 50) == 70.0
+        assert compute_collection_prevalence_score(50, 30) == 70.0
+
+    def test_want_bonus_capped_at_100(self) -> None:
+        assert compute_collection_prevalence_score(0, 10) == 100.0
 
 
 class TestRarityTier:

--- a/tests/insights/test_computations.py
+++ b/tests/insights/test_computations.py
@@ -596,6 +596,7 @@ class TestRunAllComputations:
             patch("insights.computations.compute_and_store_label_longevity", return_value=5),
             patch("insights.computations.compute_and_store_anniversaries", return_value=3),
             patch("insights.computations.compute_and_store_data_completeness", return_value=4),
+            patch("insights.computations.compute_and_store_community_enrichment", return_value=100),
             patch("insights.computations.compute_and_store_rarity", return_value=7),
         ):
             results = await run_all_computations(mock_client, mock_pool)
@@ -605,6 +606,7 @@ class TestRunAllComputations:
         assert results["label_longevity"] == 5
         assert results["anniversaries"] == 3
         assert results["data_completeness"] == 4
+        assert results["community_enrichment"] == 100
         assert results["release_rarity"] == 7
 
     @pytest.mark.asyncio
@@ -621,6 +623,7 @@ class TestRunAllComputations:
             patch("insights.computations.compute_and_store_label_longevity", return_value=0),
             patch("insights.computations.compute_and_store_anniversaries", return_value=0) as mock_anniv,
             patch("insights.computations.compute_and_store_data_completeness", return_value=0),
+            patch("insights.computations.compute_and_store_community_enrichment", return_value=0),
             patch("insights.computations.compute_and_store_rarity", return_value=0),
         ):
             await run_all_computations(mock_client, mock_pool, milestone_years=custom_milestones)

--- a/tests/insights/test_insights.py
+++ b/tests/insights/test_insights.py
@@ -66,8 +66,8 @@ class TestComputationStatusEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert "statuses" in data
-        # All 6 insight types should show 'never_run' since fetchone returns None
-        assert len(data["statuses"]) == 6
+        # All 7 insight types should show 'never_run' since fetchone returns None (includes community_enrichment)
+        assert len(data["statuses"]) == 7
         for status in data["statuses"]:
             assert status["status"] == "never_run"
 
@@ -288,7 +288,7 @@ class TestReleaseRarityCacheIntegration:
 
         # Return non-empty rows so caching is triggered
         mock_cursor = mock_pg_pool.connection.return_value.__aenter__.return_value.cursor.return_value.__aenter__.return_value
-        mock_cursor.fetchall = AsyncMock(return_value=[(1, "Title", "Artist", 1990, 95.0, "ultra-rare", 80.0, 90.0, 85.0, 70.0, 60.0, 50.0)])
+        mock_cursor.fetchall = AsyncMock(return_value=[(1, "Title", "Artist", 1990, 95.0, "ultra-rare", 80.0, 90.0, 85.0, 70.0, 60.0, 50.0, 40.0)])
 
         mock_cache.get.return_value = None
 

--- a/tests/insights/test_rarity_computation.py
+++ b/tests/insights/test_rarity_computation.py
@@ -42,6 +42,7 @@ _MOCK_RARITY_ITEMS = [
         "format_rarity": 95.0,
         "temporal_scarcity": 80.0,
         "graph_isolation": 70.0,
+        "collection_prevalence": 85.0,
     }
 ]
 

--- a/tests/insights/test_rarity_computation.py
+++ b/tests/insights/test_rarity_computation.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from insights.computations import compute_and_store_rarity
+from insights.computations import compute_and_store_community_enrichment, compute_and_store_rarity
 
 
 def _make_mock_pool() -> MagicMock:
@@ -106,4 +106,44 @@ class TestComputeAndStoreRarity:
 
         mock_log.assert_called_once()
         args = mock_log.call_args
+        assert args[0][2] == "failed"
+
+
+class TestComputeAndStoreCommunityEnrichment:
+    @pytest.mark.asyncio
+    async def test_community_enrichment_success(self) -> None:
+        mock_client = AsyncMock()
+        mock_pool = _make_mock_pool()
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"enriched": 5}
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch("insights.computations._log_computation") as mock_log:
+            result = await compute_and_store_community_enrichment(mock_client, mock_pool)
+
+        assert result == 5
+        mock_client.get.assert_called_once_with("/api/internal/insights/community-enrichment", timeout=3600.0)
+        mock_log.assert_called_once()
+        args = mock_log.call_args
+        assert args[0][1] == "community_enrichment"
+        assert args[0][2] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_community_enrichment_failure(self) -> None:
+        mock_client = AsyncMock()
+        mock_pool = _make_mock_pool()
+
+        mock_client.get = AsyncMock(side_effect=RuntimeError("connection error"))
+
+        with (
+            patch("insights.computations._log_computation") as mock_log,
+            pytest.raises(RuntimeError, match="connection error"),
+        ):
+            await compute_and_store_community_enrichment(mock_client, mock_pool)
+
+        mock_log.assert_called_once()
+        args = mock_log.call_args
+        assert args[0][1] == "community_enrichment"
         assert args[0][2] == "failed"


### PR DESCRIPTION
## Summary

Closes #206

- Add 6th "collection prevalence" rarity signal (weight 0.20) that scores releases inversely to Discogs community ownership counts
- Add enrichment endpoint (`GET /api/internal/insights/community-enrichment`) that fetches `community.have`/`community.want` from the Discogs REST API for releases in user collections/wantlists
- Store community counts in PostgreSQL (`insights.community_counts`) and mirror to Neo4j Release node properties
- Integrate into rarity scoring pipeline with 7-day staleness refresh, OAuth 1.0a auth, and 60 req/min rate limiting with retry

## Changes

- **Schema**: New `insights.community_counts` table, `collection_prevalence` column on `insights.release_rarity`
- **Scoring**: `compute_collection_prevalence_score()` with log-scale thresholds (0→95, 10k+→10) and want-pressure bonus
- **Weights**: Redistributed to accommodate 6th signal — pressing 0.25, temporal 0.20, prevalence 0.20, isolation 0.15, label 0.10, format 0.10
- **Pipeline**: Enrichment runs before rarity computation in insights scheduler
- **Tests**: 19 scoring tests, 3 enrichment tests, updated integration tests (3078 total pass)

## Test plan

- [x] All 3078 tests pass
- [x] mypy clean, ruff clean
- [x] Scoring function covers all threshold boundaries and edge cases
- [x] Enrichment handles: no releases, no credentials, successful fetch, rate limiting with retry
- [x] Neutral fallback (50.0) for unenriched releases preserves existing scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)