### PR TITLE
fix(explore): mount Ask pill via importmap for dompurify and marked

### DIFF
--- a/explore/__tests__/importmap-coverage.test.js
+++ b/explore/__tests__/importmap-coverage.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const staticDir = path.join(__dirname, '..', 'static');
+const jsDir = path.join(staticDir, 'js');
+const indexHtml = fs.readFileSync(path.join(staticDir, 'index.html'), 'utf8');
+
+function extractImportMap(html) {
+    const match = html.match(/<script\s+type="importmap"[^>]*>([\s\S]*?)<\/script>/);
+    if (!match) return {};
+    const parsed = JSON.parse(match[1]);
+    return parsed.imports || {};
+}
+
+function findBareSpecifiers(source) {
+    const specifiers = [];
+    const pattern = /(?:^|\s|;)import\s+(?:[^'"\n]+?\s+from\s+)?['"]([^'"\n]+)['"]/g;
+    let match;
+    while ((match = pattern.exec(source)) !== null) {
+        const specifier = match[1];
+        const isRelative = specifier.startsWith('./') || specifier.startsWith('../') || specifier.startsWith('/');
+        const isUrl = /^https?:/i.test(specifier);
+        if (isRelative || isUrl) continue;
+        specifiers.push(specifier);
+    }
+    return specifiers;
+}
+
+function collectBareSpecifiers(dir) {
+    const out = new Map();
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (entry.isDirectory()) {
+            for (const [spec, files] of collectBareSpecifiers(path.join(dir, entry.name))) {
+                const existing = out.get(spec) ?? [];
+                out.set(spec, [...existing, ...files]);
+            }
+            continue;
+        }
+        if (!entry.name.endsWith('.js') && !entry.name.endsWith('.mjs')) continue;
+        const full = path.join(dir, entry.name);
+        const source = fs.readFileSync(full, 'utf8');
+        for (const specifier of findBareSpecifiers(source)) {
+            const existing = out.get(specifier) ?? [];
+            out.set(specifier, [...existing, path.relative(jsDir, full)]);
+        }
+    }
+    return out;
+}
+
+describe('importmap covers all bare module specifiers in static/js', () => {
+    it('every bare specifier imported by static JS is declared in index.html importmap', () => {
+        const imports = extractImportMap(indexHtml);
+        const mapped = new Set(Object.keys(imports));
+        const bareSpecs = collectBareSpecifiers(jsDir);
+        const missing = [];
+        for (const [spec, files] of bareSpecs) {
+            if (!mapped.has(spec)) missing.push({ spec, files });
+        }
+        expect(missing, `bare specifiers missing from importmap: ${JSON.stringify(missing, null, 2)}`).toEqual([]);
+    });
+
+    it('importmap is defined before the first <script type="module">', () => {
+        const importMapIdx = indexHtml.indexOf('<script type="importmap"');
+        const firstModuleIdx = indexHtml.indexOf('<script type="module"');
+        expect(importMapIdx, 'importmap missing from index.html').toBeGreaterThanOrEqual(0);
+        expect(firstModuleIdx, 'no module script found').toBeGreaterThanOrEqual(0);
+        expect(importMapIdx).toBeLessThan(firstModuleIdx);
+    });
+});

--- a/explore/static/index.html
+++ b/explore/static/index.html
@@ -18,8 +18,16 @@
     <script src="https://d3js.org/d3.v7.min.js" integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i" crossorigin="anonymous"></script>
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js" integrity="sha384-Hl48Kq2HifOWdXEjMsKo6qxqvRLTYqIGbvlENBmkHAxZKIGCXv43H6W1jA671RzC" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.8/dist/cdn.min.js" integrity="sha384-LXWjKwDZz29o7TduNe+r/UxaolHh5FsSvy2W7bDHSZ8jJeGgDeuNnsDNHoxpSgDi" crossorigin="anonymous"></script>
+    <script type="importmap">
+    {
+      "imports": {
+        "dompurify": "https://cdn.jsdelivr.net/npm/dompurify@3.4.0/+esm",
+        "marked": "https://cdn.jsdelivr.net/npm/marked@18.0.0/+esm"
+      }
+    }
+    </script>
     <link rel="stylesheet" href="css/styles.css">
-    <link rel="stylesheet" href="/css/nlq-pill.css">
+    <link rel="stylesheet" href="css/nlq-pill.css">
     <style>[x-cloak] { display: none !important; }</style>
     <style>
 /* Tailwind .hidden fallback — tailwind.css is only built during Docker builds,


### PR DESCRIPTION
## Summary

- The global Ask pill introduced in #304 never mounted in production — `nlq-markdown.js` uses bare module specifiers (`dompurify`, `marked`) but explore serves static files with no bundler, so the browser throws `Failed to resolve module specifier "dompurify"`. The error cascades through the module chain (`nlq.js` → `nlq-summary-strip.js` → `nlq-markdown.js`), `window.NlqInit` is never set, and `app.js`'s `DOMContentLoaded` handler finds nothing to call. Vitest tests passed throughout because jsdom resolves from `node_modules`.
- Fix: add an `<script type="importmap">` in `explore/static/index.html` mapping both specifiers to pinned `cdn.jsdelivr.net/.../+esm` URLs (matching the existing pinned-CDN pattern used for d3, plotly, and alpine).
- Regression test: `explore/__tests__/importmap-coverage.test.js` scans every `static/js/**/*.js` for bare `import` specifiers and asserts each one is declared in the importmap, and that the importmap appears before the first module script.
- Drive-by: normalize `nlq-pill.css` `href` from `/css/nlq-pill.css` to `css/nlq-pill.css` to match the file's existing relative-path convention for own static assets.

## Test plan

- [x] `just test-js` — 987 tests passing (up from 985; includes the 2 new regression tests)
- [ ] Reload explore in the browser and confirm:
  - [ ] Ask pill appears on page load
  - [ ] Browser console shows no module-resolution errors
  - [ ] Submitting a query streams a summary strip with applied actions
  - [ ] `nlq-pill.css` still loads correctly after the href change

🤖 Generated with [Claude Code](https://claude.com/claude-code)