### PR TITLE
feat(digger): M1 explore frontend — Digger pane, wantlist controls, bulk/filters/stats, unified settings

### DIFF
--- a/explore/__tests__/api-client.test.js
+++ b/explore/__tests__/api-client.test.js
@@ -1319,4 +1319,325 @@ describe('ApiClient', () => {
             }));
         });
     });
+
+    // --- Digger ---
+
+    describe('getDiggerSettings', () => {
+        it('should GET /api/digger/settings with Authorization header', async () => {
+            let capturedUrl, capturedOptions;
+            vi.stubGlobal('fetch', async (url, options) => {
+                capturedUrl = url;
+                capturedOptions = options;
+                return { ok: true, status: 200, json: async () => ({ enabled: true, currency: 'USD' }) };
+            });
+
+            await window.apiClient.getDiggerSettings('my-token');
+            expect(capturedUrl).toBe('/api/digger/settings');
+            expect(capturedOptions.headers['Authorization']).toBe('Bearer my-token');
+        });
+
+        it('should return { ok:true, status:200, body } on success', async () => {
+            const settingsData = {
+                enabled: true,
+                country_code: 'US',
+                currency: 'USD',
+                scheduled_cadence: 'weekly',
+                preferred_model: 'haiku',
+                daily_token_cap_interactive: 10000,
+                daily_token_cap_scheduled: 50000,
+            };
+            vi.stubGlobal('fetch', async () => ({
+                ok: true,
+                status: 200,
+                json: async () => settingsData,
+            }));
+
+            const result = await window.apiClient.getDiggerSettings('token');
+            expect(result.ok).toBe(true);
+            expect(result.status).toBe(200);
+            expect(result.body).toEqual(settingsData);
+        });
+
+        it('should return { ok:false, status:404, body } when digger not enabled', async () => {
+            vi.stubGlobal('fetch', async () => ({
+                ok: false,
+                status: 404,
+                json: async () => ({ detail: 'Digger not enabled' }),
+            }));
+
+            const result = await window.apiClient.getDiggerSettings('token');
+            expect(result.ok).toBe(false);
+            expect(result.status).toBe(404);
+            expect(result.body).toEqual({ detail: 'Digger not enabled' });
+        });
+
+        it('should return body:null when json() throws (empty body)', async () => {
+            vi.stubGlobal('fetch', async () => ({
+                ok: false,
+                status: 500,
+                json: async () => { throw new Error('not json'); },
+            }));
+
+            const result = await window.apiClient.getDiggerSettings('token');
+            expect(result.ok).toBe(false);
+            expect(result.status).toBe(500);
+            expect(result.body).toBeNull();
+        });
+    });
+
+    describe('putDiggerSettings', () => {
+        it('should PUT /api/digger/settings with Authorization and Content-Type headers', async () => {
+            let capturedUrl, capturedOptions;
+            vi.stubGlobal('fetch', async (url, options) => {
+                capturedUrl = url;
+                capturedOptions = options;
+                return { ok: true, status: 204, json: async () => { throw new Error('no body'); } };
+            });
+
+            const settings = { enabled: true, currency: 'USD', scheduled_cadence: 'weekly', preferred_model: 'haiku' };
+            await window.apiClient.putDiggerSettings('my-token', settings);
+            expect(capturedUrl).toBe('/api/digger/settings');
+            expect(capturedOptions.method).toBe('PUT');
+            expect(capturedOptions.headers['Authorization']).toBe('Bearer my-token');
+            expect(capturedOptions.headers['Content-Type']).toBe('application/json');
+        });
+
+        it('should serialize settings as JSON body', async () => {
+            let capturedOptions;
+            vi.stubGlobal('fetch', async (_url, options) => {
+                capturedOptions = options;
+                return { ok: true, status: 204, json: async () => { throw new Error('no body'); } };
+            });
+
+            const settings = { enabled: false, country_code: 'GB', currency: 'GBP', scheduled_cadence: 'monthly', preferred_model: 'opus', daily_token_cap_interactive: null, daily_token_cap_scheduled: null };
+            await window.apiClient.putDiggerSettings('token', settings);
+            expect(JSON.parse(capturedOptions.body)).toEqual(settings);
+        });
+
+        it('should return { ok:true, status:204, body:null } on 204 No Content', async () => {
+            vi.stubGlobal('fetch', async () => ({
+                ok: true,
+                status: 204,
+                json: async () => { throw new Error('no body'); },
+            }));
+
+            const result = await window.apiClient.putDiggerSettings('token', { enabled: true });
+            expect(result.ok).toBe(true);
+            expect(result.status).toBe(204);
+            expect(result.body).toBeNull();
+        });
+
+        it('should return { ok:false, status:422, body } on validation error', async () => {
+            vi.stubGlobal('fetch', async () => ({
+                ok: false,
+                status: 422,
+                json: async () => ({ detail: 'Validation error' }),
+            }));
+
+            const result = await window.apiClient.putDiggerSettings('token', { enabled: 'bad' });
+            expect(result.ok).toBe(false);
+            expect(result.status).toBe(422);
+            expect(result.body).toEqual({ detail: 'Validation error' });
+        });
+    });
+
+    describe('getDiggerWantlist', () => {
+        it('should GET /api/digger/wantlist with Authorization header', async () => {
+            let capturedUrl, capturedOptions;
+            vi.stubGlobal('fetch', async (url, options) => {
+                capturedUrl = url;
+                capturedOptions = options;
+                return { ok: true, status: 200, json: async () => ({ items: [] }) };
+            });
+
+            await window.apiClient.getDiggerWantlist('my-token');
+            expect(capturedUrl).toBe('/api/digger/wantlist');
+            expect(capturedOptions.headers['Authorization']).toBe('Bearer my-token');
+        });
+
+        it('should return { ok:true, status:200, body } with items array on success', async () => {
+            const wantlistData = {
+                items: [
+                    {
+                        release_id: 12345,
+                        title: 'Loveless',
+                        artist: 'My Bloody Valentine',
+                        year: 1991,
+                        tier: 'must',
+                        min_media_condition: 'VG+',
+                        min_sleeve_condition: 'VG',
+                        max_price_cents: 5000,
+                        active_listings: 3,
+                        last_scraped_at: '2026-01-01T00:00:00Z',
+                    },
+                ],
+            };
+            vi.stubGlobal('fetch', async () => ({
+                ok: true,
+                status: 200,
+                json: async () => wantlistData,
+            }));
+
+            const result = await window.apiClient.getDiggerWantlist('token');
+            expect(result.ok).toBe(true);
+            expect(result.status).toBe(200);
+            expect(result.body).toEqual(wantlistData);
+        });
+
+        it('should return { ok:false, status:401, body } on unauthorized', async () => {
+            vi.stubGlobal('fetch', async () => ({
+                ok: false,
+                status: 401,
+                json: async () => ({ detail: 'Unauthorized' }),
+            }));
+
+            const result = await window.apiClient.getDiggerWantlist('bad-token');
+            expect(result.ok).toBe(false);
+            expect(result.status).toBe(401);
+            expect(result.body).toEqual({ detail: 'Unauthorized' });
+        });
+
+        it('should return body:null when json() throws', async () => {
+            vi.stubGlobal('fetch', async () => ({
+                ok: false,
+                status: 503,
+                json: async () => { throw new Error('no body'); },
+            }));
+
+            const result = await window.apiClient.getDiggerWantlist('token');
+            expect(result.body).toBeNull();
+        });
+    });
+
+    describe('setDiggerPriority', () => {
+        it('should PUT /api/digger/wantlist/{releaseId}/priority with Authorization and Content-Type headers', async () => {
+            let capturedUrl, capturedOptions;
+            vi.stubGlobal('fetch', async (url, options) => {
+                capturedUrl = url;
+                capturedOptions = options;
+                return { ok: true, status: 204, json: async () => { throw new Error('no body'); } };
+            });
+
+            await window.apiClient.setDiggerPriority('my-token', 12345, { tier: 'must' });
+            expect(capturedUrl).toBe('/api/digger/wantlist/12345/priority');
+            expect(capturedOptions.method).toBe('PUT');
+            expect(capturedOptions.headers['Authorization']).toBe('Bearer my-token');
+            expect(capturedOptions.headers['Content-Type']).toBe('application/json');
+        });
+
+        it('should serialize the patch as JSON body', async () => {
+            let capturedOptions;
+            vi.stubGlobal('fetch', async (_url, options) => {
+                capturedOptions = options;
+                return { ok: true, status: 204, json: async () => { throw new Error('no body'); } };
+            });
+
+            const patch = { tier: 'nice', min_media_condition: 'VG+', max_price_cents: 3000 };
+            await window.apiClient.setDiggerPriority('token', 99, patch);
+            expect(JSON.parse(capturedOptions.body)).toEqual(patch);
+        });
+
+        it('should build URL with integer releaseId', async () => {
+            let capturedUrl;
+            vi.stubGlobal('fetch', async (url) => {
+                capturedUrl = url;
+                return { ok: true, status: 204, json: async () => { throw new Error('no body'); } };
+            });
+
+            await window.apiClient.setDiggerPriority('token', 67890, {});
+            expect(capturedUrl).toBe('/api/digger/wantlist/67890/priority');
+        });
+
+        it('should return { ok:true, status:204, body:null } on 204 No Content', async () => {
+            vi.stubGlobal('fetch', async () => ({
+                ok: true,
+                status: 204,
+                json: async () => { throw new Error('no body'); },
+            }));
+
+            const result = await window.apiClient.setDiggerPriority('token', 1, { tier: 'eventually' });
+            expect(result.ok).toBe(true);
+            expect(result.status).toBe(204);
+            expect(result.body).toBeNull();
+        });
+
+        it('should return { ok:false, status:404, body } when release not in wantlist', async () => {
+            vi.stubGlobal('fetch', async () => ({
+                ok: false,
+                status: 404,
+                json: async () => ({ detail: 'Release not in wantlist' }),
+            }));
+
+            const result = await window.apiClient.setDiggerPriority('token', 9999, { tier: 'must' });
+            expect(result.ok).toBe(false);
+            expect(result.status).toBe(404);
+            expect(result.body).toEqual({ detail: 'Release not in wantlist' });
+        });
+    });
+
+    describe('bulkSetDiggerTier', () => {
+        it('should POST /api/digger/wantlist/bulk-tier with Authorization and Content-Type headers', async () => {
+            let capturedUrl, capturedOptions;
+            vi.stubGlobal('fetch', async (url, options) => {
+                capturedUrl = url;
+                capturedOptions = options;
+                return { ok: true, status: 200, json: async () => ({ updated: 3 }) };
+            });
+
+            await window.apiClient.bulkSetDiggerTier('my-token', [1, 2, 3], 'must');
+            expect(capturedUrl).toBe('/api/digger/wantlist/bulk-tier');
+            expect(capturedOptions.method).toBe('POST');
+            expect(capturedOptions.headers['Authorization']).toBe('Bearer my-token');
+            expect(capturedOptions.headers['Content-Type']).toBe('application/json');
+        });
+
+        it('should serialize release_ids and tier as JSON body', async () => {
+            let capturedOptions;
+            vi.stubGlobal('fetch', async (_url, options) => {
+                capturedOptions = options;
+                return { ok: true, status: 200, json: async () => ({ updated: 2 }) };
+            });
+
+            await window.apiClient.bulkSetDiggerTier('token', [111, 222], 'nice');
+            expect(JSON.parse(capturedOptions.body)).toEqual({ release_ids: [111, 222], tier: 'nice' });
+        });
+
+        it('should return { ok:true, status:200, body } with updated count on success', async () => {
+            vi.stubGlobal('fetch', async () => ({
+                ok: true,
+                status: 200,
+                json: async () => ({ updated: 5 }),
+            }));
+
+            const result = await window.apiClient.bulkSetDiggerTier('token', [1, 2, 3, 4, 5], 'eventually');
+            expect(result.ok).toBe(true);
+            expect(result.status).toBe(200);
+            expect(result.body).toEqual({ updated: 5 });
+            expect(result.body.updated).toBe(5);
+        });
+
+        it('should return { ok:false, status:422, body } on validation error', async () => {
+            vi.stubGlobal('fetch', async () => ({
+                ok: false,
+                status: 422,
+                json: async () => ({ detail: 'Invalid tier' }),
+            }));
+
+            const result = await window.apiClient.bulkSetDiggerTier('token', [1], 'bad-tier');
+            expect(result.ok).toBe(false);
+            expect(result.status).toBe(422);
+            expect(result.body).toEqual({ detail: 'Invalid tier' });
+        });
+
+        it('should return body:null when json() throws', async () => {
+            vi.stubGlobal('fetch', async () => ({
+                ok: false,
+                status: 500,
+                json: async () => { throw new Error('no body'); },
+            }));
+
+            const result = await window.apiClient.bulkSetDiggerTier('token', [], 'must');
+            expect(result.body).toBeNull();
+        });
+    });
 });

--- a/explore/__tests__/digger.test.js
+++ b/explore/__tests__/digger.test.js
@@ -1,0 +1,591 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { loadScript } from './helpers.js';
+
+/**
+ * Create minimal DOM elements required by DiggerPane.
+ */
+function setupDiggerDOM() {
+    document.body.textContent = '';
+    const ids = ['diggerPane', 'diggerLoading', 'diggerBody', 'diggerHeaderActions'];
+    for (const id of ids) {
+        const el = document.createElement('div');
+        el.id = id;
+        document.body.appendChild(el);
+    }
+}
+
+describe('DiggerPane', () => {
+    beforeEach(() => {
+        setupDiggerDOM();
+        delete globalThis.window;
+        globalThis.window = globalThis;
+        window.authManager = {
+            getToken: vi.fn().mockReturnValue('test-token'),
+            isLoggedIn: vi.fn().mockReturnValue(true),
+        };
+        window.apiClient = {
+            getDiggerSettings: vi.fn(),
+            getDiggerWantlist: vi.fn(),
+        };
+        window.exploreApp = undefined;
+        loadScript('digger.js');
+    });
+
+    // ------------------------------------------------------------------ //
+    // No token guard
+    // ------------------------------------------------------------------ //
+
+    describe('no token', () => {
+        it('should not call api when no token', async () => {
+            window.authManager.getToken.mockReturnValue(null);
+            await window.diggerPane.init();
+            expect(window.apiClient.getDiggerSettings).not.toHaveBeenCalled();
+            expect(window.apiClient.getDiggerWantlist).not.toHaveBeenCalled();
+        });
+
+        it('should not render anything when no token', async () => {
+            window.authManager.getToken.mockReturnValue(null);
+            const body = document.getElementById('diggerBody');
+            const initialContent = body.innerHTML;
+            await window.diggerPane.init();
+            expect(body.innerHTML).toBe(initialContent);
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // Onboarding — settings 404
+    // ------------------------------------------------------------------ //
+
+    describe('settings 404 → onboarding', () => {
+        beforeEach(() => {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: false,
+                status: 404,
+                body: null,
+            });
+        });
+
+        it('should render onboarding card', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            expect(body.querySelector('.digger-onboarding')).not.toBeNull();
+        });
+
+        it('should show "Open Digger Settings" button', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const btn = body.querySelector('button');
+            expect(btn).not.toBeNull();
+            expect(btn.textContent).toContain('Open Digger Settings');
+        });
+
+        it('should NOT load wantlist on 404', async () => {
+            await window.diggerPane.init();
+            expect(window.apiClient.getDiggerWantlist).not.toHaveBeenCalled();
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // Onboarding — enabled: false
+    // ------------------------------------------------------------------ //
+
+    describe('settings ok + enabled:false → onboarding', () => {
+        beforeEach(() => {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: true,
+                status: 200,
+                body: {
+                    enabled: false,
+                    country_code: 'US',
+                    currency: 'USD',
+                    scheduled_cadence: 'daily',
+                    preferred_model: 'claude-opus',
+                    daily_token_cap_interactive: 10000,
+                    daily_token_cap_scheduled: 50000,
+                },
+            });
+        });
+
+        it('should render onboarding card when enabled is false', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            expect(body.querySelector('.digger-onboarding')).not.toBeNull();
+        });
+
+        it('should NOT load wantlist when disabled', async () => {
+            await window.diggerPane.init();
+            expect(window.apiClient.getDiggerWantlist).not.toHaveBeenCalled();
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // Onboarding button navigation
+    // ------------------------------------------------------------------ //
+
+    describe('onboarding button click', () => {
+        beforeEach(() => {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: false,
+                status: 404,
+                body: null,
+            });
+        });
+
+        it('should call exploreApp._switchPane("settings") when clicked', async () => {
+            window.exploreApp = { _switchPane: vi.fn() };
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const btn = body.querySelector('button');
+            btn.click();
+            expect(window.exploreApp._switchPane).toHaveBeenCalledWith('settings');
+        });
+
+        it('should set _previousPane before switching', async () => {
+            window.exploreApp = { _switchPane: vi.fn() };
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const btn = body.querySelector('button');
+            btn.click();
+            expect(window.exploreApp._previousPane).toBe('digger');
+        });
+
+        it('should not throw when exploreApp is undefined', async () => {
+            window.exploreApp = undefined;
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const btn = body.querySelector('button');
+            expect(() => btn.click()).not.toThrow();
+        });
+
+        it('should not throw when exploreApp is null', async () => {
+            window.exploreApp = null;
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const btn = body.querySelector('button');
+            expect(() => btn.click()).not.toThrow();
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // Enabled + wantlist with items
+    // ------------------------------------------------------------------ //
+
+    describe('enabled + wantlist with 2 items', () => {
+        const twoItems = [
+            {
+                release_id: 1,
+                title: 'OK Computer',
+                artist: 'Radiohead',
+                year: 1997,
+                tier: 'A',
+                min_media_condition: 'VG+',
+                min_sleeve_condition: 'VG',
+                max_price_cents: 5000,
+                active_listings: 12,
+                last_scraped_at: '2026-05-01T10:00:00Z',
+            },
+            {
+                release_id: 2,
+                title: 'Homogenic',
+                artist: 'Bjork',
+                year: 1997,
+                tier: 'B',
+                min_media_condition: null,
+                min_sleeve_condition: null,
+                max_price_cents: null,
+                active_listings: 0,
+                last_scraped_at: null,
+            },
+        ];
+
+        beforeEach(() => {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: true,
+                status: 200,
+                body: {
+                    enabled: true,
+                    country_code: 'US',
+                    currency: 'USD',
+                    scheduled_cadence: 'daily',
+                    preferred_model: 'claude-opus',
+                    daily_token_cap_interactive: 10000,
+                    daily_token_cap_scheduled: 50000,
+                },
+            });
+            window.apiClient.getDiggerWantlist.mockResolvedValue({
+                ok: true,
+                status: 200,
+                body: { items: twoItems },
+            });
+        });
+
+        it('should render a table with 2 body rows', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const rows = body.querySelectorAll('tbody tr');
+            expect(rows).toHaveLength(2);
+        });
+
+        it('should render artist name in first row', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const firstRow = body.querySelectorAll('tbody tr')[0];
+            expect(firstRow.textContent).toContain('Radiohead');
+        });
+
+        it('should render title in first row', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const firstRow = body.querySelectorAll('tbody tr')[0];
+            expect(firstRow.textContent).toContain('OK Computer');
+        });
+
+        it('should render year in first row', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const firstRow = body.querySelectorAll('tbody tr')[0];
+            expect(firstRow.textContent).toContain('1997');
+        });
+
+        it('should render tier in first row', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const firstRow = body.querySelectorAll('tbody tr')[0];
+            expect(firstRow.textContent).toContain('A');
+        });
+
+        it('should render active_listings in first row', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const firstRow = body.querySelectorAll('tbody tr')[0];
+            expect(firstRow.textContent).toContain('12');
+        });
+
+        it('should set data-release-id on each row', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const rows = body.querySelectorAll('tbody tr');
+            expect(rows[0].dataset.releaseId).toBe('1');
+            expect(rows[1].dataset.releaseId).toBe('2');
+        });
+
+        it('should show "never" for null last_scraped_at in second row', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const secondRow = body.querySelectorAll('tbody tr')[1];
+            expect(secondRow.textContent).toContain('never');
+        });
+
+        it('should show a formatted date for non-null last_scraped_at', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const firstRow = body.querySelectorAll('tbody tr')[0];
+            // Should have some date text — not "never", not empty
+            const lastCell = firstRow.querySelectorAll('td');
+            const lastScrapedCell = lastCell[lastCell.length - 1];
+            expect(lastScrapedCell.textContent).not.toBe('never');
+            expect(lastScrapedCell.textContent.trim().length).toBeGreaterThan(0);
+        });
+
+        it('should store items in _items', async () => {
+            await window.diggerPane.init();
+            expect(window.diggerPane._items).toHaveLength(2);
+        });
+
+        it('should store settings in _settings', async () => {
+            await window.diggerPane.init();
+            expect(window.diggerPane._settings).not.toBeNull();
+            expect(window.diggerPane._settings.enabled).toBe(true);
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // Enabled + empty wantlist
+    // ------------------------------------------------------------------ //
+
+    describe('enabled + empty wantlist', () => {
+        beforeEach(() => {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: true,
+                status: 200,
+                body: { enabled: true, country_code: 'US', currency: 'USD', scheduled_cadence: 'daily', preferred_model: 'claude-opus', daily_token_cap_interactive: 10000, daily_token_cap_scheduled: 50000 },
+            });
+            window.apiClient.getDiggerWantlist.mockResolvedValue({
+                ok: true,
+                status: 200,
+                body: { items: [] },
+            });
+        });
+
+        it('should render empty state message', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            expect(body.querySelector('.user-pane-empty')).not.toBeNull();
+        });
+
+        it('should NOT render a table when empty', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            expect(body.querySelector('table')).toBeNull();
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // Loading overlay
+    // ------------------------------------------------------------------ //
+
+    describe('loading overlay', () => {
+        it('should remove active class from loading overlay after successful load', async () => {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: true,
+                status: 200,
+                body: { enabled: true, country_code: 'US', currency: 'USD', scheduled_cadence: 'daily', preferred_model: 'claude-opus', daily_token_cap_interactive: 10000, daily_token_cap_scheduled: 50000 },
+            });
+            window.apiClient.getDiggerWantlist.mockResolvedValue({
+                ok: true,
+                status: 200,
+                body: { items: [] },
+            });
+            await window.diggerPane.init();
+            const loading = document.getElementById('diggerLoading');
+            expect(loading.classList.contains('active')).toBe(false);
+        });
+
+        it('should remove active class from loading overlay after 404', async () => {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: false,
+                status: 404,
+                body: null,
+            });
+            await window.diggerPane.init();
+            const loading = document.getElementById('diggerLoading');
+            expect(loading.classList.contains('active')).toBe(false);
+        });
+
+        it('should remove active class from loading overlay on API error', async () => {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: false,
+                status: 500,
+                body: null,
+            });
+            await window.diggerPane.init();
+            const loading = document.getElementById('diggerLoading');
+            expect(loading.classList.contains('active')).toBe(false);
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // Error / unexpected response
+    // ------------------------------------------------------------------ //
+
+    describe('settings error (non-404)', () => {
+        it('should render an error message on 500', async () => {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: false,
+                status: 500,
+                body: null,
+            });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            // Should show something — not empty
+            expect(body.textContent.trim().length).toBeGreaterThan(0);
+        });
+
+        it('should NOT load wantlist on settings error', async () => {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: false,
+                status: 500,
+                body: null,
+            });
+            await window.diggerPane.init();
+            expect(window.apiClient.getDiggerWantlist).not.toHaveBeenCalled();
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // Wantlist load failure
+    // ------------------------------------------------------------------ //
+
+    describe('wantlist load error', () => {
+        beforeEach(() => {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: true,
+                status: 200,
+                body: { enabled: true, country_code: 'US', currency: 'USD', scheduled_cadence: 'weekly', preferred_model: 'sonnet', daily_token_cap_interactive: 200000, daily_token_cap_scheduled: 100000 },
+            });
+            window.apiClient.getDiggerWantlist.mockResolvedValue({
+                ok: false,
+                status: 500,
+                body: null,
+            });
+        });
+
+        it('should attempt to load the wantlist when settings are enabled', async () => {
+            await window.diggerPane.init();
+            expect(window.apiClient.getDiggerWantlist).toHaveBeenCalled();
+        });
+
+        it('should render the error state (not the empty state) when the wantlist request fails', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const icon = body.querySelector('.user-pane-empty .material-symbols-outlined');
+            // Error state uses error_outline; the empty state uses travel_explore.
+            expect(icon).not.toBeNull();
+            expect(icon.textContent).toBe('error_outline');
+            expect(body.querySelector('table')).toBeNull();
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // Table header columns
+    // ------------------------------------------------------------------ //
+
+    describe('table columns', () => {
+        beforeEach(() => {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: true,
+                status: 200,
+                body: { enabled: true, country_code: 'US', currency: 'USD', scheduled_cadence: 'daily', preferred_model: 'claude-opus', daily_token_cap_interactive: 10000, daily_token_cap_scheduled: 50000 },
+            });
+            window.apiClient.getDiggerWantlist.mockResolvedValue({
+                ok: true,
+                status: 200,
+                body: {
+                    items: [{
+                        release_id: 42,
+                        title: 'Test Album',
+                        artist: 'Test Artist',
+                        year: 2000,
+                        tier: 'C',
+                        min_media_condition: null,
+                        min_sleeve_condition: null,
+                        max_price_cents: null,
+                        active_listings: 3,
+                        last_scraped_at: null,
+                    }],
+                },
+            });
+        });
+
+        it('should render table with Artist column header', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const headers = body.querySelectorAll('th');
+            const headerTexts = Array.from(headers).map(h => h.textContent.trim());
+            expect(headerTexts).toContain('Artist');
+        });
+
+        it('should render table with Title column header', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const headers = body.querySelectorAll('th');
+            const headerTexts = Array.from(headers).map(h => h.textContent.trim());
+            expect(headerTexts).toContain('Title');
+        });
+
+        it('should render table with Year column header', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const headers = body.querySelectorAll('th');
+            const headerTexts = Array.from(headers).map(h => h.textContent.trim());
+            expect(headerTexts).toContain('Year');
+        });
+
+        it('should render table with Tier column header', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const headers = body.querySelectorAll('th');
+            const headerTexts = Array.from(headers).map(h => h.textContent.trim());
+            expect(headerTexts).toContain('Tier');
+        });
+
+        it('should render table with Active listings column header', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const headers = body.querySelectorAll('th');
+            const headerTexts = Array.from(headers).map(h => h.textContent.trim());
+            expect(headerTexts.some(t => t.toLowerCase().includes('active'))).toBe(true);
+        });
+
+        it('should render table with Last scraped column header', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const headers = body.querySelectorAll('th');
+            const headerTexts = Array.from(headers).map(h => h.textContent.trim());
+            expect(headerTexts.some(t => t.toLowerCase().includes('scraped') || t.toLowerCase().includes('last'))).toBe(true);
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // Null value fallbacks
+    // ------------------------------------------------------------------ //
+
+    describe('null field fallbacks', () => {
+        beforeEach(() => {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: true,
+                status: 200,
+                body: { enabled: true, country_code: 'US', currency: 'USD', scheduled_cadence: 'daily', preferred_model: 'claude-opus', daily_token_cap_interactive: 10000, daily_token_cap_scheduled: 50000 },
+            });
+        });
+
+        it('should show "—" for null artist', async () => {
+            window.apiClient.getDiggerWantlist.mockResolvedValue({
+                ok: true,
+                status: 200,
+                body: { items: [{ release_id: 1, title: 'T', artist: null, year: 2000, tier: 'A', min_media_condition: null, min_sleeve_condition: null, max_price_cents: null, active_listings: 0, last_scraped_at: null }] },
+            });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const row = body.querySelector('tbody tr');
+            const cells = row.querySelectorAll('td');
+            expect(cells[0].textContent).toBe('—');
+        });
+
+        it('should show "—" for null title', async () => {
+            window.apiClient.getDiggerWantlist.mockResolvedValue({
+                ok: true,
+                status: 200,
+                body: { items: [{ release_id: 1, title: null, artist: 'A', year: 2000, tier: 'A', min_media_condition: null, min_sleeve_condition: null, max_price_cents: null, active_listings: 0, last_scraped_at: null }] },
+            });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const row = body.querySelector('tbody tr');
+            const cells = row.querySelectorAll('td');
+            expect(cells[1].textContent).toBe('—');
+        });
+
+        it('should show "—" for null year', async () => {
+            window.apiClient.getDiggerWantlist.mockResolvedValue({
+                ok: true,
+                status: 200,
+                body: { items: [{ release_id: 1, title: 'T', artist: 'A', year: null, tier: 'A', min_media_condition: null, min_sleeve_condition: null, max_price_cents: null, active_listings: 0, last_scraped_at: null }] },
+            });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const row = body.querySelector('tbody tr');
+            const cells = row.querySelectorAll('td');
+            expect(cells[2].textContent).toBe('—');
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // Concurrent load guard
+    // ------------------------------------------------------------------ //
+
+    describe('concurrent load guard', () => {
+        it('should not allow concurrent init calls', async () => {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: false,
+                status: 404,
+                body: null,
+            });
+            // Fire two concurrent inits
+            const p1 = window.diggerPane.init();
+            const p2 = window.diggerPane.init();
+            await Promise.all([p1, p2]);
+            // Should only call once
+            expect(window.apiClient.getDiggerSettings).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/explore/__tests__/digger.test.js
+++ b/explore/__tests__/digger.test.js
@@ -26,6 +26,7 @@ describe('DiggerPane', () => {
         window.apiClient = {
             getDiggerSettings: vi.fn(),
             getDiggerWantlist: vi.fn(),
+            setDiggerPriority: vi.fn(),
         };
         window.exploreApp = undefined;
         loadScript('digger.js');
@@ -177,7 +178,7 @@ describe('DiggerPane', () => {
                 title: 'OK Computer',
                 artist: 'Radiohead',
                 year: 1997,
-                tier: 'A',
+                tier: 'must',
                 min_media_condition: 'VG+',
                 min_sleeve_condition: 'VG',
                 max_price_cents: 5000,
@@ -189,9 +190,9 @@ describe('DiggerPane', () => {
                 title: 'Homogenic',
                 artist: 'Bjork',
                 year: 1997,
-                tier: 'B',
-                min_media_condition: null,
-                min_sleeve_condition: null,
+                tier: 'nice',
+                min_media_condition: 'VG',
+                min_sleeve_condition: 'G+',
                 max_price_cents: null,
                 active_listings: 0,
                 last_scraped_at: null,
@@ -247,11 +248,13 @@ describe('DiggerPane', () => {
             expect(firstRow.textContent).toContain('1997');
         });
 
-        it('should render tier in first row', async () => {
+        it('should render tier buttons (not plain text) in first row', async () => {
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
             const firstRow = body.querySelectorAll('tbody tr')[0];
-            expect(firstRow.textContent).toContain('A');
+            // Tier is now a segmented toggle — should have tier buttons
+            const tierBtns = firstRow.querySelectorAll('.digger-tier-btn');
+            expect(tierBtns.length).toBe(3);
         });
 
         it('should render active_listings in first row', async () => {
@@ -456,9 +459,9 @@ describe('DiggerPane', () => {
                         title: 'Test Album',
                         artist: 'Test Artist',
                         year: 2000,
-                        tier: 'C',
-                        min_media_condition: null,
-                        min_sleeve_condition: null,
+                        tier: 'nice',
+                        min_media_condition: 'VG',
+                        min_sleeve_condition: 'G+',
                         max_price_cents: null,
                         active_listings: 3,
                         last_scraped_at: null,
@@ -499,6 +502,30 @@ describe('DiggerPane', () => {
             expect(headerTexts).toContain('Tier');
         });
 
+        it('should render table with Media column header', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const headers = body.querySelectorAll('th');
+            const headerTexts = Array.from(headers).map(h => h.textContent.trim());
+            expect(headerTexts).toContain('Media');
+        });
+
+        it('should render table with Sleeve column header', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const headers = body.querySelectorAll('th');
+            const headerTexts = Array.from(headers).map(h => h.textContent.trim());
+            expect(headerTexts).toContain('Sleeve');
+        });
+
+        it('should render table with Max price column header', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const headers = body.querySelectorAll('th');
+            const headerTexts = Array.from(headers).map(h => h.textContent.trim());
+            expect(headerTexts.some(t => t.toLowerCase().includes('price'))).toBe(true);
+        });
+
         it('should render table with Active listings column header', async () => {
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
@@ -513,6 +540,13 @@ describe('DiggerPane', () => {
             const headers = body.querySelectorAll('th');
             const headerTexts = Array.from(headers).map(h => h.textContent.trim());
             expect(headerTexts.some(t => t.toLowerCase().includes('scraped') || t.toLowerCase().includes('last'))).toBe(true);
+        });
+
+        it('should render exactly 9 column headers', async () => {
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const headers = body.querySelectorAll('th');
+            expect(headers).toHaveLength(9);
         });
     });
 
@@ -533,7 +567,7 @@ describe('DiggerPane', () => {
             window.apiClient.getDiggerWantlist.mockResolvedValue({
                 ok: true,
                 status: 200,
-                body: { items: [{ release_id: 1, title: 'T', artist: null, year: 2000, tier: 'A', min_media_condition: null, min_sleeve_condition: null, max_price_cents: null, active_listings: 0, last_scraped_at: null }] },
+                body: { items: [{ release_id: 1, title: 'T', artist: null, year: 2000, tier: 'nice', min_media_condition: 'VG', min_sleeve_condition: 'G+', max_price_cents: null, active_listings: 0, last_scraped_at: null }] },
             });
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
@@ -546,7 +580,7 @@ describe('DiggerPane', () => {
             window.apiClient.getDiggerWantlist.mockResolvedValue({
                 ok: true,
                 status: 200,
-                body: { items: [{ release_id: 1, title: null, artist: 'A', year: 2000, tier: 'A', min_media_condition: null, min_sleeve_condition: null, max_price_cents: null, active_listings: 0, last_scraped_at: null }] },
+                body: { items: [{ release_id: 1, title: null, artist: 'A', year: 2000, tier: 'nice', min_media_condition: 'VG', min_sleeve_condition: 'G+', max_price_cents: null, active_listings: 0, last_scraped_at: null }] },
             });
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
@@ -559,7 +593,7 @@ describe('DiggerPane', () => {
             window.apiClient.getDiggerWantlist.mockResolvedValue({
                 ok: true,
                 status: 200,
-                body: { items: [{ release_id: 1, title: 'T', artist: 'A', year: null, tier: 'A', min_media_condition: null, min_sleeve_condition: null, max_price_cents: null, active_listings: 0, last_scraped_at: null }] },
+                body: { items: [{ release_id: 1, title: 'T', artist: 'A', year: null, tier: 'nice', min_media_condition: 'VG', min_sleeve_condition: 'G+', max_price_cents: null, active_listings: 0, last_scraped_at: null }] },
             });
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
@@ -586,6 +620,546 @@ describe('DiggerPane', () => {
             await Promise.all([p1, p2]);
             // Should only call once
             expect(window.apiClient.getDiggerSettings).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // Tier toggle controls
+    // ------------------------------------------------------------------ //
+
+    describe('tier toggle', () => {
+        const makeItem = (tier) => ({
+            release_id: 10,
+            title: 'Test',
+            artist: 'Artist',
+            year: 2020,
+            tier,
+            min_media_condition: 'VG',
+            min_sleeve_condition: 'G+',
+            max_price_cents: null,
+            active_listings: 0,
+            last_scraped_at: null,
+        });
+
+        function setupWantlist(tier) {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: true, status: 200,
+                body: { enabled: true, country_code: 'US', currency: 'USD', scheduled_cadence: 'daily', preferred_model: 'claude-opus', daily_token_cap_interactive: 10000, daily_token_cap_scheduled: 50000 },
+            });
+            window.apiClient.getDiggerWantlist.mockResolvedValue({
+                ok: true, status: 200,
+                body: { items: [makeItem(tier)] },
+            });
+        }
+
+        it('should render 3 tier buttons', async () => {
+            setupWantlist('must');
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const row = body.querySelector('tbody tr');
+            const btns = row.querySelectorAll('.digger-tier-btn');
+            expect(btns).toHaveLength(3);
+        });
+
+        it('should label buttons must / nice / eventually', async () => {
+            setupWantlist('must');
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const btns = body.querySelectorAll('.digger-tier-btn');
+            const labels = Array.from(btns).map(b => b.textContent);
+            expect(labels).toEqual(['must', 'nice', 'eventually']);
+        });
+
+        it('should mark current tier button as active and aria-pressed=true', async () => {
+            setupWantlist('nice');
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const btns = body.querySelectorAll('.digger-tier-btn');
+            const niceBtn = Array.from(btns).find(b => b.textContent === 'nice');
+            expect(niceBtn.classList.contains('active')).toBe(true);
+            expect(niceBtn.getAttribute('aria-pressed')).toBe('true');
+        });
+
+        it('should mark non-current tier buttons as inactive and aria-pressed=false', async () => {
+            setupWantlist('must');
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const btns = body.querySelectorAll('.digger-tier-btn');
+            const niceBtn = Array.from(btns).find(b => b.textContent === 'nice');
+            const eventuallyBtn = Array.from(btns).find(b => b.textContent === 'eventually');
+            expect(niceBtn.classList.contains('active')).toBe(false);
+            expect(niceBtn.getAttribute('aria-pressed')).toBe('false');
+            expect(eventuallyBtn.classList.contains('active')).toBe(false);
+            expect(eventuallyBtn.getAttribute('aria-pressed')).toBe('false');
+        });
+
+        it('should have a role=group container with aria-label="Tier"', async () => {
+            setupWantlist('must');
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const group = body.querySelector('[role="group"][aria-label="Tier"]');
+            expect(group).not.toBeNull();
+        });
+
+        it('clicking a different tier calls setDiggerPriority with new tier', async () => {
+            setupWantlist('must');
+            window.apiClient.setDiggerPriority.mockResolvedValue({ ok: true, status: 204, body: null });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const btns = body.querySelectorAll('.digger-tier-btn');
+            const niceBtn = Array.from(btns).find(b => b.textContent === 'nice');
+            niceBtn.click();
+            await new Promise(r => setTimeout(r, 0)); // flush microtasks
+            expect(window.apiClient.setDiggerPriority).toHaveBeenCalledWith(
+                'test-token', 10, { tier: 'nice' }
+            );
+        });
+
+        it('clicking the already-active tier does NOT call setDiggerPriority', async () => {
+            setupWantlist('must');
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const btns = body.querySelectorAll('.digger-tier-btn');
+            const mustBtn = Array.from(btns).find(b => b.textContent === 'must');
+            mustBtn.click();
+            await new Promise(r => setTimeout(r, 0));
+            expect(window.apiClient.setDiggerPriority).not.toHaveBeenCalled();
+        });
+
+        it('on tier success, updates aria-pressed and active class for all buttons', async () => {
+            setupWantlist('must');
+            window.apiClient.setDiggerPriority.mockResolvedValue({ ok: true, status: 204, body: null });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const btns = body.querySelectorAll('.digger-tier-btn');
+            const eventuallyBtn = Array.from(btns).find(b => b.textContent === 'eventually');
+            const mustBtn = Array.from(btns).find(b => b.textContent === 'must');
+            eventuallyBtn.click();
+            await new Promise(r => setTimeout(r, 0));
+            expect(eventuallyBtn.getAttribute('aria-pressed')).toBe('true');
+            expect(eventuallyBtn.classList.contains('active')).toBe(true);
+            expect(mustBtn.getAttribute('aria-pressed')).toBe('false');
+            expect(mustBtn.classList.contains('active')).toBe(false);
+        });
+
+        it('on tier success, updates in-memory item tier', async () => {
+            setupWantlist('must');
+            window.apiClient.setDiggerPriority.mockResolvedValue({ ok: true, status: 204, body: null });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const btns = body.querySelectorAll('.digger-tier-btn');
+            const niceBtn = Array.from(btns).find(b => b.textContent === 'nice');
+            niceBtn.click();
+            await new Promise(r => setTimeout(r, 0));
+            expect(window.diggerPane._items[0].tier).toBe('nice');
+        });
+
+        it('on tier failure, leaves buttons unchanged', async () => {
+            setupWantlist('must');
+            window.apiClient.setDiggerPriority.mockResolvedValue({ ok: false, status: 400, body: null });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const btns = body.querySelectorAll('.digger-tier-btn');
+            const niceBtn = Array.from(btns).find(b => b.textContent === 'nice');
+            const mustBtn = Array.from(btns).find(b => b.textContent === 'must');
+            niceBtn.click();
+            await new Promise(r => setTimeout(r, 0));
+            // must remains active
+            expect(mustBtn.getAttribute('aria-pressed')).toBe('true');
+            expect(mustBtn.classList.contains('active')).toBe(true);
+            // nice stays inactive
+            expect(niceBtn.getAttribute('aria-pressed')).toBe('false');
+            expect(niceBtn.classList.contains('active')).toBe(false);
+        });
+
+        it('on tier failure, in-memory item tier is unchanged', async () => {
+            setupWantlist('must');
+            window.apiClient.setDiggerPriority.mockResolvedValue({ ok: false, status: 500, body: null });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const btns = body.querySelectorAll('.digger-tier-btn');
+            const niceBtn = Array.from(btns).find(b => b.textContent === 'nice');
+            niceBtn.click();
+            await new Promise(r => setTimeout(r, 0));
+            expect(window.diggerPane._items[0].tier).toBe('must');
+        });
+
+        it('tier click does nothing when no token', async () => {
+            setupWantlist('must');
+            await window.diggerPane.init();
+            window.authManager.getToken.mockReturnValue(null);
+            const body = document.getElementById('diggerBody');
+            const btns = body.querySelectorAll('.digger-tier-btn');
+            const niceBtn = Array.from(btns).find(b => b.textContent === 'nice');
+            niceBtn.click();
+            await new Promise(r => setTimeout(r, 0));
+            expect(window.apiClient.setDiggerPriority).not.toHaveBeenCalled();
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // Media condition select
+    // ------------------------------------------------------------------ //
+
+    describe('media condition select', () => {
+        function setupWantlistMedia(min_media_condition) {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: true, status: 200,
+                body: { enabled: true, country_code: 'US', currency: 'USD', scheduled_cadence: 'daily', preferred_model: 'claude-opus', daily_token_cap_interactive: 10000, daily_token_cap_scheduled: 50000 },
+            });
+            window.apiClient.getDiggerWantlist.mockResolvedValue({
+                ok: true, status: 200,
+                body: { items: [{
+                    release_id: 20,
+                    title: 'Media Test',
+                    artist: 'Artist',
+                    year: 2021,
+                    tier: 'nice',
+                    min_media_condition,
+                    min_sleeve_condition: 'G+',
+                    max_price_cents: null,
+                    active_listings: 0,
+                    last_scraped_at: null,
+                }] },
+            });
+        }
+
+        it('should render a media select in each row', async () => {
+            setupWantlistMedia('VG+');
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const row = body.querySelector('tbody tr');
+            // Media is the 5th cell (index 4), sleeve is 6th (index 5)
+            const cells = row.querySelectorAll('td');
+            const mediaSelect = cells[4].querySelector('select');
+            expect(mediaSelect).not.toBeNull();
+        });
+
+        it('should render all 8 media condition options (no blank)', async () => {
+            setupWantlistMedia('VG');
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const mediaSelect = cells[4].querySelector('select');
+            // Exactly 8 conditions: M, NM, VG+, VG, G+, G, F, P
+            expect(mediaSelect.options.length).toBe(8);
+            const values = Array.from(mediaSelect.options).map(o => o.value);
+            expect(values).toEqual(['M', 'NM', 'VG+', 'VG', 'G+', 'G', 'F', 'P']);
+        });
+
+        it('should pre-select the current media condition', async () => {
+            setupWantlistMedia('VG+');
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const mediaSelect = cells[4].querySelector('select');
+            expect(mediaSelect.value).toBe('VG+');
+        });
+
+        it('changing media select calls setDiggerPriority with min_media_condition', async () => {
+            setupWantlistMedia('VG');
+            window.apiClient.setDiggerPriority.mockResolvedValue({ ok: true, status: 204, body: null });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const mediaSelect = cells[4].querySelector('select');
+            mediaSelect.value = 'NM';
+            mediaSelect.dispatchEvent(new Event('change'));
+            await new Promise(r => setTimeout(r, 0));
+            expect(window.apiClient.setDiggerPriority).toHaveBeenCalledWith(
+                'test-token', 20, { min_media_condition: 'NM' }
+            );
+        });
+
+        it('on media select success, updates in-memory item', async () => {
+            setupWantlistMedia('VG');
+            window.apiClient.setDiggerPriority.mockResolvedValue({ ok: true, status: 204, body: null });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const mediaSelect = cells[4].querySelector('select');
+            mediaSelect.value = 'M';
+            mediaSelect.dispatchEvent(new Event('change'));
+            await new Promise(r => setTimeout(r, 0));
+            expect(window.diggerPane._items[0].min_media_condition).toBe('M');
+        });
+
+        it('on media select failure, reverts the select and leaves in-memory unchanged', async () => {
+            setupWantlistMedia('VG');
+            window.apiClient.setDiggerPriority.mockResolvedValue({ ok: false, status: 500, body: null });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const mediaSelect = cells[4].querySelector('select');
+            mediaSelect.value = 'M';
+            mediaSelect.dispatchEvent(new Event('change'));
+            await new Promise(r => setTimeout(r, 0));
+            // Reverted to original
+            expect(mediaSelect.value).toBe('VG');
+            expect(window.diggerPane._items[0].min_media_condition).toBe('VG');
+        });
+
+        it('media select change does nothing when no token', async () => {
+            setupWantlistMedia('VG');
+            await window.diggerPane.init();
+            window.authManager.getToken.mockReturnValue(null);
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const mediaSelect = cells[4].querySelector('select');
+            mediaSelect.value = 'NM';
+            mediaSelect.dispatchEvent(new Event('change'));
+            await new Promise(r => setTimeout(r, 0));
+            expect(window.apiClient.setDiggerPriority).not.toHaveBeenCalled();
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // Sleeve condition select
+    // ------------------------------------------------------------------ //
+
+    describe('sleeve condition select', () => {
+        function setupWantlistSleeve(min_sleeve_condition) {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: true, status: 200,
+                body: { enabled: true, country_code: 'US', currency: 'USD', scheduled_cadence: 'daily', preferred_model: 'claude-opus', daily_token_cap_interactive: 10000, daily_token_cap_scheduled: 50000 },
+            });
+            window.apiClient.getDiggerWantlist.mockResolvedValue({
+                ok: true, status: 200,
+                body: { items: [{
+                    release_id: 30,
+                    title: 'Sleeve Test',
+                    artist: 'Artist',
+                    year: 2021,
+                    tier: 'eventually',
+                    min_media_condition: 'VG',
+                    min_sleeve_condition,
+                    max_price_cents: null,
+                    active_listings: 0,
+                    last_scraped_at: null,
+                }] },
+            });
+        }
+
+        it('should render a sleeve select in each row', async () => {
+            setupWantlistSleeve('VG');
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const sleeveSelect = cells[5].querySelector('select');
+            expect(sleeveSelect).not.toBeNull();
+        });
+
+        it('should render all 10 sleeve condition options (no blank)', async () => {
+            setupWantlistSleeve('VG');
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const sleeveSelect = cells[5].querySelector('select');
+            // Exactly 10 conditions: M, NM, VG+, VG, G+, G, F, P, generic, no_cover
+            expect(sleeveSelect.options.length).toBe(10);
+            const values = Array.from(sleeveSelect.options).map(o => o.value);
+            expect(values).toEqual(['M', 'NM', 'VG+', 'VG', 'G+', 'G', 'F', 'P', 'generic', 'no_cover']);
+        });
+
+        it('should pre-select the current sleeve condition', async () => {
+            setupWantlistSleeve('generic');
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const sleeveSelect = cells[5].querySelector('select');
+            expect(sleeveSelect.value).toBe('generic');
+        });
+
+        it('changing sleeve select calls setDiggerPriority with min_sleeve_condition', async () => {
+            setupWantlistSleeve('VG');
+            window.apiClient.setDiggerPriority.mockResolvedValue({ ok: true, status: 204, body: null });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const sleeveSelect = cells[5].querySelector('select');
+            sleeveSelect.value = 'no_cover';
+            sleeveSelect.dispatchEvent(new Event('change'));
+            await new Promise(r => setTimeout(r, 0));
+            expect(window.apiClient.setDiggerPriority).toHaveBeenCalledWith(
+                'test-token', 30, { min_sleeve_condition: 'no_cover' }
+            );
+        });
+
+        it('on sleeve select failure, reverts the select and leaves in-memory unchanged', async () => {
+            setupWantlistSleeve('VG');
+            window.apiClient.setDiggerPriority.mockResolvedValue({ ok: false, status: 500, body: null });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const sleeveSelect = cells[5].querySelector('select');
+            sleeveSelect.value = 'M';
+            sleeveSelect.dispatchEvent(new Event('change'));
+            await new Promise(r => setTimeout(r, 0));
+            expect(sleeveSelect.value).toBe('VG');
+            expect(window.diggerPane._items[0].min_sleeve_condition).toBe('VG');
+        });
+
+        it('sleeve select change does nothing when no token', async () => {
+            setupWantlistSleeve('VG');
+            await window.diggerPane.init();
+            window.authManager.getToken.mockReturnValue(null);
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const sleeveSelect = cells[5].querySelector('select');
+            sleeveSelect.value = 'NM';
+            sleeveSelect.dispatchEvent(new Event('change'));
+            await new Promise(r => setTimeout(r, 0));
+            expect(window.apiClient.setDiggerPriority).not.toHaveBeenCalled();
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // Max price input
+    // ------------------------------------------------------------------ //
+
+    describe('max price input', () => {
+        function setupWantlistPrice(max_price_cents) {
+            window.apiClient.getDiggerSettings.mockResolvedValue({
+                ok: true, status: 200,
+                body: { enabled: true, country_code: 'US', currency: 'USD', scheduled_cadence: 'daily', preferred_model: 'claude-opus', daily_token_cap_interactive: 10000, daily_token_cap_scheduled: 50000 },
+            });
+            window.apiClient.getDiggerWantlist.mockResolvedValue({
+                ok: true, status: 200,
+                body: { items: [{
+                    release_id: 40,
+                    title: 'Price Test',
+                    artist: 'Artist',
+                    year: 2021,
+                    tier: 'nice',
+                    min_media_condition: 'VG',
+                    min_sleeve_condition: 'G+',
+                    max_price_cents,
+                    active_listings: 0,
+                    last_scraped_at: null,
+                }] },
+            });
+        }
+
+        it('should render a number input for max price', async () => {
+            setupWantlistPrice(1000);
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const priceInput = cells[6].querySelector('input[type="number"]');
+            expect(priceInput).not.toBeNull();
+        });
+
+        it('should display cents as dollars (5000 cents → "50")', async () => {
+            setupWantlistPrice(5000);
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const priceInput = cells[6].querySelector('input[type="number"]');
+            expect(priceInput.value).toBe('50');
+        });
+
+        it('should display empty string when max_price_cents is null', async () => {
+            setupWantlistPrice(null);
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const priceInput = cells[6].querySelector('input[type="number"]');
+            expect(priceInput.value).toBe('');
+        });
+
+        it('entering a dollar value calls setDiggerPriority with cents', async () => {
+            setupWantlistPrice(null);
+            window.apiClient.setDiggerPriority.mockResolvedValue({ ok: true, status: 204, body: null });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const priceInput = cells[6].querySelector('input[type="number"]');
+            priceInput.value = '12.50';
+            priceInput.dispatchEvent(new Event('change'));
+            await new Promise(r => setTimeout(r, 0));
+            expect(window.apiClient.setDiggerPriority).toHaveBeenCalledWith(
+                'test-token', 40, { max_price_cents: 1250 }
+            );
+        });
+
+        it('clearing the price input sends max_price_cents: null', async () => {
+            setupWantlistPrice(5000);
+            window.apiClient.setDiggerPriority.mockResolvedValue({ ok: true, status: 204, body: null });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const priceInput = cells[6].querySelector('input[type="number"]');
+            priceInput.value = '';
+            priceInput.dispatchEvent(new Event('change'));
+            await new Promise(r => setTimeout(r, 0));
+            expect(window.apiClient.setDiggerPriority).toHaveBeenCalledWith(
+                'test-token', 40, { max_price_cents: null }
+            );
+        });
+
+        it('on price success, updates in-memory item max_price_cents', async () => {
+            setupWantlistPrice(null);
+            window.apiClient.setDiggerPriority.mockResolvedValue({ ok: true, status: 204, body: null });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const priceInput = cells[6].querySelector('input[type="number"]');
+            priceInput.value = '25';
+            priceInput.dispatchEvent(new Event('change'));
+            await new Promise(r => setTimeout(r, 0));
+            expect(window.diggerPane._items[0].max_price_cents).toBe(2500);
+        });
+
+        it('on price failure, reverts input to original value and leaves in-memory unchanged', async () => {
+            setupWantlistPrice(3000);
+            window.apiClient.setDiggerPriority.mockResolvedValue({ ok: false, status: 500, body: null });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const priceInput = cells[6].querySelector('input[type="number"]');
+            priceInput.value = '99';
+            priceInput.dispatchEvent(new Event('change'));
+            await new Promise(r => setTimeout(r, 0));
+            expect(priceInput.value).toBe('30');
+            expect(window.diggerPane._items[0].max_price_cents).toBe(3000);
+        });
+
+        it('price input change does nothing when no token', async () => {
+            setupWantlistPrice(null);
+            await window.diggerPane.init();
+            window.authManager.getToken.mockReturnValue(null);
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const priceInput = cells[6].querySelector('input[type="number"]');
+            priceInput.value = '10';
+            priceInput.dispatchEvent(new Event('change'));
+            await new Promise(r => setTimeout(r, 0));
+            expect(window.apiClient.setDiggerPriority).not.toHaveBeenCalled();
+        });
+
+        it('treats a non-numeric entry as a clear (number input sanitizes it to empty → null)', async () => {
+            setupWantlistPrice(5000);
+            window.apiClient.setDiggerPriority.mockResolvedValue({ ok: true, status: 204, body: null });
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const priceInput = cells[6].querySelector('input[type="number"]');
+            priceInput.value = 'abc'; // type=number sanitizes this to '' (browsers + jsdom)
+            priceInput.dispatchEvent(new Event('change'));
+            await new Promise(r => setTimeout(r, 0));
+            expect(window.apiClient.setDiggerPriority).toHaveBeenCalledWith(
+                'test-token', 40, { max_price_cents: null }
+            );
+        });
+
+        it('input has correct min and step attributes', async () => {
+            setupWantlistPrice(null);
+            await window.diggerPane.init();
+            const body = document.getElementById('diggerBody');
+            const cells = body.querySelector('tbody tr').querySelectorAll('td');
+            const priceInput = cells[6].querySelector('input[type="number"]');
+            expect(priceInput.min).toBe('0');
+            expect(priceInput.step).toBe('0.01');
         });
     });
 });

--- a/explore/__tests__/digger.test.js
+++ b/explore/__tests__/digger.test.js
@@ -542,11 +542,11 @@ describe('DiggerPane', () => {
             expect(headerTexts.some(t => t.toLowerCase().includes('scraped') || t.toLowerCase().includes('last'))).toBe(true);
         });
 
-        it('should render exactly 9 column headers', async () => {
+        it('should render exactly 10 column headers (leading select column + 9 data columns)', async () => {
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
             const headers = body.querySelectorAll('th');
-            expect(headers).toHaveLength(9);
+            expect(headers).toHaveLength(10);
         });
     });
 
@@ -573,7 +573,8 @@ describe('DiggerPane', () => {
             const body = document.getElementById('diggerBody');
             const row = body.querySelector('tbody tr');
             const cells = row.querySelectorAll('td');
-            expect(cells[0].textContent).toBe('—');
+            // cells[0] is the row-selection checkbox; artist is cells[1].
+            expect(cells[1].textContent).toBe('—');
         });
 
         it('should show "—" for null title', async () => {
@@ -586,7 +587,8 @@ describe('DiggerPane', () => {
             const body = document.getElementById('diggerBody');
             const row = body.querySelector('tbody tr');
             const cells = row.querySelectorAll('td');
-            expect(cells[1].textContent).toBe('—');
+            // cells[0] = select checkbox, cells[1] = artist, cells[2] = title.
+            expect(cells[2].textContent).toBe('—');
         });
 
         it('should show "—" for null year', async () => {
@@ -599,7 +601,8 @@ describe('DiggerPane', () => {
             const body = document.getElementById('diggerBody');
             const row = body.querySelector('tbody tr');
             const cells = row.querySelectorAll('td');
-            expect(cells[2].textContent).toBe('—');
+            // cells[0] = select checkbox, cells[1] = artist, cells[2] = title, cells[3] = year.
+            expect(cells[3].textContent).toBe('—');
         });
     });
 
@@ -829,9 +832,8 @@ describe('DiggerPane', () => {
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
             const row = body.querySelector('tbody tr');
-            // Media is the 5th cell (index 4), sleeve is 6th (index 5)
-            const cells = row.querySelectorAll('td');
-            const mediaSelect = cells[4].querySelector('select');
+            // Media is the first <select> in the row; sleeve is the second.
+            const mediaSelect = row.querySelectorAll('select')[0];
             expect(mediaSelect).not.toBeNull();
         });
 
@@ -839,8 +841,7 @@ describe('DiggerPane', () => {
             setupWantlistMedia('VG');
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const mediaSelect = cells[4].querySelector('select');
+            const mediaSelect = body.querySelector('tbody tr').querySelectorAll('select')[0];
             // Exactly 8 conditions: M, NM, VG+, VG, G+, G, F, P
             expect(mediaSelect.options.length).toBe(8);
             const values = Array.from(mediaSelect.options).map(o => o.value);
@@ -851,8 +852,7 @@ describe('DiggerPane', () => {
             setupWantlistMedia('VG+');
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const mediaSelect = cells[4].querySelector('select');
+            const mediaSelect = body.querySelector('tbody tr').querySelectorAll('select')[0];
             expect(mediaSelect.value).toBe('VG+');
         });
 
@@ -861,8 +861,7 @@ describe('DiggerPane', () => {
             window.apiClient.setDiggerPriority.mockResolvedValue({ ok: true, status: 204, body: null });
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const mediaSelect = cells[4].querySelector('select');
+            const mediaSelect = body.querySelector('tbody tr').querySelectorAll('select')[0];
             mediaSelect.value = 'NM';
             mediaSelect.dispatchEvent(new Event('change'));
             await new Promise(r => setTimeout(r, 0));
@@ -876,8 +875,7 @@ describe('DiggerPane', () => {
             window.apiClient.setDiggerPriority.mockResolvedValue({ ok: true, status: 204, body: null });
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const mediaSelect = cells[4].querySelector('select');
+            const mediaSelect = body.querySelector('tbody tr').querySelectorAll('select')[0];
             mediaSelect.value = 'M';
             mediaSelect.dispatchEvent(new Event('change'));
             await new Promise(r => setTimeout(r, 0));
@@ -889,8 +887,7 @@ describe('DiggerPane', () => {
             window.apiClient.setDiggerPriority.mockResolvedValue({ ok: false, status: 500, body: null });
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const mediaSelect = cells[4].querySelector('select');
+            const mediaSelect = body.querySelector('tbody tr').querySelectorAll('select')[0];
             mediaSelect.value = 'M';
             mediaSelect.dispatchEvent(new Event('change'));
             await new Promise(r => setTimeout(r, 0));
@@ -904,8 +901,7 @@ describe('DiggerPane', () => {
             await window.diggerPane.init();
             window.authManager.getToken.mockReturnValue(null);
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const mediaSelect = cells[4].querySelector('select');
+            const mediaSelect = body.querySelector('tbody tr').querySelectorAll('select')[0];
             mediaSelect.value = 'NM';
             mediaSelect.dispatchEvent(new Event('change'));
             await new Promise(r => setTimeout(r, 0));
@@ -944,8 +940,7 @@ describe('DiggerPane', () => {
             setupWantlistSleeve('VG');
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const sleeveSelect = cells[5].querySelector('select');
+            const sleeveSelect = body.querySelector('tbody tr').querySelectorAll('select')[1];
             expect(sleeveSelect).not.toBeNull();
         });
 
@@ -953,8 +948,7 @@ describe('DiggerPane', () => {
             setupWantlistSleeve('VG');
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const sleeveSelect = cells[5].querySelector('select');
+            const sleeveSelect = body.querySelector('tbody tr').querySelectorAll('select')[1];
             // Exactly 10 conditions: M, NM, VG+, VG, G+, G, F, P, generic, no_cover
             expect(sleeveSelect.options.length).toBe(10);
             const values = Array.from(sleeveSelect.options).map(o => o.value);
@@ -965,8 +959,7 @@ describe('DiggerPane', () => {
             setupWantlistSleeve('generic');
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const sleeveSelect = cells[5].querySelector('select');
+            const sleeveSelect = body.querySelector('tbody tr').querySelectorAll('select')[1];
             expect(sleeveSelect.value).toBe('generic');
         });
 
@@ -975,8 +968,7 @@ describe('DiggerPane', () => {
             window.apiClient.setDiggerPriority.mockResolvedValue({ ok: true, status: 204, body: null });
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const sleeveSelect = cells[5].querySelector('select');
+            const sleeveSelect = body.querySelector('tbody tr').querySelectorAll('select')[1];
             sleeveSelect.value = 'no_cover';
             sleeveSelect.dispatchEvent(new Event('change'));
             await new Promise(r => setTimeout(r, 0));
@@ -990,8 +982,7 @@ describe('DiggerPane', () => {
             window.apiClient.setDiggerPriority.mockResolvedValue({ ok: false, status: 500, body: null });
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const sleeveSelect = cells[5].querySelector('select');
+            const sleeveSelect = body.querySelector('tbody tr').querySelectorAll('select')[1];
             sleeveSelect.value = 'M';
             sleeveSelect.dispatchEvent(new Event('change'));
             await new Promise(r => setTimeout(r, 0));
@@ -1004,8 +995,7 @@ describe('DiggerPane', () => {
             await window.diggerPane.init();
             window.authManager.getToken.mockReturnValue(null);
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const sleeveSelect = cells[5].querySelector('select');
+            const sleeveSelect = body.querySelector('tbody tr').querySelectorAll('select')[1];
             sleeveSelect.value = 'NM';
             sleeveSelect.dispatchEvent(new Event('change'));
             await new Promise(r => setTimeout(r, 0));
@@ -1044,8 +1034,7 @@ describe('DiggerPane', () => {
             setupWantlistPrice(1000);
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const priceInput = cells[6].querySelector('input[type="number"]');
+            const priceInput = body.querySelector('tbody tr').querySelector('input[type="number"]');
             expect(priceInput).not.toBeNull();
         });
 
@@ -1053,8 +1042,7 @@ describe('DiggerPane', () => {
             setupWantlistPrice(5000);
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const priceInput = cells[6].querySelector('input[type="number"]');
+            const priceInput = body.querySelector('tbody tr').querySelector('input[type="number"]');
             expect(priceInput.value).toBe('50');
         });
 
@@ -1062,8 +1050,7 @@ describe('DiggerPane', () => {
             setupWantlistPrice(null);
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const priceInput = cells[6].querySelector('input[type="number"]');
+            const priceInput = body.querySelector('tbody tr').querySelector('input[type="number"]');
             expect(priceInput.value).toBe('');
         });
 
@@ -1072,8 +1059,7 @@ describe('DiggerPane', () => {
             window.apiClient.setDiggerPriority.mockResolvedValue({ ok: true, status: 204, body: null });
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const priceInput = cells[6].querySelector('input[type="number"]');
+            const priceInput = body.querySelector('tbody tr').querySelector('input[type="number"]');
             priceInput.value = '12.50';
             priceInput.dispatchEvent(new Event('change'));
             await new Promise(r => setTimeout(r, 0));
@@ -1087,8 +1073,7 @@ describe('DiggerPane', () => {
             window.apiClient.setDiggerPriority.mockResolvedValue({ ok: true, status: 204, body: null });
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const priceInput = cells[6].querySelector('input[type="number"]');
+            const priceInput = body.querySelector('tbody tr').querySelector('input[type="number"]');
             priceInput.value = '';
             priceInput.dispatchEvent(new Event('change'));
             await new Promise(r => setTimeout(r, 0));
@@ -1102,8 +1087,7 @@ describe('DiggerPane', () => {
             window.apiClient.setDiggerPriority.mockResolvedValue({ ok: true, status: 204, body: null });
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const priceInput = cells[6].querySelector('input[type="number"]');
+            const priceInput = body.querySelector('tbody tr').querySelector('input[type="number"]');
             priceInput.value = '25';
             priceInput.dispatchEvent(new Event('change'));
             await new Promise(r => setTimeout(r, 0));
@@ -1115,8 +1099,7 @@ describe('DiggerPane', () => {
             window.apiClient.setDiggerPriority.mockResolvedValue({ ok: false, status: 500, body: null });
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const priceInput = cells[6].querySelector('input[type="number"]');
+            const priceInput = body.querySelector('tbody tr').querySelector('input[type="number"]');
             priceInput.value = '99';
             priceInput.dispatchEvent(new Event('change'));
             await new Promise(r => setTimeout(r, 0));
@@ -1129,8 +1112,7 @@ describe('DiggerPane', () => {
             await window.diggerPane.init();
             window.authManager.getToken.mockReturnValue(null);
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const priceInput = cells[6].querySelector('input[type="number"]');
+            const priceInput = body.querySelector('tbody tr').querySelector('input[type="number"]');
             priceInput.value = '10';
             priceInput.dispatchEvent(new Event('change'));
             await new Promise(r => setTimeout(r, 0));
@@ -1142,8 +1124,7 @@ describe('DiggerPane', () => {
             window.apiClient.setDiggerPriority.mockResolvedValue({ ok: true, status: 204, body: null });
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const priceInput = cells[6].querySelector('input[type="number"]');
+            const priceInput = body.querySelector('tbody tr').querySelector('input[type="number"]');
             priceInput.value = 'abc'; // type=number sanitizes this to '' (browsers + jsdom)
             priceInput.dispatchEvent(new Event('change'));
             await new Promise(r => setTimeout(r, 0));
@@ -1156,10 +1137,293 @@ describe('DiggerPane', () => {
             setupWantlistPrice(null);
             await window.diggerPane.init();
             const body = document.getElementById('diggerBody');
-            const cells = body.querySelector('tbody tr').querySelectorAll('td');
-            const priceInput = cells[6].querySelector('input[type="number"]');
+            const priceInput = body.querySelector('tbody tr').querySelector('input[type="number"]');
             expect(priceInput.min).toBe('0');
             expect(priceInput.step).toBe('0.01');
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // T4 — bulk-actions toolbar, filters, selection, stats banner
+    // ------------------------------------------------------------------ //
+
+    // A representative dataset spanning all tiers and listing availabilities.
+    const T4_ITEMS = [
+        { release_id: 1, title: 'A1', artist: 'AA', year: 2001, tier: 'must',       min_media_condition: 'VG+', min_sleeve_condition: 'VG', max_price_cents: 5000, active_listings: 12, last_scraped_at: '2026-05-01T10:00:00Z' },
+        { release_id: 2, title: 'A2', artist: 'AB', year: 2002, tier: 'must',       min_media_condition: 'VG',  min_sleeve_condition: 'G+', max_price_cents: null, active_listings: 0,  last_scraped_at: null },
+        { release_id: 3, title: 'A3', artist: 'AC', year: 2003, tier: 'nice',       min_media_condition: 'VG',  min_sleeve_condition: 'G+', max_price_cents: null, active_listings: 4,  last_scraped_at: null },
+        { release_id: 4, title: 'A4', artist: 'AD', year: 2004, tier: 'eventually', min_media_condition: 'VG',  min_sleeve_condition: 'G+', max_price_cents: null, active_listings: 0,  last_scraped_at: null },
+        { release_id: 5, title: 'A5', artist: 'AE', year: 2005, tier: 'eventually', min_media_condition: 'VG',  min_sleeve_condition: 'G+', max_price_cents: null, active_listings: 7,  last_scraped_at: null },
+    ];
+
+    function setupT4(items = T4_ITEMS) {
+        window.apiClient.bulkSetDiggerTier = vi.fn();
+        window.apiClient.getDiggerSettings.mockResolvedValue({
+            ok: true, status: 200,
+            body: { enabled: true, country_code: 'US', currency: 'USD', scheduled_cadence: 'daily', preferred_model: 'claude-opus', daily_token_cap_interactive: 10000, daily_token_cap_scheduled: 50000 },
+        });
+        window.apiClient.getDiggerWantlist.mockResolvedValue({
+            ok: true, status: 200,
+            body: { items: items.map(i => ({ ...i })) },
+        });
+    }
+
+    const rowCheckbox = (tr) => tr.querySelector('input[type="checkbox"]');
+    const allRows = () => document.querySelectorAll('#diggerBody tbody tr');
+    const bulkBar = () => document.querySelector('#diggerBody .digger-bulk-bar');
+    const selectAll = () => document.querySelector('#diggerBody thead input[type="checkbox"]');
+
+    describe('row selection', () => {
+        it('row checkbox toggling adds then removes the id and shows/hides the bulk bar', async () => {
+            setupT4();
+            await window.diggerPane.init();
+            // Bar hidden at 0 selected.
+            const barAtZero = bulkBar();
+            expect(barAtZero === null || barAtZero.classList.contains('hidden')).toBe(true);
+
+            const cb = rowCheckbox(allRows()[0]);
+            cb.click();
+            expect(window.diggerPane._selected.has(1)).toBe(true);
+            const barAtOne = bulkBar();
+            expect(barAtOne).not.toBeNull();
+            expect(barAtOne.classList.contains('hidden')).toBe(false);
+            expect(barAtOne.textContent).toContain('1 selected');
+
+            cb.click();
+            expect(window.diggerPane._selected.has(1)).toBe(false);
+            const barBack = bulkBar();
+            expect(barBack === null || barBack.classList.contains('hidden')).toBe(true);
+        });
+
+        it('checking a row does NOT full re-render the table', async () => {
+            setupT4();
+            await window.diggerPane.init();
+            const tbodyBefore = document.querySelector('#diggerBody tbody');
+            rowCheckbox(allRows()[0]).click();
+            const tbodyAfter = document.querySelector('#diggerBody tbody');
+            expect(tbodyAfter).toBe(tbodyBefore); // same node — no re-render
+        });
+
+        it('select-all checks all visible rows and populates selection', async () => {
+            setupT4();
+            await window.diggerPane.init();
+            selectAll().click();
+            expect(window.diggerPane._selected.size).toBe(5);
+            for (const tr of allRows()) {
+                expect(rowCheckbox(tr).checked).toBe(true);
+            }
+            expect(bulkBar().textContent).toContain('5 selected');
+        });
+
+        it('unchecking select-all clears the selection and the bar', async () => {
+            setupT4();
+            await window.diggerPane.init();
+            const sa = selectAll();
+            sa.click();
+            expect(window.diggerPane._selected.size).toBe(5);
+            sa.click();
+            expect(window.diggerPane._selected.size).toBe(0);
+            for (const tr of allRows()) {
+                expect(rowCheckbox(tr).checked).toBe(false);
+            }
+            const bar = bulkBar();
+            expect(bar === null || bar.classList.contains('hidden')).toBe(true);
+        });
+    });
+
+    describe('filters', () => {
+        const tierFilterSelect = () => document.querySelector('#diggerBody .digger-filters select');
+        const hideToggle = () => document.querySelector('#diggerBody .digger-filters input[type="checkbox"]');
+
+        it("tier filter 'must' renders only must rows; 'all' shows everything", async () => {
+            setupT4();
+            await window.diggerPane.init();
+            expect(allRows()).toHaveLength(5);
+
+            const sel = tierFilterSelect();
+            sel.value = 'must';
+            sel.dispatchEvent(new Event('change'));
+            expect(allRows()).toHaveLength(2);
+            for (const tr of allRows()) {
+                expect(['1', '2']).toContain(tr.dataset.releaseId);
+            }
+
+            sel.value = 'all';
+            sel.dispatchEvent(new Event('change'));
+            expect(allRows()).toHaveLength(5);
+        });
+
+        it('hide-no-listings hides rows with active_listings === 0', async () => {
+            setupT4();
+            await window.diggerPane.init();
+            const toggle = hideToggle();
+            toggle.checked = true;
+            toggle.dispatchEvent(new Event('change'));
+            // release_ids 2 and 4 have 0 listings → hidden.
+            const ids = Array.from(allRows()).map(tr => tr.dataset.releaseId);
+            expect(ids).toEqual(['1', '3', '5']);
+        });
+
+        it('select-all respects the active filter (only visible rows)', async () => {
+            setupT4();
+            await window.diggerPane.init();
+            const sel = tierFilterSelect();
+            sel.value = 'must';
+            sel.dispatchEvent(new Event('change'));
+            selectAll().click();
+            expect(Array.from(window.diggerPane._selected).sort()).toEqual([1, 2]);
+        });
+
+        it('filter changes preserve selection checked-state for still-visible rows', async () => {
+            setupT4();
+            await window.diggerPane.init();
+            // Select a must row (1) and an eventually row (5).
+            rowCheckbox(allRows()[0]).click(); // id 1 (must)
+            rowCheckbox(allRows()[4]).click(); // id 5 (eventually)
+            expect(window.diggerPane._selected.size).toBe(2);
+
+            const sel = tierFilterSelect();
+            sel.value = 'must';
+            sel.dispatchEvent(new Event('change'));
+            // Only id 1 visible now; selection set is preserved (still has 1 and 5).
+            const visibleRow = allRows()[0];
+            expect(visibleRow.dataset.releaseId).toBe('1');
+            expect(rowCheckbox(visibleRow).checked).toBe(true);
+            expect(window.diggerPane._selected.has(5)).toBe(true);
+        });
+    });
+
+    describe('bulk actions bar', () => {
+        const bulkTierSelect = () => bulkBar().querySelector('select');
+        const applyBtn = () => Array.from(bulkBar().querySelectorAll('button')).find(b => /apply/i.test(b.textContent));
+        const clearBtn = () => Array.from(bulkBar().querySelectorAll('button')).find(b => /clear/i.test(b.textContent));
+
+        it('Apply calls bulkSetDiggerTier with selected ids and chosen tier, then refreshes', async () => {
+            setupT4();
+            window.apiClient.bulkSetDiggerTier.mockResolvedValue({ ok: true, status: 200, body: { updated: 2 } });
+            await window.diggerPane.init();
+            rowCheckbox(allRows()[2]).click(); // id 3
+            rowCheckbox(allRows()[4]).click(); // id 5
+
+            const tierSel = bulkTierSelect();
+            tierSel.value = 'must';
+            tierSel.dispatchEvent(new Event('change'));
+
+            applyBtn().click();
+            await new Promise(r => setTimeout(r, 0));
+
+            expect(window.apiClient.bulkSetDiggerTier).toHaveBeenCalledTimes(1);
+            const [tokenArg, idsArg, tierArg] = window.apiClient.bulkSetDiggerTier.mock.calls[0];
+            expect(tokenArg).toBe('test-token');
+            expect([...idsArg].sort()).toEqual([3, 5]);
+            expect(tierArg).toBe('must');
+
+            // Refresh re-fetches the wantlist and clears selection.
+            expect(window.apiClient.getDiggerWantlist).toHaveBeenCalledTimes(2);
+            expect(window.diggerPane._selected.size).toBe(0);
+        });
+
+        it('Apply does nothing when there is no token', async () => {
+            setupT4();
+            await window.diggerPane.init();
+            rowCheckbox(allRows()[0]).click();
+            window.authManager.getToken.mockReturnValue(null);
+            applyBtn().click();
+            await new Promise(r => setTimeout(r, 0));
+            expect(window.apiClient.bulkSetDiggerTier).not.toHaveBeenCalled();
+            // Selection preserved.
+            expect(window.diggerPane._selected.size).toBe(1);
+        });
+
+        it('Apply failure keeps the selection', async () => {
+            setupT4();
+            window.apiClient.bulkSetDiggerTier.mockResolvedValue({ ok: false, status: 500, body: null });
+            await window.diggerPane.init();
+            rowCheckbox(allRows()[0]).click();
+            applyBtn().click();
+            await new Promise(r => setTimeout(r, 0));
+            expect(window.apiClient.bulkSetDiggerTier).toHaveBeenCalledTimes(1);
+            expect(window.diggerPane._selected.size).toBe(1);
+            // No re-fetch on failure.
+            expect(window.apiClient.getDiggerWantlist).toHaveBeenCalledTimes(1);
+        });
+
+        it('bulk tier select shows title-case labels matching the filter', async () => {
+            setupT4();
+            await window.diggerPane.init();
+            const labels = Array.from(bulkTierSelect().options).map(o => o.textContent);
+            expect(labels).toEqual(['Must', 'Nice', 'Eventually']);
+        });
+
+        it('ignores a second Apply click while the first request is in flight', async () => {
+            setupT4();
+            let resolveApply;
+            window.apiClient.bulkSetDiggerTier.mockReturnValue(new Promise((res) => { resolveApply = res; }));
+            await window.diggerPane.init();
+            rowCheckbox(allRows()[0]).click(); // id 1
+
+            applyBtn().click(); // starts the in-flight request (button disabled, guard set)
+            applyBtn().click(); // should be ignored
+            expect(window.apiClient.bulkSetDiggerTier).toHaveBeenCalledTimes(1);
+
+            // Let the first request finish cleanly.
+            resolveApply({ ok: true, status: 200, body: { updated: 1 } });
+            await new Promise(r => setTimeout(r, 0));
+        });
+
+        it('Clear empties the selection, unchecks rows, and hides the bar', async () => {
+            setupT4();
+            await window.diggerPane.init();
+            selectAll().click();
+            expect(window.diggerPane._selected.size).toBe(5);
+            clearBtn().click();
+            expect(window.diggerPane._selected.size).toBe(0);
+            for (const tr of allRows()) {
+                expect(rowCheckbox(tr).checked).toBe(false);
+            }
+            const bar = bulkBar();
+            expect(bar === null || bar.classList.contains('hidden')).toBe(true);
+        });
+    });
+
+    describe('stats banner', () => {
+        const statCards = () => document.querySelectorAll('#diggerBody .digger-stats .stat-card');
+
+        it('shows correct per-tier counts and must-available count (from all items)', async () => {
+            setupT4();
+            await window.diggerPane.init();
+            const text = document.querySelector('#diggerBody .digger-stats').textContent;
+            // T4_ITEMS: 2 must, 1 nice, 2 eventually; must with listings>0 = 1 (id 1).
+            expect(text).toContain('Must');
+            expect(text).toContain('Nice');
+            expect(text).toContain('Eventually');
+            expect(text).toMatch(/Must available/i);
+            // Banner renders one card per metric.
+            expect(statCards().length).toBeGreaterThanOrEqual(4);
+        });
+
+        it('stats are independent of active filters', async () => {
+            setupT4();
+            await window.diggerPane.init();
+            const before = document.querySelector('#diggerBody .digger-stats').textContent;
+            const sel = document.querySelector('#diggerBody .digger-filters select');
+            sel.value = 'must';
+            sel.dispatchEvent(new Event('change'));
+            const after = document.querySelector('#diggerBody .digger-stats').textContent;
+            expect(after).toBe(before);
+        });
+
+        it('counts reflect the dataset exactly', async () => {
+            setupT4();
+            await window.diggerPane.init();
+            const cards = Array.from(statCards());
+            const findCard = (label) => cards.find(c => c.querySelector('.stat-label')?.textContent.toLowerCase().includes(label));
+            expect(findCard('must').querySelector('.stat-value').textContent).toContain('2');
+            expect(findCard('nice').querySelector('.stat-value').textContent).toContain('1');
+            expect(findCard('eventually').querySelector('.stat-value').textContent).toContain('2');
+            // Must available: 1 of 2.
+            const avail = cards.find(c => c.querySelector('.stat-label')?.textContent.toLowerCase().includes('available'));
+            expect(avail.querySelector('.stat-value').textContent).toContain('1');
         });
     });
 });

--- a/explore/__tests__/settings.test.js
+++ b/explore/__tests__/settings.test.js
@@ -67,7 +67,65 @@ function setupMocks() {
             json: async () => ({ message: '2FA has been enabled' }),
         }),
         twoFactorDisable: vi.fn().mockResolvedValue({ ok: true }),
+        getDiggerSettings: vi.fn().mockResolvedValue({ ok: false, status: 404, body: null }),
+        putDiggerSettings: vi.fn().mockResolvedValue({ ok: true, status: 204, body: null }),
     };
+}
+
+/** Add the Digger settings card elements to the current DOM fixture. */
+function setupDiggerCardDOM() {
+    const card = document.createElement('div');
+    card.id = 'settingsDiggerCard';
+
+    const enabled = document.createElement('input');
+    enabled.type = 'checkbox';
+    enabled.id = 'diggerEnabled';
+    card.appendChild(enabled);
+
+    for (const id of ['diggerCountry', 'diggerCurrency']) {
+        const inp = document.createElement('input');
+        inp.type = 'text';
+        inp.id = id;
+        card.appendChild(inp);
+    }
+
+    for (const id of ['diggerCapInteractive', 'diggerCapScheduled']) {
+        const inp = document.createElement('input');
+        inp.type = 'number';
+        inp.id = id;
+        card.appendChild(inp);
+    }
+
+    const cadence = document.createElement('select');
+    cadence.id = 'diggerCadence';
+    for (const v of ['off', 'weekly', 'biweekly', 'monthly']) {
+        const opt = document.createElement('option');
+        opt.value = v;
+        cadence.appendChild(opt);
+    }
+    card.appendChild(cadence);
+
+    const model = document.createElement('select');
+    model.id = 'diggerModel';
+    for (const v of ['haiku', 'sonnet', 'opus']) {
+        const opt = document.createElement('option');
+        opt.value = v;
+        model.appendChild(opt);
+    }
+    card.appendChild(model);
+
+    for (const id of ['diggerSettingsError', 'diggerSettingsSuccess']) {
+        const el = document.createElement('div');
+        el.id = id;
+        if (id === 'diggerSettingsSuccess') el.classList.add('hidden');
+        card.appendChild(el);
+    }
+
+    const btn = document.createElement('button');
+    btn.id = 'diggerSettingsSaveBtn';
+    card.appendChild(btn);
+
+    document.body.appendChild(card);
 }
 
 describe('SettingsPane', () => {
@@ -678,6 +736,259 @@ describe('SettingsPane', () => {
             expect(window.settingsPane._camelToKebab('setupTotp')).toBe('setup-totp');
             expect(window.settingsPane._camelToKebab('disableTotp')).toBe('disable-totp');
             expect(window.settingsPane._camelToKebab('myLongName')).toBe('my-long-name');
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // Digger settings card
+    // ------------------------------------------------------------------ //
+
+    describe('Digger settings card', () => {
+        beforeEach(() => {
+            setupDiggerCardDOM();
+        });
+
+        const FULL_SETTINGS = {
+            enabled: true,
+            country_code: 'GB',
+            currency: 'GBP',
+            scheduled_cadence: 'monthly',
+            preferred_model: 'opus',
+            daily_token_cap_interactive: 150000,
+            daily_token_cap_scheduled: 75000,
+        };
+
+        describe('_loadDiggerSettings', () => {
+            it('should populate all fields from a GET ok response', async () => {
+                window.apiClient.getDiggerSettings.mockResolvedValue({ ok: true, status: 200, body: FULL_SETTINGS });
+
+                await window.settingsPane._loadDiggerSettings();
+
+                expect(document.getElementById('diggerEnabled').checked).toBe(true);
+                expect(document.getElementById('diggerCountry').value).toBe('GB');
+                expect(document.getElementById('diggerCurrency').value).toBe('GBP');
+                expect(document.getElementById('diggerCadence').value).toBe('monthly');
+                expect(document.getElementById('diggerModel').value).toBe('opus');
+                expect(document.getElementById('diggerCapInteractive').value).toBe('150000');
+                expect(document.getElementById('diggerCapScheduled').value).toBe('75000');
+            });
+
+            it('should populate empty country when country_code is null', async () => {
+                window.apiClient.getDiggerSettings.mockResolvedValue({
+                    ok: true,
+                    status: 200,
+                    body: { ...FULL_SETTINGS, country_code: null },
+                });
+
+                await window.settingsPane._loadDiggerSettings();
+
+                expect(document.getElementById('diggerCountry').value).toBe('');
+            });
+
+            it('should populate defaults on a 404 response', async () => {
+                window.apiClient.getDiggerSettings.mockResolvedValue({ ok: false, status: 404, body: null });
+
+                await window.settingsPane._loadDiggerSettings();
+
+                expect(document.getElementById('diggerEnabled').checked).toBe(false);
+                expect(document.getElementById('diggerCountry').value).toBe('');
+                expect(document.getElementById('diggerCurrency').value).toBe('USD');
+                expect(document.getElementById('diggerCadence').value).toBe('weekly');
+                expect(document.getElementById('diggerModel').value).toBe('sonnet');
+                expect(document.getElementById('diggerCapInteractive').value).toBe('200000');
+                expect(document.getElementById('diggerCapScheduled').value).toBe('100000');
+            });
+
+            it('should return early (no API call) when the card element is absent', async () => {
+                document.getElementById('settingsDiggerCard').remove();
+
+                await window.settingsPane._loadDiggerSettings();
+
+                expect(window.apiClient.getDiggerSettings).not.toHaveBeenCalled();
+            });
+
+            it('should return early (no API call) when there is no token', async () => {
+                window.authManager.getToken.mockReturnValue(null);
+
+                await window.settingsPane._loadDiggerSettings();
+
+                expect(window.apiClient.getDiggerSettings).not.toHaveBeenCalled();
+            });
+
+            it('should leave fields as-is on a non-404 error response', async () => {
+                window.apiClient.getDiggerSettings.mockResolvedValue({ ok: false, status: 500, body: null });
+                document.getElementById('diggerCurrency').value = 'EUR';
+
+                await window.settingsPane._loadDiggerSettings();
+
+                expect(document.getElementById('diggerCurrency').value).toBe('EUR');
+            });
+
+            it('should swallow network errors without throwing', async () => {
+                window.apiClient.getDiggerSettings.mockRejectedValue(new Error('network'));
+
+                await expect(window.settingsPane._loadDiggerSettings()).resolves.toBeUndefined();
+            });
+        });
+
+        describe('_handleSaveDiggerSettings', () => {
+            function fillFields({ enabled = true, country = 'us', currency = 'usd', cadence = 'weekly', model = 'sonnet', capI = '300000', capS = '120000' } = {}) {
+                document.getElementById('diggerEnabled').checked = enabled;
+                document.getElementById('diggerCountry').value = country;
+                document.getElementById('diggerCurrency').value = currency;
+                document.getElementById('diggerCadence').value = cadence;
+                document.getElementById('diggerModel').value = model;
+                document.getElementById('diggerCapInteractive').value = capI;
+                document.getElementById('diggerCapScheduled').value = capS;
+            }
+
+            it('should call putDiggerSettings with the correct body and show success', async () => {
+                fillFields();
+
+                await window.settingsPane._handleSaveDiggerSettings();
+
+                expect(window.apiClient.putDiggerSettings).toHaveBeenCalledWith('test-token', {
+                    enabled: true,
+                    country_code: 'US',
+                    currency: 'USD',
+                    scheduled_cadence: 'weekly',
+                    preferred_model: 'sonnet',
+                    daily_token_cap_interactive: 300000,
+                    daily_token_cap_scheduled: 120000,
+                });
+                expect(document.getElementById('diggerSettingsSuccess').textContent).toBe('Digger settings saved');
+                expect(document.getElementById('diggerSettingsSuccess').classList.contains('hidden')).toBe(false);
+            });
+
+            it('should send null country_code when country is empty', async () => {
+                fillFields({ country: '' });
+
+                await window.settingsPane._handleSaveDiggerSettings();
+
+                expect(window.apiClient.putDiggerSettings.mock.calls[0][1].country_code).toBeNull();
+            });
+
+            it('should send null token caps when cap fields are empty', async () => {
+                fillFields({ capI: '', capS: '' });
+
+                await window.settingsPane._handleSaveDiggerSettings();
+
+                const body = window.apiClient.putDiggerSettings.mock.calls[0][1];
+                expect(body.daily_token_cap_interactive).toBeNull();
+                expect(body.daily_token_cap_scheduled).toBeNull();
+            });
+
+            it('should send enabled false when checkbox unchecked', async () => {
+                fillFields({ enabled: false });
+
+                await window.settingsPane._handleSaveDiggerSettings();
+
+                expect(window.apiClient.putDiggerSettings.mock.calls[0][1].enabled).toBe(false);
+            });
+
+            it('should show an error and keep the form on save failure', async () => {
+                window.apiClient.putDiggerSettings.mockResolvedValue({ ok: false, status: 400, body: { detail: 'Bad cadence' } });
+                fillFields();
+
+                await window.settingsPane._handleSaveDiggerSettings();
+
+                expect(document.getElementById('diggerSettingsError').textContent).toBe('Bad cadence');
+                expect(document.getElementById('diggerSettingsSuccess').classList.contains('hidden')).toBe(true);
+            });
+
+            it('should show a generic error when failure has no detail', async () => {
+                window.apiClient.putDiggerSettings.mockResolvedValue({ ok: false, status: 500, body: null });
+                fillFields();
+
+                await window.settingsPane._handleSaveDiggerSettings();
+
+                expect(document.getElementById('diggerSettingsError').textContent).toBe('Failed to save Digger settings');
+            });
+
+            it('should show a network error on exception', async () => {
+                window.apiClient.putDiggerSettings.mockRejectedValue(new Error('boom'));
+                fillFields();
+
+                await window.settingsPane._handleSaveDiggerSettings();
+
+                expect(document.getElementById('diggerSettingsError').textContent).toBe('Network error — please try again');
+            });
+
+            it('should reject an invalid currency length and not call the API', async () => {
+                fillFields({ currency: 'US' });
+
+                await window.settingsPane._handleSaveDiggerSettings();
+
+                expect(document.getElementById('diggerSettingsError').textContent).toBe('Currency must be a 3-letter code');
+                expect(window.apiClient.putDiggerSettings).not.toHaveBeenCalled();
+            });
+
+            it('should reject an invalid country length and not call the API', async () => {
+                fillFields({ country: 'USA' });
+
+                await window.settingsPane._handleSaveDiggerSettings();
+
+                expect(document.getElementById('diggerSettingsError').textContent).toBe('Country code must be a 2-letter code');
+                expect(window.apiClient.putDiggerSettings).not.toHaveBeenCalled();
+            });
+
+            it('should reject a negative token cap and not call the API', async () => {
+                fillFields({ capI: '-5' });
+
+                await window.settingsPane._handleSaveDiggerSettings();
+
+                expect(document.getElementById('diggerSettingsError').textContent).toBe('Daily token caps must be non-negative whole numbers');
+                expect(window.apiClient.putDiggerSettings).not.toHaveBeenCalled();
+            });
+
+            it('should reject a non-integer token cap and not call the API', async () => {
+                fillFields({ capS: '1.5' });
+
+                await window.settingsPane._handleSaveDiggerSettings();
+
+                expect(document.getElementById('diggerSettingsError').textContent).toBe('Daily token caps must be non-negative whole numbers');
+                expect(window.apiClient.putDiggerSettings).not.toHaveBeenCalled();
+            });
+
+            it('should show Not authenticated when there is no token', async () => {
+                window.authManager.getToken.mockReturnValue(null);
+                fillFields();
+
+                await window.settingsPane._handleSaveDiggerSettings();
+
+                expect(document.getElementById('diggerSettingsError').textContent).toBe('Not authenticated');
+                expect(window.apiClient.putDiggerSettings).not.toHaveBeenCalled();
+            });
+
+            it('should re-enable the save button after completion', async () => {
+                fillFields();
+
+                await window.settingsPane._handleSaveDiggerSettings();
+
+                expect(document.getElementById('diggerSettingsSaveBtn').disabled).toBe(false);
+            });
+
+            it('should be wired to the save button click via init', async () => {
+                const spy = vi.spyOn(window.settingsPane, '_handleSaveDiggerSettings');
+                window.settingsPane.init();
+
+                document.getElementById('diggerSettingsSaveBtn').click();
+
+                expect(spy).toHaveBeenCalled();
+            });
+        });
+
+        describe('init integration', () => {
+            it('should load Digger settings via init when the card is present', async () => {
+                window.apiClient.getDiggerSettings.mockResolvedValue({ ok: true, status: 200, body: FULL_SETTINGS });
+
+                window.settingsPane.init();
+                // Allow the async _loadDiggerSettings to resolve.
+                await Promise.resolve();
+                await Promise.resolve();
+
+                expect(window.apiClient.getDiggerSettings).toHaveBeenCalledWith('test-token');
+            });
         });
     });
 });

--- a/explore/static/css/styles.css
+++ b/explore/static/css/styles.css
@@ -2569,11 +2569,70 @@ select option {
     margin: 1rem 1.5rem 1.5rem;
 }
 
-/* 9-column layout: Artist Title Year Tier Media Sleeve Price Listings Scraped */
-.digger-table .col-artist   { width: 14%; }
-.digger-table .col-title    { width: 18%; }
+/* Stats banner — reuses .stats-row / .stat-card tokens. */
+.digger-stats {
+    grid-template-columns: repeat(4, 1fr);
+}
+
+/* Controls row — filters on the left, bulk-actions bar on the right. */
+.digger-controls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    padding: 0 1.5rem 0.5rem;
+}
+
+.digger-filters {
+    margin-bottom: 0; /* override .gap-filters bottom margin in this context */
+}
+
+/* Bulk-actions bar — visually distinct flex row, hidden until ≥1 selected. */
+.digger-bulk-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.4rem 0.75rem;
+    background: var(--inner-bg);
+    border: 1px solid var(--blue-accent);
+    border-radius: 0.5rem;
+}
+
+.digger-bulk-bar.hidden {
+    display: none;
+}
+
+.digger-bulk-count {
+    font-size: 0.85rem;
+    color: var(--text-mid);
+    white-space: nowrap;
+}
+
+.digger-bulk-tier {
+    min-width: 8rem;
+}
+
+.digger-bulk-clear {
+    background: none;
+    border: none;
+    color: var(--text-mid);
+    font-size: 0.85rem;
+    cursor: pointer;
+    padding: 0.25rem 0.5rem;
+    transition: color 0.15s;
+}
+
+.digger-bulk-clear:hover {
+    color: var(--text-high);
+}
+
+/* 10-column layout: Select Artist Title Year Tier Media Sleeve Price Listings Scraped */
+.digger-table .col-select   { width: 3%; text-align: center; }
+.digger-table .col-artist   { width: 13%; }
+.digger-table .col-title    { width: 17%; }
 .digger-table .col-year     { width: 5%; }
-.digger-table .col-tier     { width: 14%; }
+.digger-table .col-tier     { width: 13%; }
 .digger-table .col-media    { width: 9%; }
 .digger-table .col-sleeve   { width: 10%; }
 .digger-table .col-price    { width: 9%; }

--- a/explore/static/css/styles.css
+++ b/explore/static/css/styles.css
@@ -2555,3 +2555,23 @@ select option {
     font-size: 0.8125rem;
     color: var(--text-high);
 }
+
+/* ============================================================
+   Digger pane
+   ============================================================ */
+
+.digger-onboarding {
+    max-width: 36rem;
+    margin: 2rem auto;
+}
+
+.digger-table-wrap {
+    margin: 1rem 1.5rem 1.5rem;
+}
+
+.digger-table .col-artist { width: 20%; }
+.digger-table .col-title  { width: 28%; }
+.digger-table .col-year   { width: 8%; }
+.digger-table .col-tier   { width: 8%; }
+.digger-table .col-listings { width: 14%; }
+.digger-table .col-scraped  { width: 22%; }

--- a/explore/static/css/styles.css
+++ b/explore/static/css/styles.css
@@ -2471,6 +2471,17 @@ select option {
     color: var(--text-high);
 }
 
+/* Digger settings — enable checkbox row */
+.digger-settings-checkbox-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.digger-settings-checkbox-row .settings-label {
+    min-width: 0;
+}
+
 /* 2FA status badges */
 .twofa-badge {
     display: inline-block;

--- a/explore/static/css/styles.css
+++ b/explore/static/css/styles.css
@@ -2569,9 +2569,31 @@ select option {
     margin: 1rem 1.5rem 1.5rem;
 }
 
-.digger-table .col-artist { width: 20%; }
-.digger-table .col-title  { width: 28%; }
-.digger-table .col-year   { width: 8%; }
-.digger-table .col-tier   { width: 8%; }
-.digger-table .col-listings { width: 14%; }
-.digger-table .col-scraped  { width: 22%; }
+/* 9-column layout: Artist Title Year Tier Media Sleeve Price Listings Scraped */
+.digger-table .col-artist   { width: 14%; }
+.digger-table .col-title    { width: 18%; }
+.digger-table .col-year     { width: 5%; }
+.digger-table .col-tier     { width: 14%; }
+.digger-table .col-media    { width: 9%; }
+.digger-table .col-sleeve   { width: 10%; }
+.digger-table .col-price    { width: 9%; }
+.digger-table .col-listings { width: 10%; }
+.digger-table .col-scraped  { width: 11%; }
+
+/* Tier segmented control — three chips side-by-side */
+.digger-tier-group {
+    display: flex;
+    gap: 0.2rem;
+}
+
+.digger-tier-btn {
+    padding: 0.15rem 0.45rem;
+    font-size: 0.72rem;
+}
+
+/* Compact selects / number inputs inside table cells */
+.digger-cell-control {
+    width: 100%;
+    padding: 0.2rem 0.35rem;
+    font-size: 0.78rem;
+}

--- a/explore/static/index.html
+++ b/explore/static/index.html
@@ -590,6 +590,11 @@ body {
                         <span class="material-symbols-outlined">search_off</span>Missing
                     </a>
                 </li>
+                <li id="navDigger">
+                    <a class="nav-link" href="#" data-pane="digger">
+                        <span class="material-symbols-outlined">travel_explore</span>Digger
+                    </a>
+                </li>
             </ul>
         </nav>
     </header>
@@ -1084,6 +1089,21 @@ body {
             </div>
         </div>
 
+        <!-- Digger pane — AI-powered record-hunting assistant -->
+        <div class="pane" id="diggerPane">
+            <div class="user-pane-header">
+                <h5><span class="material-symbols-outlined mr-2" style="font-size:20px;vertical-align:middle">travel_explore</span>Digger</h5>
+                <div class="flex gap-2" id="diggerHeaderActions"></div>
+            </div>
+            <div class="user-pane-body">
+                <div class="loading-overlay" id="diggerLoading">
+                    <div class="spinner" role="status"></div>
+                    <p class="mt-2 text-text-mid">Loading...</p>
+                </div>
+                <div id="diggerBody"></div>
+            </div>
+        </div>
+
         <!-- Settings pane — account management (no nav tab, activated from dropdown) -->
         <div class="pane" id="settingsPane">
             <div class="settings-page">
@@ -1176,6 +1196,7 @@ body {
     <script src="js/theme.js"></script>
     <script type="module" src="js/nlq.js"></script>
     <script src="js/settings.js"></script>
+    <script src="js/digger.js"></script>
     <script src="js/app.js"></script>
     <div id="nlqPillMount"></div>
 </body>

--- a/explore/static/index.html
+++ b/explore/static/index.html
@@ -1175,6 +1175,58 @@ body {
                         <!-- Populated dynamically by settings.js -->
                     </div>
                 </div>
+
+                <!-- Digger Card -->
+                <div class="settings-card" id="settingsDiggerCard">
+                    <div class="settings-card-header">
+                        <span class="material-symbols-outlined">travel_explore</span>
+                        <h3>Digger</h3>
+                    </div>
+                    <div class="settings-card-body">
+                        <div class="digger-settings-checkbox-row mb-3">
+                            <input type="checkbox" id="diggerEnabled">
+                            <label for="diggerEnabled" class="settings-label">Enable Digger</label>
+                        </div>
+                        <div class="mb-3">
+                            <label for="diggerCountry" class="settings-label">Country code</label>
+                            <input type="text" class="form-input-dark" id="diggerCountry" maxlength="2" placeholder="e.g. US (optional)">
+                        </div>
+                        <div class="mb-3">
+                            <label for="diggerCurrency" class="settings-label">Currency</label>
+                            <input type="text" class="form-input-dark" id="diggerCurrency" maxlength="3" placeholder="e.g. USD">
+                        </div>
+                        <div class="mb-3">
+                            <label for="diggerCadence" class="settings-label">Scheduled cadence</label>
+                            <select class="form-input-dark" id="diggerCadence">
+                                <option value="off">Off</option>
+                                <option value="weekly">Weekly</option>
+                                <option value="biweekly">Biweekly</option>
+                                <option value="monthly">Monthly</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="diggerModel" class="settings-label">Preferred model</label>
+                            <select class="form-input-dark" id="diggerModel">
+                                <option value="haiku">Haiku</option>
+                                <option value="sonnet">Sonnet</option>
+                                <option value="opus">Opus</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="diggerCapInteractive" class="settings-label">Daily token cap (interactive)</label>
+                            <input type="number" min="0" class="form-input-dark" id="diggerCapInteractive" placeholder="200000">
+                        </div>
+                        <div class="mb-3">
+                            <label for="diggerCapScheduled" class="settings-label">Daily token cap (scheduled)</label>
+                            <input type="number" min="0" class="form-input-dark" id="diggerCapScheduled" placeholder="100000">
+                        </div>
+                        <div class="mb-2 min-h-[1.2rem] text-sm text-accent-red" id="diggerSettingsError"></div>
+                        <div class="mb-2 min-h-[1.2rem] text-sm text-accent-green hidden" id="diggerSettingsSuccess"></div>
+                        <button class="btn-primary" id="diggerSettingsSaveBtn" type="button">
+                            <span class="material-symbols-outlined mr-1" style="font-size:18px">save</span>Save Digger Settings
+                        </button>
+                    </div>
+                </div>
                 </div><!-- /.settings-grid -->
             </div>
         </div>

--- a/explore/static/js/api-client.js
+++ b/explore/static/js/api-client.js
@@ -566,6 +566,85 @@ class ApiClient {
         }
     }
 
+    // --- Digger ---
+
+    /**
+     * Get Digger settings for the current user.
+     * Returns 404 (ok:false, status:404) when Digger is not enabled for this user.
+     * @param {string} token - JWT auth token
+     * @returns {Promise<{ok: boolean, status: number, body: Object|null}>}
+     */
+    async getDiggerSettings(token) {
+        const response = await fetch('/api/digger/settings', {
+            headers: { 'Authorization': `Bearer ${token}` },
+        });
+        const body = await response.json().catch(() => null);
+        return { ok: response.ok, status: response.status, body };
+    }
+
+    /**
+     * Update Digger settings for the current user.
+     * @param {string} token - JWT auth token
+     * @param {Object} settings - Settings object to persist
+     * @returns {Promise<{ok: boolean, status: number, body: Object|null}>} 204 → body null
+     */
+    async putDiggerSettings(token, settings) {
+        const response = await fetch('/api/digger/settings', {
+            method: 'PUT',
+            headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify(settings),
+        });
+        const body = await response.json().catch(() => null);
+        return { ok: response.ok, status: response.status, body };
+    }
+
+    /**
+     * Get the Digger wantlist with per-item priority info.
+     * @param {string} token - JWT auth token
+     * @returns {Promise<{ok: boolean, status: number, body: Object|null}>} body = { items: [...] }
+     */
+    async getDiggerWantlist(token) {
+        const response = await fetch('/api/digger/wantlist', {
+            headers: { 'Authorization': `Bearer ${token}` },
+        });
+        const body = await response.json().catch(() => null);
+        return { ok: response.ok, status: response.status, body };
+    }
+
+    /**
+     * Set the priority (tier, conditions, max price) for a single wantlist release.
+     * @param {string} token - JWT auth token
+     * @param {number} releaseId - Discogs release ID
+     * @param {Object} patch - Partial update (tier?, min_media_condition?, min_sleeve_condition?, max_price_cents?)
+     * @returns {Promise<{ok: boolean, status: number, body: Object|null}>} 204 → body null
+     */
+    async setDiggerPriority(token, releaseId, patch) {
+        const response = await fetch(`/api/digger/wantlist/${encodeURIComponent(releaseId)}/priority`, {
+            method: 'PUT',
+            headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify(patch),
+        });
+        const body = await response.json().catch(() => null);
+        return { ok: response.ok, status: response.status, body };
+    }
+
+    /**
+     * Bulk-update the tier for multiple wantlist releases.
+     * @param {string} token - JWT auth token
+     * @param {number[]} releaseIds - Array of Discogs release IDs
+     * @param {string} tier - Target tier ("must"|"nice"|"eventually")
+     * @returns {Promise<{ok: boolean, status: number, body: Object|null}>} body = { updated: n }
+     */
+    async bulkSetDiggerTier(token, releaseIds, tier) {
+        const response = await fetch('/api/digger/wantlist/bulk-tier', {
+            method: 'POST',
+            headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ release_ids: releaseIds, tier }),
+        });
+        const body = await response.json().catch(() => null);
+        return { ok: response.ok, status: response.status, body };
+    }
+
     /**
      * Send a natural language query with SSE streaming.
      * @param {string} query - Natural language question

--- a/explore/static/js/app.js
+++ b/explore/static/js/app.js
@@ -462,7 +462,7 @@ class ExploreApp {
         }
 
         // If we just logged out and were on a personal pane, switch to explore
-        if (!loggedIn && ['collection', 'wantlist', 'recommendations'].includes(this.activePane)) {
+        if (!loggedIn && ['collection', 'wantlist', 'recommendations', 'digger'].includes(this.activePane)) {
             this._switchPane('explore');
         }
     }
@@ -911,6 +911,8 @@ class ExploreApp {
             window.genreTreeView.load();
         } else if (pane === 'credits' && window.creditsPanel) {
             window.creditsPanel.load();
+        } else if (pane === 'digger' && window.authManager.isLoggedIn()) {
+            window.diggerPane.init();
         } else if (pane === 'settings') {
             window.settingsPane.init();
         }

--- a/explore/static/js/digger.js
+++ b/explore/static/js/digger.js
@@ -15,6 +15,12 @@ class DiggerPane {
         this._items = [];
         this._isLoading = false;
 
+        // T4 — bulk-actions / filter / selection state.
+        this._selected = new Set();          // selected release_ids
+        this._tierFilter = 'all';            // 'all' | 'must' | 'nice' | 'eventually'
+        this._hideNoListings = false;        // hide items with active_listings === 0
+        this._bulkApplying = false;          // in-flight guard for bulk-tier Apply
+
         this._loading = document.getElementById('diggerLoading');
         this._body = document.getElementById('diggerBody');
     }
@@ -129,7 +135,271 @@ class DiggerPane {
             return;
         }
 
+        // Top-to-bottom: stats banner → controls (filters + bulk bar) → table.
+        this._renderStatsBanner();
+        this._renderControls();
         this._renderTable();
+    }
+
+    /**
+     * Re-fetch the wantlist and fully re-render (stats + controls + table).
+     * Reuses _loadWantlist, which sets _items and calls _renderContent.
+     */
+    async refresh() {
+        const token = window.authManager.getToken();
+        if (!token) return;
+        await this._loadWantlist(token);
+    }
+
+    // ------------------------------------------------------------------ //
+    // Stats banner
+    // ------------------------------------------------------------------ //
+
+    /**
+     * Render the stats banner. Computed from ALL items (never the filtered set).
+     *
+     * NOTE: This banner reflects state at the last FULL render (init / filter
+     * change / bulk refresh). Per-row tier edits (T3) intentionally do NOT update
+     * the banner live — those controls are kept decoupled from the banner.
+     */
+    _renderStatsBanner() {
+        const counts = { must: 0, nice: 0, eventually: 0 };
+        let mustAvailable = 0;
+        for (const item of this._items) {
+            if (counts[item.tier] != null) counts[item.tier] += 1;
+            if (item.tier === 'must' && item.active_listings > 0) mustAvailable += 1;
+        }
+
+        const row = document.createElement('div');
+        row.className = 'stats-row digger-stats';
+
+        row.appendChild(this._buildStatCard('Must', String(counts.must)));
+        row.appendChild(this._buildStatCard('Nice', String(counts.nice)));
+        row.appendChild(this._buildStatCard('Eventually', String(counts.eventually)));
+        row.appendChild(this._buildStatCard('Must available', `${mustAvailable} / ${counts.must}`));
+
+        this._body.appendChild(row);
+    }
+
+    /**
+     * Build a single stat card (label + value).
+     * @param {string} label
+     * @param {string} value
+     * @returns {HTMLDivElement}
+     */
+    _buildStatCard(label, value) {
+        const card = document.createElement('div');
+        card.className = 'stat-card';
+
+        const lbl = document.createElement('div');
+        lbl.className = 'stat-label';
+        lbl.textContent = label;
+        card.appendChild(lbl);
+
+        const val = document.createElement('div');
+        val.className = 'stat-value';
+        val.textContent = value;
+        card.appendChild(val);
+
+        return card;
+    }
+
+    // ------------------------------------------------------------------ //
+    // Controls — filters + bulk-actions bar
+    // ------------------------------------------------------------------ //
+
+    _renderControls() {
+        const controls = document.createElement('div');
+        controls.className = 'digger-controls';
+
+        controls.appendChild(this._renderFilters());
+        controls.appendChild(this._renderBulkBar());
+
+        this._body.appendChild(controls);
+    }
+
+    /**
+     * Build the filters bar (tier filter + hide-no-listings toggle).
+     * @returns {HTMLDivElement}
+     */
+    _renderFilters() {
+        const filters = document.createElement('div');
+        filters.className = 'gap-filters digger-filters';
+
+        // Tier filter select.
+        const tierSelect = document.createElement('select');
+        tierSelect.className = 'form-input-dark gap-format-select digger-filter-select';
+        tierSelect.setAttribute('aria-label', 'Filter by tier');
+        const tierOptions = [
+            { value: 'all',        label: 'All tiers' },
+            { value: 'must',       label: 'Must' },
+            { value: 'nice',       label: 'Nice' },
+            { value: 'eventually', label: 'Eventually' },
+        ];
+        for (const { value, label } of tierOptions) {
+            const opt = document.createElement('option');
+            opt.value = value;
+            opt.textContent = label;
+            if (value === this._tierFilter) opt.selected = true;
+            tierSelect.appendChild(opt);
+        }
+        tierSelect.addEventListener('change', () => {
+            this._tierFilter = tierSelect.value;
+            this._renderTable();
+        });
+        filters.appendChild(tierSelect);
+
+        // Hide-no-listings toggle.
+        const hideLabel = document.createElement('label');
+        hideLabel.className = 'gap-filter-toggle digger-filter-toggle';
+        const hideCheckbox = document.createElement('input');
+        hideCheckbox.type = 'checkbox';
+        hideCheckbox.checked = this._hideNoListings;
+        hideCheckbox.addEventListener('change', () => {
+            this._hideNoListings = hideCheckbox.checked;
+            this._renderTable();
+        });
+        hideLabel.append(hideCheckbox, ' Hide items with no listings');
+        filters.appendChild(hideLabel);
+
+        return filters;
+    }
+
+    /**
+     * Build the bulk-actions bar. Hidden when nothing is selected.
+     * @returns {HTMLDivElement}
+     */
+    _renderBulkBar() {
+        const bar = document.createElement('div');
+        bar.className = 'digger-bulk-bar';
+        this._bulkBar = bar;
+
+        // Selection count.
+        const count = document.createElement('span');
+        count.className = 'digger-bulk-count';
+        this._bulkCount = count;
+        bar.appendChild(count);
+
+        // Tier select (bulk target).
+        const tierSelect = document.createElement('select');
+        tierSelect.className = 'form-input-dark digger-bulk-tier';
+        tierSelect.setAttribute('aria-label', 'Bulk tier');
+        for (const tier of DIGGER_TIERS) {
+            const opt = document.createElement('option');
+            opt.value = tier;
+            // Title-case label to match the tier filter select (e.g. "Must").
+            opt.textContent = tier.charAt(0).toUpperCase() + tier.slice(1);
+            tierSelect.appendChild(opt);
+        }
+        this._bulkTierSelect = tierSelect;
+        bar.appendChild(tierSelect);
+
+        // Apply button.
+        const applyBtn = document.createElement('button');
+        applyBtn.type = 'button';
+        applyBtn.className = 'btn-primary digger-bulk-apply';
+        applyBtn.textContent = 'Apply';
+        applyBtn.addEventListener('click', () => this._applyBulkTier());
+        this._bulkApplyBtn = applyBtn;
+        bar.appendChild(applyBtn);
+
+        // Clear button.
+        const clearBtn = document.createElement('button');
+        clearBtn.type = 'button';
+        clearBtn.className = 'digger-bulk-clear';
+        clearBtn.textContent = 'Clear';
+        clearBtn.addEventListener('click', () => this._clearSelection());
+        bar.appendChild(clearBtn);
+
+        this._updateBulkBar();
+        return bar;
+    }
+
+    /**
+     * Update the bulk bar's visibility and selection count to match _selected.
+     */
+    _updateBulkBar() {
+        if (!this._bulkBar) return;
+        const n = this._selected.size;
+        if (this._bulkCount) this._bulkCount.textContent = `${n} selected`;
+        this._bulkBar.classList.toggle('hidden', n === 0);
+    }
+
+    /**
+     * Apply the chosen tier to all selected releases, then refresh on success.
+     */
+    async _applyBulkTier() {
+        if (this._bulkApplying) return; // guard against double-submit while a request is in flight
+        const token = window.authManager.getToken();
+        if (!token) return;
+        if (this._selected.size === 0) return;
+
+        const tier = this._bulkTierSelect ? this._bulkTierSelect.value : DIGGER_TIERS[0];
+        const ids = Array.from(this._selected);
+
+        this._bulkApplying = true;
+        if (this._bulkApplyBtn) this._bulkApplyBtn.disabled = true;
+        try {
+            const res = await window.apiClient.bulkSetDiggerTier(token, ids, tier);
+            if (res && res.ok) {
+                // Clear selection and re-fetch so tiers + stats reflect the change.
+                this._selected.clear();
+                await this.refresh();
+            }
+            // On failure: keep selection so the user can retry.
+        } finally {
+            this._bulkApplying = false;
+            // On success, refresh() rebuilt the bar (this._bulkApplyBtn now points at the
+            // fresh, hidden button); on failure it is the same button we disabled above.
+            if (this._bulkApplyBtn) this._bulkApplyBtn.disabled = false;
+        }
+    }
+
+    /**
+     * Toggle selection for all currently visible items.
+     * @param {boolean} checked
+     */
+    _toggleSelectAll(checked) {
+        const visible = this._getVisibleItems();
+        for (const item of visible) {
+            if (checked) {
+                this._selected.add(item.release_id);
+            } else {
+                this._selected.delete(item.release_id);
+            }
+        }
+        // Reflect on the visible row checkboxes without a full re-render.
+        const rows = this._body.querySelectorAll('.digger-table tbody tr');
+        for (const tr of rows) {
+            const cb = tr.querySelector('input[type="checkbox"]');
+            if (cb) cb.checked = checked;
+        }
+        this._syncSelectAllCheckbox();
+        this._updateBulkBar();
+    }
+
+    /**
+     * Keep the header select-all checkbox in sync with row selection state.
+     */
+    _syncSelectAllCheckbox() {
+        const selectAll = this._body.querySelector('.digger-table thead input[type="checkbox"]');
+        if (!selectAll) return;
+        const visible = this._getVisibleItems();
+        selectAll.checked = visible.length > 0 && visible.every((it) => this._selected.has(it.release_id));
+    }
+
+    /**
+     * Clear the entire selection, uncheck visible rows, and hide the bulk bar.
+     */
+    _clearSelection() {
+        this._selected.clear();
+        const rows = this._body.querySelectorAll('.digger-table tbody tr');
+        for (const tr of rows) {
+            const cb = tr.querySelector('input[type="checkbox"]');
+            if (cb) cb.checked = false;
+        }
+        this._syncSelectAllCheckbox();
+        this._updateBulkBar();
     }
 
     _renderEmpty() {
@@ -170,7 +440,27 @@ class DiggerPane {
         this._body.appendChild(empty);
     }
 
+    /**
+     * Items currently visible given the active filters.
+     * @returns {Array<Object>}
+     */
+    _getVisibleItems() {
+        return this._items.filter((item) => {
+            if (this._tierFilter !== 'all' && item.tier !== this._tierFilter) return false;
+            if (this._hideNoListings && !(item.active_listings > 0)) return false;
+            return true;
+        });
+    }
+
+    /**
+     * Render (or re-render) just the table rows for the currently visible items.
+     * Removes any existing table wrap first so filter changes don't stack tables.
+     */
     _renderTable() {
+        // Drop any prior table (filter re-render) without touching banner/controls.
+        const existing = this._body.querySelector('.digger-table-wrap');
+        if (existing) existing.remove();
+
         const wrap = document.createElement('div');
         wrap.className = 'release-table-wrap digger-table-wrap';
 
@@ -183,6 +473,19 @@ class DiggerPane {
         // Header
         const thead = document.createElement('thead');
         const headerRow = document.createElement('tr');
+
+        // Leading select-all column.
+        const thSelect = document.createElement('th');
+        thSelect.className = 'col-select';
+        const selectAll = document.createElement('input');
+        selectAll.type = 'checkbox';
+        selectAll.setAttribute('aria-label', 'Select all');
+        const visibleNow = this._getVisibleItems();
+        selectAll.checked = visibleNow.length > 0 && visibleNow.every((it) => this._selected.has(it.release_id));
+        selectAll.addEventListener('change', () => this._toggleSelectAll(selectAll.checked));
+        thSelect.appendChild(selectAll);
+        headerRow.appendChild(thSelect);
+
         const columns = [
             { label: 'Artist',          cls: 'col-artist' },
             { label: 'Title',           cls: 'col-title' },
@@ -203,9 +506,9 @@ class DiggerPane {
         thead.appendChild(headerRow);
         table.appendChild(thead);
 
-        // Body
+        // Body — only visible items.
         const tbody = document.createElement('tbody');
-        for (const item of this._items) {
+        for (const item of visibleNow) {
             tbody.appendChild(this._buildRow(item));
         }
         table.appendChild(tbody);
@@ -223,6 +526,26 @@ class DiggerPane {
     _buildRow(item) {
         const tr = document.createElement('tr');
         tr.dataset.releaseId = String(item.release_id);
+
+        // Row-selection checkbox (leading column)
+        const tdSelect = document.createElement('td');
+        tdSelect.className = 'col-select';
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = this._selected.has(item.release_id);
+        checkbox.setAttribute('aria-label', 'Select row');
+        checkbox.addEventListener('change', () => {
+            if (checkbox.checked) {
+                this._selected.add(item.release_id);
+            } else {
+                this._selected.delete(item.release_id);
+            }
+            // Single-checkbox toggle: update the bulk bar only — no full re-render.
+            this._updateBulkBar();
+            this._syncSelectAllCheckbox();
+        });
+        tdSelect.appendChild(checkbox);
+        tr.appendChild(tdSelect);
 
         // Artist (plain text)
         const tdArtist = document.createElement('td');

--- a/explore/static/js/digger.js
+++ b/explore/static/js/digger.js
@@ -1,0 +1,257 @@
+/**
+ * Digger pane controller — AI-powered record-hunting assistant.
+ *
+ * Shows an onboarding card when Digger is not enabled for the user,
+ * otherwise loads and renders the user's digger wantlist as a table.
+ */
+class DiggerPane {
+    constructor() {
+        this._settings = null;
+        this._items = [];
+        this._isLoading = false;
+
+        this._loading = document.getElementById('diggerLoading');
+        this._body = document.getElementById('diggerBody');
+    }
+
+    /**
+     * Entry point — called by ExploreApp._switchPane('digger').
+     * Loads settings and branches into onboarding or wantlist table.
+     */
+    async init() {
+        const token = window.authManager.getToken();
+        if (!token) return;
+
+        if (this._isLoading) return;
+        this._isLoading = true;
+
+        if (this._loading) this._loading.classList.add('active');
+
+        try {
+            const res = await window.apiClient.getDiggerSettings(token);
+
+            if (res.status === 404 || (res.ok && res.body && res.body.enabled === false)) {
+                // Digger not enabled — store whatever we got and show onboarding
+                this._settings = res.body || null;
+                this._renderOnboarding();
+            } else if (res.ok && res.body) {
+                // Digger enabled — load wantlist
+                this._settings = res.body;
+                await this._loadWantlist(token);
+            } else {
+                // Unexpected error
+                this._renderError('Could not load Digger settings. Please try again later.');
+            }
+        } finally {
+            this._isLoading = false;
+            if (this._loading) this._loading.classList.remove('active');
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // Wantlist loading
+    // ------------------------------------------------------------------ //
+
+    async _loadWantlist(token) {
+        const res = await window.apiClient.getDiggerWantlist(token);
+        if (res.ok && res.body) {
+            this._items = res.body.items || [];
+            this._renderContent();
+        } else {
+            // Distinguish a failed load from a genuinely empty wantlist.
+            this._renderError('Could not load your Digger wantlist. Please try again later.');
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // Rendering
+    // ------------------------------------------------------------------ //
+
+    _renderOnboarding() {
+        if (!this._body) return;
+        this._body.textContent = '';
+
+        const card = document.createElement('div');
+        card.className = 'digger-onboarding settings-card';
+
+        const header = document.createElement('div');
+        header.className = 'settings-card-header';
+
+        const icon = document.createElement('span');
+        icon.className = 'material-symbols-outlined';
+        icon.textContent = 'travel_explore';
+        header.appendChild(icon);
+
+        const title = document.createElement('h3');
+        title.textContent = 'Digger';
+        header.appendChild(title);
+
+        card.appendChild(header);
+
+        const body = document.createElement('div');
+        body.className = 'settings-card-body';
+
+        const desc = document.createElement('p');
+        desc.className = 'text-text-mid text-sm mb-3';
+        desc.textContent =
+            'Digger is your AI-powered record-hunting assistant. ' +
+            'Enable it to automatically track new listings for your wantlist items, ' +
+            'with smart condition and price filtering.';
+        body.appendChild(desc);
+
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'btn-primary';
+        btn.textContent = 'Open Digger Settings';
+        btn.addEventListener('click', () => {
+            if (window.exploreApp) {
+                window.exploreApp._previousPane = 'digger';
+                window.exploreApp._switchPane('settings');
+            }
+        });
+        body.appendChild(btn);
+
+        card.appendChild(body);
+        this._body.appendChild(card);
+    }
+
+    _renderContent() {
+        if (!this._body) return;
+        this._body.textContent = '';
+
+        if (!this._items || this._items.length === 0) {
+            this._renderEmpty();
+            return;
+        }
+
+        this._renderTable();
+    }
+
+    _renderEmpty() {
+        if (!this._body) return;
+        this._body.textContent = '';
+
+        const empty = document.createElement('div');
+        empty.className = 'user-pane-empty';
+
+        const icon = document.createElement('span');
+        icon.className = 'material-symbols-outlined icon-3x mb-3';
+        icon.textContent = 'travel_explore';
+        empty.appendChild(icon);
+
+        const msg = document.createElement('p');
+        msg.textContent = 'No wantlist items found. Add records to your Discogs wantlist and sync to get started.';
+        empty.appendChild(msg);
+
+        this._body.appendChild(empty);
+    }
+
+    _renderError(message) {
+        if (!this._body) return;
+        this._body.textContent = '';
+
+        const empty = document.createElement('div');
+        empty.className = 'user-pane-empty';
+
+        const icon = document.createElement('span');
+        icon.className = 'material-symbols-outlined icon-3x mb-3';
+        icon.textContent = 'error_outline';
+        empty.appendChild(icon);
+
+        const msg = document.createElement('p');
+        msg.textContent = message || 'Could not load Digger. Please try again later.';
+        empty.appendChild(msg);
+
+        this._body.appendChild(empty);
+    }
+
+    _renderTable() {
+        const wrap = document.createElement('div');
+        wrap.className = 'release-table-wrap digger-table-wrap';
+
+        const scroll = document.createElement('div');
+        scroll.className = 'release-table-scroll';
+
+        const table = document.createElement('table');
+        table.className = 'release-table digger-table';
+
+        // Header
+        const thead = document.createElement('thead');
+        const headerRow = document.createElement('tr');
+        const columns = [
+            { label: 'Artist', cls: 'col-artist' },
+            { label: 'Title', cls: 'col-title' },
+            { label: 'Year', cls: 'col-year' },
+            { label: 'Tier', cls: 'col-tier' },
+            { label: 'Active listings', cls: 'col-listings' },
+            { label: 'Last scraped', cls: 'col-scraped' },
+        ];
+        for (const { label, cls } of columns) {
+            const th = document.createElement('th');
+            th.className = cls;
+            th.textContent = label;
+            headerRow.appendChild(th);
+        }
+        thead.appendChild(headerRow);
+        table.appendChild(thead);
+
+        // Body
+        const tbody = document.createElement('tbody');
+        for (const item of this._items) {
+            tbody.appendChild(this._buildRow(item));
+        }
+        table.appendChild(tbody);
+
+        scroll.appendChild(table);
+        wrap.appendChild(scroll);
+        this._body.appendChild(wrap);
+    }
+
+    /**
+     * Build a single table row for a wantlist item.
+     * Kept as a separate helper so T3 can extend it.
+     * @param {Object} item - Wantlist item from API
+     * @returns {HTMLTableRowElement}
+     */
+    _buildRow(item) {
+        const tr = document.createElement('tr');
+        tr.dataset.releaseId = String(item.release_id);
+
+        const cells = [
+            item.artist || '—',
+            item.title  || '—',
+            item.year   != null ? String(item.year) : '—',
+            item.tier   || '—',
+            item.active_listings != null ? String(item.active_listings) : '0',
+            this._formatScrapedAt(item.last_scraped_at),
+        ];
+
+        for (const text of cells) {
+            const td = document.createElement('td');
+            td.textContent = text;
+            tr.appendChild(td);
+        }
+
+        return tr;
+    }
+
+    // ------------------------------------------------------------------ //
+    // Utilities
+    // ------------------------------------------------------------------ //
+
+    /**
+     * Format last_scraped_at ISO string as a locale date, or "never" if null.
+     * @param {string|null} iso
+     * @returns {string}
+     */
+    _formatScrapedAt(iso) {
+        if (!iso) return 'never';
+        try {
+            return new Date(iso).toLocaleDateString();
+        } catch {
+            return 'never';
+        }
+    }
+}
+
+window.diggerPane = new DiggerPane();

--- a/explore/static/js/digger.js
+++ b/explore/static/js/digger.js
@@ -4,6 +4,11 @@
  * Shows an onboarding card when Digger is not enabled for the user,
  * otherwise loads and renders the user's digger wantlist as a table.
  */
+
+const DIGGER_TIERS = ['must', 'nice', 'eventually'];
+const DIGGER_CONDITIONS = ['M', 'NM', 'VG+', 'VG', 'G+', 'G', 'F', 'P'];
+const DIGGER_SLEEVE_CONDITIONS = ['M', 'NM', 'VG+', 'VG', 'G+', 'G', 'F', 'P', 'generic', 'no_cover'];
+
 class DiggerPane {
     constructor() {
         this._settings = null;
@@ -179,12 +184,15 @@ class DiggerPane {
         const thead = document.createElement('thead');
         const headerRow = document.createElement('tr');
         const columns = [
-            { label: 'Artist', cls: 'col-artist' },
-            { label: 'Title', cls: 'col-title' },
-            { label: 'Year', cls: 'col-year' },
-            { label: 'Tier', cls: 'col-tier' },
+            { label: 'Artist',          cls: 'col-artist' },
+            { label: 'Title',           cls: 'col-title' },
+            { label: 'Year',            cls: 'col-year' },
+            { label: 'Tier',            cls: 'col-tier' },
+            { label: 'Media',           cls: 'col-media' },
+            { label: 'Sleeve',          cls: 'col-sleeve' },
+            { label: 'Max price',       cls: 'col-price' },
             { label: 'Active listings', cls: 'col-listings' },
-            { label: 'Last scraped', cls: 'col-scraped' },
+            { label: 'Last scraped',    cls: 'col-scraped' },
         ];
         for (const { label, cls } of columns) {
             const th = document.createElement('th');
@@ -209,7 +217,6 @@ class DiggerPane {
 
     /**
      * Build a single table row for a wantlist item.
-     * Kept as a separate helper so T3 can extend it.
      * @param {Object} item - Wantlist item from API
      * @returns {HTMLTableRowElement}
      */
@@ -217,22 +224,188 @@ class DiggerPane {
         const tr = document.createElement('tr');
         tr.dataset.releaseId = String(item.release_id);
 
-        const cells = [
-            item.artist || '—',
-            item.title  || '—',
-            item.year   != null ? String(item.year) : '—',
-            item.tier   || '—',
-            item.active_listings != null ? String(item.active_listings) : '0',
-            this._formatScrapedAt(item.last_scraped_at),
-        ];
+        // Artist (plain text)
+        const tdArtist = document.createElement('td');
+        tdArtist.textContent = item.artist || '—';
+        tr.appendChild(tdArtist);
 
-        for (const text of cells) {
-            const td = document.createElement('td');
-            td.textContent = text;
-            tr.appendChild(td);
-        }
+        // Title (plain text)
+        const tdTitle = document.createElement('td');
+        tdTitle.textContent = item.title || '—';
+        tr.appendChild(tdTitle);
+
+        // Year (plain text)
+        const tdYear = document.createElement('td');
+        tdYear.textContent = item.year != null ? String(item.year) : '—';
+        tr.appendChild(tdYear);
+
+        // Tier (segmented toggle)
+        const tdTier = document.createElement('td');
+        tdTier.appendChild(this._buildTierToggle(item));
+        tr.appendChild(tdTier);
+
+        // Media condition (select)
+        const tdMedia = document.createElement('td');
+        tdMedia.appendChild(this._buildConditionSelect(item, 'media'));
+        tr.appendChild(tdMedia);
+
+        // Sleeve condition (select)
+        const tdSleeve = document.createElement('td');
+        tdSleeve.appendChild(this._buildConditionSelect(item, 'sleeve'));
+        tr.appendChild(tdSleeve);
+
+        // Max price (number input, dollars)
+        const tdPrice = document.createElement('td');
+        tdPrice.appendChild(this._buildMaxPriceInput(item));
+        tr.appendChild(tdPrice);
+
+        // Active listings (plain text)
+        const tdListings = document.createElement('td');
+        tdListings.textContent = item.active_listings != null ? String(item.active_listings) : '0';
+        tr.appendChild(tdListings);
+
+        // Last scraped (plain text)
+        const tdScraped = document.createElement('td');
+        tdScraped.textContent = this._formatScrapedAt(item.last_scraped_at);
+        tr.appendChild(tdScraped);
 
         return tr;
+    }
+
+    /**
+     * Build a segmented tier toggle for a row item.
+     * @param {Object} item
+     * @returns {HTMLDivElement}
+     */
+    _buildTierToggle(item) {
+        const group = document.createElement('div');
+        group.setAttribute('role', 'group');
+        group.setAttribute('aria-label', 'Tier');
+        group.className = 'digger-tier-group';
+
+        for (const tier of DIGGER_TIERS) {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'search-chip digger-tier-btn';
+            btn.textContent = tier;
+            btn.dataset.tier = tier;
+
+            const isActive = item.tier === tier;
+            btn.setAttribute('aria-pressed', String(isActive));
+            if (isActive) btn.classList.add('active');
+
+            btn.addEventListener('click', async () => {
+                if (btn.getAttribute('aria-pressed') === 'true') return; // already active
+
+                const token = window.authManager.getToken();
+                if (!token) return;
+
+                const res = await window.apiClient.setDiggerPriority(token, item.release_id, { tier });
+
+                if (res.ok) {
+                    // Update in-memory state
+                    item.tier = tier;
+                    // Update all buttons in the group
+                    const allBtns = group.querySelectorAll('.digger-tier-btn');
+                    for (const b of allBtns) {
+                        const pressed = b.dataset.tier === tier;
+                        b.setAttribute('aria-pressed', String(pressed));
+                        b.classList.toggle('active', pressed);
+                    }
+                }
+                // On failure: leave buttons as-is (no visual change committed)
+            });
+
+            group.appendChild(btn);
+        }
+
+        return group;
+    }
+
+    /**
+     * Build a condition <select> for media or sleeve.
+     * @param {Object} item
+     * @param {'media'|'sleeve'} type
+     * @returns {HTMLSelectElement}
+     */
+    _buildConditionSelect(item, type) {
+        const isMedia = type === 'media';
+        const options = isMedia ? DIGGER_CONDITIONS : DIGGER_SLEEVE_CONDITIONS;
+        const currentValue = isMedia ? item.min_media_condition : item.min_sleeve_condition;
+
+        const sel = document.createElement('select');
+        sel.className = 'form-input-dark digger-cell-control';
+
+        for (const val of options) {
+            const opt = document.createElement('option');
+            opt.value = val;
+            opt.textContent = val;
+            if (val === currentValue) opt.selected = true;
+            sel.appendChild(opt);
+        }
+
+        sel.addEventListener('change', async () => {
+            const token = window.authManager.getToken();
+            if (!token) return;
+
+            const value = sel.value;
+            const patch = isMedia
+                ? { min_media_condition: value }
+                : { min_sleeve_condition: value };
+
+            const res = await window.apiClient.setDiggerPriority(token, item.release_id, patch);
+
+            if (res.ok) {
+                // Update in-memory state
+                if (isMedia) {
+                    item.min_media_condition = value;
+                } else {
+                    item.min_sleeve_condition = value;
+                }
+            } else {
+                // Revert the control to the item's unchanged value
+                sel.value = isMedia ? item.min_media_condition : item.min_sleeve_condition;
+            }
+        });
+
+        return sel;
+    }
+
+    /**
+     * Build a max-price number input (displays dollars, stores cents).
+     * @param {Object} item
+     * @returns {HTMLInputElement}
+     */
+    _buildMaxPriceInput(item) {
+        const input = document.createElement('input');
+        input.type = 'number';
+        input.min = '0';
+        input.step = '0.01';
+        input.className = 'form-input-dark digger-cell-control';
+
+        input.value = item.max_price_cents != null ? String(item.max_price_cents / 100) : '';
+
+        input.addEventListener('change', async () => {
+            const token = window.authManager.getToken();
+            if (!token) return;
+
+            // Note: <input type="number"> sanitizes non-numeric text to '' (per the HTML
+            // spec, in browsers and jsdom alike), so `raw` is always either '' or a valid
+            // number string — NaN cannot reach the API here.
+            const raw = input.value.trim();
+            const max_price_cents = raw === '' ? null : Math.round(Number(raw) * 100);
+
+            const res = await window.apiClient.setDiggerPriority(token, item.release_id, { max_price_cents });
+
+            if (res.ok) {
+                item.max_price_cents = max_price_cents;
+            } else {
+                // Revert to the item's unchanged value
+                input.value = item.max_price_cents != null ? String(item.max_price_cents / 100) : '';
+            }
+        });
+
+        return input;
     }
 
     // ------------------------------------------------------------------ //

--- a/explore/static/js/settings.js
+++ b/explore/static/js/settings.js
@@ -15,6 +15,7 @@ class SettingsPane {
     /** Called when pane activates. Loads profile, renders 2FA, binds events once. */
     init() {
         this._loadProfile();
+        this._loadDiggerSettings();
         this._renderTwoFaState();
 
         if (!this._initialized) {
@@ -76,6 +77,146 @@ class SettingsPane {
         const changeBtn = document.getElementById('changePasswordBtn');
         if (changeBtn) {
             changeBtn.addEventListener('click', () => this._handleChangePassword());
+        }
+
+        const diggerSaveBtn = document.getElementById('diggerSettingsSaveBtn');
+        if (diggerSaveBtn) {
+            diggerSaveBtn.addEventListener('click', () => this._handleSaveDiggerSettings());
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // Digger settings card
+    // ------------------------------------------------------------------ //
+
+    /** Load Digger settings into the card. Returns early if the card or token is absent. */
+    async _loadDiggerSettings() {
+        const card = document.getElementById('settingsDiggerCard');
+        if (!card) return;
+
+        const token = window.authManager.getToken();
+        if (!token) return;
+
+        let res;
+        try {
+            res = await window.apiClient.getDiggerSettings(token);
+        } catch {
+            return;
+        }
+
+        if (res && res.ok && res.body) {
+            this._populateDiggerFields(res.body);
+        } else if (res && res.status === 404) {
+            // Not enabled yet — populate with sensible defaults.
+            this._populateDiggerFields({
+                enabled: false,
+                country_code: '',
+                currency: 'USD',
+                scheduled_cadence: 'weekly',
+                preferred_model: 'sonnet',
+                daily_token_cap_interactive: 200000,
+                daily_token_cap_scheduled: 100000,
+            });
+        }
+        // Other errors: leave fields as-is.
+    }
+
+    /** Populate the Digger settings inputs from a settings object. */
+    _populateDiggerFields(settings) {
+        const enabledEl = document.getElementById('diggerEnabled');
+        if (enabledEl) enabledEl.checked = Boolean(settings.enabled);
+
+        const countryEl = document.getElementById('diggerCountry');
+        if (countryEl) countryEl.value = settings.country_code || '';
+
+        const currencyEl = document.getElementById('diggerCurrency');
+        if (currencyEl) currencyEl.value = settings.currency || '';
+
+        const cadenceEl = document.getElementById('diggerCadence');
+        if (cadenceEl && settings.scheduled_cadence) cadenceEl.value = settings.scheduled_cadence;
+
+        const modelEl = document.getElementById('diggerModel');
+        if (modelEl && settings.preferred_model) modelEl.value = settings.preferred_model;
+
+        const capInteractiveEl = document.getElementById('diggerCapInteractive');
+        if (capInteractiveEl) {
+            capInteractiveEl.value = settings.daily_token_cap_interactive == null ? '' : String(settings.daily_token_cap_interactive);
+        }
+
+        const capScheduledEl = document.getElementById('diggerCapScheduled');
+        if (capScheduledEl) {
+            capScheduledEl.value = settings.daily_token_cap_scheduled == null ? '' : String(settings.daily_token_cap_scheduled);
+        }
+    }
+
+    /** Save Digger settings from the card to the API. */
+    async _handleSaveDiggerSettings() {
+        const errorEl = document.getElementById('diggerSettingsError');
+        const successEl = document.getElementById('diggerSettingsSuccess');
+        if (!errorEl || !successEl) return;
+
+        errorEl.textContent = '';
+        successEl.textContent = '';
+        successEl.classList.add('hidden');
+
+        const enabled = document.getElementById('diggerEnabled').checked;
+        const country = document.getElementById('diggerCountry').value.trim().toUpperCase();
+        const currency = document.getElementById('diggerCurrency').value.trim().toUpperCase();
+        const cadence = document.getElementById('diggerCadence').value;
+        const model = document.getElementById('diggerModel').value;
+        const capInteractiveRaw = document.getElementById('diggerCapInteractive').value.trim();
+        const capScheduledRaw = document.getElementById('diggerCapScheduled').value.trim();
+
+        // Validation: currency required as exactly 3 letters.
+        if (!/^[A-Z]{3}$/.test(currency)) {
+            errorEl.textContent = 'Currency must be a 3-letter code';
+            return;
+        }
+        // Country optional; if present must be exactly 2 letters.
+        if (country && !/^[A-Z]{2}$/.test(country)) {
+            errorEl.textContent = 'Country code must be a 2-letter code';
+            return;
+        }
+        // Token caps optional; if present must be non-negative whole numbers. A digits-only
+        // check rejects negatives, decimals, and exponent notation (which a number input
+        // otherwise keeps) so a nonsensical cap never reaches the API.
+        if (capInteractiveRaw !== '' && !/^\d+$/.test(capInteractiveRaw)) {
+            errorEl.textContent = 'Daily token caps must be non-negative whole numbers';
+            return;
+        }
+        if (capScheduledRaw !== '' && !/^\d+$/.test(capScheduledRaw)) {
+            errorEl.textContent = 'Daily token caps must be non-negative whole numbers';
+            return;
+        }
+
+        const body = {
+            enabled,
+            country_code: country || null,
+            currency,
+            scheduled_cadence: cadence,
+            preferred_model: model,
+            daily_token_cap_interactive: capInteractiveRaw === '' ? null : parseInt(capInteractiveRaw, 10),
+            daily_token_cap_scheduled: capScheduledRaw === '' ? null : parseInt(capScheduledRaw, 10),
+        };
+
+        const token = window.authManager.getToken();
+        if (!token) { errorEl.textContent = 'Not authenticated'; return; }
+
+        const btn = document.getElementById('diggerSettingsSaveBtn');
+        if (btn) btn.disabled = true;
+
+        try {
+            const res = await window.apiClient.putDiggerSettings(token, body);
+            if (res.ok) {
+                successEl.textContent = 'Digger settings saved';
+                successEl.classList.remove('hidden');
+            } else {
+                errorEl.textContent = (res.body && res.body.detail) || 'Failed to save Digger settings';
+            }
+        } catch {
+            errorEl.textContent = 'Network error — please try again';
+        } finally {
+            if (btn) btn.disabled = false;
         }
     }
 


### PR DESCRIPTION
## Summary

PR 4 of 5 in the Digger M1 rollout — the **explore frontend layer** (plan Tasks 22–25). Adds a logged-in **Digger pane** to the Explore SPA, wired to the `/api/digger/*` API that merged in #341.

> **Reconciliation note:** the plan drafted this layer as React 19 + Vite + react-router + React Testing Library under `explore/src/digger/*.tsx`. None of that exists in this repo — `explore/` is **vanilla classic-script JS** (`static/js/*.js`, `window.*` singletons), one `index.html`, styled with hand-written CSS, tested with Vitest + `@testing-library/dom` (jsdom). Every task was re-implemented against the *real* conventions (verified up-front with read-only exploration), and wired to the **actually-merged** #341 contract (note: `WantlistItemOut` has **no `cover_image_url`**; settings token caps are non-null ints).

## What's included

- **API client** (`api-client.js`): `getDiggerSettings` / `putDiggerSettings` / `getDiggerWantlist` / `setDiggerPriority` / `bulkSetDiggerTier` — Bearer auth, uniform `{ok,status,body}` envelope (mirrors `triggerSync`), 204/404-safe.
- **Digger pane** (`digger.js`, new): onboarding card when Digger isn't enabled (CTA → Settings pane); wantlist table with per-row **tier toggle** (must/nice/eventually), media/sleeve **condition** selects, and **max-price** input (optimistic update + revert-on-failure); **bulk-tier** toolbar with row selection + select-all; **tier / hide-no-listings filters**; and a **stats banner** (per-tier counts + Must-available).
- **App wiring** (`app.js`): `_switchPane('digger')` branch + logout redirect; nav entry + pane markup + script tag in `index.html`.
- **Unified settings** (`settings.js` + `index.html`): a **Digger card in the existing Settings pane** (enable, country, currency, cadence, model, token caps) → `putDiggerSettings`, with validation. Per the design decision, all Digger config lives in one place — not a separate drawer.

## End-to-end flow

Login → **Digger** nav (`#navSecondary`) → pane loads settings → if not enabled, onboarding card → **Open Digger Settings** → Settings pane Digger card → enable + configure → back to Digger pane → wantlist with live tiers, active-listing counts, per-row + bulk tier editing, filters, and stats.

## Testing

- `just test-js`: **1144 passing** (28 files), up from 1105 baseline — **+39 net new** across `api-client.test.js`, `digger.test.js`, `settings.test.js`.
- `digger.js` ~99% statement coverage; new `settings.js` code ~96%.
- Executed via subagent-driven-development: per task, implementer → spec-compliance review → code-quality review → fix loop, then this whole-PR review.

## Notes / decisions

- **Routing:** the Explore app has no URL routing — views are panes (`data-pane` + `.active`); `explore.py` serves `index.html` only at `/`. So `/digger/wantlist` is realized as the **Digger pane**, consistent with every other view. No server change needed.
- **Placement:** a new **Digger pane**, separate from the existing Discogs "Wantlist" pane.
- Declined adding an in-flight guard to `settings.js _loadDiggerSettings` (flagged by review): it matches the sibling `_loadProfile()`'s unguarded pattern, and the race is benign (concurrent GETs of the same resource return identical data).

## Deferred to PR 5 (integration/docs)

Perftest entries (`tests/perftest/`) for the new digger endpoints and broader docs/CLAUDE.md updates — intentionally not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
