### PR TITLE
fix: align explore search bar inline with brand and login

### DIFF
--- a/explore/static/css/styles.css
+++ b/explore/static/css/styles.css
@@ -111,11 +111,14 @@
     border-bottom: 1px solid var(--border-color);
 }
 
-/* Top bar: brand | search | utilities */
+/* Top bar: 3-column grid so brand | search | utils stay vertically aligned
+   regardless of how tall the optional NLQ extras row beneath search becomes. */
 .navbar-top {
-    display: flex;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    grid-template-rows: auto auto;
     align-items: center;
-    gap: 1rem;
+    column-gap: 1rem;
     padding: 0.5rem 1rem;
 }
 
@@ -124,6 +127,8 @@
     align-items: center;
     gap: 0.625rem;
     flex-shrink: 0;
+    grid-column: 1;
+    grid-row: 1;
 }
 
 .navbar-title {
@@ -140,11 +145,27 @@
     text-decoration: none;
 }
 
-/* Search — flex-grow to fill center */
+/* Search — centered in column 2 of the navbar grid */
 .navbar-search {
-    flex: 1;
+    grid-column: 2;
+    grid-row: 1;
+    justify-self: center;
+    width: 100%;
     max-width: 520px;
-    margin: 0 auto;
+}
+
+/* Optional NLQ extras row (Search/Ask toggle + Ask panel) — sits below the
+   search input in row 2 so the input stays inline with brand and login. */
+.navbar-search-extras {
+    grid-column: 2;
+    grid-row: 2;
+    justify-self: center;
+    width: 100%;
+    max-width: 520px;
+}
+
+#searchAskToggle {
+    margin-top: 0.5rem;
 }
 
 /* Utilities cluster */
@@ -153,6 +174,8 @@
     align-items: center;
     gap: 0.5rem;
     flex-shrink: 0;
+    grid-column: 3;
+    grid-row: 1;
 }
 
 .navbar-icon-btn {
@@ -287,7 +310,7 @@
     width: 400px;
 }
 
-.search-container .flex {
+.search-container > .flex {
     width: 100%;
 }
 

--- a/explore/static/index.html
+++ b/explore/static/index.html
@@ -466,8 +466,13 @@ body {
                     </button>
                 </div>
                 <div class="autocomplete-dropdown" id="autocompleteDropdown"></div>
+            </div>
+
+            <!-- NLQ Search/Ask toggle + panel — separate row 2 of navbar grid
+                 so the search input above stays vertically aligned with brand and login. -->
+            <div class="navbar-search-extras">
                 <!-- NLQ Search/Ask Toggle -->
-                <div id="searchAskToggle" style="display: none;" class="flex gap-1 mt-2">
+                <div id="searchAskToggle" style="display: none;" class="flex gap-1 justify-center">
                     <button id="searchModeBtn" class="px-3 py-1 text-xs rounded-full bg-purple-accent text-white">Search</button>
                     <button id="askModeBtn" class="px-3 py-1 text-xs rounded-full bg-inner-bg text-text-mid border border-border-color hover:bg-bg-hover">Ask</button>
                 </div>


### PR DESCRIPTION
## Summary

- The Search/Ask NLQ toggle was nested inside `.navbar-search`, making the search column 72px tall while brand and login were 32px. With `align-items: center`, the input row floated to the top of its column and visually misaligned with brand/login.
- Switched `.navbar-top` from flex to a 3-column CSS grid (`auto 1fr auto`) with two rows. Brand, search input, and login are pinned to row 1.
- Moved `#searchAskToggle` and `#nlqPanel` out of `.navbar-search` into a sibling `.navbar-search-extras` div that occupies row 2 of column 2, so the input row stays inline with brand and login regardless of NLQ state.

### Before
The search bar sat below the logo's center line because the toggle was expanding its container.

### After
Brand, search input, and login button all share the same horizontal centerline. Search/Ask toggle (when NLQ is enabled) sits centered in row 2 below the search input, above the tab bar.

## Test plan

- [x] All 953 explore JS tests pass (`just test-js`)
- [x] Verified live by injecting CSS into the deployed page: row 1 brand/input/login centered at y=27; extras row at y=62-96; tabs start at y=104, no overlap
- [ ] Visual review on staging after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)