### PR TITLE
fix: 2FA recovery codes display, sync rate limit, taste strip gap, btn-danger

### DIFF
--- a/api/notifications.py
+++ b/api/notifications.py
@@ -57,6 +57,12 @@ class BrevoNotificationChannel:
         )
 
         logger.debug("🔑 Sending password reset email", email=email)
+        # Click tracking cannot be disabled per-message via the v3 transactional
+        # API — the SDK's `headers` field rejects standard email headers, and
+        # `X-Mailin-Track*` are SMTP-relay only. To prevent password reset URLs
+        # from being wrapped in a sendibt2.com redirect, click tracking must be
+        # turned off in the Brevo dashboard (Senders, Domains & IPs → your
+        # sending domain → Tracking, or Account Settings → Tracking).
         try:
             await asyncio.to_thread(
                 self._client.transactional_emails.send_transac_email,
@@ -67,9 +73,6 @@ class BrevoNotificationChannel:
                     email=self._sender_email,
                 ),
                 to=[SendTransacEmailRequestToItem(email=email)],
-                # Disable Brevo link tracking so the reset URL is delivered
-                # as-is rather than wrapped in a tracking redirect.
-                headers={"X-Mailin-Track-Links": "0", "X-Mailin-Track": "0"},
             )
             logger.info("📧 Password reset email sent", email=email)
         except Exception:

--- a/api/routers/sync.py
+++ b/api/routers/sync.py
@@ -88,7 +88,7 @@ async def _get_current_user(
 
 
 @router.post("/api/sync", status_code=status.HTTP_202_ACCEPTED)
-@limiter.limit("2/10minute")
+@limiter.limit("10/minute")
 async def trigger_sync(
     request: Request,  # noqa: ARG001 — required by slowapi rate limiter
     current_user: Annotated[dict[str, Any], Depends(_get_current_user)],
@@ -175,7 +175,7 @@ async def trigger_sync(
 
     # Set cooldown BEFORE releasing lock to prevent TOCTOU race
     if _redis:
-        await _redis.setex(f"sync:cooldown:{user_id}", 600, "1")
+        await _redis.setex(f"sync:cooldown:{user_id}", 60, "1")
         await _redis.delete(f"sync:lock:{user_id}")  # Safe: cooldown is already in place
 
     logger.info("🔄 Sync triggered", user_id=user_id, sync_id=sync_id)

--- a/explore/__tests__/api-client.test.js
+++ b/explore/__tests__/api-client.test.js
@@ -801,31 +801,50 @@ describe('ApiClient', () => {
     });
 
     describe('sync methods', () => {
-        it('triggerSync should return null without token', async () => {
+        it('triggerSync should return not-ok envelope without token', async () => {
             const result = await window.apiClient.triggerSync(null);
-            expect(result).toBeNull();
+            expect(result).toEqual({ ok: false, status: 0, body: null });
         });
 
         it('triggerSync should use POST method', async () => {
             let capturedOptions;
             vi.stubGlobal('fetch', async (_url, options) => {
                 capturedOptions = options;
-                return { ok: true, json: async () => ({ syncing: true }) };
+                return { ok: true, status: 202, json: async () => ({ syncing: true }) };
             });
-
-            await window.apiClient.triggerSync('token');
-            expect(capturedOptions.method).toBe('POST');
-            expect(capturedOptions.headers['Authorization']).toBe('Bearer token');
-        });
-
-        it('triggerSync should return null on HTTP error', async () => {
-            const mockFetch = createMockFetch({
-                '/api/sync': { status: 500 },
-            });
-            vi.stubGlobal('fetch', mockFetch);
 
             const result = await window.apiClient.triggerSync('token');
-            expect(result).toBeNull();
+            expect(capturedOptions.method).toBe('POST');
+            expect(capturedOptions.headers['Authorization']).toBe('Bearer token');
+            expect(result.ok).toBe(true);
+            expect(result.status).toBe(202);
+            expect(result.body).toEqual({ syncing: true });
+        });
+
+        it('triggerSync should surface 429 status and body', async () => {
+            vi.stubGlobal('fetch', async () => ({
+                ok: false,
+                status: 429,
+                json: async () => ({ status: 'cooldown', message: 'Sync rate limited.' }),
+            }));
+
+            const result = await window.apiClient.triggerSync('token');
+            expect(result.ok).toBe(false);
+            expect(result.status).toBe(429);
+            expect(result.body).toEqual({ status: 'cooldown', message: 'Sync rate limited.' });
+        });
+
+        it('triggerSync should surface 500 status with null body', async () => {
+            vi.stubGlobal('fetch', async () => ({
+                ok: false,
+                status: 500,
+                json: async () => { throw new Error('not json'); },
+            }));
+
+            const result = await window.apiClient.triggerSync('token');
+            expect(result.ok).toBe(false);
+            expect(result.status).toBe(500);
+            expect(result.body).toBeNull();
         });
 
         it('getSyncStatus should return null without token', async () => {

--- a/explore/__tests__/app.test.js
+++ b/explore/__tests__/app.test.js
@@ -2584,9 +2584,9 @@ describe('app.js NLQ wiring (inline simulation)', () => {
         toggle.style.display = 'none';
 
         const enabled = await nlqPanel.checkEnabled();
-        if (enabled) toggle.style.display = '';
+        if (enabled) toggle.style.display = 'flex';
 
-        expect(toggle.style.display).toBe('');
+        expect(toggle.style.display).toBe('flex');
     });
 
     it('? keyboard shortcut should trigger askModeBtn click', () => {
@@ -2648,7 +2648,7 @@ describe('app.js NLQ wiring (inline simulation)', () => {
         toggle.style.display = 'none';
 
         const enabled = await nlqPanel.checkEnabled();
-        if (enabled) toggle.style.display = '';
+        if (enabled) toggle.style.display = 'flex';
 
         expect(toggle.style.display).toBe('none');
     });

--- a/explore/__tests__/settings.test.js
+++ b/explore/__tests__/settings.test.js
@@ -52,13 +52,19 @@ function setupMocks() {
 
     window.apiClient = {
         changePassword: vi.fn().mockResolvedValue({ ok: true }),
+        // Real /api/auth/2fa/setup returns secret, otpauth_uri, AND recovery_codes.
         twoFactorSetup: vi.fn().mockResolvedValue({
             ok: true,
-            json: async () => ({ secret: 'JBSWY3DPEHPK3PXP', provisioning_uri: 'otpauth://totp/test' }),
+            json: async () => ({
+                secret: 'JBSWY3DPEHPK3PXP',
+                otpauth_uri: 'otpauth://totp/test',
+                recovery_codes: ['code1', 'code2', 'code3', 'code4'],
+            }),
         }),
+        // Real /api/auth/2fa/confirm returns only {message} — no codes.
         twoFactorConfirm: vi.fn().mockResolvedValue({
             ok: true,
-            json: async () => ({ recovery_codes: ['code1', 'code2', 'code3', 'code4'] }),
+            json: async () => ({ message: '2FA has been enabled' }),
         }),
         twoFactorDisable: vi.fn().mockResolvedValue({ ok: true }),
     };
@@ -486,7 +492,8 @@ describe('SettingsPane', () => {
             expect(window.settingsPane._twoFaState).toBe('setup');
             expect(window.settingsPane._setupData).toEqual({
                 secret: 'JBSWY3DPEHPK3PXP',
-                provisioning_uri: 'otpauth://totp/test',
+                otpauth_uri: 'otpauth://totp/test',
+                recovery_codes: ['code1', 'code2', 'code3', 'code4'],
             });
         });
 

--- a/explore/__tests__/user-panes.test.js
+++ b/explore/__tests__/user-panes.test.js
@@ -52,7 +52,7 @@ describe('UserPanes', () => {
             getTasteCard: vi.fn().mockResolvedValue(null),
             getCollectionGaps: vi.fn().mockResolvedValue(null),
             getCollectionFormats: vi.fn().mockResolvedValue({ formats: [] }),
-            triggerSync: vi.fn().mockResolvedValue(false),
+            triggerSync: vi.fn().mockResolvedValue({ ok: false, status: 500, body: null }),
             authorizeDiscogs: vi.fn().mockResolvedValue(null),
             verifyDiscogs: vi.fn().mockResolvedValue(null),
             revokeDiscogs: vi.fn().mockResolvedValue(null),
@@ -632,12 +632,26 @@ describe('UserPanes', () => {
 
         it('should reset sync button state after completion', async () => {
             const btn = document.getElementById('syncBtn');
-            window.apiClient.triggerSync.mockResolvedValue(false);
+            window.apiClient.triggerSync.mockResolvedValue({ ok: false, status: 500, body: null });
+            window.alert = vi.fn();
 
             await userPanes.triggerSync();
 
             expect(btn.classList.contains('syncing')).toBe(false);
             expect(btn.disabled).toBe(false);
+        });
+
+        it('should show cooldown message on 429', async () => {
+            window.apiClient.triggerSync.mockResolvedValue({
+                ok: false,
+                status: 429,
+                body: { status: 'cooldown', message: 'Sync rate limited.' },
+            });
+            window.alert = vi.fn();
+
+            await userPanes.triggerSync();
+
+            expect(window.alert).toHaveBeenCalledWith('Sync rate limited.');
         });
     });
 

--- a/explore/__tests__/user-panes.test.js
+++ b/explore/__tests__/user-panes.test.js
@@ -653,6 +653,90 @@ describe('UserPanes', () => {
 
             expect(window.alert).toHaveBeenCalledWith('Sync rate limited.');
         });
+
+        it('should fall back to default cooldown message on 429 with empty body', async () => {
+            window.apiClient.triggerSync.mockResolvedValue({
+                ok: false,
+                status: 429,
+                body: null,
+            });
+            window.alert = vi.fn();
+
+            await userPanes.triggerSync();
+
+            expect(window.alert).toHaveBeenCalledWith(
+                'Sync was triggered very recently. Please wait a moment before trying again.',
+            );
+        });
+
+        it('should show service-unavailable message on 503', async () => {
+            window.apiClient.triggerSync.mockResolvedValue({
+                ok: false,
+                status: 503,
+                body: { detail: 'Service not ready' },
+            });
+            window.alert = vi.fn();
+
+            await userPanes.triggerSync();
+
+            expect(window.alert).toHaveBeenCalledWith(
+                'Sync service is not ready. Please try again in a moment.',
+            );
+        });
+
+        it('should show body.detail on generic non-ok status', async () => {
+            window.apiClient.triggerSync.mockResolvedValue({
+                ok: false,
+                status: 400,
+                body: { detail: 'Discogs not connected' },
+            });
+            window.alert = vi.fn();
+
+            await userPanes.triggerSync();
+
+            expect(window.alert).toHaveBeenCalledWith('Discogs not connected');
+        });
+
+        it('should prefer body.message when body.detail is missing', async () => {
+            window.apiClient.triggerSync.mockResolvedValue({
+                ok: false,
+                status: 500,
+                body: { message: 'Custom server error' },
+            });
+            window.alert = vi.fn();
+
+            await userPanes.triggerSync();
+
+            expect(window.alert).toHaveBeenCalledWith('Custom server error');
+        });
+
+        it('should reload panes after success and not alert', async () => {
+            vi.useFakeTimers();
+            try {
+                window.apiClient.triggerSync.mockResolvedValue({
+                    ok: true,
+                    status: 202,
+                    body: { sync_id: 'abc-123', status: 'started' },
+                });
+                window.alert = vi.fn();
+                const loadCollectionSpy = vi.spyOn(userPanes, 'loadCollection');
+                const loadWantlistSpy = vi.spyOn(userPanes, 'loadWantlist');
+                const clearTasteCacheSpy = vi.spyOn(userPanes, 'clearTasteCache');
+                const loadTasteFingerprintSpy = vi.spyOn(userPanes, 'loadTasteFingerprint');
+
+                await userPanes.triggerSync();
+                expect(window.alert).not.toHaveBeenCalled();
+
+                vi.advanceTimersByTime(2000);
+
+                expect(loadCollectionSpy).toHaveBeenCalledWith(true);
+                expect(loadWantlistSpy).toHaveBeenCalledWith(true);
+                expect(clearTasteCacheSpy).toHaveBeenCalled();
+                expect(loadTasteFingerprintSpy).toHaveBeenCalled();
+            } finally {
+                vi.useRealTimers();
+            }
+        });
     });
 
     describe('_buildReleaseTable', () => {

--- a/explore/static/css/styles.css
+++ b/explore/static/css/styles.css
@@ -1776,6 +1776,12 @@ select option {
 /* Taste Fingerprint Strip                                            */
 /* ------------------------------------------------------------------ */
 
+/* Collapse the wrapper when the taste fingerprint API hasn't returned data
+   (timeout, < 10 items, or service unavailable) so it leaves no blank gap. */
+#tasteStrip:empty {
+    display: none;
+}
+
 .taste-strip {
     display: grid;
     grid-template-columns: 1fr 1.5fr 1fr;

--- a/explore/static/js/api-client.js
+++ b/explore/static/js/api-client.js
@@ -404,13 +404,13 @@ class ApiClient {
     // --- Sync ---
 
     async triggerSync(token) {
-        if (!token) return null;
+        if (!token) return { ok: false, status: 0, body: null };
         const response = await fetch('/api/sync', {
             method: 'POST',
             headers: { 'Authorization': `Bearer ${token}` },
         });
-        if (!response.ok) return null;
-        return response.json();
+        const body = await response.json().catch(() => null);
+        return { ok: response.ok, status: response.status, body };
     }
 
     async getSyncStatus(token) {

--- a/explore/static/js/app.js
+++ b/explore/static/js/app.js
@@ -1579,7 +1579,10 @@ document.addEventListener('DOMContentLoaded', () => {
     nlqPanel.checkEnabled().then(enabled => {
         if (enabled) {
             const toggle = document.getElementById('searchAskToggle');
-            if (toggle) toggle.style.display = '';
+            // Set explicit `flex` rather than '' — clearing the inline style
+            // should fall back to the Tailwind `flex` class but isn't
+            // reliable across browsers when the inline rule was set in HTML.
+            if (toggle) toggle.style.display = 'flex';
         }
     });
 

--- a/explore/static/js/settings.js
+++ b/explore/static/js/settings.js
@@ -492,8 +492,9 @@ class SettingsPane {
         try {
             const response = await window.apiClient.twoFactorConfirm(token, code);
             if (response.ok) {
-                const data = await response.json();
-                this._recoveryCodes = data.recovery_codes || [];
+                await response.json().catch(() => ({}));
+                // Recovery codes were returned by /api/auth/2fa/setup, not /confirm.
+                this._recoveryCodes = this._setupData?.recovery_codes || [];
                 window.authManager.updateTotpEnabled(true);
                 this._twoFaState = 'recovery';
                 this._renderTwoFaState();

--- a/explore/static/js/user-panes.js
+++ b/explore/static/js/user-panes.js
@@ -361,7 +361,7 @@ class UserPanes {
 
         try {
             const result = await window.apiClient.triggerSync(token);
-            if (result) {
+            if (result.ok) {
                 // Reload panes after a short delay to allow sync to start
                 setTimeout(() => {
                     this.loadCollection(true);
@@ -369,8 +369,14 @@ class UserPanes {
                     this.clearTasteCache();
                     this.loadTasteFingerprint();
                 }, 2000);
+            } else if (result.status === 429) {
+                const msg = result.body?.message || result.body?.detail || 'Sync was triggered very recently. Please wait a moment before trying again.';
+                alert(msg);
+            } else if (result.status === 503) {
+                alert('Sync service is not ready. Please try again in a moment.');
             } else {
-                alert('Sync could not be started. Please try again later.');
+                const msg = result.body?.detail || result.body?.message || 'Sync could not be started. Please try again later.';
+                alert(msg);
             }
         } finally {
             if (btn) { btn.classList.remove('syncing'); btn.disabled = false; }

--- a/explore/tailwind.input.css
+++ b/explore/tailwind.input.css
@@ -25,6 +25,10 @@
         @apply btn-base bg-purple-500 text-white hover:bg-purple-300 focus:ring-purple-500;
     }
 
+    .btn-danger {
+        @apply btn-base bg-accent-red text-white hover:bg-red-700 focus:ring-accent-red;
+    }
+
     .btn-outline-secondary {
         @apply btn-base border border-border-color text-text-mid hover:bg-card-bg hover:text-text-high focus:ring-border-color;
     }

--- a/tests/api/test_notifications.py
+++ b/tests/api/test_notifications.py
@@ -59,9 +59,12 @@ class TestBrevoNotificationChannel:
         assert call_kwargs.kwargs["sender"].email == "noreply@test.com"
         assert call_kwargs.kwargs["sender"].name == "Test Sender"
         assert call_kwargs.kwargs["to"][0].email == "user@example.com"
-        # Verify link tracking is disabled for password reset emails
-        assert call_kwargs.kwargs["headers"]["X-Mailin-Track-Links"] == "0"
-        assert call_kwargs.kwargs["headers"]["X-Mailin-Track"] == "0"
+        # Brevo's v3 transactional API rejects standard email headers (the SDK's
+        # `headers` field only accepts `sender.ip`, `X-Mailin-custom`, etc.), so
+        # `X-Mailin-Track*` cannot disable click tracking per-message — that
+        # must be turned off in the Brevo dashboard. We assert no headers field
+        # is sent so dead/misleading code can't reappear.
+        assert "headers" not in call_kwargs.kwargs
 
     @pytest.mark.asyncio
     async def test_send_password_reset_swallows_api_error(self) -> None:

--- a/tests/api/test_sync.py
+++ b/tests/api/test_sync.py
@@ -351,7 +351,7 @@ class TestSyncRedisCooldown:
         mock_redis.setex.assert_awaited_once()
         setex_args = mock_redis.setex.call_args[0]
         assert setex_args[0] == f"sync:cooldown:{TEST_USER_ID}"
-        assert setex_args[1] == 600
+        assert setex_args[1] == 60
 
     def test_redis_none_skips_cooldown(self, test_client: TestClient, mock_cur: AsyncMock, auth_headers: dict[str, str]) -> None:
         import asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.94.0"
+version = "0.94.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -88,9 +88,9 @@ dependencies = [
     { name = "sniffio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/d7/11a649b986da06aaeb81334632f1843d70e3797f54ca4a9c5d604b7987d0/anthropic-0.94.0.tar.gz", hash = "sha256:dde8c57de73538c5136c1bca9b16da92e75446b53a73562cc911574e4934435c", size = 654236, upload-time = "2026-04-10T22:27:59.853Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/f2/fb4a04ff676742588a41f94dd318883d6d77e88e2b5e20b664ae3bf20e1b/anthropic-0.94.1.tar.gz", hash = "sha256:96c7033069c16074f90638dff8bf1f1616f9eefeb8ef7d1b0df4a0393ab34685", size = 654451, upload-time = "2026-04-13T18:08:18.453Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/ac/7185750e8688f6ff79b0e3d6a61372c88b81ba81fcda8798c70598e18aca/anthropic-0.94.0-py3-none-any.whl", hash = "sha256:42550b401eed8fcd7f6654234560f99c428306301bca726d32bca4bfb6feb748", size = 627519, upload-time = "2026-04-10T22:27:57.541Z" },
+    { url = "https://files.pythonhosted.org/packages/05/18/6d5b5948cbe450d3c98336c8a8c4804aedb3ab24fa37922d05063f8ba266/anthropic-0.94.1-py3-none-any.whl", hash = "sha256:58fb20dc60f35e75a5a82a1c73a3e196ac3b18ff2ed4826cba345f4adb78919d", size = 627710, upload-time = "2026-04-13T18:08:19.629Z" },
 ]
 
 [[package]]
@@ -538,100 +538,100 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aio-pika", specifier = ">=9.0.0" },
-    { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.42.0" },
-    { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.0" },
-    { name = "brevo-python", marker = "extra == 'api'", specifier = ">=1.0.0" },
-    { name = "cryptography", marker = "extra == 'api'", specifier = ">=43.0.0" },
+    { name = "aio-pika", specifier = ">=9.6.2" },
+    { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.94.1" },
+    { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.9.4" },
+    { name = "brevo-python", marker = "extra == 'api'", specifier = ">=4.0.10" },
+    { name = "cryptography", marker = "extra == 'api'", specifier = ">=46.0.7" },
     { name = "defusedxml", marker = "extra == 'api'", specifier = ">=0.7.1" },
-    { name = "dict-hash", specifier = ">=1.1.0" },
+    { name = "dict-hash", specifier = ">=1.3.7" },
     { name = "discogsography", extras = ["api", "brainzgraphinator", "brainztableinator", "dashboard", "explore", "graphinator", "insights", "mcp-server", "schema-init", "tableinator", "dev", "utilities"], marker = "extra == 'all'" },
-    { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.115.6" },
-    { name = "fastapi", marker = "extra == 'dashboard'", specifier = ">=0.115.6" },
-    { name = "fastapi", marker = "extra == 'explore'", specifier = ">=0.115.6" },
-    { name = "fastapi", marker = "extra == 'insights'", specifier = ">=0.115.0" },
-    { name = "httpx", marker = "extra == 'api'", specifier = ">=0.27.0" },
-    { name = "httpx", marker = "extra == 'dashboard'", specifier = ">=0.27.0" },
-    { name = "httpx", marker = "extra == 'explore'", specifier = ">=0.27.0" },
-    { name = "httpx", marker = "extra == 'insights'", specifier = ">=0.27.0" },
-    { name = "mcp", extras = ["cli"], marker = "extra == 'mcp-server'", specifier = ">=1.12.0" },
-    { name = "multidict", specifier = ">=6.5.1" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
+    { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.135.3" },
+    { name = "fastapi", marker = "extra == 'dashboard'", specifier = ">=0.135.3" },
+    { name = "fastapi", marker = "extra == 'explore'", specifier = ">=0.135.3" },
+    { name = "fastapi", marker = "extra == 'insights'", specifier = ">=0.135.3" },
+    { name = "httpx", marker = "extra == 'api'", specifier = ">=0.28.1" },
+    { name = "httpx", marker = "extra == 'dashboard'", specifier = ">=0.28.1" },
+    { name = "httpx", marker = "extra == 'explore'", specifier = ">=0.28.1" },
+    { name = "httpx", marker = "extra == 'insights'", specifier = ">=0.28.1" },
+    { name = "mcp", extras = ["cli"], marker = "extra == 'mcp-server'", specifier = ">=1.27.0" },
+    { name = "multidict", specifier = ">=6.7.1" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.20.1" },
     { name = "neo4j-rust-ext", specifier = ">=6.1.0" },
     { name = "neo4j-rust-ext", marker = "extra == 'api'", specifier = ">=6.1.0" },
     { name = "neo4j-rust-ext", marker = "extra == 'brainzgraphinator'", specifier = ">=6.1.0" },
     { name = "neo4j-rust-ext", marker = "extra == 'dashboard'", specifier = ">=6.1.0" },
     { name = "neo4j-rust-ext", marker = "extra == 'graphinator'", specifier = ">=6.1.0" },
     { name = "neo4j-rust-ext", marker = "extra == 'schema-init'", specifier = ">=6.1.0" },
-    { name = "orjson", specifier = ">=3.9.0" },
-    { name = "orjson", marker = "extra == 'api'", specifier = ">=3.9.0" },
-    { name = "orjson", marker = "extra == 'explore'", specifier = ">=3.9.0" },
-    { name = "pika", specifier = ">=1.3.0" },
-    { name = "playwright", marker = "extra == 'dev'", specifier = ">=1.40.0" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.5.0" },
-    { name = "prometheus-client", marker = "extra == 'dashboard'", specifier = ">=0.21.1" },
-    { name = "psutil", marker = "extra == 'utilities'", specifier = ">=5.9.0" },
-    { name = "psycopg", extras = ["binary"], specifier = ">=3.0.0" },
-    { name = "psycopg", extras = ["binary"], marker = "extra == 'api'", specifier = ">=3.1.0" },
-    { name = "psycopg", extras = ["binary"], marker = "extra == 'brainztableinator'", specifier = ">=3.1.0" },
-    { name = "psycopg", extras = ["binary"], marker = "extra == 'dashboard'", specifier = ">=3.1.0" },
-    { name = "psycopg", extras = ["binary"], marker = "extra == 'schema-init'", specifier = ">=3.1.0" },
-    { name = "psycopg", extras = ["binary"], marker = "extra == 'tableinator'", specifier = ">=3.1.0" },
-    { name = "pydantic", marker = "extra == 'api'", specifier = ">=2.10.5" },
-    { name = "pydantic", marker = "extra == 'dashboard'", specifier = ">=2.10.5" },
-    { name = "pydantic", marker = "extra == 'explore'", specifier = ">=2.10.5" },
+    { name = "orjson", specifier = ">=3.11.8" },
+    { name = "orjson", marker = "extra == 'api'", specifier = ">=3.11.8" },
+    { name = "orjson", marker = "extra == 'explore'", specifier = ">=3.11.8" },
+    { name = "pika", specifier = ">=1.3.2" },
+    { name = "playwright", marker = "extra == 'dev'", specifier = ">=1.58.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.1" },
+    { name = "prometheus-client", marker = "extra == 'dashboard'", specifier = ">=0.25.0" },
+    { name = "psutil", marker = "extra == 'utilities'", specifier = ">=7.2.2" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'api'", specifier = ">=3.3.3" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'brainztableinator'", specifier = ">=3.3.3" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'dashboard'", specifier = ">=3.3.3" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'schema-init'", specifier = ">=3.3.3" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'tableinator'", specifier = ">=3.3.3" },
+    { name = "pydantic", marker = "extra == 'api'", specifier = ">=2.13.0" },
+    { name = "pydantic", marker = "extra == 'dashboard'", specifier = ">=2.13.0" },
+    { name = "pydantic", marker = "extra == 'explore'", specifier = ">=2.13.0" },
     { name = "pyotp", marker = "extra == 'api'", specifier = ">=2.9.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
-    { name = "pytest-playwright", marker = "extra == 'dev'", specifier = ">=0.4.3" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
+    { name = "pytest-playwright", marker = "extra == 'dev'", specifier = ">=0.7.2" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.4.0" },
-    { name = "python-multipart", marker = "extra == 'dashboard'", specifier = ">=0.0.20" },
-    { name = "python-multipart", marker = "extra == 'explore'", specifier = ">=0.0.20" },
+    { name = "python-multipart", marker = "extra == 'dashboard'", specifier = ">=0.0.26" },
+    { name = "python-multipart", marker = "extra == 'explore'", specifier = ">=0.0.26" },
     { name = "pyyaml", marker = "extra == 'api'", specifier = ">=6.0.3" },
-    { name = "redis", extras = ["hiredis"], specifier = ">=6.2.0" },
-    { name = "redis", extras = ["hiredis"], marker = "extra == 'api'", specifier = ">=6.2.0" },
-    { name = "requests", marker = "extra == 'utilities'", specifier = ">=2.31.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "redis", extras = ["hiredis"], specifier = ">=7.4.0" },
+    { name = "redis", extras = ["hiredis"], marker = "extra == 'api'", specifier = ">=7.4.0" },
+    { name = "requests", marker = "extra == 'utilities'", specifier = ">=2.33.1" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.10" },
     { name = "slowapi", marker = "extra == 'api'", specifier = ">=0.1.9" },
-    { name = "sse-starlette", marker = "extra == 'api'", specifier = ">=2.0.0" },
-    { name = "structlog", specifier = ">=24.0.0" },
-    { name = "structlog", marker = "extra == 'api'", specifier = ">=24.0.0" },
-    { name = "structlog", marker = "extra == 'explore'", specifier = ">=24.0.0" },
-    { name = "structlog", marker = "extra == 'mcp-server'", specifier = ">=24.0.0" },
-    { name = "structlog", marker = "extra == 'schema-init'", specifier = ">=24.0.0" },
-    { name = "tqdm", specifier = ">=4.65.0" },
-    { name = "types-defusedxml", marker = "extra == 'dev'", specifier = ">=0.7.0.20260402" },
-    { name = "types-psutil", marker = "extra == 'dev'", specifier = ">=6.1.0.20241102" },
-    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250915" },
-    { name = "types-tqdm", marker = "extra == 'dev'", specifier = ">=4.67.0.20250516" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'api'", specifier = ">=0.34.0" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'dashboard'", specifier = ">=0.34.0" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'explore'", specifier = ">=0.34.0" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'insights'", specifier = ">=0.32.0" },
-    { name = "websockets", marker = "extra == 'dashboard'", specifier = ">=14.2" },
+    { name = "sse-starlette", marker = "extra == 'api'", specifier = ">=3.3.4" },
+    { name = "structlog", specifier = ">=25.5.0" },
+    { name = "structlog", marker = "extra == 'api'", specifier = ">=25.5.0" },
+    { name = "structlog", marker = "extra == 'explore'", specifier = ">=25.5.0" },
+    { name = "structlog", marker = "extra == 'mcp-server'", specifier = ">=25.5.0" },
+    { name = "structlog", marker = "extra == 'schema-init'", specifier = ">=25.5.0" },
+    { name = "tqdm", specifier = ">=4.67.3" },
+    { name = "types-defusedxml", marker = "extra == 'dev'", specifier = ">=0.7.0.20260408" },
+    { name = "types-psutil", marker = "extra == 'dev'", specifier = ">=7.2.2.20260408" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20260408" },
+    { name = "types-tqdm", marker = "extra == 'dev'", specifier = ">=4.67.3.20260408" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'api'", specifier = ">=0.44.0" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'dashboard'", specifier = ">=0.44.0" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'explore'", specifier = ">=0.44.0" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'insights'", specifier = ">=0.44.0" },
+    { name = "websockets", marker = "extra == 'dashboard'", specifier = ">=16.0" },
 ]
 provides-extras = ["api", "dashboard", "brainzgraphinator", "graphinator", "insights", "tableinator", "brainztableinator", "dev", "utilities", "explore", "schema-init", "mcp-server", "all"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "bandit", specifier = ">=1.7.0" },
-    { name = "fakeredis", specifier = ">=2.0.0" },
+    { name = "bandit", specifier = ">=1.9.4" },
+    { name = "fakeredis", specifier = ">=2.35.1" },
     { name = "mdformat", specifier = ">=1.0.0" },
     { name = "mdformat-gfm", specifier = ">=1.0.0" },
-    { name = "mypy", specifier = ">=1.8.0" },
+    { name = "mypy", specifier = ">=1.20.1" },
     { name = "pillow", specifier = ">=12.2.0" },
-    { name = "pip-audit", specifier = ">=2.7.0" },
-    { name = "pre-commit", specifier = ">=3.5.0" },
-    { name = "pytest", specifier = ">=7.4.0" },
-    { name = "pytest-asyncio", specifier = ">=0.24.0" },
-    { name = "pytest-cov", specifier = ">=4.1.0" },
+    { name = "pip-audit", specifier = ">=2.10.0" },
+    { name = "pre-commit", specifier = ">=4.5.1" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "ruff", specifier = ">=0.1.0" },
-    { name = "types-psutil", specifier = ">=6.1.0.20241102" },
-    { name = "types-tqdm", specifier = ">=4.67.0.20250516" },
-    { name = "types-xmltodict", specifier = ">=0.14.0.20241009" },
+    { name = "ruff", specifier = ">=0.15.10" },
+    { name = "types-psutil", specifier = ">=7.2.2.20260408" },
+    { name = "types-tqdm", specifier = ">=4.67.3.20260408" },
+    { name = "types-xmltodict", specifier = ">=1.0.1.20260408" },
 ]
 
 [[package]]
@@ -656,19 +656,19 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "brevo-python", specifier = ">=1.0.0" },
-    { name = "cryptography", specifier = ">=43.0.0" },
-    { name = "fastapi", specifier = ">=0.115.6" },
-    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "brevo-python", specifier = ">=4.0.10" },
+    { name = "cryptography", specifier = ">=46.0.7" },
+    { name = "fastapi", specifier = ">=0.135.3" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "neo4j-rust-ext", specifier = ">=6.1.0" },
-    { name = "orjson", specifier = ">=3.9.0" },
-    { name = "psycopg", extras = ["binary"], specifier = ">=3.1.0" },
-    { name = "pydantic", specifier = ">=2.10.5" },
+    { name = "orjson", specifier = ">=3.11.8" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
+    { name = "pydantic", specifier = ">=2.13.0" },
     { name = "pyotp", specifier = ">=2.9.0" },
-    { name = "redis", extras = ["hiredis"], specifier = ">=6.2.0" },
+    { name = "redis", extras = ["hiredis"], specifier = ">=7.4.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
-    { name = "structlog", specifier = ">=24.0.0" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
+    { name = "structlog", specifier = ">=25.5.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.44.0" },
 ]
 
 [[package]]
@@ -722,10 +722,10 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aio-pika", specifier = ">=9.0.0" },
+    { name = "aio-pika", specifier = ">=9.6.2" },
     { name = "neo4j-rust-ext", specifier = ">=6.1.0" },
-    { name = "pika", specifier = ">=1.3.0" },
-    { name = "psycopg", extras = ["binary"], specifier = ">=3.0.0" },
+    { name = "pika", specifier = ">=1.3.2" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
 ]
 
 [[package]]
@@ -750,19 +750,19 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aio-pika", specifier = ">=9.0.0" },
-    { name = "fastapi", specifier = ">=0.115.6" },
-    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "aio-pika", specifier = ">=9.6.2" },
+    { name = "fastapi", specifier = ">=0.135.3" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "neo4j-rust-ext", specifier = ">=6.1.0" },
-    { name = "orjson", specifier = ">=3.9.0" },
-    { name = "pika", specifier = ">=1.3.0" },
-    { name = "prometheus-client", specifier = ">=0.21.1" },
-    { name = "psycopg", extras = ["binary"], specifier = ">=3.1.0" },
-    { name = "pydantic", specifier = ">=2.10.5" },
-    { name = "python-multipart", specifier = ">=0.0.20" },
-    { name = "structlog", specifier = ">=24.0.0" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
-    { name = "websockets", specifier = ">=14.2" },
+    { name = "orjson", specifier = ">=3.11.8" },
+    { name = "pika", specifier = ">=1.3.2" },
+    { name = "prometheus-client", specifier = ">=0.25.0" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
+    { name = "pydantic", specifier = ">=2.13.0" },
+    { name = "python-multipart", specifier = ">=0.0.26" },
+    { name = "structlog", specifier = ">=25.5.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.44.0" },
+    { name = "websockets", specifier = ">=16.0" },
 ]
 
 [[package]]
@@ -781,13 +781,13 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastapi", specifier = ">=0.115.6" },
-    { name = "httpx", specifier = ">=0.27.0" },
-    { name = "orjson", specifier = ">=3.9.0" },
-    { name = "pydantic", specifier = ">=2.10.5" },
-    { name = "python-multipart", specifier = ">=0.0.20" },
-    { name = "structlog", specifier = ">=24.0.0" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
+    { name = "fastapi", specifier = ">=0.135.3" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "orjson", specifier = ">=3.11.8" },
+    { name = "pydantic", specifier = ">=2.13.0" },
+    { name = "python-multipart", specifier = ">=0.0.26" },
+    { name = "structlog", specifier = ">=25.5.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.44.0" },
 ]
 
 [[package]]
@@ -805,12 +805,12 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aio-pika", specifier = ">=9.0.0" },
-    { name = "dict-hash", specifier = ">=1.1.0" },
+    { name = "aio-pika", specifier = ">=9.6.2" },
+    { name = "dict-hash", specifier = ">=1.3.7" },
     { name = "neo4j-rust-ext", specifier = ">=6.1.0" },
-    { name = "orjson", specifier = ">=3.9.0" },
-    { name = "pika", specifier = ">=1.3.0" },
-    { name = "structlog", specifier = ">=24.0.0" },
+    { name = "orjson", specifier = ">=3.11.8" },
+    { name = "pika", specifier = ">=1.3.2" },
+    { name = "structlog", specifier = ">=25.5.0" },
 ]
 
 [[package]]
@@ -843,8 +843,8 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "neo4j-rust-ext", specifier = ">=6.1.0" },
-    { name = "psycopg", extras = ["binary"], specifier = ">=3.1.0" },
-    { name = "structlog", specifier = ">=24.0.0" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
+    { name = "structlog", specifier = ">=25.5.0" },
 ]
 
 [[package]]
@@ -862,12 +862,12 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aio-pika", specifier = ">=9.0.0" },
-    { name = "dict-hash", specifier = ">=1.1.0" },
-    { name = "orjson", specifier = ">=3.9.0" },
-    { name = "pika", specifier = ">=1.3.0" },
-    { name = "psycopg", extras = ["binary"], specifier = ">=3.1.0" },
-    { name = "structlog", specifier = ">=24.0.0" },
+    { name = "aio-pika", specifier = ">=9.6.2" },
+    { name = "dict-hash", specifier = ">=1.3.7" },
+    { name = "orjson", specifier = ">=3.11.8" },
+    { name = "pika", specifier = ">=1.3.2" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
+    { name = "structlog", specifier = ">=25.5.0" },
 ]
 
 [[package]]
@@ -908,15 +908,15 @@ wheels = [
 
 [[package]]
 name = "fakeredis"
-version = "2.35.0"
+version = "2.35.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "redis", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "sortedcontainers", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/b9/c40b92cd49155a8ebbdc983cb50c02fc1c87d3a53f19aa420aefb96b00a3/fakeredis-2.35.0.tar.gz", hash = "sha256:5d1a0192c2c559e55b2d05328d86282ddd2079c1712a91e6d1b3010e0dd45ca6", size = 189000, upload-time = "2026-04-09T18:02:14.746Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/50/b748233c02fa77e5105238190cc9bb58b852eb1c8b1d0763230d3a5b745a/fakeredis-2.35.1.tar.gz", hash = "sha256:5bae5eba7b9d93cb968944ac40936373cf2397ff71667d4b595df65c3d2e413f", size = 189118, upload-time = "2026-04-12T17:05:58.539Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/43/83508ccf8177a840aec118bf4d20b0c25ddca6ccecd13f1f89caabcb1a45/fakeredis-2.35.0-py3-none-any.whl", hash = "sha256:565d337a5492e8c19be33a89e7acc078374741c65cb6d4413bd8818346b8c252", size = 129578, upload-time = "2026-04-09T18:02:13.264Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/27/b8b057a23f7777177e92d3a602fd866751b6b45014964548997e92e048fd/fakeredis-2.35.1-py3-none-any.whl", hash = "sha256:67d97e11f562b7870e11e5c30cf182270bfb2dd37f6707dba47cc6d91628d1b9", size = 129678, upload-time = "2026-04-12T17:05:56.86Z" },
 ]
 
 [[package]]
@@ -1356,7 +1356,7 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.20.0"
+version = "1.20.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "librt", marker = "(platform_machine == 'arm64' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
@@ -1364,24 +1364,24 @@ dependencies = [
     { name = "pathspec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/b0089fe7fef0a994ae5ee07029ced0526082c6cfaaa4c10d40a10e33b097/mypy-1.20.0.tar.gz", hash = "sha256:eb96c84efcc33f0b5e0e04beacf00129dd963b67226b01c00b9dfc8affb464c3", size = 3815028, upload-time = "2026-03-31T16:55:14.959Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/3d/5b373635b3146264eb7a68d09e5ca11c305bbb058dfffbb47c47daf4f632/mypy-1.20.1.tar.gz", hash = "sha256:6fc3f4ecd52de81648fed1945498bf42fa2993ddfad67c9056df36ae5757f804", size = 3815892, upload-time = "2026-04-13T02:46:51.474Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/a7/f64ea7bd592fa431cb597418b6dec4a47f7d0c36325fec7ac67bc8402b94/mypy-1.20.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b20c8b0fd5877abdf402e79a3af987053de07e6fb208c18df6659f708b535134", size = 14485344, upload-time = "2026-03-31T16:49:16.78Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/72/8927d84cfc90c6abea6e96663576e2e417589347eb538749a464c4c218a0/mypy-1.20.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:367e5c993ba34d5054d11937d0485ad6dfc60ba760fa326c01090fc256adf15c", size = 13327400, upload-time = "2026-03-31T16:53:08.02Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/4a/11ab99f9afa41aa350178d24a7d2da17043228ea10f6456523f64b5a6cf6/mypy-1.20.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f799d9db89fc00446f03281f84a221e50018fc40113a3ba9864b132895619ebe", size = 13706384, upload-time = "2026-03-31T16:52:28.577Z" },
-    { url = "https://files.pythonhosted.org/packages/42/79/694ca73979cfb3535ebfe78733844cd5aff2e63304f59bf90585110d975a/mypy-1.20.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:555658c611099455b2da507582ea20d2043dfdfe7f5ad0add472b1c6238b433f", size = 14700378, upload-time = "2026-03-31T16:48:45.527Z" },
-    { url = "https://files.pythonhosted.org/packages/84/24/a022ccab3a46e3d2cdf2e0e260648633640eb396c7e75d5a42818a8d3971/mypy-1.20.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:efe8d70949c3023698c3fca1e94527e7e790a361ab8116f90d11221421cd8726", size = 14932170, upload-time = "2026-03-31T16:49:36.038Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/0e/6ca4a84cbed9e62384bc0b2974c90395ece5ed672393e553996501625fc5/mypy-1.20.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0f42dfaab7ec1baff3b383ad7af562ab0de573c5f6edb44b2dab016082b89948", size = 14483331, upload-time = "2026-03-31T16:52:57.999Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/c5/5fe9d8a729dd9605064691816243ae6c49fde0bd28f6e5e17f6a24203c43/mypy-1.20.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:31b5dbb55293c1bd27c0fc813a0d2bb5ceef9d65ac5afa2e58f829dab7921fd5", size = 13342047, upload-time = "2026-03-31T16:54:21.555Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/33/e18bcfa338ca4e6b2771c85d4c5203e627d0c69d9de5c1a2cf2ba13320ba/mypy-1.20.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49d11c6f573a5a08f77fad13faff2139f6d0730ebed2cfa9b3d2702671dd7188", size = 13719585, upload-time = "2026-03-31T16:51:53.89Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/8d/93491ff7b79419edc7eabf95cb3b3f7490e2e574b2855c7c7e7394ff933f/mypy-1.20.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d3243c406773185144527f83be0e0aefc7bf4601b0b2b956665608bf7c98a83", size = 14685075, upload-time = "2026-03-31T16:54:04.464Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/9d/d924b38a4923f8d164bf2b4ec98bf13beaf6e10a5348b4b137eadae40a6e/mypy-1.20.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a79c1eba7ac4209f2d850f0edd0a2f8bba88cbfdfefe6fb76a19e9d4fe5e71a2", size = 14919141, upload-time = "2026-03-31T16:54:51.785Z" },
-    { url = "https://files.pythonhosted.org/packages/12/28/e617e67b3be9d213cda7277913269c874eb26472489f95d09d89765ce2d8/mypy-1.20.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:26c8b52627b6552f47ff11adb4e1509605f094e29815323e487fc0053ebe93d1", size = 15534710, upload-time = "2026-03-31T16:52:12.506Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/0c/3b5f2d3e45dc7169b811adce8451679d9430399d03b168f9b0489f43adaa/mypy-1.20.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:39362cdb4ba5f916e7976fccecaab1ba3a83e35f60fa68b64e9a70e221bb2436", size = 14393013, upload-time = "2026-03-31T16:54:41.186Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/49/edc8b0aa145cc09c1c74f7ce2858eead9329931dcbbb26e2ad40906daa4e/mypy-1.20.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34506397dbf40c15dc567635d18a21d33827e9ab29014fb83d292a8f4f8953b6", size = 15047240, upload-time = "2026-03-31T16:54:31.955Z" },
-    { url = "https://files.pythonhosted.org/packages/42/37/a946bb416e37a57fa752b3100fd5ede0e28df94f92366d1716555d47c454/mypy-1.20.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:555493c44a4f5a1b58d611a43333e71a9981c6dbe26270377b6f8174126a0526", size = 15858565, upload-time = "2026-03-31T16:53:36.997Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/99/7690b5b5b552db1bd4ff362e4c0eb3107b98d680835e65823fbe888c8b78/mypy-1.20.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2721f0ce49cb74a38f00c50da67cb7d36317b5eda38877a49614dc018e91c787", size = 16087874, upload-time = "2026-03-31T16:52:48.313Z" },
-    { url = "https://files.pythonhosted.org/packages/21/66/4d734961ce167f0fd8380769b3b7c06dbdd6ff54c2190f3f2ecd22528158/mypy-1.20.0-py3-none-any.whl", hash = "sha256:a6e0641147cbfa7e4e94efdb95c2dab1aff8cfc159ded13e07f308ddccc8c48e", size = 2636365, upload-time = "2026-03-31T16:51:44.911Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e8/ef0991aa24c8f225df10b034f3c2681213cb54cf247623c6dec9a5744e70/mypy-1.20.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f3886c03e40afefd327bd70b3f634b39ea82e87f314edaa4d0cce4b927ddcc1", size = 14500739, upload-time = "2026-04-13T02:46:05.442Z" },
+    { url = "https://files.pythonhosted.org/packages/23/73/416ebec3047636ed89fa871dc8c54bf05e9e20aa9499da59790d7adb312d/mypy-1.20.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e860eb3904f9764e83bafd70c8250bdffdc7dde6b82f486e8156348bf7ceb184", size = 13314735, upload-time = "2026-04-13T02:46:47.154Z" },
+    { url = "https://files.pythonhosted.org/packages/10/1e/1505022d9c9ac2e014a384eb17638fb37bf8e9d0a833ea60605b66f8f7ba/mypy-1.20.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4b5aac6e785719da51a84f5d09e9e843d473170a9045b1ea7ea1af86225df4b", size = 13704356, upload-time = "2026-04-13T02:45:19.773Z" },
+    { url = "https://files.pythonhosted.org/packages/98/91/275b01f5eba5c467a3318ec214dd865abb66e9c811231c8587287b92876a/mypy-1.20.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f37b6cd0fe2ad3a20f05ace48ca3523fc52ff86940e34937b439613b6854472e", size = 14696420, upload-time = "2026-04-13T02:45:24.205Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/57/b3779e134e1b7250d05f874252780d0a88c068bc054bcff99ca20a3a2986/mypy-1.20.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e4bbb0f6b54ce7cc350ef4a770650d15fa70edd99ad5267e227133eda9c94218", size = 14936093, upload-time = "2026-04-13T02:45:32.087Z" },
+    { url = "https://files.pythonhosted.org/packages/40/cd/db831e84c81d57d4886d99feee14e372f64bbec6a9cb1a88a19e243f2ef5/mypy-1.20.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:12927b9c0ed794daedcf1dab055b6c613d9d5659ac511e8d936d96f19c087d12", size = 14483064, upload-time = "2026-04-13T02:45:26.901Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/82/74e62e7097fa67da328ac8ece8de09133448c04d20ddeaeba251a3000f01/mypy-1.20.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:752507dd481e958b2c08fc966d3806c962af5a9433b5bf8f3bdd7175c20e34fe", size = 13335694, upload-time = "2026-04-13T02:46:12.514Z" },
+    { url = "https://files.pythonhosted.org/packages/74/c4/97e9a0abe4f3cdbbf4d079cb87a03b786efeccf5bf2b89fe4f96939ab2e6/mypy-1.20.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c614655b5a065e56274c6cbbe405f7cf7e96c0654db7ba39bc680238837f7b08", size = 13726365, upload-time = "2026-04-13T02:45:17.422Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/aa/a19d884a8d28fcd3c065776323029f204dbc774e70ec9c85eba228b680de/mypy-1.20.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c3f6221a76f34d5100c6d35b3ef6b947054123c3f8d6938a4ba00b1308aa572", size = 14693472, upload-time = "2026-04-13T02:46:41.253Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/cc9324bd21cf786592b44bf3b5d224b3923c1230ec9898d508d00241d465/mypy-1.20.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4bdfc06303ac06500af71ea0cdbe995c502b3c9ba32f3f8313523c137a25d1b6", size = 14919266, upload-time = "2026-04-13T02:46:28.37Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/af/af9e46b0c8eabbce9fc04a477564170f47a1c22b308822282a59b7ff315f/mypy-1.20.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:168472149dd8cc505c98cefd21ad77e4257ed6022cd5ed2fe2999bed56977a5a", size = 15547508, upload-time = "2026-04-13T02:46:25.588Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/cd/39c9e4ad6ba33e069e5837d772a9e6c304b4a5452a14a975d52b36444650/mypy-1.20.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:eb674600309a8f22790cca883a97c90299f948183ebb210fbef6bcee07cb1986", size = 14399557, upload-time = "2026-04-13T02:46:10.021Z" },
+    { url = "https://files.pythonhosted.org/packages/83/c1/3fd71bdc118ffc502bf57559c909927bb7e011f327f7bb8e0488e98a5870/mypy-1.20.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef2b2e4cc464ba9795459f2586923abd58a0055487cbe558cb538ea6e6bc142a", size = 15045789, upload-time = "2026-04-13T02:45:10.81Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/73/6f07ff8b57a7d7b3e6e5bf34685d17632382395c8bb53364ec331661f83e/mypy-1.20.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dee461d396dd46b3f0ed5a098dbc9b8860c81c46ad44fa071afcfbc149f167c9", size = 15850795, upload-time = "2026-04-13T02:45:03.349Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e2/f7dffec1c7767078f9e9adf0c786d1fe0ff30964a77eb213c09b8b58cb76/mypy-1.20.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e364926308b3e66f1361f81a566fc1b2f8cd47fc8525e8136d4058a65a4b4f02", size = 16088539, upload-time = "2026-04-13T02:46:17.841Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/28/926bd972388e65a39ee98e188ccf67e81beb3aacfd5d6b310051772d974b/mypy-1.20.1-py3-none-any.whl", hash = "sha256:1aae28507f253fe82d883790d1c0a0d35798a810117c88184097fe8881052f06", size = 2636553, upload-time = "2026-04-13T02:46:30.45Z" },
 ]
 
 [[package]]
@@ -1775,7 +1775,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.12.5"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1783,38 +1783,38 @@ dependencies = [
     { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typing-inspection", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6b/69fd5c7194b21ebde0f8637e2a4ddc766ada29d472bfa6a5ca533d79549a/pydantic-2.13.0.tar.gz", hash = "sha256:b89b575b6e670ebf6e7448c01b41b244f471edd276cd0b6fe02e7e7aca320070", size = 843468, upload-time = "2026-04-13T10:51:35.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d7/c3a52c61f5b7be648e919005820fbac33028c6149994cd64453f49951c17/pydantic-2.13.0-py3-none-any.whl", hash = "sha256:ab0078b90da5f3e2fd2e71e3d9b457ddcb35d0350854fbda93b451e28d56baaf", size = 471872, upload-time = "2026-04-13T10:51:33.343Z" },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.41.5"
+version = "2.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/0a/9414cddf82eda3976b14048cc0fa8f5b5d1aecb0b22e1dcd2dbfe0e139b1/pydantic_core-2.46.0.tar.gz", hash = "sha256:82d2498c96be47b47e903e1378d1d0f770097ec56ea953322f39936a7cf34977", size = 471441, upload-time = "2026-04-13T09:06:33.813Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
-    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
-    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
-    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
-    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
-    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
-    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
-    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/df/05/ab3b0742bad1d51822f1af0c4232208408902bdcfc47601f3b812e09e6c2/pydantic_core-2.46.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:a05900c37264c070c683c650cbca8f83d7cbb549719e645fcd81a24592eac788", size = 2116814, upload-time = "2026-04-13T09:04:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/98/08/30b43d9569d69094a0899a199711c43aa58fce6ce80f6a8f7693673eb995/pydantic_core-2.46.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8de8e482fd4f1e3f36c50c6aac46d044462615d8f12cfafc6bebeaa0909eea22", size = 1951867, upload-time = "2026-04-13T09:04:02.364Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a0/bf9a1ba34537c2ed3872a48195291138fdec8fe26c4009776f00d63cf0c8/pydantic_core-2.46.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c525ecf8a4cdf198327b65030a7d081867ad8e60acb01a7214fff95cf9832d47", size = 1977040, upload-time = "2026-04-13T09:06:16.088Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f8/5885350203b72e96438eee7f94de0d8f0442f4627237ca8ef75de34db1cd/pydantic_core-2.46.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7897078fe8a13b73623c0955dfb2b3d2c9acb7177aac25144758c9e5a5265aaa", size = 2098522, upload-time = "2026-04-13T09:04:23.239Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/53/1958eacbfddc41aadf5ae86dd85041bf054b675f34a2fa76385935f96070/pydantic_core-2.46.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:ee1547a6b8243e73dd10f585555e5a263395e55ce6dea618a078570a1e889aef", size = 2190148, upload-time = "2026-04-13T09:06:56.151Z" },
+    { url = "https://files.pythonhosted.org/packages/71/a7/abdb924620b1ac535c690b36ad5b8871f376104090f8842c08625cecf1d3/pydantic_core-2.46.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:004a2081c881abfcc6854a4623da6a09090a0d7c1398a6ae7133ca1256cee70b", size = 2383167, upload-time = "2026-04-13T09:04:52.643Z" },
+    { url = "https://files.pythonhosted.org/packages/36/3b/914891d384cdbf9a6f464eb13713baa22ea1e453d4da80fb7da522079370/pydantic_core-2.46.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:4fc801c290342350ffc82d77872054a934b2e24163727263362170c1db5416ca", size = 2113349, upload-time = "2026-04-13T09:04:59.407Z" },
+    { url = "https://files.pythonhosted.org/packages/35/95/3a0c6f65e231709fb3463e32943c69d10285cb50203a2130a4732053a06d/pydantic_core-2.46.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0a36f2cc88170cc177930afcc633a8c15907ea68b59ac16bd180c2999d714940", size = 1949170, upload-time = "2026-04-13T09:06:09.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/63/d845c36a608469fe7bee226edeff0984c33dbfe7aecd755b0e7ab5a275c4/pydantic_core-2.46.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2a3912e0c568a1f99d4d6d3e41def40179d61424c0ca1c8c87c4877d7f6fd7fb", size = 1977914, upload-time = "2026-04-13T09:04:56.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e4/566101a561492ce8454f0844ca29c3b675a6b3a7b3ff577db85ed05c8c50/pydantic_core-2.46.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67e2c2e171b78db8154da602de72ffdc473c6ee51de8a9d80c0f1cd4051abfc7", size = 2102533, upload-time = "2026-04-13T09:06:58.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/3b/807d5b035ec891b57b9079ce881f48263936c37bd0d154a056e7fd152afb/pydantic_core-2.46.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:15ed8e5bde505133d96b41702f31f06829c46b05488211a5b1c7877e11de5eb5", size = 2188293, upload-time = "2026-04-13T09:07:07.614Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/90/8718e4ae98c4e8a7325afdc079be82be1e131d7a47cb6c098844a9531ffe/pydantic_core-2.46.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e1155708540f13845bf68d5ac511a55c76cfe2e057ed12b4bf3adac1581fc5c2", size = 2377155, upload-time = "2026-04-13T09:06:18.081Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/30/1177dde61b200785c4739665e3aa03a9d4b2c25d2d0408b07d585e633965/pydantic_core-2.46.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5e7cdd4398bee1aaeafe049ac366b0f887451d9ae418fd8785219c13fea2f928", size = 2107447, upload-time = "2026-04-13T09:05:46.314Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/60/4e0f61f99bdabbbc309d364a2791e1ba31e778a4935bc43391a7bdec0744/pydantic_core-2.46.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5c2c92d82808e27cef3f7ab3ed63d657d0c755e0dbe5b8a58342e37bdf09bd2e", size = 1926927, upload-time = "2026-04-13T09:06:20.371Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/d0/67f89a8269152c1d6eaa81f04e75a507372ebd8ca7382855a065222caa80/pydantic_core-2.46.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bab80af91cd7014b45d1089303b5f844a9d91d7da60eabf3d5f9694b32a6655", size = 1966613, upload-time = "2026-04-13T09:07:05.389Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2c/f0d744e3dab7bd026a3f4670a97a295157cff923a2666d30a15a70a7e3d0/pydantic_core-2.46.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e20bc5add1dd9bc3b9a3600d40632e679376569098345500799a6ad7c5d46c72", size = 2104621, upload-time = "2026-04-13T09:04:34.388Z" },
+    { url = "https://files.pythonhosted.org/packages/32/7b/b3025618ed4c4e4cbaa9882731c19625db6669896b621760ea95bc1125ef/pydantic_core-2.46.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d14cc5a6f260fa78e124061eebc5769af6534fc837e9a62a47f09a2c341fa4ea", size = 2171222, upload-time = "2026-04-13T09:07:29.929Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1b/5e65807001b84972476300c1f49aea2b4971b7e9fffb5c2654877dadd274/pydantic_core-2.46.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:8ef749be6ed0d69dba31902aaa8255a9bb269ae50c93888c4df242d8bb7acd9e", size = 2377062, upload-time = "2026-04-13T09:07:39.945Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Batch fix for several reported issues with 2FA setup, sync, button styling, and the explore UI.

- **Recovery codes were blank** — `settings.js` read `recovery_codes` from the `/api/auth/2fa/confirm` response, but the backend only returns `{message}` there. The plaintext codes are returned by `/api/auth/2fa/setup` and were already cached in `_setupData`. Now reads from the correct field. Also fixes Copy Codes which was copying an empty string.
- **Disable 2FA button misaligned** — the `.btn-danger` class used by `settings.js` was never defined in `tailwind.input.css`. Added a definition matching the other `btn-*` variants so it picks up flex centering from `btn-base`.
- **Sync rate limit too aggressive** — slowapi `2/10minute` → `10/minute`, Redis cooldown `600s` → `60s`. Frontend now reads the 429 message body from the backend instead of showing a generic "Please try again later" alert.
- **Empty box between stats and collection table** — the `#tasteStrip` wrapper was leaving a blank gap when the taste fingerprint API timed out / was unavailable. Added `#tasteStrip:empty { display: none; }`.
- **Brevo password reset link wrapping** — removed dead `X-Mailin-Track*` headers. The Brevo SDK rejects standard email headers (per its own signature: _"Standard email headers are not supported"_), so per-message click-tracking control is impossible via the v3 transactional API. **Click tracking must be turned off in the Brevo dashboard** (Senders, Domains & IPs → sending domain → Tracking, or Account Settings → Tracking).
- **Test mocks fixed** — `settings.test.js` now mirrors the real API contract (`setup` returns `otpauth_uri` + `recovery_codes`; `confirm` returns `{message}`). The previous mocks lied about the contract and let the recovery-codes bug ship.

## Not in scope

- **NLQ pieces missing in UI** — this turned out to be a configuration issue, not a bug. The Search/Ask toggle requires both `NLQ_ENABLED=true` and `NLQ_API_KEY` to be set on the API service. Set both env vars and the toggle appears.

## Test plan

- [x] `vitest run` — 955 / 955 passing
- [x] `uv run pytest tests/api/test_sync.py tests/api/test_notifications.py tests/api/test_auth.py tests/api/test_auth_router.py` — 110 / 110 passing
- [ ] After merge: rebuild explore Docker image so the css-builder stage regenerates `tailwind.css` with the new `.btn-danger` class
- [ ] After merge: manually verify in browser
  - 2FA setup → confirm → recovery codes display + Copy Codes works
  - Disable 2FA button shows red with centered icon + text
  - Sync trigger shows backend message text on 429 (and works again after 60s)
  - Empty box between stats and collection table is gone
  - Password reset email link is no longer wrapped (after disabling tracking in Brevo dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)