### PR TITLE
chore: update-project.sh ⇄ phaze parity (floor-sync, cap-flag, full action SHA-pinning)

### DIFF
--- a/.github/actions/docker-build-cache/action.yml
+++ b/.github/actions/docker-build-cache/action.yml
@@ -47,7 +47,7 @@ runs:
     - name: 💾 Cache Docker layers
       id: docker-cache
       if: inputs.use-cache == 'true'
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
       with:
         path: ${{ runner.temp }}/.buildx-cache
         # Primary key based on dependencies only (no github.sha)

--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -17,19 +17,19 @@ runs:
   using: composite
   steps:
     - name: 📦 Install uv
-      uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
+      uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v6.4.3
       with:
         version: latest
         enable-cache: true
         cache-dependency-glob: ${{ inputs.cache-dependency-glob }}
 
     - name: 🐍 Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: 💾 Cache virtualenv
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
       with:
         path: .venv
         key: ${{ runner.os }}-python-${{ inputs.python-version }}-${{ hashFiles('**/uv.lock', '**/pyproject.toml') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       code-changed: ${{ steps.filter.outputs.code-changed }}
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -209,7 +209,7 @@ jobs:
           echo "IMAGE_NAME=$(echo "${{ github.repository }}" | tr "[:upper:]" "[:lower:]")" >> "$GITHUB_ENV"
 
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
 
@@ -233,14 +233,14 @@ jobs:
 
       - name: 🔒 Log in to the GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🛡️ Anchore security scan - discogsography/${{ matrix.name }}
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
         with:
           path: ${{ matrix.name }}
 
@@ -262,7 +262,7 @@ jobs:
 
       - name: 📊 Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.name }}
           tags: |
@@ -272,7 +272,7 @@ jobs:
             type=schedule,pattern={{date 'YYYYMMDD'}}
 
       - name: 🔧 Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
         with:
           platforms: linux/amd64
           driver-opts: |
@@ -280,7 +280,7 @@ jobs:
             network=host
 
       - name: 🚀 Build and push Docker image to GitHub Container Registry - discogsography/${{ matrix.name }}
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           file: ${{ matrix.name }}/Dockerfile

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,13 +23,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84  # v1.0.127
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,13 +27,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84  # v1.0.127
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: 🧹 Cleanup Docker Images - ${{ matrix.package }}
-        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
+        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4  # v1.0.16
         with:
           delete-partial-images: true
           delete-untagged: true

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 🔧 Setup Python and UV
         uses: ./.github/actions/setup-python-uv
@@ -28,12 +28,12 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: 🔧 Setup Just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 💾 Cache pre-commit
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-pre-commit-v3-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -42,7 +42,7 @@ jobs:
 
       # Tools cache (arkade)
       - name: 💾 Cache tools
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.arkade
           key: ${{ runner.os }}-tools-arkade-v1
@@ -51,17 +51,18 @@ jobs:
             ${{ runner.os }}-tools-
 
       - name: 🔧 Install arkade
-        uses: alexellis/arkade-get@1eef818e467c387d3f50cfe0d2c565d1cbe82b03 # master
+        uses: alexellis/arkade-get@1eef818e467c387d3f50cfe0d2c565d1cbe82b03  # master
         with:
           hadolint: latest
 
       - name: 🦀 Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: 💾 Cache Rust dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/docker-compose-validate.yml
+++ b/.github/workflows/docker-compose-validate.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 🔧 Install docker-compose
-        uses: alexellis/arkade-get@1eef818e467c387d3f50cfe0d2c565d1cbe82b03 # master
+        uses: alexellis/arkade-get@1eef818e467c387d3f50cfe0d2c565d1cbe82b03  # master
         with:
           docker-compose: ${{ env.COMPOSE_VERSION }}
 

--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 🔧 Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
       - name: 🔍 Validate Dockerfile with hadolint
-        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         with:
           dockerfile: ${{ matrix.sub-project }}/Dockerfile
           failure-threshold: error

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 🔧 Setup Python and UV
         uses: ./.github/actions/setup-python-uv
@@ -73,12 +73,12 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: 🔧 Setup Just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "🔧 Setup Node.js"
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -86,7 +86,7 @@ jobs:
 
       # Browser cache (Playwright)
       - name: 🌐 Cache Playwright browsers
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
             ~/.cache/ms-playwright
@@ -167,7 +167,7 @@ jobs:
 
       - name: 📤 Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: playwright-results-${{ matrix.os }}-${{ matrix.browser }}-${{ matrix.device || 'desktop' }}
           path: test-results/
@@ -177,7 +177,7 @@ jobs:
 
       - name: 🎥 Upload test videos
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: playwright-videos-${{ matrix.os }}-${{ matrix.browser }}-${{ matrix.device || 'desktop' }}
           path: test-results/**/*.webm
@@ -187,7 +187,7 @@ jobs:
 
       - name: 📊 Upload E2E coverage to Codecov
         if: always()  # Upload coverage even if tests fail
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: SimplicityGuy/discogsography
@@ -203,7 +203,7 @@ jobs:
 
       - name: "📊 Upload E2E JS coverage to Codecov"
         if: always()
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: SimplicityGuy/discogsography
@@ -216,7 +216,7 @@ jobs:
 
       - name: 📊 E2E Coverage Report
         if: github.event_name == 'pull_request' && steps.coverage-setup.outputs.coverage-exists == 'true'
-        uses: slavcodev/coverage-monitor-action@398c4cbbb710e549a8407fdef96ae8b9454d0463 # v1.10.0
+        uses: slavcodev/coverage-monitor-action@398c4cbbb710e549a8407fdef96ae8b9454d0463  # v1.10.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           coverage_path: "coverage-summary.json"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 🔧 Setup Python and UV
         uses: ./.github/actions/setup-python-uv
@@ -34,7 +34,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: 🔧 Setup Just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -48,7 +48,7 @@ jobs:
         run: just security
 
       - name: 🌐 Run osv-scanner (multi-ecosystem vulnerability scan)
-        uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2  # v2.3.8
 
   semgrep:
     name: Semgrep CE Scan
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 🔬 Run semgrep scan
         run: semgrep scan --config auto --error --sarif --output semgrep.sarif
@@ -88,7 +88,7 @@ jobs:
         if: always()
 
       - name: 📤 Upload SARIF to GitHub Advanced Security
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4.35.5
         with:
           sarif_file: semgrep.sarif
         if: always()
@@ -100,13 +100,15 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 🦀 Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
 
       - name: 💾 Cache Rust dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
             ~/.cargo/bin/
@@ -120,12 +122,12 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: 📦 Install cargo-audit and cargo-deny
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d  # v2.79.2
         with:
           tool: cargo-audit,cargo-deny
 
       - name: 🔧 Setup Just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -142,12 +144,12 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0 # Full history required for comprehensive secret scanning
 
       - name: 🔑 Run TruffleHog (secret detection)
-        uses: trufflesecurity/trufflehog@v3.95.3
+        uses: trufflesecurity/trufflehog@37b77001d0174ebec2fcca2bd83ff83a6d45a3ab  # v3.95.3
         with:
           path: ./
           extra_args: --only-verified
@@ -159,10 +161,10 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 🛡️ Run trivy (filesystem vulnerability scan)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -171,7 +173,7 @@ jobs:
           severity: HIGH,CRITICAL
 
       - name: 📤 Upload trivy SARIF results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4.35.5
         if: always()
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 🔧 Setup Python and UV
         uses: ./.github/actions/setup-python-uv
@@ -37,7 +37,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: 🔧 Setup Just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: 📊 Upload coverage (api)
         if: always()
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: SimplicityGuy/discogsography
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 🔧 Setup Python and UV
         uses: ./.github/actions/setup-python-uv
@@ -77,7 +77,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: 🔧 Setup Just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -89,7 +89,7 @@ jobs:
 
       - name: 📊 Upload coverage (common)
         if: always()
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: SimplicityGuy/discogsography
@@ -109,7 +109,7 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 🔧 Setup Python and UV
         uses: ./.github/actions/setup-python-uv
@@ -117,7 +117,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: 🔧 Setup Just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -134,7 +134,7 @@ jobs:
 
       - name: 📊 Upload coverage (dashboard)
         if: always()
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: SimplicityGuy/discogsography
@@ -154,7 +154,7 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 🔧 Setup Python and UV
         uses: ./.github/actions/setup-python-uv
@@ -162,7 +162,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: 🔧 Setup Just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -174,7 +174,7 @@ jobs:
 
       - name: 📊 Upload coverage (explore)
         if: always()
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: SimplicityGuy/discogsography
@@ -194,7 +194,7 @@ jobs:
 
     steps:
       - name: "🔀 Checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: "🔧 Setup Python and UV"
         uses: ./.github/actions/setup-python-uv
@@ -202,7 +202,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: "🔧 Setup Just"
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -214,7 +214,7 @@ jobs:
 
       - name: "📊 Upload coverage (insights)"
         if: always()
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: SimplicityGuy/discogsography
@@ -234,7 +234,7 @@ jobs:
 
     steps:
       - name: "🔀 Checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: "🔧 Setup Python and UV"
         uses: ./.github/actions/setup-python-uv
@@ -242,7 +242,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: "🔧 Setup Just"
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -254,7 +254,7 @@ jobs:
 
       - name: "📊 Upload coverage (mcp-server)"
         if: always()
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: SimplicityGuy/discogsography
@@ -274,7 +274,7 @@ jobs:
 
     steps:
       - name: "🔀 Checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: "🔧 Setup Python and UV"
         uses: ./.github/actions/setup-python-uv
@@ -282,7 +282,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: "🔧 Setup Just"
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -294,7 +294,7 @@ jobs:
 
       - name: "📊 Upload coverage (brainzgraphinator)"
         if: always()
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: SimplicityGuy/discogsography
@@ -314,7 +314,7 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 🔧 Setup Python and UV
         uses: ./.github/actions/setup-python-uv
@@ -322,7 +322,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: 🔧 Setup Just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -334,7 +334,7 @@ jobs:
 
       - name: 📊 Upload coverage (graphinator)
         if: always()
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: SimplicityGuy/discogsography
@@ -354,7 +354,7 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 🔧 Setup Python and UV
         uses: ./.github/actions/setup-python-uv
@@ -362,7 +362,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: 🔧 Setup Just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -374,7 +374,7 @@ jobs:
 
       - name: 📊 Upload coverage (schema-init)
         if: always()
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: SimplicityGuy/discogsography
@@ -394,7 +394,7 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 🔧 Setup Python and UV
         uses: ./.github/actions/setup-python-uv
@@ -402,7 +402,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: 🔧 Setup Just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -414,7 +414,7 @@ jobs:
 
       - name: 📊 Upload coverage (tableinator)
         if: always()
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: SimplicityGuy/discogsography
@@ -434,7 +434,7 @@ jobs:
 
     steps:
       - name: "🔀 Checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: "🔧 Setup Python and UV"
         uses: ./.github/actions/setup-python-uv
@@ -442,7 +442,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: "🔧 Setup Just"
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -454,7 +454,7 @@ jobs:
 
       - name: "📊 Upload coverage (brainztableinator)"
         if: always()
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: SimplicityGuy/discogsography
@@ -474,17 +474,17 @@ jobs:
 
     steps:
       - name: "🔀 Checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: "🔧 Setup Node.js"
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: explore/package-lock.json
 
       - name: "🔧 Setup Just"
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -496,7 +496,7 @@ jobs:
 
       - name: "📊 Upload coverage (explore-js)"
         if: always()
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: SimplicityGuy/discogsography
@@ -516,7 +516,7 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: 🔍 Check if Rust extractor exists
         id: check-rust
@@ -537,23 +537,26 @@ jobs:
 
       - name: 🔧 Setup Just
         if: steps.check-rust.outputs.exists == 'true'
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🦀 Setup Rust toolchain
         if: steps.check-rust.outputs.exists == 'true'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
+          toolchain: stable
           components: llvm-tools-preview
 
       - name: 📦 Install cargo-llvm-cov
         if: steps.check-rust.outputs.exists == 'true'
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d  # v2.79.2
+        with:
+          tool: cargo-llvm-cov
 
       - name: 💾 Cache Rust dependencies
         if: steps.check-rust.outputs.exists == 'true'
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
             ~/.cargo/bin/
@@ -572,7 +575,7 @@ jobs:
 
       - name: 📊 Upload Rust coverage reports
         if: steps.check-rust.outputs.exists == 'true'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: SimplicityGuy/discogsography

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: 🔀 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -44,12 +44,12 @@ jobs:
           python-version: "3.13"
 
       - name: 🔧 Setup Just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
 
       # hadolint is required by the `just lint` pre-commit hook invoked
       # indirectly from scripts/update-project.sh. Mirrors code-quality.yml.
       - name: 🔧 Install hadolint
-        uses: alexellis/arkade-get@1eef818e467c387d3f50cfe0d2c565d1cbe82b03 # master
+        uses: alexellis/arkade-get@1eef818e467c387d3f50cfe0d2c565d1cbe82b03  # master
         with:
           hadolint: latest
 
@@ -137,7 +137,7 @@ jobs:
 
       - name: 📤 Upload update logs
         if: always() && steps.update.outputs.no_changes != 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: update-logs
           path: |
@@ -153,7 +153,7 @@ jobs:
       - name: 📝 Create Pull Request
         if: steps.update.outputs.no_changes != 'true'
         id: create-pr
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v.8.1.1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: automation/updates

--- a/scripts/update-project.sh
+++ b/scripts/update-project.sh
@@ -5,17 +5,24 @@
 # This script provides a safe and comprehensive way to update:
 # - Python version across all project files
 # - Python package dependencies via uv (all version types)
+# - Dependency floors (>=) in every pyproject.toml, raised to match uv.lock
 # - Rust crate dependencies in Rust extractor (main, dev, build)
 # - Node.js dependencies in Explore frontend tests (npm)
-# - UV package manager version in Dockerfiles and GitHub workflows
+# - UV package manager version in Dockerfiles and GitHub workflows/actions
 # - Pre-commit hooks to latest versions
-# - Docker base images to latest versions
+# - Docker dependency review (FROM base images, uv image, compose service images)
+#
+# It also flags capped dependencies (those with a ',<X' upper bound) that have a
+# newer release available beyond the cap, so they can be reviewed manually.
 #
 # Tool invocations delegate to `just` commands wherever possible, keeping the
 # justfile as the single source of truth for command definitions.
 #
 # Ecosystem behavior:
-#   Python (uv):  uv lock --upgrade respects >=X.Y constraints (includes majors)
+#   Python (uv):  uv lock --upgrade refreshes uv.lock within the existing >=X.Y
+#                 floors (this includes majors). It never raises the floors
+#                 themselves, so sync_dependency_floors() does that after the lock
+#                 so pyproject.toml minimums track what is actually resolved.
 #   Rust (cargo): minor/patch = cargo update (lock file only)
 #                 major (--major) = cargo upgrade --incompatible + cargo update
 #
@@ -385,43 +392,89 @@ update_uv_version() {
     print_success "UV version in Dockerfiles is already up to date ($current_uv)"
   fi
 
-  # Update GitHub workflows that use setup-uv action
-  print_info "Checking GitHub workflows for setup-uv updates..."
+  # Update setup-uv action references (workflows + composite actions).
+  # NOTE: setup-uv lives in .github/actions/setup-python-uv/action.yml in this
+  # repo, NOT in the workflows, so we must scan both trees. Pin format:
+  # astral-sh/setup-uv@<40-char-sha>  # vX.Y.Z  (two spaces before '#', matching
+  # the repo's SHA-pin convention so yamllint stays happy).
+  print_info "Checking GitHub Actions for setup-uv updates (workflows + composite actions)..."
 
-  for workflow in .github/workflows/*.yml; do
-    if [[ -f "$workflow" ]] && grep -q "astral-sh/setup-uv@" "$workflow"; then
-      local current_commit
-      current_commit=$(grep -oE "astral-sh/setup-uv@[a-f0-9]+" "$workflow" | head -1 | cut -d'@' -f2)
+  if [[ -n "$latest_setup_uv_commit" ]] && [[ "$latest_setup_uv_commit" != "null" ]]; then
+    local f
+    local setup_uv_files=()
+    while IFS= read -r f; do
+      [[ -n "$f" ]] && setup_uv_files+=("$f")
+    done < <(grep -rlE "astral-sh/setup-uv@" .github/workflows .github/actions 2>/dev/null || true)
 
+    local workflow current_commit
+    for workflow in "${setup_uv_files[@]:-}"; do
+      [[ -f "$workflow" ]] || continue
+      current_commit=$(grep -oE "astral-sh/setup-uv@[a-f0-9]{40}" "$workflow" | head -1 | cut -d'@' -f2)
       if [[ -n "$current_commit" ]] && [[ "$current_commit" != "$latest_setup_uv_commit" ]]; then
-        print_info "Updating setup-uv in $(basename "$workflow")"
-
         if [[ "$DRY_RUN" == false ]]; then
           backup_file "$workflow"
-
-          # Update the action reference
+          # Replace the ref AND its version comment in one shot so the SHA and the
+          # `# vX.Y.Z` comment always stay in sync (two spaces before '#').
           if [[ "$OSTYPE" == "darwin"* ]]; then
-            sed -i '' "s/astral-sh\/setup-uv@[a-f0-9]\{40\}/astral-sh\/setup-uv@$latest_setup_uv_commit/g" "$workflow"
-            # Update the comment with version number
-            sed -i '' "s/# v[0-9.]\+/# $latest_setup_uv/g" "$workflow"
+            sed -i '' "s|\(astral-sh/setup-uv@\).*|\1$latest_setup_uv_commit  # $latest_setup_uv|" "$workflow"
           else
-            sed -i "s/astral-sh\/setup-uv@[a-f0-9]\{40\}/astral-sh\/setup-uv@$latest_setup_uv_commit/g" "$workflow"
-            sed -i "s/# v[0-9.]\+/# $latest_setup_uv/g" "$workflow"
+            sed -i "s|\(astral-sh/setup-uv@\).*|\1$latest_setup_uv_commit  # $latest_setup_uv|" "$workflow"
           fi
-
-          print_success "Updated $(basename "$workflow")"
-          WORKFLOW_CHANGES+=("$(basename "$workflow"): setup-uv ${current_commit:0:7} → ${latest_setup_uv_commit:0:7}")
+          print_success "Updated ${workflow#./} (setup-uv → ${latest_setup_uv_commit:0:7} $latest_setup_uv)"
+          WORKFLOW_CHANGES+=("${workflow#./}: setup-uv ${current_commit:0:7} → ${latest_setup_uv_commit:0:7}")
           CHANGES_MADE=true
         else
-          print_info "[DRY RUN] Would update setup-uv in $(basename "$workflow")"
+          print_info "[DRY RUN] Would update setup-uv in ${workflow#./}"
         fi
       fi
-    fi
-  done
+    done
+  fi
 
   if [[ $(array_length WORKFLOW_CHANGES) -eq 0 ]]; then
-    print_success "GitHub workflows are already up to date"
+    print_success "setup-uv action is already up to date"
   fi
+}
+
+# Review the full Docker dependency surface.
+#
+# This SURFACES every Docker dependency so nothing is silently missed; it does
+# not mutate anything itself. Division of labour:
+#   - uv binary image (ghcr.io/astral-sh/uv) -> bumped by update_uv_version()
+#   - Python base image (python:X-slim)      -> bumped by update_python_version() (--python)
+#   - other FROM base images (node, rust, debian) + docker-compose service
+#     images (postgres, neo4j, rabbitmq, redis, ...) -> tracked by Dependabot's
+#     docker group
+#   - apt packages -> intentionally unpinned / distro-managed (see DL3008 pragmas)
+update_docker_images() {
+  print_section "$EMOJI_DOCKER" "Reviewing Docker Dependencies"
+
+  local dockerfiles=()
+  while IFS= read -r df; do
+    [[ -n "$df" ]] && dockerfiles+=("$df")
+  done < <(find . -maxdepth 3 -name "Dockerfile" -type f \
+    -not -path './.worktrees/*' -not -path './.claude/*' -not -path './backups/*' | sort)
+
+  local df matches
+  print_info "Base + tool images in Dockerfiles (FROM lines and the uv image):"
+  for df in "${dockerfiles[@]:-}"; do
+    [[ -f "$df" ]] || continue
+    matches=$(grep -nE "^FROM |ghcr.io/astral-sh/uv:" "$df" 2>/dev/null) || true
+    [[ -n "$matches" ]] && echo "$matches" | sed "s|^|  ${df#./}:|"
+  done
+
+  local compose
+  print_info "Service images in docker-compose:"
+  for compose in docker-compose*.yml; do
+    [[ -f "$compose" ]] || continue
+    matches=$(grep -nE "^[[:space:]]*image:" "$compose" 2>/dev/null) || true
+    [[ -n "$matches" ]] && echo "$matches" | sed "s|^|  $compose:|"
+  done
+
+  print_info "Dependency ownership:"
+  print_info "  • uv image (ghcr.io/astral-sh/uv)   → managed by update_uv_version()"
+  print_info "  • Python base (python:X-slim)       → managed by --python"
+  print_info "  • Other FROM tags (node, rust, debian) + compose service images → Dependabot docker group"
+  print_info "  • apt packages                      → distro-managed (intentionally unpinned; see 'hadolint ignore=DL3008')"
 }
 
 # Update pre-commit hooks to latest versions
@@ -498,6 +551,7 @@ verify_dependency_updates() {
   print_success "✓ Python optional dependencies ([project.optional-dependencies])"
   print_success "✓ Python dev dependencies ([dependency-groups])"
   print_success "✓ Python build dependencies ([build-system])"
+  print_success "✓ Python dependency floors raised to match uv.lock (root + members)"
 
   # Rust dependencies
   if [[ -f "extractor/Cargo.toml" ]]; then
@@ -732,6 +786,269 @@ update_python_packages() {
     print_success "Completed Python dependency updates"
   else
     print_info "[DRY RUN] Would run: just sync"
+  fi
+}
+
+# Raise the `>=` floors in every pyproject.toml to match the versions actually
+# pinned in the single root uv.lock.
+#
+# `uv lock --upgrade` refreshes the lockfile WITHIN the existing floors but never
+# raises the floors themselves — this is the gap Dependabot otherwise opens PRs
+# for. This closes it so the declared minimums track what is actually resolved.
+#
+# Monorepo specifics: this is a uv WORKSPACE with one root uv.lock, so we iterate
+# the root pyproject.toml AND every workspace member, resolving each requirement
+# against that single lock. We cover [project.dependencies],
+# [project.optional-dependencies].* sub-arrays and [dependency-groups].*, and we
+# rewrite ONLY the `>=` floor token — caps (`,<X`), extras (`pkg[redis]`), env
+# markers (`; sys_platform ...`) and trailing inline comments are preserved. The
+# editing is line-based (tomllib cannot write), then we re-run `uv lock` so the
+# lockfile's recorded requirement metadata matches the raised floors.
+sync_dependency_floors() {
+  print_section "$EMOJI_PACKAGE" "Syncing Dependency Floors"
+
+  local apply_val=1
+  [[ "$DRY_RUN" == true ]] && apply_val=0
+
+  local output
+  output=$(
+    APPLY="$apply_val" uv run python - <<'PY'
+import os
+import re
+import tomllib
+from pathlib import Path
+
+apply = os.environ.get("APPLY") == "1"
+
+try:
+    from packaging.version import InvalidVersion, Version
+
+    def strictly_newer(candidate: str, current: str) -> bool:
+        try:
+            return Version(candidate) > Version(current)
+        except InvalidVersion:
+            # uv.lock always resolves at or above the floor, so default to True.
+            return True
+except ImportError:  # packaging should be present, but never block on it.
+
+    def strictly_newer(candidate: str, current: str) -> bool:
+        return True
+
+
+# Discover every pyproject.toml in the workspace: root + members.
+root = Path("pyproject.toml")
+root_data = tomllib.loads(root.read_text())
+members = root_data.get("tool", {}).get("uv", {}).get("workspace", {}).get("members", [])
+pyprojects = [root]
+for member in members:
+    candidate = Path(member) / "pyproject.toml"
+    if candidate.exists():
+        pyprojects.append(candidate)
+
+# Resolve every requirement against the single root uv.lock.
+lock = tomllib.loads(Path("uv.lock").read_text())
+locked = {p["name"].lower().replace("_", "-"): p["version"] for p in lock.get("package", [])}
+
+header_re = re.compile(r"^\[\[?(?P<name>[^\]]+)\]\]?\s*$")
+open_re = re.compile(r"^(?P<key>[A-Za-z0-9._-]+)\s*=\s*\[\s*(#.*)?$")
+close_re = re.compile(r"^\s*\]")
+entry_re = re.compile(r'^(?P<indent>\s*)"(?P<spec>[^"]+)"(?P<trail>.*)$')
+spec_re = re.compile(
+    r"^(?P<name>[A-Za-z0-9._-]+(?:\[[A-Za-z0-9._,-]+\])?)"
+    r"(?P<specs>[<>=!~][^;]*)?"
+    r"(?P<marker>;.*)?$"
+)
+floor_re = re.compile(r">=\s*([^,;\s]+)")
+
+total = 0
+for pyproject in pyprojects:
+    lines = pyproject.read_text().split("\n")
+    out: list[str] = []
+    section = ""
+    in_array = False
+    process = False
+    changes: list[tuple[str, str, str]] = []
+    for line in lines:
+        if not in_array:
+            header = header_re.match(line.strip())
+            if header:
+                section = header.group("name")
+                out.append(line)
+                continue
+            opener = open_re.match(line.strip())
+            if opener:
+                key = opener.group("key")
+                process = (
+                    (section == "project" and key == "dependencies")
+                    or section == "project.optional-dependencies"
+                    or section == "dependency-groups"
+                )
+                in_array = True
+                out.append(line)
+                continue
+            out.append(line)
+            continue
+        # Inside an array.
+        if close_re.match(line):
+            in_array = False
+            process = False
+            out.append(line)
+            continue
+        if process:
+            matched = entry_re.match(line)
+            if matched:
+                parsed = spec_re.match(matched.group("spec"))
+                specs = parsed.group("specs") if parsed else None
+                if parsed and specs:
+                    base = parsed.group("name").split("[")[0].lower().replace("_", "-")
+                    locked_version = locked.get(base)
+                    floor = floor_re.search(specs)
+                    if locked_version and floor:
+                        current = floor.group(1)
+                        if current != locked_version and strictly_newer(locked_version, current):
+                            new_specs = specs[: floor.start(1)] + locked_version + specs[floor.end(1) :]
+                            new_spec = parsed.group("name") + new_specs + (parsed.group("marker") or "")
+                            changes.append((base, current, locked_version))
+                            out.append(f'{matched.group("indent")}"{new_spec}"{matched.group("trail")}')
+                            continue
+        out.append(line)
+    for base, old, new in changes:
+        print(f"BUMPED {pyproject}: {base} {old} -> {new}")
+    if apply and changes:
+        pyproject.write_text("\n".join(out))
+    total += len(changes)
+
+print(f"FLOORS_CHANGED={total}")
+PY
+  )
+
+  echo "$output" | grep -E "^BUMPED " | sed 's/^BUMPED /  /' || true
+
+  local changed
+  changed=$(echo "$output" | sed -n 's/^FLOORS_CHANGED=//p')
+  changed=${changed:-0}
+
+  if [[ "$DRY_RUN" == true ]]; then
+    if [[ "$changed" -gt 0 ]]; then
+      print_info "[DRY RUN] Would raise $changed dependency floor(s) across pyproject.toml files to match uv.lock"
+    else
+      print_success "[DRY RUN] All dependency floors already match uv.lock"
+    fi
+    return
+  fi
+
+  if [[ "$changed" -gt 0 ]]; then
+    print_info "Re-locking so uv.lock requirement metadata matches the raised floors..."
+    uv lock >/dev/null 2>&1 || uv lock
+    CHANGES_MADE=true
+    FILE_CHANGES+=("pyproject.toml (root + members): raised $changed dependency floor(s) to match uv.lock")
+    print_success "Raised $changed dependency floor(s) to match uv.lock"
+  else
+    print_success "All dependency floors already match uv.lock"
+  fi
+}
+
+# Flag capped dependencies (`,<X` upper bound) with a release available AT OR
+# BEYOND the cap. `uv lock --upgrade` cannot cross a cap on its own, so raising
+# it is a deliberate human decision — we only warn, never edit.
+#
+# Monorepo specifics: caps are parsed from ALL pyproject.toml files (root +
+# members) across [project.dependencies], [project.optional-dependencies] and
+# [dependency-groups]. We cross-reference `uv pip list --outdated`, compare with
+# packaging.version, and skip the workspace's own packages (discogsography*).
+flag_capped_dependencies() {
+  print_section "$EMOJI_VERIFY" "Checking Capped Dependencies"
+
+  if [[ "$DRY_RUN" == true ]]; then
+    print_info "[DRY RUN] Would flag capped dependencies with releases beyond their cap"
+    return
+  fi
+
+  local outdated
+  outdated=$(uv pip list --outdated 2>/dev/null) || true
+
+  local output
+  output=$(
+    OUTDATED="$outdated" uv run python - <<'PY'
+import os
+import re
+import tomllib
+from pathlib import Path
+
+try:
+    from packaging.version import InvalidVersion, Version
+
+    def at_or_beyond_cap(latest: str, cap: str) -> bool:
+        try:
+            return Version(latest) >= Version(cap)
+        except InvalidVersion:
+            return True
+except ImportError:
+
+    def at_or_beyond_cap(latest: str, cap: str) -> bool:
+        return True
+
+
+root_data = tomllib.loads(Path("pyproject.toml").read_text())
+members = root_data.get("tool", {}).get("uv", {}).get("workspace", {}).get("members", [])
+pyprojects = [Path("pyproject.toml")] + [Path(m) / "pyproject.toml" for m in members]
+
+name_re = re.compile(r"^([A-Za-z0-9._-]+)")
+cap_re = re.compile(r"<\s*([0-9][^,;\s]*)")
+caps: dict[str, str] = {}
+own: set[str] = set()
+
+for pyproject in pyprojects:
+    if not pyproject.exists():
+        continue
+    try:
+        data = tomllib.loads(pyproject.read_text())
+    except tomllib.TOMLDecodeError:
+        continue
+    project = data.get("project", {})
+    own_name = project.get("name")
+    if own_name:
+        own.add(own_name.lower().replace("_", "-"))
+    specs: list[str] = list(project.get("dependencies", []))
+    for group in project.get("optional-dependencies", {}).values():
+        specs.extend(s for s in group if isinstance(s, str))
+    for group in data.get("dependency-groups", {}).values():
+        specs.extend(s for s in group if isinstance(s, str))
+    for spec in specs:
+        name_match = name_re.match(spec)
+        cap_match = cap_re.search(spec.split(";")[0])
+        if name_match and cap_match:
+            caps[name_match.group(1).lower().replace("_", "-")] = cap_match.group(1)
+
+latest: dict[str, str] = {}
+for raw in os.environ.get("OUTDATED", "").splitlines():
+    parts = raw.split()
+    if len(parts) >= 3 and parts[0] != "Package" and not parts[0].startswith("-"):
+        latest[parts[0].lower().replace("_", "-")] = parts[2]
+
+flagged = 0
+for name, cap in sorted(caps.items()):
+    if name in own:
+        continue
+    newest = latest.get(name)
+    if newest and at_or_beyond_cap(newest, cap):
+        print(f"FLAG {name}: {newest} available, capped at <{cap}")
+        flagged += 1
+print(f"CAPPED_FLAGGED={flagged}")
+PY
+  )
+
+  local flagged
+  flagged=$(echo "$output" | sed -n 's/^CAPPED_FLAGGED=//p')
+  flagged=${flagged:-0}
+
+  if [[ "$flagged" -gt 0 ]]; then
+    while IFS= read -r line; do
+      print_warning "${line#FLAG }"
+    done < <(echo "$output" | grep -E "^FLAG ")
+    print_info "Raise the cap in pyproject.toml manually, then re-run: just lock-upgrade && just sync"
+  else
+    print_success "No capped dependencies have releases beyond their cap"
   fi
 }
 
@@ -1341,14 +1658,23 @@ main() {
   # Update Python version if requested
   update_python_version
 
-  # Update UV version in Dockerfiles
+  # Update UV version in Dockerfiles and GitHub Actions
   update_uv_version
+
+  # Review the full Docker dependency surface (FROM images, uv image, compose)
+  update_docker_images
 
   # Update pre-commit hooks
   update_precommit_hooks
 
   # Update Python packages (ALL types: core, optional, dev, build)
   update_python_packages
+
+  # Raise pyproject.toml floors to match the freshly resolved uv.lock
+  sync_dependency_floors
+
+  # Warn about capped deps with releases available beyond their cap
+  flag_capped_dependencies
 
   # Update Rust crates (minor/patch via cargo update; major via cargo upgrade with --major)
   update_rust_crates


### PR DESCRIPTION
## Summary

Brings `scripts/update-project.sh` in line with phaze's enhanced updater
(phaze [#71](https://github.com/SimplicityGuy/phaze/pull/71), now merged), adapted to
discogsography's shape: a **uv workspace** (root `pyproject.toml` + 11 member packages,
single root `uv.lock`), a Rust extractor, and a Node frontend. All existing
Rust/Node/multi-service/security-sweep behavior is preserved.

> **Parity note:** `sync_dependency_floors()` and `flag_capped_dependencies()` did not
> exist in the shared lineage of these two scripts until phaze added them in #71.
> discogsography's updater lacked them; this PR adds the monorepo-adapted equivalents,
> bringing the two scripts back into parity. They are intentional new capabilities, not a
> regression.

## New capabilities

**1. `sync_dependency_floors()`** — runs right after the lock+sync step. `uv lock --upgrade`
refreshes `uv.lock` *within* the existing `>=` floors but never raises the floors themselves
(the job Dependabot otherwise opens PRs for). This raises the floors in `pyproject.toml` to
match what's actually locked.

- **Monorepo adaptation:** iterates **every** `pyproject.toml` (root + all 11 members) and
  resolves each against the **single root `uv.lock`**.
- Covers `[project.dependencies]`, every `[project.optional-dependencies].*` sub-array, and
  every `[dependency-groups].*` array.
- Rewrites **only** the `>=` floor token — caps (`,<X`), extras (`pkg[redis]`), env markers
  (`; sys_platform ...`) and trailing inline comments are preserved.
- Inline `uv run python` heredoc (`tomllib` + `packaging`), **not** a tracked `.py`
  (`scripts/` is type/lint-checked). Re-runs `uv lock` afterward so recorded requirement
  metadata matches. Honors `--dry-run`; prints one `BUMPED <file>: <pkg> <old> -> <new>`
  line per change (file-qualified for monorepo clarity).

**2. `flag_capped_dependencies()`** — warns when a `,<X`-capped dependency has a release at or
beyond the cap (uv can't cross a cap; raising it is a human decision). Cross-references
`uv pip list --outdated`, parses caps from **all** `pyproject.toml` files, compares with
`packaging.version`, and skips the workspace's own packages. Honors `--dry-run`.
*(discogsography currently has no capped deps, so this reports none — it's future-proofing.)*

## Parity audit (items 3–6)

3. **GitHub Actions SHA-pinning** — every `uses:` in `.github/workflows/` **and**
   `.github/actions/` is now `owner/repo@<40-char-sha>  # vX.Y.Z`. 18 floating actions
   resolved to SHAs; the 8 pre-existing pins normalized to the two-space comment style;
   `create-pull-request` comment fixed (`# v.8.1.1` → `# v8.1.1`).
   `dtolnay/rust-toolchain@stable` and `taiki-e/install-action@cargo-llvm-cov` are pinned
   with explicit `toolchain: stable` / `tool: cargo-llvm-cov` to preserve behavior after
   losing the channel/tool shorthand. `update_uv_version()` now also scans `.github/actions/`
   (setup-uv lives in the composite action here, not the workflows) and pins it the same way.
4. **Dockerfiles** — every `apt-get install` already carries a `# hadolint ignore=DL3008`
   pragma; confirmed `hadolint` is clean for all 11 Dockerfiles.
5. **Pre-commit** — confirmed `hadolint` runs in `.pre-commit-config.yaml`, every hook `rev:`
   has a `# frozen: vX.Y.Z` comment, and `shfmt` covers `scripts/update-project.sh`.
6. **`update_docker_images()`** — new function surfaces the full Docker dependency surface
   (all `FROM` base images incl. node/rust/debian, the uv image, and compose service images
   like postgres/neo4j/rabbitmq/redis), noting Dependabot-managed vs distro-managed (apt).

## Comment-spacing convention

The task spec mandated **two** spaces before `#`. This repo's `.yamllint` only requires
`min-spaces-from-content: 1` (so one space passes here — the "or yamllint fails" rule is
phaze's), and the 8 existing pins used one space. Per maintainer direction, all entries —
new and existing — are standardized to **two** spaces, and the script writes setup-uv pins
the same way. Heads-up: Dependabot writes one space, so it may re-introduce drift on future
action bumps.

## Validation

- `shellcheck --severity=warning` — clean
- `shfmt` (repo args) — clean
- `./scripts/update-project.sh --dry-run` — exits 0, exercises every section, writes nothing
- `pre-commit run --all-files` — 29/29 hooks pass
- Floor-sync write path tested in isolation: caps/extras/markers/inline comments preserved,
  no-op when locked == floor (dry-run reports 91 proposed floor bumps across the workspace)
- Cap-flag tested with synthetic `--outdated` data (flags correctly) and against the real
  workspace (reports none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
