### PR TITLE
fix: broken /static/brand/ paths, narrow account settings, blank 2FA QR

### DIFF
--- a/dashboard/static/admin.html
+++ b/dashboard/static/admin.html
@@ -10,12 +10,12 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@1.3.1/dist/chartjs-adapter-luxon.umd.min.js" integrity="sha384-7cWzHabR6ZyfMWzZgVssYaOQRTccHUWZ0F09AanlF3RAJ/JNyFnIma2JTYIVKEUP" crossorigin="anonymous"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
-    <link rel="icon" type="image/x-icon" href="/static/brand/favicon.ico">
-    <link rel="icon" type="image/png" sizes="32x32" href="/static/brand/favicon-32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/static/brand/favicon-16.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/static/brand/apple-touch-icon.png">
-    <link rel="manifest" href="/static/brand/site.webmanifest">
-    <meta property="og:image" content="/static/brand/og_image.png">
+    <link rel="icon" type="image/x-icon" href="/brand/favicon.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="/brand/favicon-32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/brand/favicon-16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/brand/apple-touch-icon.png">
+    <link rel="manifest" href="/brand/site.webmanifest">
+    <meta property="og:image" content="/brand/og_image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <style>
@@ -221,7 +221,7 @@
             <div class="flex items-center space-x-5">
                 <!-- Logo -->
                 <div aria-label="Discogsography logo">
-                    <img src="/static/brand/icon_dark.png" alt="Discogsography" style="width:40px;height:40px;border-radius:50%;">
+                    <img src="/brand/icon_dark.png" alt="Discogsography" style="width:40px;height:40px;border-radius:50%;">
                 </div>
                 <div>
                     <h1 class="text-xl font-semibold tracking-tight">Discogsography Admin</h1>

--- a/dashboard/static/brand/site.webmanifest
+++ b/dashboard/static/brand/site.webmanifest
@@ -4,12 +4,12 @@
   "description": "The Choon Network \u2014 music knowledge graph",
   "icons": [
     {
-      "src": "/static/brand/favicon-192.png",
+      "src": "/brand/favicon-192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/static/brand/favicon-512.png",
+      "src": "/brand/favicon-512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -7,12 +7,12 @@
     <link href="/tailwind.css" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
-    <link rel="icon" type="image/x-icon" href="/static/brand/favicon.ico">
-    <link rel="icon" type="image/png" sizes="32x32" href="/static/brand/favicon-32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/static/brand/favicon-16.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/static/brand/apple-touch-icon.png">
-    <link rel="manifest" href="/static/brand/site.webmanifest">
-    <meta property="og:image" content="/static/brand/og_image.png">
+    <link rel="icon" type="image/x-icon" href="/brand/favicon.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="/brand/favicon-32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/brand/favicon-16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/brand/apple-touch-icon.png">
+    <link rel="manifest" href="/brand/site.webmanifest">
+    <meta property="og:image" content="/brand/og_image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <style>
@@ -89,7 +89,7 @@
                  its own size and shape.
                  ============================================================ -->
             <div id="app-logo" aria-label="Discogsography logo">
-                <img src="/static/brand/icon_dark.png" alt="Discogsography" style="width:40px;height:40px;border-radius:50%;">
+                <img src="/brand/icon_dark.png" alt="Discogsography" style="width:40px;height:40px;border-radius:50%;">
             </div>
             <!-- END LOGO -->
 

--- a/explore/static/brand/site.webmanifest
+++ b/explore/static/brand/site.webmanifest
@@ -4,12 +4,12 @@
   "description": "The Choon Network \u2014 music knowledge graph",
   "icons": [
     {
-      "src": "/static/brand/favicon-192.png",
+      "src": "/brand/favicon-192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/static/brand/favicon-512.png",
+      "src": "/brand/favicon-512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/explore/static/css/styles.css
+++ b/explore/static/css/styles.css
@@ -2360,11 +2360,16 @@ select option {
 /* ── Settings page ──────────────────────────────────────────────────────── */
 
 .settings-page {
-    max-width: 42rem;
-    margin: 0 auto;
-    padding: 2rem 1rem;
+    padding: 2rem 2rem;
     overflow-y: auto;
     height: 100%;
+}
+
+.settings-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(28rem, 1fr));
+    gap: 1rem;
+    align-items: start;
 }
 
 .settings-header {

--- a/explore/static/index.html
+++ b/explore/static/index.html
@@ -7,12 +7,12 @@
     <link href="tailwind.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
-    <link rel="icon" type="image/x-icon" href="/static/brand/favicon.ico">
-    <link rel="icon" type="image/png" sizes="32x32" href="/static/brand/favicon-32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/static/brand/favicon-16.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="/static/brand/apple-touch-icon.png">
-    <link rel="manifest" href="/static/brand/site.webmanifest">
-    <meta property="og:image" content="/static/brand/og_image.png">
+    <link rel="icon" type="image/x-icon" href="/brand/favicon.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="/brand/favicon-32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/brand/favicon-16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/brand/apple-touch-icon.png">
+    <link rel="manifest" href="/brand/site.webmanifest">
+    <meta property="og:image" content="/brand/og_image.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <script src="https://d3js.org/d3.v7.min.js" integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i" crossorigin="anonymous"></script>
@@ -433,7 +433,7 @@ body {
             <!-- Brand -->
             <div class="navbar-brand">
                 <div id="app-logo" class="flex-shrink-0" aria-label="Discogsography logo">
-                    <img src="/static/brand/icon_dark.png" alt="Discogsography" style="width:32px;height:32px;border-radius:50%;">
+                    <img src="/brand/icon_dark.png" alt="Discogsography" style="width:32px;height:32px;border-radius:50%;">
                 </div>
                 <a class="navbar-title" href="#">
                     <span style="font-family:'Space Grotesk',sans-serif;font-weight:700;font-size:0.95rem;letter-spacing:-0.03em;" class="t-high">discogsography</span>
@@ -1111,6 +1111,7 @@ body {
                     <h2 class="settings-title">Account Settings</h2>
                 </div>
 
+                <div class="settings-grid">
                 <!-- Profile Card -->
                 <div class="settings-card" id="settingsProfileCard">
                     <div class="settings-card-header">
@@ -1170,6 +1171,7 @@ body {
                         <!-- Populated dynamically by settings.js -->
                     </div>
                 </div>
+                </div><!-- /.settings-grid -->
             </div>
         </div>
 

--- a/explore/static/js/settings.js
+++ b/explore/static/js/settings.js
@@ -8,7 +8,7 @@ class SettingsPane {
     constructor() {
         this._initialized = false;
         this._twoFaState = 'disabled'; // disabled | setup | recovery | enabled | disableConfirm
-        this._setupData = null;        // { secret, provisioning_uri } from /api/auth/2fa/setup
+        this._setupData = null;        // { secret, otpauth_uri } from /api/auth/2fa/setup
         this._recoveryCodes = null;    // string[] from /api/auth/2fa/confirm
     }
 
@@ -229,7 +229,7 @@ class SettingsPane {
         container.appendChild(qrContainer);
         /* global QRCode */
         new QRCode(qrContainer, {
-            text: this._setupData.provisioning_uri,
+            text: this._setupData.otpauth_uri,
             width: 160,
             height: 160,
             colorDark: '#000000',


### PR DESCRIPTION
## Summary

- **Broken logo/favicons (PR #295 regression)**: StaticFiles is mounted at `/` in dashboard and explore, so `/static/brand/...` resolved to a non-existent nested `static/static/brand/` path. Fixed in `admin.html`, both `index.html` files, and both `site.webmanifest` files.
- **Narrow Account Settings view**: `.settings-page` had `max-width: 42rem` forcing a narrow centered column. Removed the cap and wrapped the three cards (Profile, Password, 2FA) in a `.settings-grid` that tiles with `auto-fit, minmax(28rem, 1fr)`.
- **Blank 2FA QR code**: Client read `this._setupData.provisioning_uri` but the API `/api/auth/2fa/setup` returns `otpauth_uri`. QRCode library received `undefined` → empty white canvas. Field name fixed in `settings.js`.

## Test plan

- [ ] Load dashboard index — logo + favicons render (not broken image)
- [ ] Load `/admin` — logo + favicons render
- [ ] Load explore index — logo + favicons render
- [ ] Open Account Settings in explore — cards use full viewport width, tile on wide screens
- [ ] Enable 2FA in explore — QR code renders scannable image, manual secret still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)