### PR TITLE
chore(extractor): remove duplicate MBID→Discogs map log

### DIFF
--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -1126,7 +1126,6 @@ pub async fn process_musicbrainz_data(
     } else {
         HashMap::new()
     };
-    info!("📊 Built MBID→Discogs map: {} entries", artist_discogs_map.len());
 
     let mut record_counts: HashMap<String, u64> = HashMap::new();
     let mut success = true;


### PR DESCRIPTION
## Summary
- Removes the second `📊 Built MBID→Discogs map: N entries` log emitted from `process_musicbrainz_data` in `extractor/src/extractor.rs`.
- The inner `build_mbid_discogs_map_from_file` (`jsonl_parser.rs:301`) already logs the same thing with additional context (the source file path), so the caller's duplicate added no information.

## Test plan
- [x] `cargo build --release` succeeds
- [x] `cargo test --release` — 34/34 tests pass
- [x] `cargo clippy --release -- -D warnings` clean
- [x] `cargo fmt` clean (pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)