### PR TITLE
feat(digger): M1 API routers — query helpers, /api/digger/* endpoints, service-token internal router

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,11 @@ DISCOGS_ROOT=/discogs-data
 # Generate with: openssl rand -hex 32
 JWT_SECRET_KEY=CHANGE_ME_IN_PRODUCTION
 
+# Digger internal service token — shared secret between the API and the digger worker
+# Gate for /api/internal/digger/* endpoints; omit or leave empty to disable those endpoints
+# Generate with: openssl rand -hex 32
+DIGGER_API_SERVICE_TOKEN=
+
 # OAuth encryption key — Fernet symmetric key used to encrypt Discogs consumer keys and OAuth tokens at rest
 # Required in production; if unset, tokens are stored in plaintext
 # Generate with: uv run python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'

--- a/api/api.py
+++ b/api/api.py
@@ -45,6 +45,7 @@ import api.routers.explore as _explore_router
 import api.routers.extraction_analysis as _extraction_analysis_router
 import api.routers.insights as _insights_router
 import api.routers.insights_compute as _insights_compute_router
+import api.routers.internal_digger as _internal_digger_router
 import api.routers.label_dna as _label_dna_router
 import api.routers.musicbrainz as _musicbrainz_router
 import api.routers.network as _network_router
@@ -246,8 +247,9 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:  # pragma: no cover
         )
         logger.info("🔗 Neo4j driver initialized")
     jwt_secret_for_neo4j = _config.jwt_secret_key if _config.neo4j_host else None
-    _dependencies.configure(jwt_secret_for_neo4j, _redis, pool=_pool)
+    _dependencies.configure(jwt_secret_for_neo4j, _redis, pool=_pool, digger_api_service_token=_config.digger_api_service_token)
     _digger_router.configure(_pool)
+    _internal_digger_router.configure(_pool)
     _sync_router.configure(_pool, _neo4j, _config, _running_syncs, _redis)
     _explore_router.configure(_neo4j, jwt_secret_for_neo4j, _redis)
     _user_router.configure(_neo4j, jwt_secret_for_neo4j)
@@ -395,6 +397,7 @@ async def metrics_middleware(request: Request, call_next: Any) -> Any:
 
 app.include_router(_auth_router.router)
 app.include_router(_digger_router.router)
+app.include_router(_internal_digger_router.router)
 app.include_router(_sync_router.router)
 app.include_router(_explore_router.router)
 app.include_router(_insights_router.router)

--- a/api/api.py
+++ b/api/api.py
@@ -365,7 +365,7 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # ty
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins or ["http://localhost:3000", "http://localhost:8003"],
-    allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allow_headers=["Authorization", "Content-Type"],
 )
 

--- a/api/api.py
+++ b/api/api.py
@@ -40,6 +40,7 @@ import api.routers.admin as _admin_router
 import api.routers.auth as _auth_router
 import api.routers.collection as _collection_router
 import api.routers.credits as _credits_router
+import api.routers.digger as _digger_router
 import api.routers.explore as _explore_router
 import api.routers.extraction_analysis as _extraction_analysis_router
 import api.routers.insights as _insights_router
@@ -246,6 +247,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:  # pragma: no cover
         logger.info("🔗 Neo4j driver initialized")
     jwt_secret_for_neo4j = _config.jwt_secret_key if _config.neo4j_host else None
     _dependencies.configure(jwt_secret_for_neo4j, _redis, pool=_pool)
+    _digger_router.configure(_pool)
     _sync_router.configure(_pool, _neo4j, _config, _running_syncs, _redis)
     _explore_router.configure(_neo4j, jwt_secret_for_neo4j, _redis)
     _user_router.configure(_neo4j, jwt_secret_for_neo4j)
@@ -392,6 +394,7 @@ async def metrics_middleware(request: Request, call_next: Any) -> Any:
 
 
 app.include_router(_auth_router.router)
+app.include_router(_digger_router.router)
 app.include_router(_sync_router.router)
 app.include_router(_explore_router.router)
 app.include_router(_insights_router.router)

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -1,8 +1,9 @@
 """Shared FastAPI dependency functions for API routers."""
 
+import hmac
 from typing import Annotated, Any
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, Header, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from psycopg.rows import dict_row
 
@@ -13,13 +14,15 @@ _security = HTTPBearer(auto_error=False)
 _jwt_secret: str | None = None
 _redis: Any = None
 _pool: Any = None
+_digger_api_service_token: str | None = None
 
 
-def configure(jwt_secret: str | None, redis: Any = None, pool: Any = None) -> None:
-    global _jwt_secret, _redis, _pool
+def configure(jwt_secret: str | None, redis: Any = None, pool: Any = None, digger_api_service_token: str | None = None) -> None:
+    global _jwt_secret, _redis, _pool, _digger_api_service_token
     _jwt_secret = jwt_secret
     _redis = redis
     _pool = pool
+    _digger_api_service_token = digger_api_service_token
 
 
 async def get_optional_user(
@@ -83,6 +86,17 @@ async def require_user(
                     status_code=status.HTTP_401_UNAUTHORIZED, detail="Token invalidated by password change", headers={"WWW-Authenticate": "Bearer"}
                 )
     return payload
+
+
+def service_token_required(x_service_token: Annotated[str | None, Header()] = None) -> None:
+    """Gate internal endpoints behind the shared digger service token (constant-time check, fail-closed)."""
+    expected = _digger_api_service_token
+    if not expected or not x_service_token or not hmac.compare_digest(x_service_token, expected):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="missing or invalid service token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
 
 async def require_admin(

--- a/api/models.py
+++ b/api/models.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 import re
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -792,3 +792,67 @@ class PersonProfileResponse(BaseModel):
     artist_id: str | None = None
     artist_name: str | None = None
     role_breakdown: list[dict[str, Any]] = Field(default_factory=list)
+
+
+# ── Digger feature models ─────────────────────────────────────────────
+
+DiggerTier = Literal["must", "nice", "eventually"]
+DiggerCadence = Literal["off", "weekly", "biweekly", "monthly"]
+DiggerModel = Literal["haiku", "sonnet", "opus"]
+DiggerCondition = Literal["M", "NM", "VG+", "VG", "G+", "G", "F", "P"]
+DiggerSleeveCondition = Literal["M", "NM", "VG+", "VG", "G+", "G", "F", "P", "generic", "no_cover"]
+
+
+class DiggerSettingsIn(BaseModel):
+    """Request body for creating or updating a user's digger settings."""
+
+    enabled: bool
+    country_code: str | None = Field(default=None, min_length=2, max_length=2)
+    currency: str = Field(min_length=3, max_length=3)
+    scheduled_cadence: DiggerCadence
+    preferred_model: DiggerModel
+    daily_token_cap_interactive: int | None = None
+    daily_token_cap_scheduled: int | None = None
+
+
+class DiggerSettingsOut(DiggerSettingsIn):
+    """Response body for a user's digger settings."""
+
+    pass
+
+
+class DiggerWantlistItemOut(BaseModel):
+    """A single item from the user's digger wantlist."""
+
+    release_id: int
+    title: str | None
+    artist: str | None
+    year: int | None
+    tier: DiggerTier
+    min_media_condition: DiggerCondition
+    min_sleeve_condition: DiggerSleeveCondition
+    max_price_cents: int | None
+    active_listings: int
+    last_scraped_at: str | None
+
+
+class DiggerWantlistResponse(BaseModel):
+    """Response body for the user's digger wantlist."""
+
+    items: list[DiggerWantlistItemOut]
+
+
+class DiggerBulkTierIn(BaseModel):
+    """Request body for bulk-setting the tier on multiple wantlist releases."""
+
+    release_ids: list[int] = Field(min_length=1, max_length=500)
+    tier: DiggerTier
+
+
+class DiggerSetPriorityIn(BaseModel):
+    """Request body for updating priority fields on a single wantlist release."""
+
+    tier: DiggerTier | None = None
+    min_media_condition: DiggerCondition | None = None
+    min_sleeve_condition: DiggerSleeveCondition | None = None
+    max_price_cents: int | None = None

--- a/api/models.py
+++ b/api/models.py
@@ -815,10 +815,20 @@ class DiggerSettingsIn(BaseModel):
     daily_token_cap_scheduled: int | None = None
 
 
-class DiggerSettingsOut(DiggerSettingsIn):
-    """Response body for a user's digger settings."""
+class DiggerSettingsOut(BaseModel):
+    """Response body for a user's digger settings.
 
-    pass
+    Token caps are always populated from NOT NULL DB columns, so they are
+    plain ints here (unlike the optional inputs on DiggerSettingsIn).
+    """
+
+    enabled: bool
+    country_code: str | None
+    currency: str
+    scheduled_cadence: DiggerCadence
+    preferred_model: DiggerModel
+    daily_token_cap_interactive: int
+    daily_token_cap_scheduled: int
 
 
 class DiggerWantlistItemOut(BaseModel):

--- a/api/queries/digger_queries.py
+++ b/api/queries/digger_queries.py
@@ -1,0 +1,196 @@
+"""SQL helpers for the digger schema, used by api/ routers.
+
+All functions take the AsyncPostgreSQLPool plus a user_id (UUID, sourced from the
+JWT 'sub' claim at the router boundary). No request body ever supplies a user_id
+directly. Async psycopg3 throughout: pool.connection() -> conn.cursor() ->
+cur.execute(sql, (params,)); %s placeholders, params as tuples.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+from psycopg.rows import dict_row
+
+
+if TYPE_CHECKING:
+    import uuid
+
+    from common import AsyncPostgreSQLPool
+
+
+Tier = Literal["must", "nice", "eventually"]
+Cadence = Literal["off", "weekly", "biweekly", "monthly"]
+Model = Literal["haiku", "sonnet", "opus"]
+
+
+@dataclass(slots=True)
+class UserDiggerSettings:
+    user_id: uuid.UUID
+    enabled: bool
+    country_code: str | None
+    currency: str
+    scheduled_cadence: Cadence
+    preferred_model: Model
+    daily_token_cap_interactive: int
+    daily_token_cap_scheduled: int
+
+
+@dataclass(slots=True)
+class WantlistPriorityRow:
+    release_id: int
+    tier: Tier
+    min_media_condition: str
+    min_sleeve_condition: str
+    max_price_cents: int | None
+
+
+async def get_user_settings(pool: AsyncPostgreSQLPool, user_id: uuid.UUID) -> UserDiggerSettings | None:
+    """Return the digger settings for a user, or None if no row exists yet."""
+    async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            "SELECT user_id, enabled, country_code, currency, scheduled_cadence, "
+            "preferred_model, daily_token_cap_interactive, daily_token_cap_scheduled "
+            "FROM digger.user_digger_settings WHERE user_id = %s",
+            (user_id,),
+        )
+        row = await cur.fetchone()
+    return None if row is None else UserDiggerSettings(**row)
+
+
+async def upsert_user_settings(
+    pool: AsyncPostgreSQLPool,
+    user_id: uuid.UUID,
+    *,
+    enabled: bool,
+    country_code: str | None,
+    currency: str,
+    scheduled_cadence: Cadence,
+    preferred_model: Model,
+    daily_token_cap_interactive: int = 200_000,
+    daily_token_cap_scheduled: int = 100_000,
+) -> None:
+    """Insert or update a user's digger settings, replacing all columns on conflict."""
+    async with pool.connection() as conn, conn.cursor() as cur:
+        await cur.execute(
+            "INSERT INTO digger.user_digger_settings "
+            "(user_id, enabled, country_code, currency, scheduled_cadence, "
+            "preferred_model, daily_token_cap_interactive, daily_token_cap_scheduled) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) "
+            "ON CONFLICT (user_id) DO UPDATE SET "
+            "enabled = EXCLUDED.enabled, country_code = EXCLUDED.country_code, "
+            "currency = EXCLUDED.currency, scheduled_cadence = EXCLUDED.scheduled_cadence, "
+            "preferred_model = EXCLUDED.preferred_model, "
+            "daily_token_cap_interactive = EXCLUDED.daily_token_cap_interactive, "
+            "daily_token_cap_scheduled = EXCLUDED.daily_token_cap_scheduled",
+            (
+                user_id,
+                enabled,
+                country_code,
+                currency,
+                scheduled_cadence,
+                preferred_model,
+                daily_token_cap_interactive,
+                daily_token_cap_scheduled,
+            ),
+        )
+
+
+async def list_wantlist_priorities(pool: AsyncPostgreSQLPool, user_id: uuid.UUID) -> list[WantlistPriorityRow]:
+    """Return all wantlist priority rows for a user, ordered by tier then release id."""
+    async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            "SELECT release_id, tier, min_media_condition, min_sleeve_condition, max_price_cents "
+            "FROM digger.user_wantlist_priorities WHERE user_id = %s ORDER BY tier, release_id",
+            (user_id,),
+        )
+        rows = await cur.fetchall()
+    return [WantlistPriorityRow(**r) for r in rows]
+
+
+async def set_wantlist_priority(
+    pool: AsyncPostgreSQLPool,
+    user_id: uuid.UUID,
+    release_id: int,
+    *,
+    tier: Tier | None = None,
+    min_media_condition: str | None = None,
+    min_sleeve_condition: str | None = None,
+    max_price_cents: int | None = None,
+) -> None:
+    """Update only the priority fields passed as non-None for one wantlist release.
+
+    Partial update: a None argument means "leave unchanged" — clearing a field
+    back to NULL is intentionally unsupported in M1. No-op (no connection opened)
+    when no fields are provided.
+    """
+    fields: list[str] = []
+    args: list[Any] = []
+    if tier is not None:
+        fields.append("tier = %s")
+        args.append(tier)
+    if min_media_condition is not None:
+        fields.append("min_media_condition = %s")
+        args.append(min_media_condition)
+    if min_sleeve_condition is not None:
+        fields.append("min_sleeve_condition = %s")
+        args.append(min_sleeve_condition)
+    if max_price_cents is not None:
+        fields.append("max_price_cents = %s")
+        args.append(max_price_cents)
+    if not fields:
+        return
+    fields.append("updated_at = now()")
+    args.extend([user_id, release_id])
+    async with pool.connection() as conn, conn.cursor() as cur:
+        await cur.execute(
+            f"UPDATE digger.user_wantlist_priorities SET {', '.join(fields)} "  # noqa: S608
+            "WHERE user_id = %s AND release_id = %s",
+            tuple(args),
+        )
+
+
+async def bulk_set_tier(pool: AsyncPostgreSQLPool, user_id: uuid.UUID, release_ids: list[int], tier: Tier) -> int:
+    """Set the tier for many of a user's wantlist releases at once; return rows updated."""
+    async with pool.connection() as conn, conn.cursor() as cur:
+        await cur.execute(
+            "UPDATE digger.user_wantlist_priorities SET tier = %s, updated_at = now() WHERE user_id = %s AND release_id = ANY(%s)",
+            (tier, user_id, release_ids),
+        )
+        return cur.rowcount
+
+
+async def get_wantlist_with_listings_counts(pool: AsyncPostgreSQLPool, user_id: uuid.UUID) -> list[dict[str, Any]]:
+    """Return a user's wantlist priorities joined with scrape state, active listing counts, and release metadata."""
+    async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            "SELECT uwp.release_id, uwp.tier, uwp.min_media_condition, "
+            "uwp.min_sleeve_condition, uwp.max_price_cents, "
+            "rs.last_scraped_at, "
+            "COUNT(l.listing_id) FILTER (WHERE l.removed_at IS NULL) AS active_listings, "
+            "uw.title, uw.artist, uw.year "
+            "FROM digger.user_wantlist_priorities uwp "
+            "LEFT JOIN digger.release_scrape_state rs ON rs.release_id = uwp.release_id "
+            "LEFT JOIN digger.listings l ON l.release_id = uwp.release_id "
+            "LEFT JOIN user_wantlists uw ON uw.user_id = uwp.user_id AND uw.release_id = uwp.release_id "
+            "WHERE uwp.user_id = %s "
+            "GROUP BY uwp.release_id, uwp.tier, uwp.min_media_condition, uwp.min_sleeve_condition, "
+            "uwp.max_price_cents, rs.last_scraped_at, uw.title, uw.artist, uw.year "
+            "ORDER BY uwp.tier, uw.artist NULLS LAST",
+            (user_id,),
+        )
+        rows = await cur.fetchall()
+    return list(rows)
+
+
+async def list_users_due_for_report(pool: AsyncPostgreSQLPool) -> list[dict[str, Any]]:
+    """Return enabled users whose scheduled cadence is on and whose next run is due (or unset)."""
+    async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            "SELECT user_id, scheduled_cadence FROM digger.user_digger_settings "
+            "WHERE enabled = true AND scheduled_cadence <> 'off' "
+            "AND (next_scheduled_run_at IS NULL OR next_scheduled_run_at <= now())"
+        )
+        rows = await cur.fetchall()
+    return list(rows)

--- a/api/routers/digger.py
+++ b/api/routers/digger.py
@@ -1,0 +1,129 @@
+"""User-facing Digger endpoints: per-user settings and wantlist priority management."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Any
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from api.dependencies import require_user
+from api.models import (
+    DiggerBulkTierIn,
+    DiggerSetPriorityIn,
+    DiggerSettingsIn,
+    DiggerSettingsOut,
+    DiggerWantlistItemOut,
+    DiggerWantlistResponse,
+)
+from api.queries import digger_queries as q
+
+
+if TYPE_CHECKING:
+    from common import AsyncPostgreSQLPool
+
+router = APIRouter(prefix="/api/digger", tags=["digger"])
+
+_pool: AsyncPostgreSQLPool | None = None
+
+
+def configure(pool: AsyncPostgreSQLPool) -> None:
+    """Inject the Postgres pool at application startup."""
+    global _pool
+    _pool = pool
+
+
+def _get_pool() -> AsyncPostgreSQLPool:
+    if _pool is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service not ready")
+    return _pool
+
+
+@router.get("/settings", response_model=DiggerSettingsOut)
+async def get_settings(current_user: Annotated[dict[str, Any], Depends(require_user)]) -> DiggerSettingsOut:
+    """Return the caller's digger settings, or 404 if they have not enabled digger."""
+    pool = _get_pool()
+    user_id = uuid.UUID(current_user["sub"])
+    s = await q.get_user_settings(pool, user_id)
+    if s is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="digger not enabled")
+    return DiggerSettingsOut(
+        enabled=s.enabled,
+        country_code=s.country_code,
+        currency=s.currency,
+        scheduled_cadence=s.scheduled_cadence,
+        preferred_model=s.preferred_model,
+        daily_token_cap_interactive=s.daily_token_cap_interactive,
+        daily_token_cap_scheduled=s.daily_token_cap_scheduled,
+    )
+
+
+@router.put("/settings", status_code=status.HTTP_204_NO_CONTENT)
+async def put_settings(body: DiggerSettingsIn, current_user: Annotated[dict[str, Any], Depends(require_user)]) -> None:
+    """Create or update the caller's digger settings."""
+    pool = _get_pool()
+    user_id = uuid.UUID(current_user["sub"])
+    await q.upsert_user_settings(
+        pool,
+        user_id,
+        enabled=body.enabled,
+        country_code=body.country_code,
+        currency=body.currency,
+        scheduled_cadence=body.scheduled_cadence,
+        preferred_model=body.preferred_model,
+        daily_token_cap_interactive=(body.daily_token_cap_interactive if body.daily_token_cap_interactive is not None else 200_000),
+        daily_token_cap_scheduled=(body.daily_token_cap_scheduled if body.daily_token_cap_scheduled is not None else 100_000),
+    )
+
+
+@router.get("/wantlist", response_model=DiggerWantlistResponse)
+async def get_wantlist(current_user: Annotated[dict[str, Any], Depends(require_user)]) -> DiggerWantlistResponse:
+    """Return the caller's wantlist with priority tiers and active-listing counts."""
+    pool = _get_pool()
+    user_id = uuid.UUID(current_user["sub"])
+    rows = await q.get_wantlist_with_listings_counts(pool, user_id)
+    items = [
+        DiggerWantlistItemOut(
+            release_id=r["release_id"],
+            tier=r["tier"],
+            min_media_condition=r["min_media_condition"],
+            min_sleeve_condition=r["min_sleeve_condition"],
+            max_price_cents=r["max_price_cents"],
+            active_listings=int(r["active_listings"] or 0),
+            last_scraped_at=r["last_scraped_at"].isoformat() if r["last_scraped_at"] else None,
+            title=r["title"],
+            artist=r["artist"],
+            year=r["year"],
+        )
+        for r in rows
+    ]
+    return DiggerWantlistResponse(items=items)
+
+
+@router.put("/wantlist/{release_id}/priority", status_code=status.HTTP_204_NO_CONTENT)
+async def set_priority(
+    release_id: int,
+    body: DiggerSetPriorityIn,
+    current_user: Annotated[dict[str, Any], Depends(require_user)],
+) -> None:
+    """Update tier and/or condition floors for one release in the caller's wantlist."""
+    pool = _get_pool()
+    user_id = uuid.UUID(current_user["sub"])
+    await q.set_wantlist_priority(
+        pool,
+        user_id,
+        release_id,
+        tier=body.tier,
+        min_media_condition=body.min_media_condition,
+        min_sleeve_condition=body.min_sleeve_condition,
+        max_price_cents=body.max_price_cents,
+    )
+
+
+@router.post("/wantlist/bulk-tier")
+async def bulk_set_tier(body: DiggerBulkTierIn, current_user: Annotated[dict[str, Any], Depends(require_user)]) -> dict[str, int]:
+    """Set the same tier on many releases at once; returns how many rows changed."""
+    pool = _get_pool()
+    user_id = uuid.UUID(current_user["sub"])
+    updated = await q.bulk_set_tier(pool, user_id, body.release_ids, body.tier)
+    return {"updated": updated}

--- a/api/routers/internal_digger.py
+++ b/api/routers/internal_digger.py
@@ -1,0 +1,66 @@
+"""Internal Digger endpoints consumed by the digger worker. Gated by a shared service token."""
+
+from typing import TYPE_CHECKING, Any
+
+# NOTE: `from __future__ import annotations` is intentionally NOT used here.
+# `user_id: UUID` is a FastAPI path param that FastAPI resolves at runtime, so
+# `UUID` must be a real runtime import. With lazy annotations, ruff's TC003 would
+# push it into TYPE_CHECKING and break path-param parsing. The `_pool`
+# annotation is therefore quoted so the TYPE_CHECKING-only import stays valid.
+# (Matches the api/routers/admin.py pattern.)
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from api.dependencies import service_token_required
+from api.queries import digger_queries as q
+
+
+if TYPE_CHECKING:
+    from common import AsyncPostgreSQLPool
+
+router = APIRouter(
+    prefix="/api/internal/digger",
+    tags=["digger-internal"],
+    dependencies=[Depends(service_token_required)],
+)
+
+_pool: "AsyncPostgreSQLPool | None" = None
+
+
+def configure(pool: "AsyncPostgreSQLPool") -> None:
+    """Inject the Postgres pool at application startup."""
+    global _pool
+    _pool = pool
+
+
+def _get_pool() -> "AsyncPostgreSQLPool":
+    if _pool is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service not ready")
+    return _pool
+
+
+@router.get("/wantlist-snapshot/{user_id}")
+async def wantlist_snapshot(user_id: UUID) -> dict[str, Any]:
+    """Return a user's wantlist priorities grouped by tier (used by the worker for scheduled runs)."""
+    pool = _get_pool()
+    rows = await q.list_wantlist_priorities(pool, user_id)
+    grouped: dict[str, list[dict[str, Any]]] = {"must": [], "nice": [], "eventually": []}
+    for r in rows:
+        grouped[r.tier].append(
+            {
+                "release_id": r.release_id,
+                "min_media_condition": r.min_media_condition,
+                "min_sleeve_condition": r.min_sleeve_condition,
+                "max_price_cents": r.max_price_cents,
+            }
+        )
+    return {"user_id": str(user_id), **grouped}
+
+
+@router.get("/users-due-for-report")
+async def users_due_for_report() -> dict[str, list[dict[str, str]]]:
+    """List users whose scheduled run is due (used by the worker scheduler)."""
+    pool = _get_pool()
+    rows = await q.list_users_due_for_report(pool)
+    return {"users": [{"user_id": str(r["user_id"]), "cadence": r["scheduled_cadence"]} for r in rows]}

--- a/common/config.py
+++ b/common/config.py
@@ -515,6 +515,9 @@ class ApiConfig:
     brevo_sender_email: str = "noreply@discogsography.com"
     brevo_sender_name: str = "Discogsography"
 
+    # Digger internal service token — shared secret between the API and the digger worker
+    digger_api_service_token: str | None = None
+
     # Admin dashboard — extractor connection
     extractor_host: str = "extractor"
     extractor_health_port: int = 8000
@@ -594,6 +597,7 @@ class ApiConfig:
         brevo_api_key = get_secret("BREVO_API_KEY") or None
         brevo_sender_email = getenv("BREVO_SENDER_EMAIL", "noreply@discogsography.com")
         brevo_sender_name = getenv("BREVO_SENDER_NAME", "Discogsography")
+        digger_api_service_token = get_secret("DIGGER_API_SERVICE_TOKEN") or None
 
         metrics_retention_days_str = getenv("METRICS_RETENTION_DAYS", "366")
         try:
@@ -635,6 +639,7 @@ class ApiConfig:
             rabbitmq_password=get_secret("RABBITMQ_PASSWORD") or "guest",
             metrics_retention_days=metrics_retention_days,
             metrics_collection_interval=metrics_collection_interval,
+            digger_api_service_token=digger_api_service_token,
         )
 
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -130,6 +130,7 @@ def test_api_config() -> ApiConfig:
         neo4j_host="bolt://localhost:7687",
         neo4j_username="neo4j",
         neo4j_password="testpassword",  # noqa: S106
+        digger_api_service_token="test-service-token",  # noqa: S106
     )
 
 
@@ -177,6 +178,7 @@ def test_client(
     import api.routers.collection as _collection_router
     import api.routers.digger as _digger_router
     import api.routers.explore as _explore_router
+    import api.routers.internal_digger as _internal_digger_router
     import api.routers.label_dna as _label_dna_router
     import api.routers.recommend as _recommend_router
     import api.routers.search as _search_router
@@ -187,6 +189,7 @@ def test_client(
 
     fake_redis = aioredis_fake.FakeRedis(server=fake_redis_server)
     _digger_router.configure(mock_pool)
+    _internal_digger_router.configure(mock_pool)
     _sync_router.configure(mock_pool, mock_neo4j, test_api_config, api_module._running_syncs, mock_redis)
     _explore_router.configure(mock_neo4j, test_api_config.jwt_secret_key, mock_redis)
     _label_dna_router.configure(mock_neo4j, mock_redis)
@@ -223,7 +226,7 @@ def test_client(
 
     import api.dependencies as _deps
 
-    _deps.configure(TEST_JWT_SECRET, mock_redis, pool=_admin_verify_pool)
+    _deps.configure(TEST_JWT_SECRET, mock_redis, pool=_admin_verify_pool, digger_api_service_token=test_api_config.digger_api_service_token)
 
     from api.nlq.config import NLQConfig
     import api.routers.nlq as _nlq_router
@@ -287,6 +290,12 @@ def reset_rate_limits() -> Generator[None]:
 def auth_headers(valid_token: str) -> dict[str, str]:
     """Authorization headers with a valid bearer token."""
     return {"Authorization": f"Bearer {valid_token}"}
+
+
+@pytest.fixture
+def service_token_headers() -> dict[str, str]:
+    """X-Service-Token header using the test service token."""
+    return {"X-Service-Token": "test-service-token"}
 
 
 def make_sample_user_row(

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -175,6 +175,7 @@ def test_client(
 
     import api.routers.admin as _admin_router
     import api.routers.collection as _collection_router
+    import api.routers.digger as _digger_router
     import api.routers.explore as _explore_router
     import api.routers.label_dna as _label_dna_router
     import api.routers.recommend as _recommend_router
@@ -185,6 +186,7 @@ def test_client(
     import api.routers.user as _user_router
 
     fake_redis = aioredis_fake.FakeRedis(server=fake_redis_server)
+    _digger_router.configure(mock_pool)
     _sync_router.configure(mock_pool, mock_neo4j, test_api_config, api_module._running_syncs, mock_redis)
     _explore_router.configure(mock_neo4j, test_api_config.jwt_secret_key, mock_redis)
     _label_dna_router.configure(mock_neo4j, mock_redis)

--- a/tests/api/test_digger_queries.py
+++ b/tests/api/test_digger_queries.py
@@ -1,0 +1,147 @@
+"""Mock-based unit tests for digger query helpers.
+
+Repo convention: no real-Postgres unit fixture; the pool is mocked
+(pool.connection() -> conn -> conn.cursor() -> cur, all AsyncMock). Real-DB
+behavior is deferred to the M1 e2e smoke.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+import uuid
+
+import pytest
+
+from api.queries import digger_queries as q
+
+
+def _mock_pool(*, fetchone: Any = None, fetchall: list[Any] | None = None, rowcount: int = 0) -> tuple[MagicMock, AsyncMock]:
+    pool = MagicMock()
+    conn = AsyncMock()
+    cur = AsyncMock()
+    cur.fetchone.return_value = fetchone
+    cur.fetchall.return_value = [] if fetchall is None else fetchall
+    cur.rowcount = rowcount
+    cur.__aenter__ = AsyncMock(return_value=cur)
+    cur.__aexit__ = AsyncMock(return_value=False)
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=False)
+    conn.cursor = MagicMock(return_value=cur)
+    pool.connection = MagicMock(return_value=conn)
+    return pool, cur
+
+
+@pytest.mark.asyncio
+async def test_get_user_settings_returns_none_when_absent() -> None:
+    pool, _cur = _mock_pool(fetchone=None)
+    assert await q.get_user_settings(pool, uuid.uuid4()) is None
+
+
+@pytest.mark.asyncio
+async def test_get_user_settings_maps_row() -> None:
+    uid = uuid.uuid4()
+    pool, cur = _mock_pool(
+        fetchone={
+            "user_id": uid,
+            "enabled": True,
+            "country_code": "US",
+            "currency": "USD",
+            "scheduled_cadence": "weekly",
+            "preferred_model": "sonnet",
+            "daily_token_cap_interactive": 200000,
+            "daily_token_cap_scheduled": 100000,
+        }
+    )
+    s = await q.get_user_settings(pool, uid)
+    assert s is not None
+    assert s.enabled is True
+    assert s.country_code == "US"
+    assert s.scheduled_cadence == "weekly"
+    sql = cur.execute.call_args.args[0]
+    assert "FROM digger.user_digger_settings" in sql
+    assert "%s" in sql and "$1" not in sql
+
+
+@pytest.mark.asyncio
+async def test_upsert_user_settings_issues_upsert_with_params() -> None:
+    uid = uuid.uuid4()
+    pool, cur = _mock_pool()
+    await q.upsert_user_settings(
+        pool,
+        uid,
+        enabled=True,
+        country_code="US",
+        currency="USD",
+        scheduled_cadence="weekly",
+        preferred_model="sonnet",
+    )
+    sql, params = cur.execute.call_args.args
+    assert "INSERT INTO digger.user_digger_settings" in sql
+    assert "ON CONFLICT (user_id) DO UPDATE" in sql
+    assert params[0] == uid and params[1] is True
+    assert params[6] == 200000 and params[7] == 100000  # default token caps
+
+
+@pytest.mark.asyncio
+async def test_list_wantlist_priorities_maps_rows() -> None:
+    pool, _cur = _mock_pool(
+        fetchall=[
+            {"release_id": 1, "tier": "must", "min_media_condition": "VG", "min_sleeve_condition": "VG", "max_price_cents": None},
+            {"release_id": 2, "tier": "nice", "min_media_condition": "NM", "min_sleeve_condition": "VG+", "max_price_cents": 5000},
+        ]
+    )
+    rows = await q.list_wantlist_priorities(pool, uuid.uuid4())
+    assert [r.release_id for r in rows] == [1, 2]
+    assert rows[0].tier == "must" and rows[1].max_price_cents == 5000
+
+
+@pytest.mark.asyncio
+async def test_set_wantlist_priority_builds_partial_update() -> None:
+    uid = uuid.uuid4()
+    pool, cur = _mock_pool()
+    await q.set_wantlist_priority(pool, uid, 42, tier="must", max_price_cents=3000)
+    sql, params = cur.execute.call_args.args
+    assert "tier = %s" in sql and "max_price_cents = %s" in sql
+    assert "min_media_condition" not in sql  # not provided -> not in SET
+    assert "updated_at = now()" in sql
+    # provided fields first, then user_id + release_id at the end
+    assert params == ("must", 3000, uid, 42)
+
+
+@pytest.mark.asyncio
+async def test_set_wantlist_priority_noop_when_nothing_provided() -> None:
+    pool, cur = _mock_pool()
+    await q.set_wantlist_priority(pool, uuid.uuid4(), 42)
+    cur.execute.assert_not_called()
+    pool.connection.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bulk_set_tier_uses_array_and_returns_rowcount() -> None:
+    uid = uuid.uuid4()
+    pool, cur = _mock_pool(rowcount=2)
+    n = await q.bulk_set_tier(pool, uid, [1, 2], "must")
+    assert n == 2
+    sql, params = cur.execute.call_args.args
+    assert "release_id = ANY(%s)" in sql
+    assert params == ("must", uid, [1, 2])
+
+
+@pytest.mark.asyncio
+async def test_get_wantlist_with_listings_counts_uses_public_wantlists() -> None:
+    pool, cur = _mock_pool(fetchall=[{"release_id": 1, "tier": "must", "active_listings": 3, "title": "X"}])
+    rows = await q.get_wantlist_with_listings_counts(pool, uuid.uuid4())
+    assert rows[0]["active_listings"] == 3
+    sql = cur.execute.call_args.args[0]
+    assert "JOIN user_wantlists uw" in sql
+    assert "discogs.user_wantlists" not in sql  # public table, not discogs schema
+    assert "cover_image_url" not in sql  # column does not exist on user_wantlists
+
+
+@pytest.mark.asyncio
+async def test_list_users_due_for_report_returns_rows() -> None:
+    pool, cur = _mock_pool(fetchall=[{"user_id": uuid.uuid4(), "scheduled_cadence": "weekly"}])
+    rows = await q.list_users_due_for_report(pool)
+    assert rows[0]["scheduled_cadence"] == "weekly"
+    sql = cur.execute.call_args.args[0]
+    assert "FROM digger.user_digger_settings" in sql
+    assert "scheduled_cadence <> 'off'" in sql

--- a/tests/api/test_digger_router.py
+++ b/tests/api/test_digger_router.py
@@ -126,3 +126,11 @@ def test_set_priority_204(test_client: TestClient, auth_headers: dict[str, str])
         )
     assert r.status_code == 204
     mock_set.assert_awaited_once()
+
+
+def test_set_priority_empty_body_returns_204(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    mock_set = AsyncMock()
+    with patch("api.routers.digger.q.set_wantlist_priority", mock_set):
+        r = test_client.put("/api/digger/wantlist/123/priority", headers=auth_headers, json={})
+    assert r.status_code == 204
+    mock_set.assert_awaited_once()

--- a/tests/api/test_digger_router.py
+++ b/tests/api/test_digger_router.py
@@ -1,0 +1,128 @@
+"""Mock-based tests for the user-facing /api/digger router."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+import uuid
+
+from fastapi.testclient import TestClient
+
+from api.queries.digger_queries import UserDiggerSettings
+
+
+def _settings() -> UserDiggerSettings:
+    return UserDiggerSettings(
+        user_id=uuid.uuid4(),
+        enabled=True,
+        country_code="US",
+        currency="USD",
+        scheduled_cadence="weekly",
+        preferred_model="sonnet",
+        daily_token_cap_interactive=200000,
+        daily_token_cap_scheduled=100000,
+    )
+
+
+def test_settings_requires_auth(test_client: TestClient) -> None:
+    r = test_client.get("/api/digger/settings")
+    assert r.status_code in (401, 403)
+
+
+def test_get_settings_404_when_not_enabled(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    with patch("api.routers.digger.q.get_user_settings", AsyncMock(return_value=None)):
+        r = test_client.get("/api/digger/settings", headers=auth_headers)
+    assert r.status_code == 404
+
+
+def test_get_settings_returns_settings(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    with patch("api.routers.digger.q.get_user_settings", AsyncMock(return_value=_settings())):
+        r = test_client.get("/api/digger/settings", headers=auth_headers)
+    assert r.status_code == 200
+    assert r.json()["enabled"] is True
+    assert r.json()["scheduled_cadence"] == "weekly"
+
+
+def test_put_settings_204_and_calls_upsert(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    mock_upsert = AsyncMock()
+    with patch("api.routers.digger.q.upsert_user_settings", mock_upsert):
+        r = test_client.put(
+            "/api/digger/settings",
+            headers=auth_headers,
+            json={
+                "enabled": True,
+                "country_code": "US",
+                "currency": "USD",
+                "scheduled_cadence": "weekly",
+                "preferred_model": "sonnet",
+            },
+        )
+    assert r.status_code == 204
+    mock_upsert.assert_awaited_once()
+
+
+def test_put_settings_preserves_explicit_zero_token_cap(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    mock_upsert = AsyncMock()
+    with patch("api.routers.digger.q.upsert_user_settings", mock_upsert):
+        r = test_client.put(
+            "/api/digger/settings",
+            headers=auth_headers,
+            json={
+                "enabled": True,
+                "country_code": "US",
+                "currency": "USD",
+                "scheduled_cadence": "weekly",
+                "preferred_model": "sonnet",
+                "daily_token_cap_interactive": 0,
+            },
+        )
+    assert r.status_code == 204
+    assert mock_upsert.await_args.kwargs["daily_token_cap_interactive"] == 0
+
+
+def test_get_wantlist_returns_items(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    rows = [
+        {
+            "release_id": 123,
+            "tier": "must",
+            "min_media_condition": "VG",
+            "min_sleeve_condition": "VG",
+            "max_price_cents": None,
+            "active_listings": 2,
+            "last_scraped_at": datetime(2026, 5, 1, tzinfo=UTC),
+            "title": "Some Title",
+            "artist": "Some Artist",
+            "year": 1999,
+        }
+    ]
+    with patch("api.routers.digger.q.get_wantlist_with_listings_counts", AsyncMock(return_value=rows)):
+        r = test_client.get("/api/digger/wantlist", headers=auth_headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["items"]) == 1
+    item = body["items"][0]
+    assert {"release_id", "tier", "active_listings"} <= set(item)
+    assert item["active_listings"] == 2
+    assert item["last_scraped_at"].startswith("2026-05-01")
+    assert "cover_image_url" not in item
+
+
+def test_bulk_set_tier(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    with patch("api.routers.digger.q.bulk_set_tier", AsyncMock(return_value=1)):
+        r = test_client.post(
+            "/api/digger/wantlist/bulk-tier",
+            headers=auth_headers,
+            json={"release_ids": [123], "tier": "must"},
+        )
+    assert r.status_code == 200
+    assert r.json()["updated"] == 1
+
+
+def test_set_priority_204(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    mock_set = AsyncMock()
+    with patch("api.routers.digger.q.set_wantlist_priority", mock_set):
+        r = test_client.put(
+            "/api/digger/wantlist/123/priority",
+            headers=auth_headers,
+            json={"tier": "nice"},
+        )
+    assert r.status_code == 204
+    mock_set.assert_awaited_once()

--- a/tests/api/test_internal_digger_router.py
+++ b/tests/api/test_internal_digger_router.py
@@ -1,0 +1,49 @@
+"""Mock-based tests for the service-token-gated internal Digger router."""
+
+from unittest.mock import AsyncMock, patch
+import uuid
+
+from fastapi.testclient import TestClient
+
+from api.queries.digger_queries import WantlistPriorityRow
+
+
+def test_wantlist_snapshot_requires_service_token(test_client: TestClient) -> None:
+    r = test_client.get("/api/internal/digger/wantlist-snapshot/00000000-0000-0000-0000-000000000000")
+    assert r.status_code == 401
+
+
+def test_wantlist_snapshot_rejects_wrong_token(test_client: TestClient) -> None:
+    r = test_client.get(
+        "/api/internal/digger/wantlist-snapshot/00000000-0000-0000-0000-000000000000",
+        headers={"X-Service-Token": "wrong-token"},
+    )
+    assert r.status_code == 401
+
+
+def test_wantlist_snapshot_returns_grouped_priorities(test_client: TestClient, service_token_headers: dict[str, str]) -> None:
+    uid = uuid.uuid4()
+    rows = [
+        WantlistPriorityRow(release_id=1, tier="must", min_media_condition="VG", min_sleeve_condition="VG", max_price_cents=None),
+        WantlistPriorityRow(release_id=2, tier="nice", min_media_condition="NM", min_sleeve_condition="VG+", max_price_cents=5000),
+    ]
+    with patch("api.routers.internal_digger.q.list_wantlist_priorities", AsyncMock(return_value=rows)):
+        r = test_client.get(f"/api/internal/digger/wantlist-snapshot/{uid}", headers=service_token_headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["user_id"] == str(uid)
+    assert "must" in body and "nice" in body and "eventually" in body
+    assert body["must"][0]["release_id"] == 1
+    assert body["nice"][0]["max_price_cents"] == 5000
+    assert body["eventually"] == []
+
+
+def test_users_due_for_report(test_client: TestClient, service_token_headers: dict[str, str]) -> None:
+    uid = uuid.uuid4()
+    rows = [{"user_id": uid, "scheduled_cadence": "weekly"}]
+    with patch("api.routers.internal_digger.q.list_users_due_for_report", AsyncMock(return_value=rows)):
+        r = test_client.get("/api/internal/digger/users-due-for-report", headers=service_token_headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["users"][0]["user_id"] == str(uid)
+    assert body["users"][0]["cadence"] == "weekly"


### PR DESCRIPTION
## Summary

PR 3 of the **Digger M1** roll-out — the **API-router layer** (Tasks 17–19 of `docs/superpowers/plans/2026-05-14-digger-m1-foundation.md`). Builds on the merged schema (#337) and scraper service (#339). A logged-in user can now read/write their Digger settings and view + tier their wantlist; the worker has service-token-gated internal endpoints.

## What's included

| Task | Area | Files |
| --- | --- | --- |
| 17 | Postgres query helpers for the `digger.*` schema | `api/queries/digger_queries.py` |
| 18 | User-facing router + Pydantic models | `api/routers/digger.py`, `api/models.py` |
| 19 | Service-token-gated internal router + auth guard | `api/routers/internal_digger.py`, `api/dependencies.py`, `common/config.py` |

### Endpoints

User-facing (`Depends(require_user)` / JWT):
- `GET /api/digger/settings` → 200 / 404 if not enabled
- `PUT /api/digger/settings` → 204
- `GET /api/digger/wantlist` → wantlist items with tier + active-listing counts
- `PUT /api/digger/wantlist/{release_id}/priority` → 204 (partial update)
- `POST /api/digger/wantlist/bulk-tier` → `{"updated": n}`

Internal (router-level `Depends(service_token_required)`, for the digger worker):
- `GET /api/internal/digger/wantlist-snapshot/{user_id}` → priorities grouped by tier
- `GET /api/internal/digger/users-due-for-report`

## Plan reconciliations (the plan was drafted against asyncpg; this repo uses async psycopg3)

- **psycopg3 throughout** — `pool.connection()` / `conn.cursor(row_factory=dict_row)` / `%s` params; no `pool.acquire()`, `$1`, or `conn.fetch*`.
- **Public `user_wantlists`** (not `discogs.user_wantlists`); **`cover_image_url` dropped** (column does not exist).
- Router pattern matches the codebase: module-global `_pool` + `configure()` set in the `api/api.py` lifespan (not `Depends(get_pool)`); main app is `api/api.py` (not `api/main.py`).
- User id comes from the JWT `sub` claim (a str) → converted with `uuid.UUID(...)`.
- `list_users_due_for_report` lives in the query module (not inline in the router) so all SQL is unit-testable.

## Security

- `service_token_required` (`api/dependencies.py`): constant-time `hmac.compare_digest`, **fail-closed** (missing/empty configured token, missing header, or mismatch → 401 with `WWW-Authenticate: Bearer`). Token configured via `DIGGER_API_SERVICE_TOKEN` on `ApiConfig` (`get_secret()`, `_FILE` Docker-secret aware).
- CORS `allow_methods` gains `PUT` (these are the first PUT endpoints in the API).

## Testing

- Mock-based unit tests (repo convention — pool/query helpers mocked): `tests/api/test_digger_queries.py` (9), `tests/api/test_digger_router.py` (9), `tests/api/test_internal_digger_router.py` (4) — incl. auth-required, wrong-token, partial-update, explicit-zero token cap, and grouped-snapshot cases.
- Full `tests/api/` suite: **1575 passed, 0 failed**. `mypy api` and `ruff` clean.
- Each task went through implementer → spec-compliance review → code-quality review; a final whole-PR review caught the CORS/`PUT` gap and the response-schema nullability fix included here.

## Deferred to PR 5 (M1 integration/docs layer)

- Perftest entries (`tests/perftest/config.yaml` / `run_perftest.py`) for the new endpoints — they require authenticated/service-token request setup, which belongs with the integration layer.
- Broader docs / `CLAUDE.md` service updates.

## Test plan

- [x] `uv run pytest tests/api -p no:warnings` → 1575 passed
- [x] `uv run mypy api` → clean (67 files)
- [x] `uv run ruff check api common tests/api` → clean
- [ ] Live e2e smoke (deferred to M1 Task 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)