### PR TITLE
chore(ci): drop Discord webhook notifications

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,13 +331,3 @@ jobs:
           if [[ -n "${{ steps.docker-cache.outputs.cache-hit }}" ]]; then
             echo "::notice title=Cache Performance::Docker cache hit for ${{ matrix.name }}"
           fi
-
-      - name: 📢 Send notification to Discord
-        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
-        if: always()
-        with:
-          title: discogsography/${{ matrix.name }}
-          description: |
-            Build duration: ${{ steps.timer.outputs.duration || 'N/A' }}s
-            Cache used: ${{ matrix.use_cache }}
-          webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -235,16 +235,3 @@ jobs:
               tail -n 100 update-output.txt
             fi
           fi
-
-      - name: 📢 Send notification to Discord
-        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
-        if: always()
-        with:
-          title: Weekly Dependency Update
-          description: |
-            ${{ steps.update.outputs.no_changes == 'true' && '✅ All dependencies are already up to date!' ||
-                (steps.create-pr.conclusion == 'success' &&
-                 format('✅ Successfully created PR with dependency updates\n🔗 [Review PR]({0})',
-                        steps.create-pr.outputs.pull-request-url) ||
-                 '❌ Failed to update dependencies') }}
-          webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/docs/github-actions-guide.md
+++ b/docs/github-actions-guide.md
@@ -49,7 +49,6 @@ on:
 - ⚡ Parallel test execution for faster feedback
 - 💾 Advanced Docker layer caching
 - 📊 Build metrics and performance tracking
-- 📢 Discord notifications with build status
 
 ### 🧹 Code Quality Workflow (`code-quality.yml`)
 
@@ -106,7 +105,6 @@ on:
 1. Runs update script
 1. Creates PR with detailed summary
 1. Assigns reviewers
-1. Sends Discord notification
 
 ### 🛡️ Security Workflow (`security.yml`)
 
@@ -248,7 +246,6 @@ Advanced Docker layer caching for faster builds.
 - Build duration tracking
 - Cache hit rate reporting
 - Performance notices in workflow logs
-- Enhanced Discord notifications with metrics
 
 ## 🛡️ Security Features
 
@@ -293,7 +290,6 @@ permissions:
 
 ### 📢 Notifications
 
-- Discord webhooks for build status
 - Detailed error messages in logs
 - PR comments for dependency updates
 - Workflow status badges in README


### PR DESCRIPTION
## Summary

- Removes the trailing `Send notification to Discord` step from `build.yml` and `update-dependencies.yml`.
- Drops the matching mentions from `docs/github-actions-guide.md` (workflow features, dep-update process steps, monitoring, and the notifications subsection).
- The `DISCORD_WEBHOOK` repo secret is no longer referenced by any workflow and can be deleted from repo settings.

## Test plan

- [x] `yamllint` and the workflow validators (pre-commit) pass on both edited workflows.
- [x] Confirm in repo settings that the `DISCORD_WEBHOOK` secret can be deleted (no other consumers).
- [ ] On next scheduled `update-dependencies` run, verify the job completes successfully without the notification step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)