### PR TITLE
fix: unblock MusicBrainz extractor during Discogs periodic wait

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -512,7 +512,7 @@ jobs:
   # ============================================================================
   test-extractor:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - name: 🔀 Checkout repository

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -435,9 +435,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -1637,9 +1637,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
@@ -2769,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -3038,9 +3038,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3642,9 +3642,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",

--- a/api/routers/admin.py
+++ b/api/routers/admin.py
@@ -371,13 +371,24 @@ async def _track_extraction(extraction_id: str) -> None:
                                 (json.dumps(record_counts), extraction_id),
                             )
 
-                        if extraction_status == "completed":
+                        # "completed" is the transient state set inside process_*_data at
+                        # the end of a successful run. The surrounding run_*_loop immediately
+                        # transitions Completed → Waiting before sleeping until the next
+                        # periodic check, so "waiting" is the dominant terminal-success value
+                        # the tracker observes. Both are recorded verbatim so operators can
+                        # tell a freshly-finished run from one already back on the schedule.
+                        if extraction_status in ("completed", "waiting"):
                             async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
                                 await cur.execute(
-                                    "UPDATE extraction_history SET status = 'completed', completed_at = NOW(), record_counts = %s WHERE id = %s",
-                                    (json.dumps(record_counts), extraction_id),
+                                    "UPDATE extraction_history SET status = %s, completed_at = NOW(), record_counts = %s WHERE id = %s",
+                                    (extraction_status, json.dumps(record_counts), extraction_id),
                                 )
-                            logger.info("✅ Extraction completed", extraction_id=extraction_id, record_counts=record_counts)
+                            logger.info(
+                                "✅ Extraction finished",
+                                extraction_id=extraction_id,
+                                status=extraction_status,
+                                record_counts=record_counts,
+                            )
                             return
 
                         if extraction_status == "failed":

--- a/dashboard/static/admin.html
+++ b/dashboard/static/admin.html
@@ -73,6 +73,9 @@
         .badge-completed {
             background: rgba(16,185,129,0.1); color: #10B981; border: 1px solid rgba(16,185,129,0.2);
         }
+        .badge-waiting {
+            background: rgba(59,130,246,0.1); color: #3B82F6; border: 1px solid rgba(59,130,246,0.2);
+        }
         .badge-failed {
             background: rgba(239,68,68,0.1); color: #EF4444; border: 1px solid rgba(239,68,68,0.2);
         }

--- a/dashboard/static/admin.js
+++ b/dashboard/static/admin.js
@@ -1317,6 +1317,7 @@ class AdminDashboard {
     _statusBadgeClass(status) {
         switch ((status || '').toLowerCase()) {
             case 'completed': return 'badge-completed';
+            case 'waiting':   return 'badge-waiting';
             case 'failed':    return 'badge-failed';
             case 'running':
             case 'pending':   return 'badge-running';

--- a/explore/package-lock.json
+++ b/explore/package-lock.json
@@ -621,9 +621,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1203,9 +1203,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.18",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
-      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
+      "version": "2.10.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1325,9 +1325,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001787",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
-      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "dev": true,
       "funding": [
         {
@@ -1516,9 +1516,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.335",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
-      "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
+      "version": "1.5.336",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
+      "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2768,9 +2768,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -3087,9 +3087,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/extractor/README.md
+++ b/extractor/README.md
@@ -424,6 +424,57 @@ Set the `LOG_LEVEL` environment variable to control logging verbosity:
 - `GET /metrics`: Prometheus-compatible metrics
 - `GET /ready`: Readiness probe for container orchestration
 
+### Extraction Status Lifecycle
+
+The `/health` response includes an `extraction_status` field that reports where the extractor is in its lifecycle. The same five values apply to both Discogs and MusicBrainz modes.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+
+    Idle : idle
+    Idle : initial state before any run
+
+    Running : running
+    Running : actively processing
+
+    Completed : completed
+    Completed : transient success<br/>(end of process_*_data)
+
+    Waiting : waiting
+    Waiting : sleeping until next<br/>periodic check
+
+    Failed : failed
+    Failed : last run failed;<br/>preserved through sleep<br/>for operator visibility
+
+    Idle --> Running : initial run or trigger
+    Running --> Completed : Ok(true)
+    Running --> Failed : Err or Ok(false)
+    Completed --> Waiting : run_*_loop before sleep
+    Waiting --> Running : periodic wake or trigger
+    Failed --> Running : next periodic attempt or trigger
+```
+
+**Transition points in code** (`extractor/src/extractor.rs`):
+
+| Transition | Set by | Line |
+|---|---|---|
+| `Idle → Running` | `process_discogs_data` / `process_musicbrainz_data` | top of function |
+| `Running → Completed` | same functions, on success | end of function |
+| `Running → Failed` | same functions, on error | end of function |
+| Early-skip → `Completed` | same functions, on `Skip` / empty-file paths | each early return |
+| `Completed → Waiting` | `run_discogs_loop` / `run_musicbrainz_loop` | immediately before `sleep(periodic_check_days)` |
+| `Waiting → Running` | next invocation of `process_*_data` | via periodic wake or `/trigger` API call |
+| `Failed → Running` | same | `Failed` persists through sleep and is overwritten by the next attempt |
+
+**Design notes:**
+
+- `Completed` is transient by design. It lives for microseconds between the end of a successful run and the loop's next iteration, at which point it becomes `Waiting`. Keeping `Completed` as a distinct value lets single-shot test paths (which call `process_*_data` without a surrounding loop) observe a clean terminal state, and preserves a race-window catch for external pollers.
+- `Waiting` is the dominant observable success state. Downstream consumers treat it as terminal success equivalent to `Completed`:
+  - The MusicBrainz extractor's `wait_for_discogs_idle` proceeds on any status ≠ `running`, so `Waiting` unblocks MusicBrainz extraction immediately instead of making it wait for the next Discogs periodic cycle.
+  - The admin dashboard's `_track_extraction` polls `/health` every 10 seconds during a manually-triggered run and accepts both `completed` and `waiting` as terminal success — it writes whichever value it observed verbatim to `extraction_history.status` so operators can tell a freshly-finished run from one already back on the schedule.
+- `Failed` is **not** overwritten by the loop's `Completed → Waiting` transition. A failed run's status persists through the 5-day sleep window so operators can see the last attempt failed, and only flips back to `Running` when the next attempt begins.
+
 ## Integration
 
 Extractor integrates with the Discogsography platform:

--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -47,13 +47,25 @@ pub struct ExtractorState {
     pub extraction_status: ExtractionStatus,
 }
 
-/// Lifecycle status of the extraction process
+/// Lifecycle status of the extraction process.
+///
+/// Transitions:
+/// - `Idle` — initial state before any extraction runs
+/// - `Running` — actively processing a run (set at the top of `process_*_data`)
+/// - `Completed` — transient success state set by `process_*_data` at the end of a run
+/// - `Waiting` — set by `run_*_loop` right before the periodic sleep; the dominant observable
+///   success state during the 5-day wait between checks. Downstream consumers (MusicBrainz
+///   extractor waiting on Discogs health, admin dashboard tracker) treat `waiting` as terminal
+///   success equivalent to `completed`.
+/// - `Failed` — the last run failed; persists through the sleep window so operators can see it,
+///   and is overwritten to `Running` when the next attempt begins.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ExtractionStatus {
     #[default]
     Idle,
     Running,
     Completed,
+    Waiting,
     Failed,
 }
 
@@ -63,6 +75,7 @@ impl ExtractionStatus {
             ExtractionStatus::Idle => "idle",
             ExtractionStatus::Running => "running",
             ExtractionStatus::Completed => "completed",
+            ExtractionStatus::Waiting => "waiting",
             ExtractionStatus::Failed => "failed",
         }
     }
@@ -98,6 +111,8 @@ pub async fn process_discogs_data(
 
     if latest_files.is_empty() {
         warn!("⚠️ No data files found");
+        let mut s = state.write().await;
+        s.extraction_status = ExtractionStatus::Completed;
         return Ok(true);
     }
 
@@ -126,6 +141,8 @@ pub async fn process_discogs_data(
     match decision {
         ProcessingDecision::Skip => {
             info!("✅ Version {} already processed, skipping", version);
+            let mut s = state.write().await;
+            s.extraction_status = ExtractionStatus::Completed;
             return Ok(true);
         }
         ProcessingDecision::Reprocess => {
@@ -151,6 +168,8 @@ pub async fn process_discogs_data(
 
     if data_files.is_empty() {
         warn!("⚠️ No data files to process");
+        let mut s = state.write().await;
+        s.extraction_status = ExtractionStatus::Completed;
         return Ok(true);
     }
 
@@ -201,6 +220,8 @@ pub async fn process_discogs_data(
             }
         }
 
+        let mut s = state.write().await;
+        s.extraction_status = ExtractionStatus::Completed;
         return Ok(true);
     }
 
@@ -773,6 +794,17 @@ pub async fn run_extraction_loop(
 
     // Start periodic check loop
     loop {
+        // Transition Completed → Waiting before sleeping so downstream observers
+        // (MusicBrainz extractor, admin dashboard tracker) can tell the difference
+        // between "just finished" and "on periodic schedule". Failed is preserved
+        // to keep the failure signal visible until the next attempt.
+        {
+            let mut s = state.write().await;
+            if s.extraction_status == ExtractionStatus::Completed {
+                s.extraction_status = ExtractionStatus::Waiting;
+            }
+        }
+
         let check_interval = Duration::from_secs(config.periodic_check_days * 24 * 60 * 60);
         info!("⏰ Waiting {} days before next check...", config.periodic_check_days);
 
@@ -931,6 +963,15 @@ pub async fn run_musicbrainz_loop(
         if shutdown_flag.load(Ordering::SeqCst) {
             info!("🛑 Shutdown detected, exiting MusicBrainz periodic check loop");
             break;
+        }
+
+        // Transition Completed → Waiting before sleeping — see the equivalent block
+        // in run_discogs_loop for rationale.
+        {
+            let mut s = state.write().await;
+            if s.extraction_status == ExtractionStatus::Completed {
+                s.extraction_status = ExtractionStatus::Waiting;
+            }
         }
 
         let check_interval = Duration::from_secs(config.periodic_check_days * 24 * 60 * 60);

--- a/extractor/src/tests/extractor_tests.rs
+++ b/extractor/src/tests/extractor_tests.rs
@@ -1051,6 +1051,41 @@ async fn test_extraction_status_set_failed_on_error() {
     assert_eq!(s.extraction_status, ExtractionStatus::Failed);
 }
 
+#[test]
+fn test_extraction_status_as_str_all_variants() {
+    assert_eq!(ExtractionStatus::Idle.as_str(), "idle");
+    assert_eq!(ExtractionStatus::Running.as_str(), "running");
+    assert_eq!(ExtractionStatus::Completed.as_str(), "completed");
+    assert_eq!(ExtractionStatus::Waiting.as_str(), "waiting");
+    assert_eq!(ExtractionStatus::Failed.as_str(), "failed");
+}
+
+#[tokio::test]
+async fn test_completed_transitions_to_waiting_in_loop() {
+    // Simulates the run_*_loop transition block: Completed → Waiting, Failed stays Failed.
+    let state = Arc::new(RwLock::new(ExtractorState::default()));
+
+    // Case 1: Completed transitions to Waiting
+    state.write().await.extraction_status = ExtractionStatus::Completed;
+    {
+        let mut s = state.write().await;
+        if s.extraction_status == ExtractionStatus::Completed {
+            s.extraction_status = ExtractionStatus::Waiting;
+        }
+    }
+    assert_eq!(state.read().await.extraction_status, ExtractionStatus::Waiting);
+
+    // Case 2: Failed does NOT transition — failure signal is preserved through the sleep
+    state.write().await.extraction_status = ExtractionStatus::Failed;
+    {
+        let mut s = state.write().await;
+        if s.extraction_status == ExtractionStatus::Completed {
+            s.extraction_status = ExtractionStatus::Waiting;
+        }
+    }
+    assert_eq!(state.read().await.extraction_status, ExtractionStatus::Failed);
+}
+
 mod wait_for_discogs_idle_tests {
     use crate::extractor::{wait_for_discogs_idle, wait_for_discogs_idle_with_interval};
     use std::sync::atomic::AtomicBool;
@@ -1102,6 +1137,27 @@ mod wait_for_discogs_idle_tests {
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(r#"{"extraction_status": "failed"}"#)
+            .create_async()
+            .await;
+
+        let shutdown = AtomicBool::new(false);
+        let url = format!("{}/health", server.url());
+        let result = wait_for_discogs_idle(&url, &shutdown).await;
+
+        assert!(result.is_ok());
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_proceeds_when_waiting() {
+        // "waiting" is the dominant observable state between periodic runs — the
+        // MusicBrainz extractor must proceed immediately instead of polling.
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/health")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"extraction_status": "waiting"}"#)
             .create_async()
             .await;
 

--- a/extractor/src/tests/health_tests.rs
+++ b/extractor/src/tests/health_tests.rs
@@ -298,3 +298,27 @@ async fn test_health_extraction_status_running() {
     let (_, json) = health_handler(State((state, trigger))).await;
     assert_eq!(json.0["extraction_status"], "running");
 }
+
+#[tokio::test]
+async fn test_health_extraction_status_waiting() {
+    let state = Arc::new(RwLock::new(ExtractorState::default()));
+    {
+        let mut s = state.write().await;
+        s.extraction_status = ExtractionStatus::Waiting;
+    }
+    let trigger = Arc::new(Mutex::new(None::<bool>));
+    let (_, json) = health_handler(State((state, trigger))).await;
+    assert_eq!(json.0["extraction_status"], "waiting");
+}
+
+#[tokio::test]
+async fn test_health_extraction_status_completed() {
+    let state = Arc::new(RwLock::new(ExtractorState::default()));
+    {
+        let mut s = state.write().await;
+        s.extraction_status = ExtractionStatus::Completed;
+    }
+    let trigger = Arc::new(Mutex::new(None::<bool>));
+    let (_, json) = health_handler(State((state, trigger))).await;
+    assert_eq!(json.0["extraction_status"], "completed");
+}

--- a/extractor/tests/extractor_di_test.rs
+++ b/extractor/tests/extractor_di_test.rs
@@ -896,10 +896,15 @@ async fn test_run_musicbrainz_loop_periodic_check_err() {
     let marker_path_clone = marker_path.clone();
     let state_clone = state.clone();
     tokio::spawn(async move {
-        // Wait for initial processing to complete by polling state
+        // Wait for initial processing to complete by polling state.
+        // After a successful run, run_*_loop transitions Completed → Waiting
+        // immediately before its next sleep, so "done" means either value.
         loop {
             let s = state_clone.read().await;
-            if s.extraction_status == ExtractionStatus::Completed {
+            if matches!(
+                s.extraction_status,
+                ExtractionStatus::Completed | ExtractionStatus::Waiting
+            ) {
                 break;
             }
             drop(s);
@@ -958,10 +963,15 @@ async fn test_run_musicbrainz_loop_periodic_check_ok_false() {
     let marker_path_clone = marker_path.clone();
     let state_clone = state.clone();
     tokio::spawn(async move {
-        // Wait for initial processing to complete
+        // Wait for initial processing to complete.
+        // After a successful run, run_*_loop transitions Completed → Waiting
+        // immediately before its next sleep, so "done" means either value.
         loop {
             let s = state_clone.read().await;
-            if s.extraction_status == ExtractionStatus::Completed {
+            if matches!(
+                s.extraction_status,
+                ExtractionStatus::Completed | ExtractionStatus::Waiting
+            ) {
                 break;
             }
             drop(s);
@@ -1216,6 +1226,7 @@ fn test_extraction_status_as_str_all_variants() {
     assert_eq!(ExtractionStatus::Idle.as_str(), "idle");
     assert_eq!(ExtractionStatus::Running.as_str(), "running");
     assert_eq!(ExtractionStatus::Completed.as_str(), "completed");
+    assert_eq!(ExtractionStatus::Waiting.as_str(), "waiting");
     assert_eq!(ExtractionStatus::Failed.as_str(), "failed");
 }
 

--- a/tests/api/test_admin_endpoints.py
+++ b/tests/api/test_admin_endpoints.py
@@ -582,6 +582,73 @@ class TestTrackExtraction:
 
             await admin_mod._track_extraction(extraction_id)
 
+        # Tracker must write the observed status verbatim — not map "completed" elsewhere.
+        executed = [call.args for call in mock_cur.execute.await_args_list]
+        terminal_calls = [args for args in executed if "completed_at = NOW()" in args[0]]
+        assert terminal_calls, "expected a terminal UPDATE with completed_at"
+        terminal_sql, terminal_params = terminal_calls[-1]
+        assert "SET status = %s" in terminal_sql
+        assert terminal_params[0] == "completed"
+
+        admin_mod._pool = original_pool
+        admin_mod._config = original_config
+
+    @pytest.mark.asyncio
+    async def test_waiting_extraction(self) -> None:
+        """Extractor transitions Completed → Waiting before the tracker's 10s poll
+        fires, so "waiting" is the common terminal-success value. The tracker must
+        accept it and write "waiting" verbatim to extraction_history.status."""
+        import api.routers.admin as admin_mod
+
+        mock_pool = MagicMock()
+        mock_cur = AsyncMock()
+        mock_conn = AsyncMock()
+        cur_ctx = AsyncMock()
+        cur_ctx.__aenter__ = AsyncMock(return_value=mock_cur)
+        cur_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_conn.cursor = MagicMock(return_value=cur_ctx)
+        conn_ctx = AsyncMock()
+        conn_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+        conn_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_pool.connection = MagicMock(return_value=conn_ctx)
+
+        mock_config = MagicMock()
+        mock_config.extractor_host = "localhost"
+        mock_config.extractor_health_port = 8000
+
+        original_pool = admin_mod._pool
+        original_config = admin_mod._config
+        admin_mod._pool = mock_pool
+        admin_mod._config = mock_config
+
+        extraction_id = str(uuid4())
+
+        with (
+            patch("api.routers.admin.asyncio.sleep", new_callable=AsyncMock),
+            patch("api.routers.admin.httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "extraction_status": "waiting",
+                "extraction_progress": {"artists": 100, "labels": 50, "masters": 25, "releases": 200},
+            }
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get = AsyncMock(return_value=mock_response)
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client_instance
+
+            await admin_mod._track_extraction(extraction_id)
+
+        # Assert the terminal UPDATE wrote "waiting" verbatim — not "completed".
+        executed = [call.args for call in mock_cur.execute.await_args_list]
+        terminal_calls = [args for args in executed if "completed_at = NOW()" in args[0]]
+        assert terminal_calls, "expected a terminal UPDATE with completed_at"
+        terminal_sql, terminal_params = terminal_calls[-1]
+        assert "SET status = %s" in terminal_sql
+        assert terminal_params[0] == "waiting"
+
         admin_mod._pool = original_pool
         admin_mod._config = original_config
 

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.94.1"
+version = "0.95.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -88,9 +88,9 @@ dependencies = [
     { name = "sniffio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/f2/fb4a04ff676742588a41f94dd318883d6d77e88e2b5e20b664ae3bf20e1b/anthropic-0.94.1.tar.gz", hash = "sha256:96c7033069c16074f90638dff8bf1f1616f9eefeb8ef7d1b0df4a0393ab34685", size = 654451, upload-time = "2026-04-13T18:08:18.453Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/cb/b1896da12f12680c39c90af1b9c9fdf75354899317e2a7900ab37fe3a640/anthropic-0.95.0.tar.gz", hash = "sha256:e4d815351489e5627f39806f12561c52b574e69be10d12fcab723264f955c11d", size = 654528, upload-time = "2026-04-14T19:04:34.114Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/18/6d5b5948cbe450d3c98336c8a8c4804aedb3ab24fa37922d05063f8ba266/anthropic-0.94.1-py3-none-any.whl", hash = "sha256:58fb20dc60f35e75a5a82a1c73a3e196ac3b18ff2ed4826cba345f4adb78919d", size = 627710, upload-time = "2026-04-13T18:08:19.629Z" },
+    { url = "https://files.pythonhosted.org/packages/64/29/a0285521eeaacf9ff5d0fad2d437389aefa0adf3db79b0e0bda49f809ce9/anthropic-0.95.0-py3-none-any.whl", hash = "sha256:9fd3503cb666446e28ab5a5d0ec7feda39968399e494bd2cca2f0b927f8aa7a6", size = 627749, upload-time = "2026-04-14T19:04:35.549Z" },
 ]
 
 [[package]]
@@ -890,11 +890,11 @@ wheels = [
 
 [[package]]
 name = "docstring-parser"
-version = "0.17.0"
+version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -937,11 +937,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.25.2"
+version = "3.28.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/17/6e8890271880903e3538660a21d63a6c1fea969ac71d0d6b608b78727fa9/filelock-3.28.0.tar.gz", hash = "sha256:4ed1010aae813c4ee8d9c660e4792475ee60c4a0ba76073ceaf862bd317e3ca6", size = 56474, upload-time = "2026-04-14T22:54:33.625Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/21/2f728888c45033d34a417bfcd248ea2564c9e08ab1bfd301377cf05d5586/filelock-3.28.0-py3-none-any.whl", hash = "sha256:de9af6712788e7171df1b28b15eba2446c69721433fa427a9bee07b17820a9db", size = 39189, upload-time = "2026-04-14T22:54:32.037Z" },
 ]
 
 [[package]]
@@ -1466,11 +1466,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
 ]
 
 [[package]]
@@ -1775,7 +1775,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.13.0"
+version = "2.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1783,38 +1783,38 @@ dependencies = [
     { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typing-inspection", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/6b/69fd5c7194b21ebde0f8637e2a4ddc766ada29d472bfa6a5ca533d79549a/pydantic-2.13.0.tar.gz", hash = "sha256:b89b575b6e670ebf6e7448c01b41b244f471edd276cd0b6fe02e7e7aca320070", size = 843468, upload-time = "2026-04-13T10:51:35.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/6b/1353beb3d1cd5cf61cdec5b6f87a9872399de3bc5cae0b7ce07ff4de2ab0/pydantic-2.13.1.tar.gz", hash = "sha256:a0f829b279ddd1e39291133fe2539d2aa46cc6b150c1706a270ff0879e3774d2", size = 843746, upload-time = "2026-04-15T14:57:19.398Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/d7/c3a52c61f5b7be648e919005820fbac33028c6149994cd64453f49951c17/pydantic-2.13.0-py3-none-any.whl", hash = "sha256:ab0078b90da5f3e2fd2e71e3d9b457ddcb35d0350854fbda93b451e28d56baaf", size = 471872, upload-time = "2026-04-13T10:51:33.343Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5a/2225f4c176dbfed0d809e848b50ef08f70e61daa667b7fa14b0d311ae44d/pydantic-2.13.1-py3-none-any.whl", hash = "sha256:9557ecc2806faaf6037f85b1fbd963d01e30511c48085f0d573650fdeaad378a", size = 471917, upload-time = "2026-04-15T14:57:17.277Z" },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.46.0"
+version = "2.46.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/0a/9414cddf82eda3976b14048cc0fa8f5b5d1aecb0b22e1dcd2dbfe0e139b1/pydantic_core-2.46.0.tar.gz", hash = "sha256:82d2498c96be47b47e903e1378d1d0f770097ec56ea953322f39936a7cf34977", size = 471441, upload-time = "2026-04-13T09:06:33.813Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/93/f97a86a7eb28faa1d038af2fd5d6166418b4433659108a4c311b57128b2d/pydantic_core-2.46.1.tar.gz", hash = "sha256:d408153772d9f298098fb5d620f045bdf0f017af0d5cb6e309ef8c205540caa4", size = 471230, upload-time = "2026-04-15T14:49:34.52Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/05/ab3b0742bad1d51822f1af0c4232208408902bdcfc47601f3b812e09e6c2/pydantic_core-2.46.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:a05900c37264c070c683c650cbca8f83d7cbb549719e645fcd81a24592eac788", size = 2116814, upload-time = "2026-04-13T09:04:12.41Z" },
-    { url = "https://files.pythonhosted.org/packages/98/08/30b43d9569d69094a0899a199711c43aa58fce6ce80f6a8f7693673eb995/pydantic_core-2.46.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8de8e482fd4f1e3f36c50c6aac46d044462615d8f12cfafc6bebeaa0909eea22", size = 1951867, upload-time = "2026-04-13T09:04:02.364Z" },
-    { url = "https://files.pythonhosted.org/packages/db/a0/bf9a1ba34537c2ed3872a48195291138fdec8fe26c4009776f00d63cf0c8/pydantic_core-2.46.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c525ecf8a4cdf198327b65030a7d081867ad8e60acb01a7214fff95cf9832d47", size = 1977040, upload-time = "2026-04-13T09:06:16.088Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/f8/5885350203b72e96438eee7f94de0d8f0442f4627237ca8ef75de34db1cd/pydantic_core-2.46.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7897078fe8a13b73623c0955dfb2b3d2c9acb7177aac25144758c9e5a5265aaa", size = 2098522, upload-time = "2026-04-13T09:04:23.239Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/53/1958eacbfddc41aadf5ae86dd85041bf054b675f34a2fa76385935f96070/pydantic_core-2.46.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:ee1547a6b8243e73dd10f585555e5a263395e55ce6dea618a078570a1e889aef", size = 2190148, upload-time = "2026-04-13T09:06:56.151Z" },
-    { url = "https://files.pythonhosted.org/packages/71/a7/abdb924620b1ac535c690b36ad5b8871f376104090f8842c08625cecf1d3/pydantic_core-2.46.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:004a2081c881abfcc6854a4623da6a09090a0d7c1398a6ae7133ca1256cee70b", size = 2383167, upload-time = "2026-04-13T09:04:52.643Z" },
-    { url = "https://files.pythonhosted.org/packages/36/3b/914891d384cdbf9a6f464eb13713baa22ea1e453d4da80fb7da522079370/pydantic_core-2.46.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:4fc801c290342350ffc82d77872054a934b2e24163727263362170c1db5416ca", size = 2113349, upload-time = "2026-04-13T09:04:59.407Z" },
-    { url = "https://files.pythonhosted.org/packages/35/95/3a0c6f65e231709fb3463e32943c69d10285cb50203a2130a4732053a06d/pydantic_core-2.46.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0a36f2cc88170cc177930afcc633a8c15907ea68b59ac16bd180c2999d714940", size = 1949170, upload-time = "2026-04-13T09:06:09.935Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/63/d845c36a608469fe7bee226edeff0984c33dbfe7aecd755b0e7ab5a275c4/pydantic_core-2.46.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2a3912e0c568a1f99d4d6d3e41def40179d61424c0ca1c8c87c4877d7f6fd7fb", size = 1977914, upload-time = "2026-04-13T09:04:56.16Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/e4/566101a561492ce8454f0844ca29c3b675a6b3a7b3ff577db85ed05c8c50/pydantic_core-2.46.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67e2c2e171b78db8154da602de72ffdc473c6ee51de8a9d80c0f1cd4051abfc7", size = 2102533, upload-time = "2026-04-13T09:06:58.664Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/3b/807d5b035ec891b57b9079ce881f48263936c37bd0d154a056e7fd152afb/pydantic_core-2.46.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:15ed8e5bde505133d96b41702f31f06829c46b05488211a5b1c7877e11de5eb5", size = 2188293, upload-time = "2026-04-13T09:07:07.614Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/90/8718e4ae98c4e8a7325afdc079be82be1e131d7a47cb6c098844a9531ffe/pydantic_core-2.46.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e1155708540f13845bf68d5ac511a55c76cfe2e057ed12b4bf3adac1581fc5c2", size = 2377155, upload-time = "2026-04-13T09:06:18.081Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/30/1177dde61b200785c4739665e3aa03a9d4b2c25d2d0408b07d585e633965/pydantic_core-2.46.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5e7cdd4398bee1aaeafe049ac366b0f887451d9ae418fd8785219c13fea2f928", size = 2107447, upload-time = "2026-04-13T09:05:46.314Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/60/4e0f61f99bdabbbc309d364a2791e1ba31e778a4935bc43391a7bdec0744/pydantic_core-2.46.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5c2c92d82808e27cef3f7ab3ed63d657d0c755e0dbe5b8a58342e37bdf09bd2e", size = 1926927, upload-time = "2026-04-13T09:06:20.371Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/d0/67f89a8269152c1d6eaa81f04e75a507372ebd8ca7382855a065222caa80/pydantic_core-2.46.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bab80af91cd7014b45d1089303b5f844a9d91d7da60eabf3d5f9694b32a6655", size = 1966613, upload-time = "2026-04-13T09:07:05.389Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/2c/f0d744e3dab7bd026a3f4670a97a295157cff923a2666d30a15a70a7e3d0/pydantic_core-2.46.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e20bc5add1dd9bc3b9a3600d40632e679376569098345500799a6ad7c5d46c72", size = 2104621, upload-time = "2026-04-13T09:04:34.388Z" },
-    { url = "https://files.pythonhosted.org/packages/32/7b/b3025618ed4c4e4cbaa9882731c19625db6669896b621760ea95bc1125ef/pydantic_core-2.46.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d14cc5a6f260fa78e124061eebc5769af6534fc837e9a62a47f09a2c341fa4ea", size = 2171222, upload-time = "2026-04-13T09:07:29.929Z" },
-    { url = "https://files.pythonhosted.org/packages/67/1b/5e65807001b84972476300c1f49aea2b4971b7e9fffb5c2654877dadd274/pydantic_core-2.46.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:8ef749be6ed0d69dba31902aaa8255a9bb269ae50c93888c4df242d8bb7acd9e", size = 2377062, upload-time = "2026-04-13T09:07:39.945Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/d2/bda39bad2f426cb5078e6ad28076614d3926704196efe0d7a2a19a99025d/pydantic_core-2.46.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:cdc8a5762a9c4b9d86e204d555444e3227507c92daba06259ee66595834de47a", size = 2119092, upload-time = "2026-04-15T14:49:50.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/69631e64d69cb3481494b2bddefe0ddd07771209f74e9106d066f9138c2a/pydantic_core-2.46.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ba381dfe9c85692c566ecb60fa5a77a697a2a8eebe274ec5e4d6ec15fafad799", size = 1951400, upload-time = "2026-04-15T14:51:06.588Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1c/21cb3db6ae997df31be8e91f213081f72ffa641cb45c89b8a1986832b1f9/pydantic_core-2.46.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1593d8de98207466dc070118322fef68307a0cc6a5625e7b386f6fdae57f9ab6", size = 1976864, upload-time = "2026-04-15T14:50:54.804Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/40/6fc24c3766a19c222a0d60d652b78f0283339d4cd4c173fab06b7ee76571/pydantic_core-2.46.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f79292435fff1d4f0c18d9cfaf214025cc88e4f5104bfaed53f173621da1c743", size = 2097474, upload-time = "2026-04-15T14:49:56.543Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/07/1c10d5ce312fc4cf86d1e50bdcdbb8ef248409597b099cab1b4bb3a093f7/pydantic_core-2.46.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:1f80535259dcdd517d7b8ca588d5ca24b4f337228e583bebedf7a3adcdf5f721", size = 2187859, upload-time = "2026-04-15T14:49:22.974Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ed/218dfeea6127fb1781a6ceca241ec6edf00e8a8933ff331af2215975a534/pydantic_core-2.46.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:f12794b1dd8ac9fb66619e0b3a0427189f5d5638e55a3de1385121a9b7bf9b39", size = 2384039, upload-time = "2026-04-15T14:53:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2b/6793fe89ab66cb2d3d6e5768044eab80bba1d0fae8fd904d0a1574712e17/pydantic_core-2.46.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:9917cb61effac7ec0f448ef491ec7584526d2193be84ff981e85cbf18b68c42a", size = 2118110, upload-time = "2026-04-15T14:50:52.947Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/87/e9a905ddfcc2fd7bd862b340c02be6ab1f827922822d425513635d0ac774/pydantic_core-2.46.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0e749679ca9f8a9d0bff95fb7f6b57bb53f2207fa42ffcc1ec86de7e0029ab89", size = 1948645, upload-time = "2026-04-15T14:51:55.577Z" },
+    { url = "https://files.pythonhosted.org/packages/15/23/26e67f86ed62ac9d6f7f3091ee5220bf14b5ac36fb811851d601365ef896/pydantic_core-2.46.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2ecacee70941e233a2dad23f7796a06f86cc10cc2fbd1c97c7dd5b5a79ffa4f", size = 1977576, upload-time = "2026-04-15T14:49:37.58Z" },
+    { url = "https://files.pythonhosted.org/packages/76/fd/19d711e4e9331f9d77f222bffc202bf30ea0d74f6419046376bb82f244c8/pydantic_core-2.46.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b83ce9fede4bc4fb649281d9857f06d30198b8f70168f18b987518d713111572", size = 2101762, upload-time = "2026-04-15T14:49:24.278Z" },
+    { url = "https://files.pythonhosted.org/packages/36/09/e4f581353bdf3f0c7de8a8b27afd14fc761da29d78146376315a6fedc487/pydantic_core-2.46.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9b176fa55f9107db5e6c86099aa5bfd934f1d3ba6a8b43f714ddeebaed3f42b7", size = 2184154, upload-time = "2026-04-15T14:52:49.629Z" },
+    { url = "https://files.pythonhosted.org/packages/30/93/25bfb08fdbef419f73290e573899ce938a327628c34e8f3a4bafeea30126/pydantic_core-2.46.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:f200fce071808a385a314b7343f5e3688d7c45746be3d64dc71ee2d3e2a13268", size = 2377964, upload-time = "2026-04-15T14:51:59.649Z" },
+    { url = "https://files.pythonhosted.org/packages/36/3a/2a018968245fffd25d5f1972714121ad309ff2de19d80019ad93494844f9/pydantic_core-2.46.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:607ff9db0b7e2012e7eef78465e69f9a0d7d1c3e7c6a84cf0c4011db0fcc3feb", size = 2111548, upload-time = "2026-04-15T14:52:08.273Z" },
+    { url = "https://files.pythonhosted.org/packages/77/5b/4103b6192213217e874e764e5467d2ff10d8873c1147d01fa432ac281880/pydantic_core-2.46.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8cda3eacaea13bd02a1bea7e457cc9fc30b91c5a91245cef9b215140f80dd78c", size = 1926745, upload-time = "2026-04-15T14:50:03.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/70/602a667cf4be4bec6c3334512b12ae4ea79ce9bfe41dc51be1fd34434453/pydantic_core-2.46.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9493279cdc7997fe19e5ed9b41f30cbc3806bd4722adb402fedb6f6d41bd72a", size = 1965922, upload-time = "2026-04-15T14:51:12.555Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0b/b7c5a631b6d5153d4a1ea4923b139aea256dc3bd99c8e6c7b312c7733146/pydantic_core-2.46.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3cd37e39b22b796ba0298fe81e9421dd7b65f97acfbb0fb19b33ffdda7b9a7b4", size = 2103439, upload-time = "2026-04-15T14:50:08.32Z" },
+    { url = "https://files.pythonhosted.org/packages/67/97/32ae283810910d274d5ba9f48f856f5f2f612410b78b249f302d297816f5/pydantic_core-2.46.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:88cd1355578852db83954dc36e4f58f299646916da976147c20cf6892ba5dc43", size = 2171184, upload-time = "2026-04-15T14:52:34.854Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/14c39ffc7399819c5448007c7bcb4e6da5669850cfb7dcbb727594290b48/pydantic_core-2.46.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:556a63ff1006934dba4eed7ea31b58274c227e29298ec398e4275eda4b905e95", size = 2378340, upload-time = "2026-04-15T14:51:02.619Z" },
 ]
 
 [[package]]
@@ -2449,7 +2449,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.2.1"
+version = "21.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2457,9 +2457,9 @@ dependencies = [
     { name = "platformdirs", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "python-discovery", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/c5/aff062c66b42e2183201a7ace10c6b2e959a9a16525c8e8ca8e59410d27a/virtualenv-21.2.1.tar.gz", hash = "sha256:b66ffe81301766c0d5e2208fc3576652c59d44e7b731fc5f5ed701c9b537fa78", size = 5844770, upload-time = "2026-04-09T18:47:11.482Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/0e/f083a76cb590e60dff3868779558eefefb8dfb7c9ed020babc7aa014ccbf/virtualenv-21.2.1-py3-none-any.whl", hash = "sha256:bd16b49c53562b28cf1a3ad2f36edb805ad71301dee70ddc449e5c88a9f919a2", size = 5828326, upload-time = "2026-04-09T18:47:09.331Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes a bug where the MusicBrainz extractor got stuck waiting forever for Discogs even though the Discogs extractor was idle (sleeping between 5-day periodic checks).

Two root causes:

1. **`process_discogs_data` leaked `Running` status on early-return paths.** Line 92 set `extraction_status = Running` at the top, but four early-returns (no files, `Skip`, empty `data_files`, empty `pending_files`) returned without resetting it. After a periodic check hit the `Skip` path, the live status stayed `"running"` for the entire 5-day sleep window, and the MusicBrainz extractor's `wait_for_discogs_idle` polled indefinitely.

2. **`"completed"` conflated "just finished" with "sleeping on schedule".** Even with the above fixed, operators looking at `/health` couldn't tell the difference between a freshly-finished run and one already back on the 5-day cycle.

## What changed

**Rust extractor** (`extractor/src/extractor.rs`)
- Fixed all four early-return paths to set `Completed` (mirrors `process_musicbrainz_data` which already did this)
- New `ExtractionStatus::Waiting` variant with full doc comment
- `run_discogs_loop` and `run_musicbrainz_loop` transition `Completed → Waiting` right before the periodic sleep; `Failed` is preserved through the sleep to keep the failure signal visible to operators
- `wait_for_discogs_idle` already proceeds on anything ≠ `"running"`, so it picks up `"waiting"` with zero logic changes

**API tracker** (`api/routers/admin.py`)
- `_track_extraction` accepts both `"completed"` and `"waiting"` as terminal success
- Writes the observed status value **verbatim** to `extraction_history.status` (no mapping) — operators can tell a just-finished run from one back on schedule

**Dashboard** (`dashboard/static/admin.{html,js}`)
- New `.badge-waiting` CSS class (blue, distinct from completed's green)
- `_statusBadgeClass` handles the `waiting` value

**Documentation** (`extractor/README.md`)
- New **Extraction Status Lifecycle** section with a Mermaid state diagram
- Transition-point table mapping each state change to its code location
- Design notes explaining why `Completed` is kept transient, why `Waiting` is dominant, and why `Failed` persists through the sleep window

## Lifecycle

` ` `mermaid
stateDiagram-v2
    [*] --> Idle
    Idle --> Running : initial run or trigger
    Running --> Completed : Ok(true)
    Running --> Failed : Err or Ok(false)
    Completed --> Waiting : run_*_loop before sleep
    Waiting --> Running : periodic wake or trigger
    Failed --> Running : next periodic attempt or trigger
` ` `

## Test plan

- [x] \`cargo test --manifest-path extractor/Cargo.toml --lib\` → 474 passed (5 new)
- [x] \`cargo clippy --manifest-path extractor/Cargo.toml --lib\` → clean
- [x] \`uv run pytest tests/api/test_admin_endpoints.py\` → 73 passed (1 new + 1 strengthened)
- [x] \`uv run ruff check .\` → clean
- [x] \`uv run mypy api/routers/admin.py\` → clean
- [x] Pre-commit hooks on commit → all passed
- [ ] Deploy to staging and verify MusicBrainz extractor starts promptly after a Discogs periodic check

🤖 Generated with [Claude Code](https://claude.com/claude-code)