### PR TITLE
feat(digger): M1 schema layer — Postgres schema, priority trigger, wantlist seed hook

### DIFF
--- a/api/syncer.py
+++ b/api/syncer.py
@@ -254,6 +254,26 @@ async def sync_collection(
     return total_synced
 
 
+async def _seed_digger_priority_for_wantlist_item(pool: AsyncPostgreSQLPool, user_id: UUID, release_id: int) -> None:
+    """Ensure digger priority rows exist for this user+release.
+
+    Creates a digger.release_scrape_state row (if absent) then a
+    digger.user_wantlist_priorities row with default tier 'nice'. Both
+    statements are ON CONFLICT DO NOTHING so the helper is fully idempotent.
+    The schema trigger maintains digger.release_scrape_state.priority_tier
+    as a side-effect of the user_wantlist_priorities INSERT.
+    """
+    async with pool.connection() as conn, conn.cursor() as cur:
+        await cur.execute(
+            "INSERT INTO digger.release_scrape_state (release_id) VALUES (%s) ON CONFLICT (release_id) DO NOTHING",
+            (release_id,),
+        )
+        await cur.execute(
+            "INSERT INTO digger.user_wantlist_priorities (user_id, release_id) VALUES (%s, %s) ON CONFLICT (user_id, release_id) DO NOTHING",
+            (user_id, release_id),
+        )
+
+
 async def sync_wantlist(
     user_uuid: UUID,
     discogs_username: str,
@@ -374,6 +394,8 @@ async def sync_wantlist(
                         batch_params,
                     )
                 total_synced += len(batch_params)
+                for row in batch_params:
+                    await _seed_digger_priority_for_wantlist_item(pg_pool, user_uuid, row[1])
 
             # Upsert to Neo4j — ensure User node and WANTS relationships
             cypher = """

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -254,23 +254,26 @@ async def sync_collection(
     return total_synced
 
 
-async def _seed_digger_priority_for_wantlist_item(pool: AsyncPostgreSQLPool, user_id: UUID, release_id: int) -> None:
-    """Ensure digger priority rows exist for this user+release.
+async def _seed_digger_priorities_for_wantlist(pool: AsyncPostgreSQLPool, user_id: UUID, release_ids: list[int]) -> None:
+    """Seed digger priority rows for a page of wantlist releases.
 
-    Creates a digger.release_scrape_state row (if absent) then a
-    digger.user_wantlist_priorities row with default tier 'nice'. Both
-    statements are ON CONFLICT DO NOTHING so the helper is fully idempotent.
-    The schema trigger maintains digger.release_scrape_state.priority_tier
-    as a side-effect of the user_wantlist_priorities INSERT.
+    For each release, ensures a digger.release_scrape_state row (parent) and a
+    digger.user_wantlist_priorities row (default tier 'nice', from the schema
+    column default). The schema trigger maintains release_scrape_state.priority_tier
+    as a side effect. Idempotent (ON CONFLICT DO NOTHING). Opens ONE pooled
+    connection per page and uses executemany; psycopg3 autocommit single-statement
+    writes — no explicit transaction needed.
     """
+    if not release_ids:
+        return
     async with pool.connection() as conn, conn.cursor() as cur:
-        await cur.execute(
+        await cur.executemany(
             "INSERT INTO digger.release_scrape_state (release_id) VALUES (%s) ON CONFLICT (release_id) DO NOTHING",
-            (release_id,),
+            [(rid,) for rid in release_ids],
         )
-        await cur.execute(
+        await cur.executemany(
             "INSERT INTO digger.user_wantlist_priorities (user_id, release_id) VALUES (%s, %s) ON CONFLICT (user_id, release_id) DO NOTHING",
-            (user_id, release_id),
+            [(user_id, rid) for rid in release_ids],
         )
 
 
@@ -394,8 +397,10 @@ async def sync_wantlist(
                         batch_params,
                     )
                 total_synced += len(batch_params)
-                for row in batch_params:
-                    await _seed_digger_priority_for_wantlist_item(pg_pool, user_uuid, row[1])
+                try:
+                    await _seed_digger_priorities_for_wantlist(pg_pool, user_uuid, [row[1] for row in batch_params])
+                except Exception as exc:  # seeding is a non-critical side-effect; never fail the sync over it
+                    logger.warning("⚠️ Failed to seed digger priorities", error=str(exc))
 
             # Upsert to Neo4j — ensure User node and WANTS relationships
             cypher = """

--- a/docs/superpowers/plans/2026-05-14-digger-m1-foundation.md
+++ b/docs/superpowers/plans/2026-05-14-digger-m1-foundation.md
@@ -521,9 +521,9 @@ git commit -m "feat(digger): trigger to maintain max-tier on release_scrape_stat
 # tests/api/test_syncer_digger_hook.py
 """Unit test for the digger wantlist-sync seed hook (mock-based).
 
-Asserts the helper issues the two idempotent INSERTs via the psycopg3 cursor
-with %s params. Real-DB row creation + trigger recompute is covered by the M1
-e2e smoke (Task 28).
+Asserts the batch helper issues the two idempotent `executemany` INSERTs via the
+psycopg3 cursor with %s params, opening a single connection. Real-DB row creation
++ trigger recompute is covered by the M1 e2e smoke (Task 28).
 """
 
 import uuid
@@ -531,7 +531,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from api.syncer import _seed_digger_priority_for_wantlist_item
+from api.syncer import _seed_digger_priorities_for_wantlist
 
 
 def _mock_pool() -> tuple[MagicMock, AsyncMock]:
@@ -548,19 +548,28 @@ def _mock_pool() -> tuple[MagicMock, AsyncMock]:
 
 
 @pytest.mark.asyncio
-async def test_seed_inserts_scrape_state_and_priority_row() -> None:
+async def test_seed_batches_scrape_state_and_priority_rows() -> None:
     pool, cur = _mock_pool()
     user_id = uuid.uuid4()
 
-    await _seed_digger_priority_for_wantlist_item(pool, user_id, release_id=12345)
+    await _seed_digger_priorities_for_wantlist(pool, user_id, [12345, 67890])
 
-    executed = [(c.args[0], c.args[1] if len(c.args) > 1 else None) for c in cur.execute.call_args_list]
-    all_sql = " ".join(sql for sql, _ in executed)
-    assert "INSERT INTO digger.release_scrape_state" in all_sql
-    assert "INSERT INTO digger.user_wantlist_priorities" in all_sql
-    # psycopg3 params are positional tuples bound to %s placeholders
-    assert any(params == (12345,) for _, params in executed)
-    assert any(params == (user_id, 12345) for _, params in executed)
+    calls = [(c.args[0], c.args[1]) for c in cur.executemany.call_args_list]
+    assert len(calls) == 2
+    state_sql, state_rows = calls[0]
+    prio_sql, prio_rows = calls[1]
+    assert "INSERT INTO digger.release_scrape_state" in state_sql
+    assert state_rows == [(12345,), (67890,)]  # parent rows first (FK order)
+    assert "INSERT INTO digger.user_wantlist_priorities" in prio_sql
+    assert prio_rows == [(user_id, 12345), (user_id, 67890)]
+
+
+@pytest.mark.asyncio
+async def test_seed_is_noop_for_empty_release_list() -> None:
+    pool, cur = _mock_pool()
+    await _seed_digger_priorities_for_wantlist(pool, uuid.uuid4(), [])
+    cur.executemany.assert_not_called()
+    pool.connection.assert_not_called()
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -572,41 +581,42 @@ Expected: ImportError — helper not defined.
 
 ```python
 # api/syncer.py — add near the wantlist sync block.
-# Reuse the AsyncPostgreSQLPool import already present in this module.
-import uuid
+# Reuse the AsyncPostgreSQLPool and UUID imports already present in this module.
 
-from common.postgres_resilient import AsyncPostgreSQLPool
-
-
-async def _seed_digger_priority_for_wantlist_item(
-    pool: AsyncPostgreSQLPool, user_id: uuid.UUID, release_id: int
+async def _seed_digger_priorities_for_wantlist(
+    pool: AsyncPostgreSQLPool, user_id: UUID, release_ids: list[int]
 ) -> None:
-    """Ensure a digger.user_wantlist_priorities row exists for this user+release.
+    """Seed digger priority rows for a page of wantlist releases.
 
-    Default tier is 'nice' (schema column default). The schema trigger maintains
-    digger.release_scrape_state.priority_tier as a side effect. Idempotent and
-    safe to call repeatedly. psycopg3 autocommit single-statement writes — no
-    explicit transaction needed.
+    For each release, ensures a digger.release_scrape_state row (parent) and a
+    digger.user_wantlist_priorities row (default tier 'nice', from the schema
+    column default). The schema trigger maintains release_scrape_state.priority_tier
+    as a side effect. Idempotent (ON CONFLICT DO NOTHING). Opens ONE pooled
+    connection per page and uses executemany; psycopg3 autocommit single-statement
+    writes — no explicit transaction needed.
     """
-    async with pool.connection() as conn:
-        async with conn.cursor() as cur:
-            await cur.execute(
-                "INSERT INTO digger.release_scrape_state (release_id) VALUES (%s) "
-                "ON CONFLICT (release_id) DO NOTHING",
-                (release_id,),
-            )
-            await cur.execute(
-                "INSERT INTO digger.user_wantlist_priorities (user_id, release_id) "
-                "VALUES (%s, %s) ON CONFLICT (user_id, release_id) DO NOTHING",
-                (user_id, release_id),
-            )
+    if not release_ids:
+        return
+    async with pool.connection() as conn, conn.cursor() as cur:
+        await cur.executemany(
+            "INSERT INTO digger.release_scrape_state (release_id) VALUES (%s) "
+            "ON CONFLICT (release_id) DO NOTHING",
+            [(rid,) for rid in release_ids],
+        )
+        await cur.executemany(
+            "INSERT INTO digger.user_wantlist_priorities (user_id, release_id) "
+            "VALUES (%s, %s) ON CONFLICT (user_id, release_id) DO NOTHING",
+            [(user_id, rid) for rid in release_ids],
+        )
 ```
 
-Inside `sync_wantlist()` (`api/syncer.py`), the wantlist rows are upserted into the public `user_wantlists` table in a **batch** (the loop already derives `release_id = item.get("id")` and skips falsy ids). Collect those ids into a list alongside the batch params, then — after the batch upsert succeeds — seed digger priorities for the whole batch using the pool already in scope:
+Inside `sync_wantlist()` (`api/syncer.py`), the wantlist rows are upserted into the public `user_wantlists` table in a **batch** (each `batch_params` tuple has `release_id` at index 1). After the per-page upsert succeeds (`total_synced += len(batch_params)`), seed digger priorities for the whole page in one call, isolated so a seeding failure logs a warning but never aborts the already-committed wantlist sync (mirrors the non-critical cache-invalidation isolation elsewhere in the syncer):
 
 ```python
-for release_id in wantlist_release_ids:
-    await _seed_digger_priority_for_wantlist_item(pool, user_id, release_id)
+try:
+    await _seed_digger_priorities_for_wantlist(pg_pool, user_uuid, [row[1] for row in batch_params])
+except Exception as exc:  # seeding is a non-critical side-effect; never fail the sync over it
+    logger.warning("⚠️ Failed to seed digger priorities", error=str(exc))
 ```
 
 - [ ] **Step 4: Run test to verify it passes**

--- a/docs/superpowers/plans/2026-05-14-digger-m1-foundation.md
+++ b/docs/superpowers/plans/2026-05-14-digger-m1-foundation.md
@@ -40,7 +40,7 @@
 - `explore/src/digger/types.ts` — TS mirrors of Pydantic models
 - `tests/digger/conftest.py`, `tests/digger/test_*.py` per module, `tests/digger/fixtures/*.html`
 - `tests/api/test_digger_router.py`, `tests/api/test_internal_digger_router.py`, `tests/api/test_digger_queries.py`, `tests/api/test_syncer_digger_hook.py`
-- `tests/schema_init/test_digger_schema.py`, `tests/schema_init/test_digger_schema_integration.py`, `tests/schema_init/test_digger_priority_trigger.py`
+- `tests/schema-init/test_digger_schema.py`, `tests/schema-init/test_digger_schema_integration.py`, `tests/schema-init/test_digger_priority_trigger.py`
 - `tests/explore/digger/*.test.tsx`
 - `tests/e2e/test_digger_m1_smoke.py`
 - `docs/digger-scraping-policy.md`
@@ -57,8 +57,21 @@
 - `pyproject.toml` (root) — add `digger` to workspace members
 - `.env.example` — `DIGGER_*` vars
 
-**Conventions assumed (verified against existing codebase before each task):**
-- Services use `common/AsyncPostgreSQLPool` for Postgres access. **Autocommit contract:** call `await conn.set_autocommit(False)` before any `async with conn.transaction()`. Single-statement writes don't need a transaction.
+**Conventions (VERIFIED against the codebase 2026-05-19 — these correct the original draft, which was written against asyncpg):**
+
+- **Postgres driver is async psycopg (psycopg3), NOT asyncpg.** `common.postgres_resilient.AsyncPostgreSQLPool` wraps `psycopg.AsyncConnection`. asyncpg is not a dependency. Access pattern:
+  ```python
+  async with pool.connection() as conn:          # NOT pool.acquire()
+      async with conn.cursor() as cur:           # psycopg cursor
+          await cur.execute("SELECT ... WHERE x = %s", (value,))  # %s, NOT $1; params as a tuple
+          row = await cur.fetchone()             # NOT conn.fetchval()/fetchrow()/fetch()
+  ```
+  Multi-statement DDL strings (no params) may be executed in a single `cur.execute(BIG_SQL)` call — psycopg3 supports this when no parameters are bound.
+- **Autocommit contract:** the pool sets `autocommit=True` on every connection. Single-statement writes (inserts/upserts) commit immediately — no transaction needed. Only call `await conn.set_autocommit(False)` before `async with conn.transaction()` for multi-statement atomic blocks; the pool restores autocommit on return.
+- **FK target for users is `users(id)` (UUID PK), NOT `users(user_id)`.** Every digger table that references the user table uses `REFERENCES users(id) ON DELETE CASCADE`. The column *name* on owning tables stays `user_id` (matches `user_wantlists.user_id`), but it points at `users(id)`.
+- **Wantlist table is public `user_wantlists`** (PK `id`, `user_id`, `release_id`, `UNIQUE(user_id, release_id)`) — there is no `discogs.user_wantlists`. `api/syncer.py::sync_wantlist()` inserts in a **batch**, so the digger seed hook runs over the batch's release_ids, not per-row.
+- **Import paths:** `schema-init/` is on `pythonpath` (hyphen dir), so its modules import top-level: `from digger_schema import DIGGER_SCHEMA_SQL` (NOT `from schema_init.digger_schema`). `api/` is a real package: `from api.syncer import ...` is correct.
+- **Test layout & strategy:** schema-init tests live in `tests/schema-init/` (hyphen); api tests in `tests/api/`. Unit tests are **mock-based** — there is no real-Postgres fixture, and `just test` runs `-m 'not e2e'` with a mocked pool. The existing mock pattern is `tests/schema-init/test_postgres_schema.py::mock_pool` (`pool.connection()` → `conn.cursor()` → `cur.execute`, all `AsyncMock`). **Real-DB behavioral checks** (e.g., trigger semantics) are deferred to the M1 e2e smoke (Task 28) and/or `@pytest.mark.e2e`; do NOT introduce a live-DB unit fixture.
 - `asyncio.Lock`, `asyncio.Queue`, `asyncio.Event`, `asyncio.Semaphore` must be lazily initialized in the first async method, never in `__init__` or at module scope.
 - Log lines use the emoji vocabulary in `docs/emoji-guide.md` — no ad-hoc emojis.
 - Tier-threshold comparisons use `>=` (boundary belongs to higher tier).
@@ -70,14 +83,13 @@
 
 **Files:**
 - Create: `schema-init/digger_schema.py`
-- Test: `tests/schema_init/test_digger_schema.py`
+- Test: `tests/schema-init/test_digger_schema.py`
 
 - [ ] **Step 1: Write the failing test**
 
 ```python
-# tests/schema_init/test_digger_schema.py
-import pytest
-from schema_init.digger_schema import DIGGER_SCHEMA_SQL
+# tests/schema-init/test_digger_schema.py
+from digger_schema import DIGGER_SCHEMA_SQL
 
 
 def test_digger_schema_sql_creates_schema_and_enums():
@@ -102,8 +114,8 @@ def test_digger_schema_sql_creates_all_tables():
 
 - [ ] **Step 2: Run test to verify it fails**
 
-`uv run pytest tests/schema_init/test_digger_schema.py -v`
-Expected: `ModuleNotFoundError: No module named 'schema_init.digger_schema'`.
+`uv run pytest tests/schema-init/test_digger_schema.py -v`
+Expected: `ModuleNotFoundError: No module named 'digger_schema'`.
 
 - [ ] **Step 3: Write the schema module**
 
@@ -208,7 +220,7 @@ CREATE INDEX IF NOT EXISTS idx_listings_seller_active
     ON digger.listings (seller_id) WHERE removed_at IS NULL;
 
 CREATE TABLE IF NOT EXISTS digger.user_wantlist_priorities (
-    user_id              uuid                    NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    user_id              uuid                    NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     release_id           bigint                  NOT NULL,
     tier                 digger.priority_tier    NOT NULL DEFAULT 'nice',
     min_media_condition  digger.condition        NOT NULL DEFAULT 'VG',
@@ -221,7 +233,7 @@ CREATE TABLE IF NOT EXISTS digger.user_wantlist_priorities (
 CREATE INDEX IF NOT EXISTS idx_uwp_release ON digger.user_wantlist_priorities (release_id);
 
 CREATE TABLE IF NOT EXISTS digger.user_digger_settings (
-    user_id                       uuid             PRIMARY KEY REFERENCES users(user_id) ON DELETE CASCADE,
+    user_id                       uuid             PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
     enabled                       bool             NOT NULL DEFAULT false,
     country_code                  char(2),
     currency                      char(3)          NOT NULL DEFAULT 'USD',
@@ -234,7 +246,7 @@ CREATE TABLE IF NOT EXISTS digger.user_digger_settings (
 
 CREATE TABLE IF NOT EXISTS digger.reports (
     report_id            uuid                     PRIMARY KEY,
-    user_id              uuid                     NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    user_id              uuid                     NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     kind                 digger.report_kind       NOT NULL,
     generated_at         timestamptz              NOT NULL DEFAULT now(),
     read_at              timestamptz,
@@ -251,7 +263,7 @@ CREATE INDEX IF NOT EXISTS idx_reports_user_time
 
 CREATE TABLE IF NOT EXISTS digger.proposals (
     proposal_id  uuid                     PRIMARY KEY,
-    user_id      uuid                     NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    user_id      uuid                     NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     session_id   uuid,
     created_at   timestamptz              NOT NULL DEFAULT now(),
     status       digger.proposal_status   NOT NULL DEFAULT 'pending',
@@ -261,7 +273,7 @@ CREATE TABLE IF NOT EXISTS digger.proposals (
 
 CREATE TABLE IF NOT EXISTS digger.agent_sessions (
     session_id              uuid           PRIMARY KEY,
-    user_id                 uuid           NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    user_id                 uuid           NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     started_at              timestamptz    NOT NULL DEFAULT now(),
     last_active_at          timestamptz    NOT NULL DEFAULT now(),
     model                   digger.model   NOT NULL,
@@ -284,13 +296,13 @@ CREATE TABLE IF NOT EXISTS digger.agent_messages (
 
 - [ ] **Step 4: Run test to verify it passes**
 
-`uv run pytest tests/schema_init/test_digger_schema.py -v`
+`uv run pytest tests/schema-init/test_digger_schema.py -v`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add schema-init/digger_schema.py tests/schema_init/test_digger_schema.py
+git add schema-init/digger_schema.py tests/schema-init/test_digger_schema.py
 git commit -m "feat(digger): add digger Postgres schema, enums, and tables"
 ```
 
@@ -300,61 +312,89 @@ git commit -m "feat(digger): add digger Postgres schema, enums, and tables"
 
 **Files:**
 - Modify: `schema-init/postgres_schema.py`
-- Test: `tests/schema_init/test_digger_schema_integration.py`
+- Test: `tests/schema-init/test_digger_schema_integration.py`
 
 - [ ] **Step 1: Write the failing test**
 
 ```python
-# tests/schema_init/test_digger_schema_integration.py
+# tests/schema-init/test_digger_schema_integration.py
+"""Verify create_postgres_schema applies the digger feature schema.
+
+Mock-based (repo convention) — there is no real-Postgres unit fixture, and
+`just test` runs `-m 'not e2e'`. Real behavioral verification of the applied
+schema (tables actually exist) lives in the M1 e2e smoke (Task 28).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
-from common.postgres_pool import AsyncPostgreSQLPool
+
+from postgres_schema import create_postgres_schema
+
+
+@pytest.fixture
+def mock_pool() -> MagicMock:
+    """Mock AsyncPostgreSQLPool: pool.connection() -> conn -> conn.cursor()."""
+    pool = MagicMock()
+    conn = AsyncMock()
+    cur = AsyncMock()
+    cur.__aenter__ = AsyncMock(return_value=cur)
+    cur.__aexit__ = AsyncMock(return_value=False)
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=False)
+    conn.cursor = MagicMock(return_value=cur)  # cursor() is sync, returns an async CM
+    pool.connection.return_value = conn
+    return pool
 
 
 @pytest.mark.asyncio
-async def test_digger_schema_applies_to_db(postgres_pool: AsyncPostgreSQLPool) -> None:
-    async with postgres_pool.acquire() as conn:
-        rows = await conn.fetch(
-            "SELECT table_name FROM information_schema.tables WHERE table_schema = 'digger'"
-        )
-        names = {r["table_name"] for r in rows}
-        assert {
-            "release_scrape_state", "sellers", "listings",
-            "user_wantlist_priorities", "user_digger_settings",
-            "reports", "proposals", "agent_sessions", "agent_messages",
-        } <= names
+async def test_create_postgres_schema_applies_digger_schema(mock_pool: MagicMock) -> None:
+    await create_postgres_schema(mock_pool)
+    cur = mock_pool.connection.return_value.cursor.return_value
+    executed = [c.args[0] for c in cur.execute.call_args_list if c.args]
+    assert any(
+        isinstance(stmt, str) and "CREATE SCHEMA IF NOT EXISTS digger" in stmt
+        for stmt in executed
+    ), "digger schema SQL was not executed by create_postgres_schema"
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-`uv run pytest tests/schema_init/test_digger_schema_integration.py -v`
-Expected: FAIL — digger tables don't exist.
+`uv run pytest tests/schema-init/test_digger_schema_integration.py -v`
+Expected: FAIL — `create_postgres_schema` does not yet execute the digger schema.
 
 - [ ] **Step 3: Wire into schema-init**
 
-In `schema-init/postgres_schema.py`, locate the function that runs ordered schema scripts and append:
+In `schema-init/postgres_schema.py`, add the import near the top (top-level module — `schema-init` is on `pythonpath`):
 
 ```python
-from schema_init.digger_schema import DIGGER_SCHEMA_SQL
-
-
-async def apply_digger_schema(conn) -> None:
-    """Apply the digger feature schema. Idempotent."""
-    logger.info("🪡 Applying digger schema")
-    await conn.execute(DIGGER_SCHEMA_SQL)
-    logger.info("✅ Digger schema applied")
+from digger_schema import DIGGER_SCHEMA_SQL
 ```
 
-Call `apply_digger_schema(conn)` in the orchestrator after the `discogs` and `musicbrainz` schema applications.
+Then, inside `create_postgres_schema`, **after** the MusicBrainz block and still inside the open `async with conn.cursor() as cursor_cm:` context (so the digger tables can FK to the already-created `users` table), apply the schema as a single multi-statement DDL string, matching the existing per-block try/except + counter style:
+
+```python
+            # ── Digger feature schema (schema, enums, tables, triggers) ───
+            try:
+                await cursor.execute(DIGGER_SCHEMA_SQL)
+                logger.info("✅ Schema: digger feature schema")
+                success_count += 1
+            except Exception as e:
+                logger.error(f"❌ Failed to create schema object 'digger feature schema': {e}")
+                failure_count += 1
+```
+
+psycopg3 runs the whole multi-statement DDL (enums, tables, indexes, triggers) in one `cursor.execute()` call because no parameters are bound. Bump the `total` count at the end of the function by `+ 1` to account for the digger schema statement so the success/failure accounting stays correct.
 
 - [ ] **Step 4: Run test to verify it passes**
 
-`uv run pytest tests/schema_init/test_digger_schema_integration.py -v`
+`uv run pytest tests/schema-init/test_digger_schema_integration.py -v`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add schema-init/postgres_schema.py tests/schema_init/test_digger_schema_integration.py
+git add schema-init/postgres_schema.py tests/schema-init/test_digger_schema_integration.py
 git commit -m "feat(digger): apply digger schema during schema-init startup"
 ```
 
@@ -364,60 +404,44 @@ git commit -m "feat(digger): apply digger schema during schema-init startup"
 
 **Files:**
 - Modify: `schema-init/digger_schema.py` — append trigger SQL
-- Test: `tests/schema_init/test_digger_priority_trigger.py`
+- Test: `tests/schema-init/test_digger_priority_trigger.py`
 
 - [ ] **Step 1: Write the failing test**
 
 ```python
-# tests/schema_init/test_digger_priority_trigger.py
-import pytest
-import uuid
+# tests/schema-init/test_digger_priority_trigger.py
+"""Structural checks for the priority-recompute trigger DDL.
+
+The trigger's runtime behavior (recompute max tier across all users wanting a
+release on INSERT/UPDATE/DELETE) needs a live Postgres and is exercised by the
+M1 e2e smoke (Task 28). These unit tests assert the DDL is present and encodes
+the must > nice > eventually precedence — no DB required.
+"""
+
+from digger_schema import DIGGER_SCHEMA_SQL
 
 
-@pytest.mark.asyncio
-async def test_priority_trigger_recomputes_max_tier(postgres_pool) -> None:
-    user_a = uuid.uuid4()
-    user_b = uuid.uuid4()
-    release_id = 999_001
-    async with postgres_pool.acquire() as conn:
-        await conn.execute("INSERT INTO users(user_id, email) VALUES ($1,$2),($3,$4)",
-                           user_a, "a@e", user_b, "b@e")
-        await conn.execute(
-            "INSERT INTO digger.release_scrape_state(release_id) VALUES ($1)", release_id
-        )
-        await conn.execute(
-            "INSERT INTO digger.user_wantlist_priorities(user_id, release_id, tier) VALUES ($1,$2,'nice')",
-            user_a, release_id,
-        )
-        tier = await conn.fetchval(
-            "SELECT priority_tier FROM digger.release_scrape_state WHERE release_id=$1",
-            release_id,
-        )
-        assert tier == "nice"
-        await conn.execute(
-            "INSERT INTO digger.user_wantlist_priorities(user_id, release_id, tier) VALUES ($1,$2,'must')",
-            user_b, release_id,
-        )
-        tier = await conn.fetchval(
-            "SELECT priority_tier FROM digger.release_scrape_state WHERE release_id=$1",
-            release_id,
-        )
-        assert tier == "must"
-        await conn.execute(
-            "DELETE FROM digger.user_wantlist_priorities WHERE user_id=$1 AND release_id=$2",
-            user_b, release_id,
-        )
-        tier = await conn.fetchval(
-            "SELECT priority_tier FROM digger.release_scrape_state WHERE release_id=$1",
-            release_id,
-        )
-        assert tier == "nice"
+def test_trigger_function_and_trigger_present() -> None:
+    sql = DIGGER_SCHEMA_SQL
+    assert "FUNCTION digger.recompute_priority_for_release" in sql
+    assert "FUNCTION digger.uwp_after_change" in sql
+    assert "CREATE TRIGGER trg_uwp_recompute" in sql
+    assert "AFTER INSERT OR UPDATE OR DELETE ON digger.user_wantlist_priorities" in sql
+
+
+def test_trigger_encodes_tier_precedence() -> None:
+    sql = DIGGER_SCHEMA_SQL
+    # must wins over nice wins over eventually in the CASE ladder
+    must_at = sql.find("bool_or(tier = 'must')")
+    nice_at = sql.find("bool_or(tier = 'nice')")
+    assert must_at != -1 and nice_at != -1
+    assert must_at < nice_at, "must must be evaluated before nice in the precedence ladder"
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-`uv run pytest tests/schema_init/test_digger_priority_trigger.py -v`
-Expected: FAIL — second assertion fails because no trigger maintains `priority_tier`.
+`uv run pytest tests/schema-init/test_digger_priority_trigger.py -v`
+Expected: FAIL — the trigger DDL is not yet present in `DIGGER_SCHEMA_SQL`.
 
 - [ ] **Step 3: Append trigger SQL**
 
@@ -473,13 +497,13 @@ FOR EACH ROW EXECUTE FUNCTION digger.uwp_after_change();
 
 - [ ] **Step 4: Run test to verify it passes**
 
-`uv run pytest tests/schema_init/test_digger_priority_trigger.py -v`
+`uv run pytest tests/schema-init/test_digger_priority_trigger.py -v`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add schema-init/digger_schema.py tests/schema_init/test_digger_priority_trigger.py
+git add schema-init/digger_schema.py tests/schema-init/test_digger_priority_trigger.py
 git commit -m "feat(digger): trigger to maintain max-tier on release_scrape_state"
 ```
 
@@ -495,29 +519,48 @@ git commit -m "feat(digger): trigger to maintain max-tier on release_scrape_stat
 
 ```python
 # tests/api/test_syncer_digger_hook.py
+"""Unit test for the digger wantlist-sync seed hook (mock-based).
+
+Asserts the helper issues the two idempotent INSERTs via the psycopg3 cursor
+with %s params. Real-DB row creation + trigger recompute is covered by the M1
+e2e smoke (Task 28).
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
+
+from api.syncer import _seed_digger_priority_for_wantlist_item
+
+
+def _mock_pool() -> tuple[MagicMock, AsyncMock]:
+    pool = MagicMock()
+    conn = AsyncMock()
+    cur = AsyncMock()
+    cur.__aenter__ = AsyncMock(return_value=cur)
+    cur.__aexit__ = AsyncMock(return_value=False)
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=False)
+    conn.cursor = MagicMock(return_value=cur)  # cursor() is sync, returns an async CM
+    pool.connection.return_value = conn
+    return pool, cur
 
 
 @pytest.mark.asyncio
-async def test_wantlist_sync_creates_default_priority_rows(postgres_pool, api_oauth_user):
-    from api.syncer import _seed_digger_priority_for_wantlist_item
+async def test_seed_inserts_scrape_state_and_priority_row() -> None:
+    pool, cur = _mock_pool()
+    user_id = uuid.uuid4()
 
-    user_id = api_oauth_user.user_id
-    await _seed_digger_priority_for_wantlist_item(postgres_pool, user_id, release_id=12345)
+    await _seed_digger_priority_for_wantlist_item(pool, user_id, release_id=12345)
 
-    async with postgres_pool.acquire() as conn:
-        row = await conn.fetchrow(
-            "SELECT tier, min_media_condition FROM digger.user_wantlist_priorities "
-            "WHERE user_id=$1 AND release_id=$2",
-            user_id, 12345,
-        )
-        scrape_state = await conn.fetchrow(
-            "SELECT priority_tier FROM digger.release_scrape_state WHERE release_id=$1",
-            12345,
-        )
-    assert row["tier"] == "nice"
-    assert row["min_media_condition"] == "VG"
-    assert scrape_state["priority_tier"] == "nice"
+    executed = [(c.args[0], c.args[1] if len(c.args) > 1 else None) for c in cur.execute.call_args_list]
+    all_sql = " ".join(sql for sql, _ in executed)
+    assert "INSERT INTO digger.release_scrape_state" in all_sql
+    assert "INSERT INTO digger.user_wantlist_priorities" in all_sql
+    # psycopg3 params are positional tuples bound to %s placeholders
+    assert any(params == (12345,) for _, params in executed)
+    assert any(params == (user_id, 12345) for _, params in executed)
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -528,9 +571,11 @@ Expected: ImportError — helper not defined.
 - [ ] **Step 3: Add the helper and call it from the wantlist sync loop**
 
 ```python
-# api/syncer.py — add near the wantlist sync block
+# api/syncer.py — add near the wantlist sync block.
+# Reuse the AsyncPostgreSQLPool import already present in this module.
 import uuid
-from common.postgres_pool import AsyncPostgreSQLPool
+
+from common.postgres_resilient import AsyncPostgreSQLPool
 
 
 async def _seed_digger_priority_for_wantlist_item(
@@ -538,29 +583,30 @@ async def _seed_digger_priority_for_wantlist_item(
 ) -> None:
     """Ensure a digger.user_wantlist_priorities row exists for this user+release.
 
-    Default tier is 'nice' per design spec. The schema trigger maintains
-    digger.release_scrape_state.priority_tier as a side-effect. Idempotent.
+    Default tier is 'nice' (schema column default). The schema trigger maintains
+    digger.release_scrape_state.priority_tier as a side effect. Idempotent and
+    safe to call repeatedly. psycopg3 autocommit single-statement writes — no
+    explicit transaction needed.
     """
-    async with pool.acquire() as conn:
-        await conn.execute(
-            "INSERT INTO digger.release_scrape_state(release_id) VALUES ($1) "
-            "ON CONFLICT (release_id) DO NOTHING",
-            release_id,
-        )
-        await conn.execute(
-            """
-            INSERT INTO digger.user_wantlist_priorities(user_id, release_id)
-            VALUES ($1, $2)
-            ON CONFLICT (user_id, release_id) DO NOTHING
-            """,
-            user_id, release_id,
-        )
+    async with pool.connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "INSERT INTO digger.release_scrape_state (release_id) VALUES (%s) "
+                "ON CONFLICT (release_id) DO NOTHING",
+                (release_id,),
+            )
+            await cur.execute(
+                "INSERT INTO digger.user_wantlist_priorities (user_id, release_id) "
+                "VALUES (%s, %s) ON CONFLICT (user_id, release_id) DO NOTHING",
+                (user_id, release_id),
+            )
 ```
 
-Inside the existing `sync_wantlist()` function, after each `INSERT INTO discogs.user_wantlists ...`, append:
+Inside `sync_wantlist()` (`api/syncer.py`), the wantlist rows are upserted into the public `user_wantlists` table in a **batch** (the loop already derives `release_id = item.get("id")` and skips falsy ids). Collect those ids into a list alongside the batch params, then — after the batch upsert succeeds — seed digger priorities for the whole batch using the pool already in scope:
 
 ```python
-await _seed_digger_priority_for_wantlist_item(pool, user_id, item.release_id)
+for release_id in wantlist_release_ids:
+    await _seed_digger_priority_for_wantlist_item(pool, user_id, release_id)
 ```
 
 - [ ] **Step 4: Run test to verify it passes**

--- a/schema-init/digger_schema.py
+++ b/schema-init/digger_schema.py
@@ -1,0 +1,171 @@
+"""Digger feature Postgres schema.
+
+Owns all digger.* tables, enums, indices, and triggers. Invoked by
+schema-init at container start (idempotent via IF NOT EXISTS).
+"""
+
+DIGGER_SCHEMA_SQL = """
+CREATE SCHEMA IF NOT EXISTS digger;
+
+DO $$ BEGIN
+    CREATE TYPE digger.priority_tier   AS ENUM ('must', 'nice', 'eventually');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+    CREATE TYPE digger.condition       AS ENUM ('M','NM','VG+','VG','G+','G','F','P');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+    CREATE TYPE digger.sleeve_condition AS ENUM ('M','NM','VG+','VG','G+','G','F','P','generic','no_cover');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+    CREATE TYPE digger.region          AS ENUM ('us','ca','eu','uk','jp','au','other');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+    CREATE TYPE digger.cadence         AS ENUM ('off','weekly','biweekly','monthly');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+    CREATE TYPE digger.model           AS ENUM ('haiku','sonnet','opus');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+    CREATE TYPE digger.report_kind     AS ENUM ('scheduled','interactive');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+    CREATE TYPE digger.change_flag     AS ENUM ('significant','none','first_run');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+    CREATE TYPE digger.confidence      AS ENUM ('high','low');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+    CREATE TYPE digger.proposal_status AS ENUM ('pending','approved','rejected','expired');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+    CREATE TYPE digger.role            AS ENUM ('system','user','assistant','tool');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS digger.sellers (
+    seller_id              bigint        PRIMARY KEY,
+    username               text          NOT NULL,
+    country_code           char(2),
+    region                 digger.region NOT NULL DEFAULT 'other',
+    feedback_count         int,
+    feedback_score         numeric(4,1),
+    ships_internationally  bool          NOT NULL DEFAULT false,
+    shipping_policy        jsonb,
+    last_refreshed_at      timestamptz   NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS digger.release_scrape_state (
+    release_id             bigint                PRIMARY KEY,
+    priority_tier          digger.priority_tier  NOT NULL DEFAULT 'eventually',
+    last_scraped_at        timestamptz,
+    next_scrape_due_at     timestamptz           NOT NULL DEFAULT now(),
+    listings_delta_7d      int                   NOT NULL DEFAULT 0,
+    consecutive_failures   int                   NOT NULL DEFAULT 0,
+    next_retry_at          timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_rss_due_tier
+    ON digger.release_scrape_state (priority_tier, next_scrape_due_at);
+
+CREATE TABLE IF NOT EXISTS digger.listings (
+    listing_id          bigint                   PRIMARY KEY,
+    release_id          bigint                   NOT NULL REFERENCES digger.release_scrape_state(release_id) ON DELETE CASCADE,
+    seller_id           bigint                   NOT NULL REFERENCES digger.sellers(seller_id) ON DELETE CASCADE,
+    price_value         numeric(10,2)            NOT NULL,
+    price_currency      char(3)                  NOT NULL,
+    media_condition     digger.condition         NOT NULL,
+    sleeve_condition    digger.sleeve_condition  NOT NULL,
+    comments            text,
+    posted_at           timestamptz,
+    first_seen_at       timestamptz              NOT NULL DEFAULT now(),
+    last_seen_at        timestamptz              NOT NULL DEFAULT now(),
+    removed_at          timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_listings_release_active
+    ON digger.listings (release_id) WHERE removed_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_listings_seller_active
+    ON digger.listings (seller_id) WHERE removed_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS digger.user_wantlist_priorities (
+    user_id              uuid                    NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    release_id           bigint                  NOT NULL,
+    tier                 digger.priority_tier    NOT NULL DEFAULT 'nice',
+    min_media_condition  digger.condition        NOT NULL DEFAULT 'VG',
+    min_sleeve_condition digger.sleeve_condition NOT NULL DEFAULT 'VG',
+    max_price_cents      int,
+    updated_at           timestamptz             NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, release_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_uwp_release ON digger.user_wantlist_priorities (release_id);
+
+CREATE TABLE IF NOT EXISTS digger.user_digger_settings (
+    user_id                       uuid             PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    enabled                       bool             NOT NULL DEFAULT false,
+    country_code                  char(2),
+    currency                      char(3)          NOT NULL DEFAULT 'USD',
+    scheduled_cadence             digger.cadence   NOT NULL DEFAULT 'off',
+    next_scheduled_run_at         timestamptz,
+    preferred_model               digger.model     NOT NULL DEFAULT 'sonnet',
+    daily_token_cap_interactive   int              NOT NULL DEFAULT 200000,
+    daily_token_cap_scheduled     int              NOT NULL DEFAULT 100000
+);
+
+CREATE TABLE IF NOT EXISTS digger.reports (
+    report_id            uuid                     PRIMARY KEY,
+    user_id              uuid                     NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    kind                 digger.report_kind       NOT NULL,
+    generated_at         timestamptz              NOT NULL DEFAULT now(),
+    read_at              timestamptz,
+    title                text                     NOT NULL,
+    summary              jsonb                    NOT NULL,
+    bundles              jsonb                    NOT NULL,
+    watching             jsonb                    NOT NULL DEFAULT '[]'::jsonb,
+    change_flag          digger.change_flag       NOT NULL,
+    shipping_confidence  digger.confidence        NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_reports_user_time
+    ON digger.reports (user_id, generated_at DESC);
+
+CREATE TABLE IF NOT EXISTS digger.proposals (
+    proposal_id  uuid                     PRIMARY KEY,
+    user_id      uuid                     NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    session_id   uuid,
+    created_at   timestamptz              NOT NULL DEFAULT now(),
+    status       digger.proposal_status   NOT NULL DEFAULT 'pending',
+    payload      jsonb                    NOT NULL,
+    expires_at   timestamptz              NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS digger.agent_sessions (
+    session_id              uuid           PRIMARY KEY,
+    user_id                 uuid           NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    started_at              timestamptz    NOT NULL DEFAULT now(),
+    last_active_at          timestamptz    NOT NULL DEFAULT now(),
+    model                   digger.model   NOT NULL,
+    total_input_tokens      int            NOT NULL DEFAULT 0,
+    total_output_tokens     int            NOT NULL DEFAULT 0,
+    total_cache_read_tokens int            NOT NULL DEFAULT 0,
+    total_cost_usd          numeric(10,4)  NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS digger.agent_messages (
+    message_id    uuid          PRIMARY KEY,
+    session_id    uuid          NOT NULL REFERENCES digger.agent_sessions(session_id) ON DELETE CASCADE,
+    role          digger.role   NOT NULL,
+    content       jsonb         NOT NULL,
+    token_counts  jsonb,
+    created_at    timestamptz   NOT NULL DEFAULT now()
+);
+"""

--- a/schema-init/digger_schema.py
+++ b/schema-init/digger_schema.py
@@ -96,6 +96,11 @@ CREATE INDEX IF NOT EXISTS idx_listings_release_active
 CREATE INDEX IF NOT EXISTS idx_listings_seller_active
     ON digger.listings (seller_id) WHERE removed_at IS NULL;
 
+-- NOTE: release_id intentionally has NO foreign key to digger.release_scrape_state.
+-- Priorities are user-owned and may be seeded before a scrape-state row exists; the
+-- uwp trigger's UPDATE of release_scrape_state.priority_tier is a harmless no-op when
+-- the parent row is absent, and the digger worker reconciles scrape state on first
+-- encounter. This decoupling lets priority seeding succeed independently of scrape state.
 CREATE TABLE IF NOT EXISTS digger.user_wantlist_priorities (
     user_id              uuid                    NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     release_id           bigint                  NOT NULL,

--- a/schema-init/digger_schema.py
+++ b/schema-init/digger_schema.py
@@ -168,4 +168,50 @@ CREATE TABLE IF NOT EXISTS digger.agent_messages (
     token_counts  jsonb,
     created_at    timestamptz   NOT NULL DEFAULT now()
 );
+
+CREATE OR REPLACE FUNCTION digger.recompute_priority_for_release(p_release_id bigint)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE
+    max_tier digger.priority_tier;
+BEGIN
+    SELECT
+        CASE
+            WHEN bool_or(tier = 'must') THEN 'must'::digger.priority_tier
+            WHEN bool_or(tier = 'nice') THEN 'nice'::digger.priority_tier
+            WHEN bool_or(tier = 'eventually') THEN 'eventually'::digger.priority_tier
+            ELSE 'eventually'::digger.priority_tier
+        END
+    INTO max_tier
+    FROM digger.user_wantlist_priorities
+    WHERE release_id = p_release_id;
+
+    IF max_tier IS NULL THEN
+        RETURN;
+    END IF;
+
+    UPDATE digger.release_scrape_state
+       SET priority_tier = max_tier
+     WHERE release_id = p_release_id
+       AND priority_tier IS DISTINCT FROM max_tier;
+END $$;
+
+CREATE OR REPLACE FUNCTION digger.uwp_after_change()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        PERFORM digger.recompute_priority_for_release(OLD.release_id);
+        RETURN OLD;
+    ELSE
+        PERFORM digger.recompute_priority_for_release(NEW.release_id);
+        IF TG_OP = 'UPDATE' AND OLD.release_id IS DISTINCT FROM NEW.release_id THEN
+            PERFORM digger.recompute_priority_for_release(OLD.release_id);
+        END IF;
+        RETURN NEW;
+    END IF;
+END $$;
+
+DROP TRIGGER IF EXISTS trg_uwp_recompute ON digger.user_wantlist_priorities;
+CREATE TRIGGER trg_uwp_recompute
+AFTER INSERT OR UPDATE OR DELETE ON digger.user_wantlist_priorities
+FOR EACH ROW EXECUTE FUNCTION digger.uwp_after_change();
 """

--- a/schema-init/digger_schema.py
+++ b/schema-init/digger_schema.py
@@ -186,6 +186,10 @@ BEGIN
     WHERE release_id = p_release_id;
 
     IF max_tier IS NULL THEN
+        UPDATE digger.release_scrape_state
+           SET priority_tier = 'eventually'
+         WHERE release_id = p_release_id
+           AND priority_tier IS DISTINCT FROM 'eventually'::digger.priority_tier;
         RETURN;
     END IF;
 
@@ -210,8 +214,7 @@ BEGIN
     END IF;
 END $$;
 
-DROP TRIGGER IF EXISTS trg_uwp_recompute ON digger.user_wantlist_priorities;
-CREATE TRIGGER trg_uwp_recompute
+CREATE OR REPLACE TRIGGER trg_uwp_recompute
 AFTER INSERT OR UPDATE OR DELETE ON digger.user_wantlist_priorities
 FOR EACH ROW EXECUTE FUNCTION digger.uwp_after_change();
 """

--- a/schema-init/postgres_schema.py
+++ b/schema-init/postgres_schema.py
@@ -10,6 +10,8 @@ from typing import Any, cast
 
 from psycopg import sql
 
+from digger_schema import DIGGER_SCHEMA_SQL
+
 
 logger = logging.getLogger(__name__)
 
@@ -756,6 +758,17 @@ async def create_postgres_schema(pool: Any) -> int:
                     logger.error(f"❌ Failed to create schema object '{name}': {e}")
                     failure_count += 1
 
+            # ── Digger feature schema (schema, enums, tables, triggers) ───
+            try:
+                await cursor.execute(DIGGER_SCHEMA_SQL)
+                logger.info("✅ Schema: digger feature schema")
+                success_count += 1
+            except Exception as e:
+                logger.error(
+                    f"❌ Failed to create schema object 'digger feature schema': {e}"
+                )
+                failure_count += 1
+
     total = (
         len(_ENTITY_TABLES) * 3
         + len(_SPECIFIC_INDEXES)
@@ -763,6 +776,7 @@ async def create_postgres_schema(pool: Any) -> int:
         + len(_INSIGHTS_TABLES)
         + len(_MUSICBRAINZ_TABLES)
         + len(_MUSICBRAINZ_INDEXES)
+        + 1  # digger feature schema
     )
     logger.info(
         f"✅ PostgreSQL schema creation complete: "

--- a/tests/api/test_syncer.py
+++ b/tests/api/test_syncer.py
@@ -486,7 +486,10 @@ class TestSyncWantlist:
             )
 
         assert result == 1
-        mock_pg_pool._mock_cur.executemany.assert_awaited_once()
+        # 3 executemany calls: 1 wantlist upsert + 2 digger priority seeds (release_scrape_state, user_wantlist_priorities)
+        assert mock_pg_pool._mock_cur.executemany.await_count == 3
+        first_sql = mock_pg_pool._mock_cur.executemany.await_args_list[0].args[0]
+        assert "user_wantlists" in first_sql
         mock_neo4j._mock_session.run.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/api/test_syncer_digger_hook.py
+++ b/tests/api/test_syncer_digger_hook.py
@@ -5,18 +5,17 @@ import uuid
 
 import pytest
 
-from api.syncer import _seed_digger_priority_for_wantlist_item
+from api.syncer import _seed_digger_priorities_for_wantlist
 
 
 TEST_USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000042")
-TEST_RELEASE_ID = 12345
 
 
 @pytest.fixture
 def mock_cur() -> AsyncMock:
     """Mock psycopg cursor."""
     cur = AsyncMock()
-    cur.execute = AsyncMock()
+    cur.executemany = AsyncMock()
     return cur
 
 
@@ -43,55 +42,38 @@ def mock_pool(mock_conn: AsyncMock) -> MagicMock:
 
 
 @pytest.mark.asyncio
-async def test_seed_digger_priority_executes_two_idempotent_inserts(
+async def test_seed_digger_priorities_batches_inserts(
     mock_pool: MagicMock,
     mock_cur: AsyncMock,
 ) -> None:
-    """Helper issues two ON CONFLICT DO NOTHING INSERTs: release_scrape_state then user_wantlist_priorities."""
-    await _seed_digger_priority_for_wantlist_item(mock_pool, TEST_USER_ID, TEST_RELEASE_ID)
+    """Helper issues two executemany calls: release_scrape_state then user_wantlist_priorities."""
+    await _seed_digger_priorities_for_wantlist(mock_pool, TEST_USER_ID, [12345, 67890])
 
-    assert mock_cur.execute.await_count == 2
-    first_call, second_call = mock_cur.execute.await_args_list
+    assert mock_cur.executemany.await_count == 2
+    first_call, second_call = mock_cur.executemany.await_args_list
 
-    # First INSERT: digger.release_scrape_state
-    first_sql, first_params = first_call.args
+    # First executemany: digger.release_scrape_state
+    first_sql, first_rows = first_call.args
     assert "digger.release_scrape_state" in first_sql
     assert "ON CONFLICT" in first_sql
     assert "DO NOTHING" in first_sql
-    assert first_params == (TEST_RELEASE_ID,)
+    assert first_rows == [(12345,), (67890,)]
 
-    # Second INSERT: digger.user_wantlist_priorities
-    second_sql, second_params = second_call.args
+    # Second executemany: digger.user_wantlist_priorities
+    second_sql, second_rows = second_call.args
     assert "digger.user_wantlist_priorities" in second_sql
     assert "ON CONFLICT" in second_sql
     assert "DO NOTHING" in second_sql
-    assert second_params == (TEST_USER_ID, TEST_RELEASE_ID)
+    assert second_rows == [(TEST_USER_ID, 12345), (TEST_USER_ID, 67890)]
 
 
 @pytest.mark.asyncio
-async def test_seed_digger_priority_is_idempotent_on_second_call(
+async def test_seed_digger_priorities_empty_is_noop(
     mock_pool: MagicMock,
     mock_cur: AsyncMock,
 ) -> None:
-    """Calling the helper twice issues the same two INSERTs both times (ON CONFLICT handles duplicates)."""
-    await _seed_digger_priority_for_wantlist_item(mock_pool, TEST_USER_ID, TEST_RELEASE_ID)
-    await _seed_digger_priority_for_wantlist_item(mock_pool, TEST_USER_ID, TEST_RELEASE_ID)
+    """Empty release_ids does nothing — no connection acquired, no executemany."""
+    await _seed_digger_priorities_for_wantlist(mock_pool, TEST_USER_ID, [])
 
-    # 2 calls x 2 INSERTs = 4 total execute calls
-    assert mock_cur.execute.await_count == 4
-
-
-@pytest.mark.asyncio
-async def test_seed_digger_priority_uses_correct_param_types(
-    mock_pool: MagicMock,
-    mock_cur: AsyncMock,
-) -> None:
-    """Params are passed as tuples (psycopg3 convention), not positional args."""
-    await _seed_digger_priority_for_wantlist_item(mock_pool, TEST_USER_ID, TEST_RELEASE_ID)
-
-    for awaited_call in mock_cur.execute.await_args_list:
-        # Each call must have exactly 2 positional args: sql string and params tuple
-        assert len(awaited_call.args) == 2
-        sql, params = awaited_call.args
-        assert isinstance(sql, str)
-        assert isinstance(params, tuple)
+    mock_pool.connection.assert_not_called()
+    mock_cur.executemany.assert_not_awaited()

--- a/tests/api/test_syncer_digger_hook.py
+++ b/tests/api/test_syncer_digger_hook.py
@@ -1,0 +1,97 @@
+"""Tests for the digger priority-seeding hook in api/syncer.py."""
+
+from unittest.mock import AsyncMock, MagicMock
+import uuid
+
+import pytest
+
+from api.syncer import _seed_digger_priority_for_wantlist_item
+
+
+TEST_USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000042")
+TEST_RELEASE_ID = 12345
+
+
+@pytest.fixture
+def mock_cur() -> AsyncMock:
+    """Mock psycopg cursor."""
+    cur = AsyncMock()
+    cur.execute = AsyncMock()
+    return cur
+
+
+@pytest.fixture
+def mock_conn(mock_cur: AsyncMock) -> AsyncMock:
+    """Mock psycopg connection that yields mock_cur from cursor()."""
+    conn = AsyncMock()
+    cur_ctx = AsyncMock()
+    cur_ctx.__aenter__ = AsyncMock(return_value=mock_cur)
+    cur_ctx.__aexit__ = AsyncMock(return_value=False)
+    conn.cursor = MagicMock(return_value=cur_ctx)
+    return conn
+
+
+@pytest.fixture
+def mock_pool(mock_conn: AsyncMock) -> MagicMock:
+    """Mock AsyncPostgreSQLPool that yields mock_conn from connection()."""
+    pool = MagicMock()
+    conn_ctx = AsyncMock()
+    conn_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+    conn_ctx.__aexit__ = AsyncMock(return_value=False)
+    pool.connection = MagicMock(return_value=conn_ctx)
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_seed_digger_priority_executes_two_idempotent_inserts(
+    mock_pool: MagicMock,
+    mock_cur: AsyncMock,
+) -> None:
+    """Helper issues two ON CONFLICT DO NOTHING INSERTs: release_scrape_state then user_wantlist_priorities."""
+    await _seed_digger_priority_for_wantlist_item(mock_pool, TEST_USER_ID, TEST_RELEASE_ID)
+
+    assert mock_cur.execute.await_count == 2
+    first_call, second_call = mock_cur.execute.await_args_list
+
+    # First INSERT: digger.release_scrape_state
+    first_sql, first_params = first_call.args
+    assert "digger.release_scrape_state" in first_sql
+    assert "ON CONFLICT" in first_sql
+    assert "DO NOTHING" in first_sql
+    assert first_params == (TEST_RELEASE_ID,)
+
+    # Second INSERT: digger.user_wantlist_priorities
+    second_sql, second_params = second_call.args
+    assert "digger.user_wantlist_priorities" in second_sql
+    assert "ON CONFLICT" in second_sql
+    assert "DO NOTHING" in second_sql
+    assert second_params == (TEST_USER_ID, TEST_RELEASE_ID)
+
+
+@pytest.mark.asyncio
+async def test_seed_digger_priority_is_idempotent_on_second_call(
+    mock_pool: MagicMock,
+    mock_cur: AsyncMock,
+) -> None:
+    """Calling the helper twice issues the same two INSERTs both times (ON CONFLICT handles duplicates)."""
+    await _seed_digger_priority_for_wantlist_item(mock_pool, TEST_USER_ID, TEST_RELEASE_ID)
+    await _seed_digger_priority_for_wantlist_item(mock_pool, TEST_USER_ID, TEST_RELEASE_ID)
+
+    # 2 calls x 2 INSERTs = 4 total execute calls
+    assert mock_cur.execute.await_count == 4
+
+
+@pytest.mark.asyncio
+async def test_seed_digger_priority_uses_correct_param_types(
+    mock_pool: MagicMock,
+    mock_cur: AsyncMock,
+) -> None:
+    """Params are passed as tuples (psycopg3 convention), not positional args."""
+    await _seed_digger_priority_for_wantlist_item(mock_pool, TEST_USER_ID, TEST_RELEASE_ID)
+
+    for awaited_call in mock_cur.execute.await_args_list:
+        # Each call must have exactly 2 positional args: sql string and params tuple
+        assert len(awaited_call.args) == 2
+        sql, params = awaited_call.args
+        assert isinstance(sql, str)
+        assert isinstance(params, tuple)

--- a/tests/schema-init/test_digger_priority_trigger.py
+++ b/tests/schema-init/test_digger_priority_trigger.py
@@ -13,7 +13,8 @@ def test_trigger_function_and_trigger_present() -> None:
     sql = DIGGER_SCHEMA_SQL
     assert "FUNCTION digger.recompute_priority_for_release" in sql
     assert "FUNCTION digger.uwp_after_change" in sql
-    assert "CREATE TRIGGER trg_uwp_recompute" in sql
+    # CREATE OR REPLACE TRIGGER avoids the drop-then-create gap on every schema-init run
+    assert "CREATE OR REPLACE TRIGGER trg_uwp_recompute" in sql
     assert "AFTER INSERT OR UPDATE OR DELETE ON digger.user_wantlist_priorities" in sql
 
 
@@ -24,3 +25,11 @@ def test_trigger_encodes_tier_precedence() -> None:
     nice_at = sql.find("bool_or(tier = 'nice')")
     assert must_at != -1 and nice_at != -1
     assert must_at < nice_at, "must must be evaluated before nice in the precedence ladder"
+
+
+def test_recompute_resets_to_eventually_when_no_wanters() -> None:
+    sql = DIGGER_SCHEMA_SQL
+    # When the last user removes a release, max_tier IS NULL and the function must
+    # deprioritize the release to 'eventually' rather than leaving a stale tier.
+    assert "SET priority_tier = 'eventually'" in sql
+    assert "priority_tier IS DISTINCT FROM 'eventually'::digger.priority_tier" in sql

--- a/tests/schema-init/test_digger_priority_trigger.py
+++ b/tests/schema-init/test_digger_priority_trigger.py
@@ -1,0 +1,26 @@
+"""Structural checks for the priority-recompute trigger DDL.
+
+The trigger's runtime behavior (recompute max tier across all users wanting a
+release on INSERT/UPDATE/DELETE) needs a live Postgres and is exercised by the
+M1 e2e smoke (Task 28). These unit tests assert the DDL is present and encodes
+the must > nice > eventually precedence — no DB required.
+"""
+
+from digger_schema import DIGGER_SCHEMA_SQL
+
+
+def test_trigger_function_and_trigger_present() -> None:
+    sql = DIGGER_SCHEMA_SQL
+    assert "FUNCTION digger.recompute_priority_for_release" in sql
+    assert "FUNCTION digger.uwp_after_change" in sql
+    assert "CREATE TRIGGER trg_uwp_recompute" in sql
+    assert "AFTER INSERT OR UPDATE OR DELETE ON digger.user_wantlist_priorities" in sql
+
+
+def test_trigger_encodes_tier_precedence() -> None:
+    sql = DIGGER_SCHEMA_SQL
+    # must wins over nice wins over eventually in the CASE ladder
+    must_at = sql.find("bool_or(tier = 'must')")
+    nice_at = sql.find("bool_or(tier = 'nice')")
+    assert must_at != -1 and nice_at != -1
+    assert must_at < nice_at, "must must be evaluated before nice in the precedence ladder"

--- a/tests/schema-init/test_digger_schema.py
+++ b/tests/schema-init/test_digger_schema.py
@@ -1,0 +1,36 @@
+from digger_schema import DIGGER_SCHEMA_SQL
+
+
+def test_digger_schema_sql_creates_schema_and_enums():
+    sql = DIGGER_SCHEMA_SQL
+    assert "CREATE SCHEMA IF NOT EXISTS digger" in sql
+    for enum_name in (
+        "priority_tier",
+        "condition",
+        "sleeve_condition",
+        "region",
+        "cadence",
+        "model",
+        "report_kind",
+        "change_flag",
+        "confidence",
+        "proposal_status",
+        "role",
+    ):
+        assert f"CREATE TYPE digger.{enum_name}" in sql
+
+
+def test_digger_schema_sql_creates_all_tables():
+    sql = DIGGER_SCHEMA_SQL
+    for table in (
+        "release_scrape_state",
+        "sellers",
+        "listings",
+        "user_wantlist_priorities",
+        "user_digger_settings",
+        "reports",
+        "proposals",
+        "agent_sessions",
+        "agent_messages",
+    ):
+        assert f"CREATE TABLE IF NOT EXISTS digger.{table}" in sql

--- a/tests/schema-init/test_digger_schema_integration.py
+++ b/tests/schema-init/test_digger_schema_integration.py
@@ -1,0 +1,37 @@
+"""Verify create_postgres_schema applies the digger feature schema.
+
+Mock-based (repo convention) — there is no real-Postgres unit fixture, and
+`just test` runs `-m 'not e2e'`. Real behavioral verification of the applied
+schema (tables actually exist) lives in the M1 e2e smoke (Task 28).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from postgres_schema import create_postgres_schema
+
+
+@pytest.fixture
+def mock_pool() -> MagicMock:
+    """Mock AsyncPostgreSQLPool: pool.connection() -> conn -> conn.cursor()."""
+    pool = MagicMock()
+    conn = AsyncMock()
+    cur = AsyncMock()
+    cur.__aenter__ = AsyncMock(return_value=cur)
+    cur.__aexit__ = AsyncMock(return_value=False)
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=False)
+    conn.cursor = MagicMock(return_value=cur)  # cursor() is sync, returns an async CM
+    pool.connection.return_value = conn
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_create_postgres_schema_applies_digger_schema(mock_pool: MagicMock) -> None:
+    await create_postgres_schema(mock_pool)
+    cur = mock_pool.connection.return_value.cursor.return_value
+    executed = [c.args[0] for c in cur.execute.call_args_list if c.args]
+    assert any(isinstance(stmt, str) and "CREATE SCHEMA IF NOT EXISTS digger" in stmt for stmt in executed), (
+        "digger schema SQL was not executed by create_postgres_schema"
+    )

--- a/tests/schema-init/test_digger_schema_integration.py
+++ b/tests/schema-init/test_digger_schema_integration.py
@@ -30,7 +30,7 @@ def mock_pool() -> MagicMock:
 @pytest.mark.asyncio
 async def test_create_postgres_schema_applies_digger_schema(mock_pool: MagicMock) -> None:
     await create_postgres_schema(mock_pool)
-    cur = mock_pool.connection.return_value.cursor.return_value
+    cur = mock_pool.connection.return_value.__aenter__.return_value.cursor.return_value
     executed = [c.args[0] for c in cur.execute.call_args_list if c.args]
     assert any(isinstance(stmt, str) and "CREATE SCHEMA IF NOT EXISTS digger" in stmt for stmt in executed), (
         "digger schema SQL was not executed by create_postgres_schema"

--- a/tests/schema-init/test_postgres_schema.py
+++ b/tests/schema-init/test_postgres_schema.py
@@ -117,6 +117,7 @@ class TestCreatePostgresSchema:
         cursor = mock_pool.connection.return_value.__aenter__.return_value.cursor.return_value
         # 3 statements per entity table (CREATE TABLE + hash index + updated_at index)
         # + specific indexes + user tables + insights tables + musicbrainz tables/indexes
+        # + 1 for the digger feature schema (single multi-statement DDL call)
         expected_calls = (
             len(_ENTITY_TABLES) * 3
             + len(_SPECIFIC_INDEXES)
@@ -124,6 +125,7 @@ class TestCreatePostgresSchema:
             + len(_INSIGHTS_TABLES)
             + len(_MUSICBRAINZ_TABLES)
             + len(_MUSICBRAINZ_INDEXES)
+            + 1  # digger feature schema
         )
         assert cursor.execute.await_count == expected_calls
 
@@ -151,6 +153,7 @@ class TestCreatePostgresSchema:
             + len(_INSIGHTS_TABLES)
             + len(_MUSICBRAINZ_TABLES)
             + len(_MUSICBRAINZ_INDEXES)
+            + 1  # digger feature schema
         )
         assert cursor.execute.await_count == expected_calls
 
@@ -186,6 +189,7 @@ class TestCreatePostgresSchema:
             + len(_INSIGHTS_TABLES)
             + len(_MUSICBRAINZ_TABLES)
             + len(_MUSICBRAINZ_INDEXES)
+            + 1  # digger feature schema
         )
         assert cursor.execute.await_count == expected_calls
 

--- a/tests/schema-init/test_postgres_schema.py
+++ b/tests/schema-init/test_postgres_schema.py
@@ -171,7 +171,12 @@ class TestCreatePostgresSchema:
         await create_postgres_schema(mock_pool)
 
         for stmt in captured:
-            assert "IF NOT EXISTS" in stmt.upper(), f"Statement is not idempotent: {stmt[:80]}..."
+            upper = stmt.upper()
+            assert "IF NOT EXISTS" in upper, f"Statement is not idempotent: {stmt[:80]}..."
+            # A multi-statement blob could still hide an un-guarded DROP that would
+            # not be idempotent — any DROP must be guarded with IF EXISTS.
+            if "DROP " in upper:
+                assert "IF EXISTS" in upper, f"Statement contains an un-guarded DROP: {stmt[:80]}..."
 
     @pytest.mark.asyncio
     async def test_all_fail_gracefully(self, mock_pool: MagicMock) -> None:


### PR DESCRIPTION
## Summary

First PR of the **Digger** feature (M1, layer 1 of ~5). This is **schema-only and purely additive** — it creates the `digger` Postgres schema and wires it into schema-init. Nothing consumes it yet; the digger worker/scraper, optimizer, API routers, and explore UI land in later layer PRs.

- **`digger` schema** (`schema-init/digger_schema.py`): 11 enums; 9 tables (`release_scrape_state`, `sellers`, `listings`, `user_wantlist_priorities`, `user_digger_settings`, `reports`, `proposals`, `agent_sessions`, `agent_messages`); supporting indexes.
- **Priority trigger**: maintains `release_scrape_state.priority_tier` as the max tier (`must > nice > eventually`) across all users wanting a release on INSERT/UPDATE/DELETE of `user_wantlist_priorities`; resets to `eventually` when the last wanter leaves.
- **Schema-init wiring** (`schema-init/postgres_schema.py`): applies `DIGGER_SCHEMA_SQL` after the user tables exist (FKs target `users(id)`), idempotent.
- **Wantlist sync hook** (`api/syncer.py`): `sync_wantlist()` now seeds default `user_wantlist_priorities` rows (tier `nice`) per synced release — batched per page (one pooled connection + `executemany`) and wrapped so a seeding failure logs a warning but never aborts the wantlist sync.
- **Plan reconciliation**: the M1 plan's schema-layer tasks (1–4) were corrected to real repo conventions (async **psycopg3**, `users(id)` FK, top-level imports, `tests/schema-init/`, mock-based tests). Later tasks (5–29) will be reconciled as each layer is built.

## Notes

- Idempotent (`IF NOT EXISTS` / `DO`-guards / `CREATE OR REPLACE`), targets PG18, safe to merge independently — no existing behavior changes for current users.
- Per repo convention, unit tests are mock/structural (no real-Postgres fixture exists). Real-DB behavior (schema apply, trigger semantics) is deferred to the M1 e2e smoke (Task 28, a later PR).

## Test plan

- [x] `uv run pytest tests/schema-init/ tests/api/` — green
- [x] Pre-commit (ruff, ruff-format, mypy, bandit) — green on all changed files
- [x] CI green
- [x] Reviewer sanity check

🤖 Generated with [Claude Code](https://claude.com/claude-code)