### PR TITLE
docs: refresh docs against codebase + README banner/badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,14 @@
 <div align="center">
 
-<img src="dashboard/static/brand/banner_dark.png" alt="discogsography" width="400" />
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="dashboard/static/brand/banner_dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="dashboard/static/brand/banner_light.png">
+  <img alt="discogsography" src="dashboard/static/brand/banner_dark.png" width="600">
+</picture>
 
-[![Build](https://github.com/SimplicityGuy/discogsography/actions/workflows/build.yml/badge.svg)](https://github.com/SimplicityGuy/discogsography/actions/workflows/build.yml)
-[![Code Quality](https://github.com/SimplicityGuy/discogsography/actions/workflows/code-quality.yml/badge.svg)](https://github.com/SimplicityGuy/discogsography/actions/workflows/code-quality.yml)
-[![Tests](https://github.com/SimplicityGuy/discogsography/actions/workflows/test.yml/badge.svg)](https://github.com/SimplicityGuy/discogsography/actions/workflows/test.yml)
-[![E2E Tests](https://github.com/SimplicityGuy/discogsography/actions/workflows/e2e-test.yml/badge.svg)](https://github.com/SimplicityGuy/discogsography/actions/workflows/e2e-test.yml)
-[![codecov](https://codecov.io/gh/SimplicityGuy/discogsography/branch/main/graph/badge.svg?token=K72AL2L2FY)](https://codecov.io/gh/SimplicityGuy/discogsography)
-![License: PolyForm Noncommercial 1.0.0](https://img.shields.io/badge/license-PolyForm--NC--1.0.0-blue)
-![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)
-![Rust](https://img.shields.io/badge/rust-stable-orange.svg)
-[![uv](https://img.shields.io/badge/uv-package%20manager-orange?logo=python)](https://github.com/astral-sh/uv)
-[![just](https://img.shields.io/badge/just-task%20runner-blue)](https://just.systems)
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![Cargo](https://img.shields.io/badge/cargo-rust%20package%20manager-brown)](https://doc.rust-lang.org/cargo/)
-[![Clippy](https://img.shields.io/badge/clippy-rust%20linter-green)](https://github.com/rust-lang/rust-clippy)
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
-[![mypy](https://img.shields.io/badge/mypy-checked-blue)](http://mypy-lang.org/)
-[![Bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)
-[![Docker](https://img.shields.io/badge/docker-ready-blue?logo=docker)](https://www.docker.com/)
-[![Claude Code](https://img.shields.io/badge/Claude%20Code-powered-orange?logo=anthropic&logoColor=white)](https://claude.ai/code)
+<br><br>
+
+[![Build](https://github.com/SimplicityGuy/discogsography/actions/workflows/build.yml/badge.svg)](https://github.com/SimplicityGuy/discogsography/actions/workflows/build.yml) [![Code Quality](https://github.com/SimplicityGuy/discogsography/actions/workflows/code-quality.yml/badge.svg)](https://github.com/SimplicityGuy/discogsography/actions/workflows/code-quality.yml) [![Tests](https://github.com/SimplicityGuy/discogsography/actions/workflows/test.yml/badge.svg)](https://github.com/SimplicityGuy/discogsography/actions/workflows/test.yml) [![E2E Tests](https://github.com/SimplicityGuy/discogsography/actions/workflows/e2e-test.yml/badge.svg)](https://github.com/SimplicityGuy/discogsography/actions/workflows/e2e-test.yml) [![codecov](https://codecov.io/gh/SimplicityGuy/discogsography/branch/main/graph/badge.svg?token=K72AL2L2FY)](https://codecov.io/gh/SimplicityGuy/discogsography) ![License: PolyForm Noncommercial 1.0.0](https://img.shields.io/badge/license-PolyForm--NC--1.0.0-blue) ![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg) ![Rust](https://img.shields.io/badge/rust-stable-orange.svg)
 
 **A modern Python 3.13+ microservices platform for transforming the complete [Discogs](https://www.discogs.com/) music database into powerful, queryable knowledge graphs and analytics engines.**
 
@@ -47,8 +36,9 @@ Perfect for music researchers, data scientists, developers, and music enthusiast
 
 ### ⚙️ Core Services
 
+
 | Service                                                       | Purpose                                          | Key Technologies                                             |
-| ------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------ |
+| --------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------------- |
 | **[🔐](docs/emoji-guide.md#service-identifiers) API**         | User accounts, JWT auth, and collection sync     | `FastAPI`, `psycopg3`, `redis`, Discogs OAuth 1.0            |
 | **[📊](docs/emoji-guide.md#service-identifiers) Dashboard**   | Real-time monitoring and admin panel             | `FastAPI`, WebSocket, reactive UI                            |
 | **[🔍](docs/emoji-guide.md#service-identifiers) Explore**     | Serves graph exploration frontend (static files) | `FastAPI`, `Tailwind CSS`, `Alpine.js`, `D3.js`, `Plotly.js` |
@@ -61,8 +51,9 @@ Perfect for music researchers, data scientists, developers, and music enthusiast
 
 ### 🎵 MusicBrainz Enrichment Services
 
+
 | Service                                                             | Purpose                                                          | Key Technologies       |
-| ------------------------------------------------------------------- | ---------------------------------------------------------------- | ---------------------- |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------ |
 | **[🧠](docs/emoji-guide.md#service-identifiers) Brainzgraphinator** | Enriches Neo4j graph with MusicBrainz metadata and relationships | `neo4j-driver`, `pika` |
 | **[🧬](docs/emoji-guide.md#service-identifiers) Brainztableinator** | Populates PostgreSQL with MusicBrainz data and external links    | `psycopg3`, `pika`     |
 
@@ -153,13 +144,14 @@ docker-compose up -d
 open http://localhost:8003
 ```
 
-| Service           | URL                    | Default Credentials                 |
-| ----------------- | ---------------------- | ----------------------------------- |
-| 🔐 **API**        | http://localhost:8004  | Register via `/api/auth/register`   |
-| 📊 **Dashboard**  | http://localhost:8003  | None                                |
-| 🔗 **Neo4j**      | http://localhost:7474  | `neo4j` / `discogsography`          |
-| 🐘 **PostgreSQL** | `localhost:5433`       | `discogsography` / `discogsography` |
-| 🐰 **RabbitMQ**   | http://localhost:15672 | `discogsography` / `discogsography` |
+
+| Service          | URL                    | Default Credentials                 |
+| ------------------ | ------------------------ | ------------------------------------- |
+| 🔐**API**        | http://localhost:8004  | Register via`/api/auth/register`    |
+| 📊**Dashboard**  | http://localhost:8003  | None                                |
+| 🔗**Neo4j**      | http://localhost:7474  | `neo4j` / `discogsography`          |
+| 🐘**PostgreSQL** | `localhost:5433`       | `discogsography` / `discogsography` |
+| 🐰**RabbitMQ**   | http://localhost:15672 | `discogsography` / `discogsography` |
 
 See the [Quick Start Guide](docs/quick-start.md) for prerequisites, local development setup, and environment configuration.
 
@@ -167,25 +159,28 @@ See the [Quick Start Guide](docs/quick-start.md) for prerequisites, local develo
 
 ### 🚀 Getting Started
 
-| Document                                          | Purpose                                                  |
-| ------------------------------------------------- | -------------------------------------------------------- |
-| **[Quick Start Guide](docs/quick-start.md)**      | ⚡ Get Discogsography running in minutes                 |
+
+| Document                                          | Purpose                                                    |
+| --------------------------------------------------- | ------------------------------------------------------------ |
+| **[Quick Start Guide](docs/quick-start.md)**      | ⚡ Get Discogsography running in minutes                   |
 | **[Configuration Guide](docs/configuration.md)**  | ⚙️ Complete environment variable and settings reference  |
 | **[Architecture Overview](docs/architecture.md)** | 🏛️ System architecture, components, data flow, and scale |
-| **[CLAUDE.md](CLAUDE.md)**                        | 🤖 Claude Code integration guide & development standards |
+| **[CLAUDE.md](CLAUDE.md)**                        | 🤖 Claude Code integration guide & development standards   |
 
 ### 💡 Usage & Data
 
-| Document                                       | Purpose                                              |
-| ---------------------------------------------- | ---------------------------------------------------- |
-| **[Usage Examples](docs/usage-examples.md)**   | 💡 Neo4j Cypher and PostgreSQL query examples        |
-| **[Database Schema](docs/database-schema.md)** | 🗄️ Complete Neo4j graph model and PostgreSQL schema  |
-| **[Monitoring Guide](docs/monitoring.md)**     | 📊 Real-time dashboard, metrics, and debug utilities |
+
+| Document                                       | Purpose                                               |
+| ------------------------------------------------ | ------------------------------------------------------- |
+| **[Usage Examples](docs/usage-examples.md)**   | 💡 Neo4j Cypher and PostgreSQL query examples         |
+| **[Database Schema](docs/database-schema.md)** | 🗄️ Complete Neo4j graph model and PostgreSQL schema |
+| **[Monitoring Guide](docs/monitoring.md)**     | 📊 Real-time dashboard, metrics, and debug utilities  |
 
 ### 👨‍💻 Development
 
+
 | Document                                                           | Purpose                                               |
-| ------------------------------------------------------------------ | ----------------------------------------------------- |
+| -------------------------------------------------------------------- | ------------------------------------------------------- |
 | **[Development Guide](docs/development.md)**                       | 💻 Project structure, tooling, and developer workflow |
 | **[Testing Guide](docs/testing-guide.md)**                         | 🧪 Unit, integration, and E2E testing with Playwright |
 | **[Logging Guide](docs/logging-guide.md)**                         | 📊 Structured logging standards and emoji conventions |
@@ -194,8 +189,9 @@ See the [Quick Start Guide](docs/quick-start.md) for prerequisites, local develo
 
 ### 🔧 Operations
 
+
 | Document                                               | Purpose                                              |
-| ------------------------------------------------------ | ---------------------------------------------------- |
+| -------------------------------------------------------- | ------------------------------------------------------ |
 | **[Troubleshooting Guide](docs/troubleshooting.md)**   | 🔧 Common issues, solutions, and debugging steps     |
 | **[Maintenance Guide](docs/maintenance.md)**           | 🔄 Package upgrades, dependency management           |
 | **[Performance Guide](docs/performance-guide.md)**     | ⚡ Database tuning, hardware specs, optimization     |
@@ -204,18 +200,20 @@ See the [Quick Start Guide](docs/quick-start.md) for prerequisites, local develo
 
 ### 🐋 Infrastructure & CI/CD
 
-| Document                                                 | Purpose                                                |
-| -------------------------------------------------------- | ------------------------------------------------------ |
-| **[Dockerfile Standards](docs/dockerfile-standards.md)** | 🐋 Best practices for writing Dockerfiles              |
-| **[Docker Security](docs/docker-security.md)**           | 🔒 Container hardening & security practices            |
-| **[GitHub Actions Guide](docs/github-actions-guide.md)** | 🚀 CI/CD workflows, automation & best practices        |
-| **[Task Automation](docs/task-automation.md)**           | ⚙️ Complete `just` and `uv run task` command reference |
-| **[Monorepo Guide](docs/monorepo-guide.md)**             | 📦 Managing Python monorepo with shared dependencies   |
+
+| Document                                                 | Purpose                                                 |
+| ---------------------------------------------------------- | --------------------------------------------------------- |
+| **[Dockerfile Standards](docs/dockerfile-standards.md)** | 🐋 Best practices for writing Dockerfiles               |
+| **[Docker Security](docs/docker-security.md)**           | 🔒 Container hardening & security practices             |
+| **[GitHub Actions Guide](docs/github-actions-guide.md)** | 🚀 CI/CD workflows, automation & best practices         |
+| **[Task Automation](docs/task-automation.md)**           | ⚙️ Complete`just` and `uv run task` command reference |
+| **[Monorepo Guide](docs/monorepo-guide.md)**             | 📦 Managing Python monorepo with shared dependencies    |
 
 ### 📋 Reference
 
+
 | Document                                                                   | Purpose                                                |
-| -------------------------------------------------------------------------- | ------------------------------------------------------ |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------- |
 | **[State Marker System](docs/state-marker-system.md)**                     | 📋 Extraction progress tracking & safe restart system  |
 | **[State Marker Periodic Updates](docs/state-marker-periodic-updates.md)** | 💾 Periodic state saves and crash recovery             |
 | **[Consumer Cancellation](docs/consumer-cancellation.md)**                 | 🔄 File completion and consumer lifecycle management   |
@@ -257,7 +255,7 @@ Some other projects working with the monthly Discogs data dump.
 - 🐍 The Python community for excellent libraries and tools
 - 🦀 The Rust community for excellent libraries and amazing performance
 
-______________________________________________________________________
+---
 
 <div align="center">
 Made with ❤️ in the Pacific Northwest

--- a/brainzgraphinator/README.md
+++ b/brainzgraphinator/README.md
@@ -15,7 +15,7 @@ The brainzgraphinator service:
 ## Architecture
 
 - **Language**: Python 3.13+
-- **Database**: Neo4j 5.x (enriches existing Discogs graph)
+- **Database**: Neo4j 2026 (calendar versioning) — enriches existing Discogs graph
 - **Message Broker**: RabbitMQ 4.x (quorum queues)
 - **Health Port**: 8011
 - **Driver**: neo4j async driver with retry and resilience
@@ -28,7 +28,7 @@ Environment variables:
 # Neo4j connection
 NEO4J_HOST=neo4j
 NEO4J_USERNAME=neo4j
-NEO4J_PASSWORD=neo4j
+NEO4J_PASSWORD=discogsography
 
 # RabbitMQ (individual vars; also supports _FILE variants for Docker secrets)
 RABBITMQ_USERNAME=discogsography

--- a/common/README.md
+++ b/common/README.md
@@ -6,7 +6,7 @@ Shared utilities and configuration for all discogsography services.
 
 - `config.py`: Centralized configuration management (environment variable parsing, defaults)
 - `health_server.py`: Lightweight HTTP health check server used by all services
-- `data_normalizer.py`: Record normalization (`normalize_record()`) that flattens XML-dict structures from the extractor into consistent formats; also provides `extract_format_names()` and `_parse_year_int()`
+- `data_normalizer.py`: Consumer-side record normalization (`normalize_record()`) — year parsing and final shaping of records. Structural normalization (flattening nested containers, stripping `@`/`#text`) is now handled upstream by the Rust extractor. Also provides `_parse_year_int()`
 - `neo4j_resilient.py`: `ResilientNeo4jDriver` / `AsyncResilientNeo4jDriver` — Neo4j driver wrappers with retry logic and connection resilience
 - `postgres_resilient.py`: `ResilientPostgreSQLPool` / `AsyncPostgreSQLPool` — PostgreSQL connection pools with retry logic
 - `rabbitmq_resilient.py`: `ResilientRabbitMQConnection` / `AsyncResilientRabbitMQ` — RabbitMQ connection wrappers with automatic reconnection

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -178,8 +178,7 @@ The `tailwind.css` stylesheet is **generated at Docker build time** and does not
 
 Two additional files in `dashboard/` (not `static/`) drive the CSS build:
 
-- `tailwind.config.js` - Tailwind CLI configuration (content paths, forms plugin)
-- `tailwind.input.css` - Tailwind source directives (`@tailwind base/components/utilities`)
+- `tailwind.input.css` - Tailwind v4 CSS-first config: `@import "tailwindcss"`, `@plugin "@tailwindcss/forms"`, and `@source` content paths
 
 The Docker build uses a dedicated **`css-builder`** stage (Node 24) to run the Tailwind CLI, which
 scans `index.html` and emits a minified `tailwind.css` into the final image. No CDN dependency is

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -5,7 +5,7 @@
 Admin accounts are created via the `admin-setup` CLI tool inside the API container:
 
 ```
-docker exec -it discogsography-api-1 admin-setup \
+docker exec -it discogsography-api admin-setup \
   --email admin@example.com --password <password>
 ```
 
@@ -14,7 +14,7 @@ Passwords must be at least 8 characters. If the email already exists, the passwo
 ## Listing Admin Accounts
 
 ```
-docker exec -it discogsography-api-1 admin-setup --list
+docker exec -it discogsography-api admin-setup --list
 ```
 
 ## Accessing the Admin Panel

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -197,7 +197,7 @@ NEO4J_PASSWORD="your-secure-password"
 | Variable            | Description         | Default          | Required |
 | ------------------- | ------------------- | ---------------- | -------- |
 | `POSTGRES_HOST`     | PostgreSQL hostname | `localhost`      | Yes      |
-| `POSTGRES_USERNAME` | PostgreSQL username | `postgres`       | Yes      |
+| `POSTGRES_USERNAME` | PostgreSQL username | (none)           | Yes      |
 | `POSTGRES_PASSWORD` | PostgreSQL password | (none)           | Yes      |
 | `POSTGRES_DATABASE` | Database name       | `discogsography` | Yes      |
 

--- a/docs/consumer-cancellation.md
+++ b/docs/consumer-cancellation.md
@@ -98,7 +98,7 @@ The periodic progress reports now include consumer status:
 
 ```
 📊 Progress: 1000 total messages processed (🎉 Artists: 500, Labels: 500, Masters: 0, Releases: 0)
-🔌 Canceled consumers: ['artists']
+🔧 Canceled consumers: ['artists']
 ✅ Active consumers: ['labels', 'masters', 'releases']
 ```
 
@@ -107,7 +107,7 @@ The periodic progress reports now include consumer status:
 Watch for these log messages:
 
 - `🎉 File processing complete for {type}!` - File marked as complete
-- `🔌 Canceling consumer for {type} after {delay}s grace period` - Consumer cancellation scheduled
+- `🔧 Canceling consumer for {type} after {delay}s grace period` - Consumer cancellation scheduled
 - `✅ Consumer for {type} successfully canceled` - Consumer successfully canceled
 - `❌ Failed to cancel consumer for {type}` - Cancellation failed (non-fatal)
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -314,7 +314,7 @@ git push origin feature/your-feature-name
 # All checks
 just lint
 just format
-just typecheck
+just lint-python
 just security
 just test
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -38,7 +38,7 @@ Neo4j stores music industry relationships as a graph, making it ideal for:
 
 ### Data Pipeline
 
-Raw XML data from the Discogs dump is parsed by the **extractor** into JSON messages and published to RabbitMQ. Each message includes a `type` field (`"data"` or `"file_complete"`), an `id`, and a `sha256` hash. Before writing to Neo4j, the **graphinator** normalizes each message using `normalize_record()`, which flattens nested XML-dict structures, extracts IDs, and parses year values. See [Extractor Message Format](#extractor-message-format) for the raw data structure.
+Raw XML data from the Discogs dump is parsed by the **extractor**, which **normalizes** each record — flattening nested XML-dict structures, stripping `@`/`#text` prefixes, and extracting IDs — *before* computing the `sha256` content hash and publishing JSON messages to RabbitMQ. Each message includes a `type` field (`"data"` or `"file_complete"`), an `id`, and a `sha256` hash, and arrives consumer-ready. The **graphinator**'s own `normalize_record()` then performs only consumer-side year parsing before writing to Neo4j. See [Extractor Message Format](#extractor-message-format) for the published data structure.
 
 ### Node Types
 
@@ -441,7 +441,7 @@ ORDER BY r.year DESC;
 
 ## Extractor Message Format
 
-The Rust extractor parses Discogs XML dumps and publishes JSON messages to RabbitMQ. Each entity type has its own queue. Messages use xmltodict conventions: XML attributes are prefixed with `@`, text content with attributes uses `#text`, and single vs multiple child elements may be an object vs array.
+The Rust extractor parses Discogs XML dumps and publishes JSON messages to RabbitMQ. Each entity type has its own queue. Messages are **normalized by the extractor before publishing**: nested containers are flattened, `@`/`#text` prefixes are stripped, and list-like fields are coerced to consistent arrays. The raw xmltodict-shaped JSON shown in the examples below (with `@`/`#text` and single-vs-array variance) exists only *internally* during parsing — it is the input to the extractor's `normalize::normalize_record()`, not what appears on the wire. The Python consumers' `normalize_record()` adds only year parsing.
 
 ### Message Envelope
 
@@ -508,7 +508,7 @@ Source XML:
 </artist>
 ```
 
-Raw JSON message:
+Internal pre-normalization shape (during XML parsing):
 
 ```json
 {
@@ -531,7 +531,7 @@ Raw JSON message:
 }
 ```
 
-After `normalize_record("artists", ...)`:
+Published `artists` message (extractor-normalized; consumers add only year parsing):
 
 ```json
 {
@@ -563,7 +563,7 @@ Source XML:
 </label>
 ```
 
-Raw JSON message:
+Internal pre-normalization shape (during XML parsing):
 
 ```json
 {
@@ -581,7 +581,7 @@ Raw JSON message:
 }
 ```
 
-After `normalize_record("labels", ...)`:
+Published `labels` message (extractor-normalized; consumers add only year parsing):
 
 ```json
 {
@@ -620,7 +620,7 @@ Source XML:
 </master>
 ```
 
-Raw JSON message:
+Internal pre-normalization shape (during XML parsing):
 
 ```json
 {
@@ -637,7 +637,7 @@ Raw JSON message:
 }
 ```
 
-After `normalize_record("masters", ...)`:
+Published `masters` message (extractor-normalized; consumers add only year parsing):
 
 ```json
 {
@@ -686,7 +686,7 @@ Source XML:
 </release>
 ```
 
-Raw JSON message:
+Internal pre-normalization shape (during XML parsing):
 
 ```json
 {
@@ -715,7 +715,7 @@ Raw JSON message:
 }
 ```
 
-After `normalize_record("releases", ...)`:
+Published `releases` message (extractor-normalized; consumers add only year parsing):
 
 ```json
 {
@@ -750,7 +750,7 @@ Notes:
 | Multiple `<el>` children | `"el": [...]` (array)                 |
 | Single `<el>` child      | `"el": {...}` (object, not array)     |
 
-This single-vs-array ambiguity is why `normalize_record()` exists: it normalizes all list-like fields to consistent arrays.
+This single-vs-array ambiguity is resolved by the extractor's `normalize::normalize_record()` (Rust), which coerces all list-like fields to consistent arrays before publishing — so consumers never see this raw shape on the wire.
 
 ## PostgreSQL Database
 
@@ -1285,10 +1285,10 @@ graph TD
 
 ### Processing Pipeline
 
-Both graphinator and tableinator follow the same normalization pipeline:
+Both graphinator and tableinator follow the same pipeline:
 
-1. Raw JSON message received from RabbitMQ
-1. `normalize_record(data_type, data)` called to flatten XML-dict structures
+1. Pre-normalized JSON message received from RabbitMQ (structural normalization already done by the extractor)
+1. `normalize_record(data_type, data)` called for consumer-side year parsing
 1. Hash-based deduplication check (skip data rewrite if unchanged, but always refresh `updated_at`)
 1. Write to database (Neo4j nodes/relationships or PostgreSQL JSONB)
 1. Acknowledge message

--- a/docs/development.md
+++ b/docs/development.md
@@ -63,12 +63,12 @@ discogsography/
 ├── 📊 dashboard/           # Real-time monitoring dashboard
 │   ├── dashboard.py        # FastAPI backend with WebSocket
 │   ├── admin_proxy.py      # Admin panel proxy to API service
-│   ├── tailwind.config.js  # Tailwind CLI configuration (content paths, plugins)
-│   ├── tailwind.input.css  # Tailwind source directives (@tailwind base/…)
+│   ├── tailwind.input.css  # Tailwind v4 CSS-first config (@import, @plugin, @source)
 │   ├── static/             # Frontend HTML/CSS/JS (Tailwind, SVG gauges)
 │   │   ├── index.html
 │   │   ├── tailwind.css    # Generated at Docker build time by css-builder stage
-│   │   ├── styles.css
+│   │   ├── admin.html      # Admin panel
+│   │   ├── admin.js
 │   │   └── dashboard.js
 │   ├── README.md
 │   └── __init__.py
@@ -81,8 +81,7 @@ discogsography/
 │   └── README.md
 ├── 🔍 explore/             # Static frontend for graph exploration UI
 │   ├── explore.py          # FastAPI static file server (health check only)
-│   ├── tailwind.config.js  # Tailwind CLI configuration (content paths, plugins)
-│   ├── tailwind.input.css  # Tailwind source directives (@tailwind base/…)
+│   ├── tailwind.input.css  # Tailwind v4 CSS-first config (@theme, @utility, @source)
 │   ├── static/             # Frontend HTML/CSS/JS (Tailwind, Alpine.js, D3.js, Plotly.js)
 │   │   ├── index.html
 │   │   ├── tailwind.css    # Generated at Docker build time by css-builder stage
@@ -281,7 +280,7 @@ uv run pre-commit run --all-files
    ```bash
    just lint
    just format
-   just typecheck
+   just lint-python
    just security
    ```
 
@@ -399,8 +398,8 @@ just format
 # Check for issues
 just lint
 
-# Type check
-just typecheck
+# Type check (ruff + mypy)
+just lint-python
 ```
 
 ### Type Hints

--- a/docs/dockerfile-standards.md
+++ b/docs/dockerfile-standards.md
@@ -11,10 +11,11 @@ All Dockerfiles must follow these standards to ensure consistency, security, and
 The standard template uses a two-stage build (builder + final). Services that require a build-time
 asset pipeline add a third stage **before** the builder stage.
 
-### Optional: CSS Build Stage (dashboard only)
+### Optional: CSS Build Stage (dashboard and explore)
 
-The dashboard uses a dedicated Node stage to run the Tailwind v4 CLI and produce a minified stylesheet
-at image build time, eliminating any CDN dependency at runtime:
+Both the dashboard and explore services use a dedicated Node stage to run the Tailwind v4 CLI and
+produce a minified stylesheet at image build time, eliminating any CDN dependency at runtime. The
+example below is the dashboard's; explore's is identical apart from the `explore/` source paths:
 
 ```dockerfile
 # ── CSS build stage ────────────────────────────────────────────────────────────

--- a/docs/emoji-guide.md
+++ b/docs/emoji-guide.md
@@ -115,7 +115,7 @@ Emojis in Discogsography serve to:
 | 🔑    | Password Reset  | Password reset links  |
 | 🛡️    | Scanning        | Security scanning     |
 | 🚀    | Build/Deploy    | Build and deployment  |
-| 📢    | Notifications   | Discord, alerts       |
+| 📢    | Notifications   | Alerts, announcements |
 | 🏷️    | Tagging         | Version tags, labels  |
 | ⏱️    | Timing          | Performance timing    |
 | 🎯    | Target          | Goals, objectives     |

--- a/docs/file-completion-tracking.md
+++ b/docs/file-completion-tracking.md
@@ -134,7 +134,7 @@ No additional configuration needed - the feature works automatically with existi
 **Consumers**:
 
 - `🎉 File processing complete for {type}!` - File completion received
-- `🔌 Canceling consumer for {type}` - Cancellation scheduled
+- `🔧 Canceling consumer for {type}` - Cancellation scheduled
 - `🏁 Received extraction_complete signal` - Extraction complete received
 - `🧹 Cleaned up N stub {Label} nodes` - Graphinator stub node cleanup
 - `🧹 Purged N stale {type} rows` - Tableinator stale row purge

--- a/docs/github-actions-guide.md
+++ b/docs/github-actions-guide.md
@@ -108,7 +108,7 @@ on:
 
 ### 🛡️ Security Workflow (`security.yml`)
 
-**Trigger**: Called by `build.yml`, weekly schedule (Monday 04:00 UTC) **Purpose**: Comprehensive
+**Trigger**: Called by `build.yml` via `workflow_call` (no schedule of its own) **Purpose**: Comprehensive
 security scanning across Python, Rust, secrets, and containers
 
 **Jobs**:

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -96,7 +96,7 @@ The dashboard includes a login-gated admin panel at `/admin` for managing extrac
 
 ```bash
 # Create an admin account (one-time setup)
-docker exec -it discogsography-api-1 admin-setup \
+docker exec -it discogsography-api admin-setup \
   --email admin@example.com --password <min-8-chars>
 
 # Access admin panel
@@ -388,7 +388,7 @@ The Insights service runs scheduled batch analytics and exposes results via the 
 
 ```bash
 # From within the Docker network:
-docker exec discogsography-insights-1 curl -s http://localhost:8009/health
+docker exec discogsography-insights curl -s http://localhost:8009/health
 # Response: {"status": "healthy"}
 ```
 
@@ -735,7 +735,7 @@ docker-compose logs -f | grep "📊"
 docker stats
 
 # Specific service
-docker stats discogsography-graphinator-1
+docker stats discogsography-graphinator
 
 # System monitor utility
 just system-monitor

--- a/docs/musicbrainz-sync.md
+++ b/docs/musicbrainz-sync.md
@@ -33,14 +33,14 @@ MusicBrainz publishes new JSONL dumps **twice weekly** (Wednesdays and Saturdays
 
 ### Initial Import
 
-1. Download MusicBrainz JSONL dumps (xz-compressed):
+1. On startup the extractor **automatically downloads the latest dump**. It reads `MUSICBRAINZ_DUMP_URL` (default `https://data.metabrainz.org/pub/musicbrainz/data/json-dumps/`), selects the newest dated dump (`YYYYMMDD-HHMMSS`), and streams each `.tar.xz` archive directly to a versioned subdirectory as `{version}/{entity}.jsonl.xz`:
 
    - `artist.jsonl.xz`
    - `label.jsonl.xz`
    - `release-group.jsonl.xz`
    - `release.jsonl.xz`
 
-1. Place files in the `musicbrainz_data` Docker volume (or mounted directory)
+   > Manual placement remains an optional override: drop pre-downloaded `.jsonl.xz` files into the `musicbrainz_data` volume and the extractor will use them instead of downloading.
 
 1. Start (or restart) the `extractor-musicbrainz` container:
 
@@ -123,6 +123,5 @@ Returns coverage statistics:
 
 ## Future Enhancements
 
-- **Automated download**: Cron job or scheduled CI to fetch latest dumps automatically
 - **Hourly replication**: MusicBrainz offers replication packets for near-real-time updates (complex, requires tracking replication sequence numbers)
 - **Delta detection**: Compare record SHA256 hashes to skip unchanged entities during re-import

--- a/docs/neo4j-indexing.md
+++ b/docs/neo4j-indexing.md
@@ -35,12 +35,16 @@ Range indexes enable fast lookups by exact value and support efficient sorting.
 
 #### ID Lookups
 
-| Index Name         | Label   | Properties | Use Case                        |
-| ------------------ | ------- | ---------- | ------------------------------- |
-| `artist_id_index`  | Artist  | id         | Graph traversal, artist details |
-| `release_id_index` | Release | id         | Release lookups                 |
-| `label_id_index`   | Label   | id         | Label lookups                   |
-| `genre_id_index`   | Genre   | id         | Genre lookups                   |
+ID lookups are served by the **uniqueness constraints**, each of which implicitly creates a backing range index — so no separate ID indexes are defined:
+
+| Constraint   | Label   | Property | Use Case                          |
+| ------------ | ------- | -------- | --------------------------------- |
+| `artist_id`  | Artist  | id       | Graph traversal, artist details   |
+| `label_id`   | Label   | id       | Label lookups                     |
+| `master_id`  | Master  | id       | Master lookups                    |
+| `release_id` | Release | id       | Release lookups                   |
+| `genre_name` | Genre   | name     | Genre lookups (no `id` property)  |
+| `style_name` | Style   | name     | Style lookups (no `id` property)  |
 
 **Example Query**:
 
@@ -49,14 +53,14 @@ MATCH (a:Artist {id: $artist_id})
 RETURN a
 ```
 
-#### Sorting Indexes
+#### Name Indexes
 
-| Index Name            | Label   | Properties | Use Case                               |
-| --------------------- | ------- | ---------- | -------------------------------------- |
-| `artist_name_index`   | Artist  | name       | Alphabetical sorting in search results |
-| `release_title_index` | Release | title      | Alphabetical sorting in search results |
-| `label_name_index`    | Label   | name       | Alphabetical sorting in search results |
-| `genre_name_index`    | Genre   | name       | Alphabetical sorting in trends         |
+| Index Name    | Label  | Properties | Use Case                          |
+| ------------- | ------ | ---------- | --------------------------------- |
+| `artist_name` | Artist | name       | Name lookups / sorting in explore |
+| `label_name`  | Label  | name       | Name lookups / sorting in explore |
+
+> Release titles and Genre/Style names are searched via full-text indexes (`release_title_fulltext`, `genre_name_fulltext`, `style_name_fulltext`) rather than range indexes.
 
 **Example Query**:
 

--- a/docs/python-version-management.md
+++ b/docs/python-version-management.md
@@ -27,7 +27,7 @@ graph LR
     ENV --> GH
     ENV --> BUILD
 
-    Script[update-python-version.sh] --> PY
+    Script[update-project.sh --python] --> PY
     Script --> DOCKER
     Script --> PYRIGHT
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -355,7 +355,7 @@ docker-compose restart [service-name]
 
 ```bash
 # Check internet connectivity
-curl -I https://discogs-data-dumps.s3.us-west-2.amazonaws.com
+curl -I https://data.discogs.com
 
 # Check extractor logs
 docker-compose logs extractor-discogs

--- a/docs/state-marker-system.md
+++ b/docs/state-marker-system.md
@@ -254,14 +254,15 @@ State markers are stored in the respective data root directories:
 
 ```
 /musicbrainz-data/
-├── artist.jsonl.xz
-├── label.jsonl.xz
-├── release-group.jsonl.xz
-├── release.jsonl.xz
-└── .mb_extraction_status_20260326.json # MusicBrainz state marker
+└── 20260326-001001/                       # Per-version subdirectory
+    ├── artist.jsonl.xz
+    ├── label.jsonl.xz
+    ├── release-group.jsonl.xz
+    ├── release.jsonl.xz
+    └── .mb_extraction_status_20260326-001001.json  # MusicBrainz state marker
 ```
 
-MusicBrainz state markers use the `.mb_extraction_status_{version}.json` naming convention to distinguish from Discogs markers. They follow the same internal structure and status values as Discogs markers, but track 4 data types (artists, labels, release-groups, releases) instead of 4 (no masters).
+MusicBrainz dumps and their marker live in a per-version subdirectory (e.g. `/musicbrainz-data/20260326-001001/`), since the extractor downloads each dated dump into its own directory. The marker uses the `.mb_extraction_status_{version}.json` naming convention to distinguish from Discogs markers. It follows the same internal structure and status values as Discogs markers, but tracks `release-groups` in place of `masters` (artists, labels, release-groups, releases instead of artists, labels, masters, releases).
 
 ## Version-Specific Tracking
 
@@ -311,7 +312,7 @@ Both Rust and Python implementations have comprehensive tests:
 **Rust:**
 
 ```bash
-cd extractor/extractor
+cd extractor
 cargo test state_marker
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,8 +26,8 @@ This guide covers common issues you might encounter while using Discogsography a
 **Diagnostic Steps**:
 
 ```bash
-# Check connectivity to Discogs S3
-curl -I https://discogs-data-dumps.s3.us-west-2.amazonaws.com
+# Check connectivity to the Discogs data host
+curl -I https://data.discogs.com
 
 # Verify disk space (need 76GB+)
 df -h /discogs-data
@@ -45,7 +45,7 @@ docker-compose logs -f extractor-discogs extractor-musicbrainz
 
    ```bash
    # Test connection
-   ping discogs-data-dumps.s3.us-west-2.amazonaws.com
+   ping data.discogs.com
    ```
 
 1. **✅ Verify 76GB+ free space**
@@ -631,7 +631,7 @@ docker-compose restart dashboard
 
 ```bash
 # Check network connectivity
-curl -I https://discogs-data-dumps.s3.us-west-2.amazonaws.com
+curl -I https://data.discogs.com
 
 # Restart extractor
 docker-compose restart extractor-discogs  # or extractor-musicbrainz

--- a/explore/README.md
+++ b/explore/README.md
@@ -2,7 +2,7 @@
 
 🔍 **Interactive Graph Exploration, Search, Analytics, and Collection Management**
 
-The Explore service serves the interactive frontend for navigating the Discogs knowledge graph, visualizing trends, searching entities, browsing user collections, and accessing precomputed analytics. Built with **Tailwind CSS** (dark theme), **Alpine.js** (reactive UI), **D3.js** (force-directed graph), and **Plotly.js** (charts). All data endpoints are consolidated in the **API service** (`/api/*`).
+The Explore service serves the interactive frontend for navigating the Discogs knowledge graph, visualizing trends, searching entities, browsing user collections, and accessing precomputed analytics. Built with **Tailwind CSS v4** (CSS-first config, "Deep Space" theme with light/dark/auto toggle), **Alpine.js** (reactive UI), **D3.js** (force-directed graph), and **Plotly.js** (charts). All data endpoints are consolidated in the **API service** (`/api/*`).
 
 ## 🌟 Features
 
@@ -24,6 +24,14 @@ The Explore frontend organizes functionality into tabbed panes:
 | **genre-tree**      | Interactive genre/style hierarchy browser                                | No            |
 | **credits**         | Credits & Provenance — person search, profile, timeline, connections     | No            |
 | **gaps**            | Collection gap finder — missing releases for an artist, label, or master | Yes           |
+
+### 💬 Ask Pill (Natural Language Queries)
+
+- **Global Ask pill**: A persistent input available across all panes for asking natural-language questions about the music knowledge graph
+- **Agent-driven UI actions**: The API converts questions into tool calls that drive the UI (run searches, open the graph, render tables) and returns inline answers
+- **Inline answers**: Responses render in place with Markdown (via `marked` + `DOMPurify`) and table formatting
+- **Context-aware suggestions**: Question suggestions surface as you type
+- Backed by the API's `/api/nlq/*` endpoints (status, query, streaming, suggestions)
 
 ### 🔍 Interactive Graph Explorer
 
@@ -437,23 +445,32 @@ explore/
 ├── __tests__/              # Vitest JavaScript test files
 ├── static/
 │   ├── index.html          # Single-page application shell
-│   ├── css/                # Tailwind-compiled styles
+│   ├── css/                # Tailwind build output + hand-written styles (styles.css, nlq-pill.css)
 │   └── js/
-│       ├── api-client.js   # API client (all fetch calls)
-│       ├── app.js          # Main controller + timeline scrubber
-│       ├── auth.js          # JWT auth state manager
-│       ├── autocomplete.js  # Search autocomplete
-│       ├── credits.js       # Credits & Provenance panel
-│       ├── graph.js         # D3 force-directed graph
-│       ├── insights.js      # Insights panel + auto-refresh
-│       ├── search.js        # Full-text search pane
-│       ├── theme.js         # Dark/light theme
-│       ├── trends.js        # Plotly trends charts
-│       └── user-panes.js   # Collection, wantlist, recommendations, gaps, taste fingerprint
+│       ├── api-client.js          # API client (all fetch calls)
+│       ├── app.js                 # Main controller + timeline scrubber
+│       ├── auth.js                # JWT auth state manager
+│       ├── autocomplete.js        # Search autocomplete
+│       ├── collaborators.js       # Collaborator network pane
+│       ├── credits.js             # Credits & Provenance panel
+│       ├── genre-tree.js          # Genre/style hierarchy browser
+│       ├── graph.js               # D3 force-directed graph
+│       ├── insights.js            # Insights panel + auto-refresh
+│       ├── nlq.js                 # Ask pill entry point
+│       ├── nlq-pill.js            # Ask pill UI surface
+│       ├── nlq-handlers.js        # Ask request/response handling
+│       ├── nlq-action-applier.js  # Applies agent-driven UI actions
+│       ├── nlq-suggestions.js     # Context-aware question suggestions
+│       ├── nlq-markdown.js        # Markdown/table rendering (marked + DOMPurify)
+│       ├── search.js              # Full-text search pane
+│       ├── settings.js            # Account settings (profile, 2FA)
+│       ├── theme.js               # Light/dark/auto theme toggle
+│       ├── trends.js              # Plotly trends charts
+│       └── user-panes.js          # Collection, wantlist, recommendations, gaps, taste fingerprint
 ├── explore.py              # Static file server + health endpoint
 ├── Dockerfile              # Production container
-├── package.json            # Node.js deps (Tailwind, Vitest)
+├── package.json            # Node.js test deps (Vitest, jsdom) + dompurify, marked
 ├── vitest.config.js        # Vitest configuration
-├── tailwind.config.js      # Tailwind CSS configuration
+├── tailwind.input.css      # Tailwind v4 CSS-first config (@theme, @utility, @source)
 └── pyproject.toml          # Python project metadata
 ```

--- a/extractor/README.md
+++ b/extractor/README.md
@@ -480,9 +480,9 @@ stateDiagram-v2
 Extractor integrates with the Discogsography platform:
 
 - **Discogs mode**: Publishes to 4 RabbitMQ fanout exchanges (`discogsography-discogs-{artists,labels,masters,releases}`) consumed by Graphinator (Neo4j) and Tableinator (PostgreSQL)
-- **MusicBrainz mode**: Publishes to 3 RabbitMQ fanout exchanges (`discogsography-musicbrainz-{artists,labels,releases}`) with MBID→Discogs ID cross-referencing
+- **MusicBrainz mode**: Publishes to 4 RabbitMQ fanout exchanges (`discogsography-musicbrainz-{artists,labels,release-groups,releases}`) with MBID→Discogs ID cross-referencing
 - Provides HTTP health, metrics, and readiness endpoints
 
 ## License
 
-MIT
+This project is licensed under the PolyForm Noncommercial License 1.0.0. See the [LICENSE](../LICENSE) file in the repository root.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -19,6 +19,7 @@ All data is fetched via the Discogsography API — the MCP server has no direct 
 | `get_graph_stats`     | Database-wide node counts                                      |
 | `get_collaborators`   | Artists who share releases with a given artist                 |
 | `get_genre_tree`      | Full genre/style hierarchy with release counts                 |
+| `nlq_query`           | Ask a natural-language question about the knowledge graph (multi-entity/relationship answers) |
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Audited all living docs and service READMEs against the current codebase and fixed staleness introduced by recent merges (Tailwind v4, license change, normalization-moved-to-Rust, MusicBrainz auto-download, NLQ/Ask pill, coverage tooling). Also applied the requested README header restyle.

Manual README edits already in the working tree were preserved: the removed tooling-badge block, the reflowed service/doc tables, and the `---` horizontal rule.

### README
- Banner now uses a light/dark `<picture>` (`prefers-color-scheme`) pointing at the real assets `dashboard/static/brand/banner_{dark,light}.png`
- All status badges collapsed onto a single line

### Doc fixes (verified against source)
- **License**: `extractor/README.md` MIT → PolyForm Noncommercial 1.0.0
- **Tailwind v4**: removed references to the deleted `tailwind.config.js` (config is now CSS-first in `tailwind.input.css`) in `docs/development.md`, `dashboard/README.md`, `explore/README.md`, `docs/dockerfile-standards.md`; "dark theme" → "Deep Space, light/dark/auto"
- **Normalization moved to Rust extractor** (PR #290): corrected `docs/database-schema.md` pipeline + message-format framing and example labels; `common/README.md` (dropped nonexistent `extract_format_names()`)
- **MusicBrainz**: 4 fanout exchanges (not 3) in `extractor/README.md`; auto-download + versioned subdirectories in `docs/musicbrainz-sync.md` and `docs/state-marker-system.md`; removed already-implemented "automated download" future-enhancement bullet
- **Discogs host**: `discogs-data-dumps.s3…` → `data.discogs.com` in `quick-start.md`, `troubleshooting.md`
- **Neo4j indexes**: `docs/neo4j-indexing.md` listed indexes that don't exist — replaced with the actual constraints / `artist_name` / `label_name`
- **Commands/config**: `just typecheck` → `just lint-python`; `POSTGRES_USERNAME` default `postgres` → required; `update-python-version.sh` → `update-project.sh --python`; `security.yml` trigger; container names `discogsography-<svc>-1` → `discogsography-<svc>`; cancel-log emoji 🔌 → 🔧
- **New features documented**: `nlq_query` MCP tool; Ask pill (NLQ) section + full JS file listing in `explore/README.md`; Neo4j version + password in `brainzgraphinator/README.md`

### Out of scope (intentionally untouched)
- `docs/superpowers/`, `graphify-out/`, `.planning/` — historical planning artifacts / generated graph output
- `docs/recent-improvements.md` — historical changelog

## Test plan
Docs-only change. Each correction was verified against the live source (`extractor/src/`, `schema-init/`, `common/`, `docker-compose.yml`, `justfile`, `.pre-commit-config.yaml`). 24 files changed, +156 / −137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)