### PR TITLE
fix(tests): correct root health-server 404 test broken by the /metrics branch

### DIFF
--- a/tests/test_health_server.py
+++ b/tests/test_health_server.py
@@ -134,7 +134,7 @@ class TestHealthHandlerDoGet:
     """Test HealthHandler.do_GET for the 404 path (lines 28-30)."""
 
     def test_do_get_returns_404_for_unknown_path(self) -> None:
-        """Test that do_GET sends 404 for paths other than /health (lines 28-30)."""
+        """Test that do_GET sends 404 for an unknown path (not /health or /metrics)."""
         from common.health_server import HealthHandler
 
         class TestHandler(HealthHandler):
@@ -143,7 +143,7 @@ class TestHealthHandlerDoGet:
                 pass
 
         handler = TestHandler()
-        handler.path = "/metrics"
+        handler.path = "/unknown"
 
         mock_send_response = MagicMock()
         mock_end_headers = MagicMock()


### PR DESCRIPTION
## Summary

`tests/test_health_server.py::TestHealthHandlerDoGet::test_do_get_returns_404_for_unknown_path` failed in the full local suite (`just test` / `update-deps`):

```
common/health_server.py:28: in do_GET
    elif self.path == "/metrics" and cast("HealthServer", self.server).metrics_enabled:
E   AttributeError: 'TestHandler' object has no attribute 'server'
```

**Cause:** this pre-existing test used `"/metrics"` as its arbitrary "unknown path" example. PR #339 turned `/metrics` into a real `HealthHandler` branch that reads `self.server.metrics_enabled` — and the test's server-less handler double has no `.server`, so it raised `AttributeError` instead of returning 404.

**Fix:** use `"/unknown"` (matching the test's name) so it exercises the 404/else branch without needing a server. The metrics-disabled→404 case is already covered by `tests/common/test_health_server.py::test_get_metrics_returns_404_when_metrics_disabled`.

## Why CI missed it
No per-service CI job runs **root-level** `tests/*.py` files (the per-service jobs run `tests/<service>/`). `tests/test_health_server.py` is only exercised by the full local `just test`. Worth a follow-up: either move this file under `tests/common/` (it duplicates the newer `tests/common/test_health_server.py`) or add a CI job that runs root-level tests.

## Test plan
- [x] `uv run pytest tests/test_health_server.py tests/common/test_health_server.py` — green on Python 3.13.13
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)