### PR TITLE
feat(digger): M1 integration + docs — compose/justfile, perftest, smoke, scraping policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,3 +77,10 @@ NEO4J_HEAP_SIZE=2G
 # POSTGRES_BATCH_MODE=true           # Enable batch processing (default: true)
 # POSTGRES_BATCH_SIZE=100            # Records per batch (default: 100)
 # POSTGRES_BATCH_FLUSH_INTERVAL=5.0  # Seconds between flushes (default: 5.0)
+
+# Optional: Digger scraper tuning (defaults shown)
+# DIGGER_RATE_BUDGET_PER_HOUR=600
+# DIGGER_SCRAPER_USER_AGENT=discogsography-digger/0.1 (github.com/SimplicityGuy/discogsography)
+# DIGGER_CB_WINDOW_SECONDS=300
+# DIGGER_CB_FAILURE_PCT=30
+# DIGGER_CB_COOLDOWN_SECONDS=1800

--- a/.github/workflows/docker-compose-validate.yml
+++ b/.github/workflows/docker-compose-validate.yml
@@ -41,7 +41,7 @@ jobs:
       - name: 🔍 Check docker-compose services
         run: |
           services=$(docker-compose config --services | sort | tr "\n" " " | sed "s/ $//")
-          expected="api brainzgraphinator brainztableinator dashboard explore"
+          expected="api brainzgraphinator brainztableinator dashboard digger explore"
           expected="$expected extractor-discogs extractor-musicbrainz graphinator"
           expected="$expected insights neo4j postgres rabbitmq redis schema-init tableinator"
 
@@ -122,12 +122,19 @@ jobs:
             exit 1
           fi
 
+          deps=$(docker-compose config | yq eval '.services.digger.depends_on | keys | sort | join(" ")' -)
+          if [ "$deps" != "postgres redis schema-init" ]; then
+            echo "❌ Digger should depend on postgres, redis, and schema-init"
+            exit 1
+          fi
+
           echo "✅ Service dependencies are correct"
 
       - name: 🛡️ Check for security best practices
         run: |
           # Check that services run as non-root user
-          for service in api brainzgraphinator brainztableinator dashboard explore extractor-discogs extractor-musicbrainz graphinator insights schema-init tableinator; do
+          for service in api brainzgraphinator brainztableinator dashboard digger explore \
+            extractor-discogs extractor-musicbrainz graphinator insights schema-init tableinator; do
             user=$(docker-compose config | yq eval ".services.$service.user" -)
             if [ -z "$user" ] || [ "$user" = "null" ]; then
               echo "❌ $service should have a user configured"
@@ -137,7 +144,8 @@ jobs:
           echo "✅ All services run as non-root user"
 
           # Check security options
-          for service in api brainzgraphinator brainztableinator dashboard explore extractor-discogs extractor-musicbrainz graphinator insights schema-init tableinator; do
+          for service in api brainzgraphinator brainztableinator dashboard digger explore \
+            extractor-discogs extractor-musicbrainz graphinator insights schema-init tableinator; do
             security_opt=$(docker-compose config | yq eval ".services.$service.security_opt[]" - | grep "no-new-privileges:true" || true)
             if [ -z "$security_opt" ]; then
               echo "❌ $service should have no-new-privileges security option"

--- a/.pip-audit-ignores
+++ b/.pip-audit-ignores
@@ -8,3 +8,5 @@
 # which remain. Only add entries here when no fix is available upstream.
 #
 # Format: VULN-ID  # package==version — short description (date added)
+
+PYSEC-2025-183  # pyjwt==2.12.1 — disputed weak-encryption advisory; key length is application-controlled (2026-05-20)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ brainzgraphinator/    Brainzgraphinator service — MusicBrainz data → Neo4j e
 brainztableinator/    Brainztableinator service — MusicBrainz data → PostgreSQL
 common/               Shared library — config, models, utilities used by all Python services
 dashboard/            Dashboard service — real-time monitoring UI
+digger/               Digger service — Discogs marketplace scraper for wantlist listings (scheduled worker)
 explore/              Explore service — static file serving for graph exploration frontend (Vitest for JS tests)
 extractor/            Rust-based extractor — high-performance Discogs XML and MusicBrainz JSONL ingestion
 graphinator/          Graphinator service — consumes messages, builds Neo4j graph
@@ -174,6 +175,7 @@ just deep-clean           # Clean + Docker volumes (destructive)
 | Tableinator       | —                               | 8002   |
 | Brainztableinator | —                               | 8010   |
 | Brainzgraphinator | —                               | 8011   |
+| Digger            | —                               | 8012   |
 | Neo4j             | 7474 (browser), 7687 (bolt)     | —      |
 | PostgreSQL        | 5433 (mapped from 5432)         | —      |
 | RabbitMQ          | 5672 (AMQP), 15672 (management) | —      |

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -316,6 +316,20 @@ services:
         delay: 5s
         max_attempts: 3
 
+  digger:
+    restart: always
+    environment:
+      POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
+      POSTGRES_USERNAME_FILE: /run/secrets/postgres_username
+    secrets:
+      - postgres_username
+      - postgres_password
+    deploy:
+      restart_policy:
+        condition: any
+        delay: 5s
+        max_attempts: 3
+
   dashboard:
     restart: always
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -597,6 +597,55 @@ services:
     volumes:
       - brainztableinator_logs:/logs
 
+  # Digger service — Discogs marketplace scraper
+  digger:
+    build:
+      context: .
+      dockerfile: digger/Dockerfile
+    image: discogsography/digger:latest
+    container_name: discogsography-digger
+    hostname: digger
+    user: "1001:1001"
+    environment:
+      DIGGER_CB_COOLDOWN_SECONDS: "1800"
+      DIGGER_CB_FAILURE_PCT: "30"
+      DIGGER_CB_WINDOW_SECONDS: "300"
+      DIGGER_RATE_BUDGET_PER_HOUR: "600"
+      DIGGER_SCRAPER_USER_AGENT: "discogsography-digger/0.1 (github.com/SimplicityGuy/discogsography)"
+      LOG_LEVEL: INFO
+      POSTGRES_DATABASE: discogsography
+      POSTGRES_HOST: postgres
+      POSTGRES_PASSWORD: discogsography
+      POSTGRES_USERNAME: discogsography
+      PYTHONUNBUFFERED: "1"
+      REDIS_HOST: redis
+    depends_on:
+      schema-init:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - discogsography
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8012/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    restart: on-failure
+    logging: *default-logging
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+    volumes:
+      - digger_logs:/logs
+
   # Dashboard service
   dashboard:
     build:
@@ -781,5 +830,6 @@ volumes:
   dashboard_logs:
   explore_logs:
   brainztableinator_logs:
+  digger_logs:
   insights_logs:
   musicbrainz_data:

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,7 @@
 | **[Neo4j Indexing](neo4j-indexing.md)**                                   | 🔗 Advanced Neo4j indexing strategies                                 |
 | **[Query Performance Optimizations](query-performance-optimizations.md)** | ⚡ Comprehensive query optimization report (249x overall improvement) |
 | **[MusicBrainz Sync Guide](musicbrainz-sync.md)**                         | 🎵 MusicBrainz data import, enrichment, and pipeline operations       |
+| **[Digger Scraping Policy](digger-scraping-policy.md)**                    | ⛏️ Discogs marketplace scraping policy, rate limits, and ToS posture  |
 | **[Recent Improvements](recent-improvements.md)**                         | 🚀 Latest platform enhancements and changelog                         |
 
 ## 🎯 Documentation by Role

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,7 @@ Discogsography is built as a microservices platform that processes large-scale m
 | **[📊](emoji-guide.md#service-identifiers) Dashboard**   | Real-time monitoring and admin panel                                                                            | `FastAPI`, WebSocket, reactive UI, `httpx`                   | 8003 (ext)              |
 | **[📈](emoji-guide.md#service-identifiers) Insights**    | Precomputed analytics and music trends                                                                          | `FastAPI`, `psycopg3`, `httpx`                               | 8008, 8009 (internal)   |
 | **[🤖](emoji-guide.md#service-identifiers) MCP Server**  | Exposes knowledge graph to AI assistants                                                                        | `FastMCP`, `httpx`                                           | stdio / streamable-http |
+| **[⛏️](emoji-guide.md#service-identifiers) Digger**      | Scrapes Discogs marketplace listings for wantlist items (scheduled worker)                                      | `httpx`, `selectolax`, `psycopg3`, `redis`                  | 8012 (health/metrics)   |
 
 ### MusicBrainz Enrichment Services
 
@@ -507,6 +508,35 @@ See [Brainzgraphinator README](../brainzgraphinator/README.md) for details.
 
 See [Brainztableinator README](../brainztableinator/README.md) for details.
 
+### Digger
+
+**Responsibilities**:
+
+- Scrape public Discogs marketplace listing pages for releases users have prioritised in their wantlist (seller-profile parsing is implemented, but the seller-profile fetch is not yet wired in M1)
+- Persist listings, sellers, and per-release scrape state to the `digger.*` PostgreSQL schema
+- Apply each user's tier, condition, and price preferences (`digger.user_wantlist_priorities`, `digger.user_digger_settings`)
+- Run on a schedule, adapting per-release scrape cadence to recent listing churn
+
+**Key Features**:
+
+- Standalone async worker — reads and writes PostgreSQL and Redis directly; does **not** use RabbitMQ and does **not** call the API service
+- Redis token-bucket rate budget (default 600 requests/hour) enforced before every request
+- SSRF-safe HTTP client restricted to a `discogs.com` hostname allow-list, with each redirect hop re-validated
+- Per-release exponential backoff (capped at 24 h) and a global circuit breaker for sustained failures
+- Listings soft-delete lifecycle: upsert on `listing_id`, soft-delete vanished listings (`removed_at`), preserve full history
+- Health and Prometheus metrics endpoints on port 8012
+- HTML parsed with `selectolax`; seller-supplied text sanitised before storage
+
+**Configuration**:
+
+- `POSTGRES_HOST`, `POSTGRES_USERNAME`, `POSTGRES_PASSWORD`, `POSTGRES_DATABASE`: PostgreSQL connection
+- `REDIS_HOST`: Redis hostname (rate budget)
+- `DIGGER_RATE_BUDGET_PER_HOUR`: Request budget per hour (default: 600)
+- `DIGGER_SCRAPER_USER_AGENT`: User-Agent header for scrape requests
+- `DIGGER_CB_WINDOW_SECONDS`, `DIGGER_CB_FAILURE_PCT`, `DIGGER_CB_COOLDOWN_SECONDS`: Circuit-breaker tuning
+
+See [Digger README](../digger/README.md) and the [Digger Scraping Policy](digger-scraping-policy.md) for the full request and Terms-of-Service posture.
+
 ### Explore Service
 
 **Responsibilities**:
@@ -821,6 +851,15 @@ See [Database Schema](database-schema.md) for details.
 - `musicbrainz.relationships`: Source/target MBIDs, relationship type, direction, attributes
 - `musicbrainz.external_links`: MBID, service name, URL (Wikipedia, Wikidata, AllMusic, etc.)
 
+**Digger Schema** (`digger.*`) — marketplace scraper data:
+
+- `digger.sellers`: Discogs seller profile, region, feedback, shipping policy
+- `digger.release_scrape_state`: Per-release priority tier, scrape scheduling, failure tracking
+- `digger.listings`: Marketplace listings with soft-delete lifecycle (`first_seen_at` / `last_seen_at` / `removed_at`)
+- `digger.user_wantlist_priorities`: Per-user tier/condition/price preferences (trigger recomputes scrape priority)
+- `digger.user_digger_settings`: Per-user enable flag, cadence, model, and token caps
+- `digger.reports`, `digger.proposals`, `digger.agent_sessions`, `digger.agent_messages`: M2/M3 scaffolding
+
 **Indexes**:
 
 - B-tree indexes on common query fields
@@ -905,6 +944,7 @@ curl http://localhost:8007/health  # Explore
 curl http://localhost:8009/health  # Insights
 curl http://localhost:8010/health  # Brainztableinator
 curl http://localhost:8011/health  # Brainzgraphinator
+curl http://localhost:8012/health  # Digger (also /metrics)
 ```
 
 ### Logging

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -244,11 +244,11 @@ POSTGRES_COMMAND_TIMEOUT=30
 
 ### Redis Configuration
 
-| Variable     | Description    | Default     | Required                       |
-| ------------ | -------------- | ----------- | ------------------------------ |
-| `REDIS_HOST` | Redis hostname | `localhost` | Yes (Dashboard, API, Insights) |
+| Variable     | Description    | Default     | Required                               |
+| ------------ | -------------- | ----------- | -------------------------------------- |
+| `REDIS_HOST` | Redis hostname | `localhost` | Yes (Dashboard, API, Insights, Digger) |
 
-**Used By**: Dashboard, API, Insights
+**Used By**: Dashboard, API, Insights, Digger
 
 **Connection Details**:
 
@@ -541,6 +541,12 @@ CORS_ORIGINS="http://localhost:8003,http://localhost:8006"
 SNAPSHOT_TTL_DAYS=28     # Snapshot expiry in days (default: 28)
 SNAPSHOT_MAX_NODES=100   # Max nodes per snapshot (default: 100)
 
+# Optional — shared service token gating the internal Digger endpoints
+# (/api/internal/digger/*). The Digger worker presents this in the
+# X-Service-Token header. Omit to leave those internal endpoints disabled.
+# In production, supply via DIGGER_API_SERVICE_TOKEN_FILE (Docker secret).
+DIGGER_API_SERVICE_TOKEN="your-service-token-here"
+
 # Optional
 JWT_EXPIRE_MINUTES=1440
 LOG_LEVEL=INFO
@@ -815,6 +821,33 @@ Health check: http://localhost:8010/health
 
 **Notes**: Brainztableinator stores all MusicBrainz data in the `musicbrainz` PostgreSQL schema — including entities without Discogs matches — with relationships and external links. Consumes from the `musicbrainz-{artists,labels,release-groups,releases}` exchanges.
 
+### Digger
+
+```bash
+# Required
+POSTGRES_HOST="localhost"
+POSTGRES_USERNAME="discogsography"
+POSTGRES_PASSWORD="discogsography"
+POSTGRES_DATABASE="discogsography"
+REDIS_HOST="localhost"           # Redis hostname (rate-budget token bucket)
+
+# Optional - Scraper
+DIGGER_RATE_BUDGET_PER_HOUR=600  # Outbound request budget per hour (default: 600)
+DIGGER_SCRAPER_USER_AGENT="discogsography-digger/0.1 (github.com/SimplicityGuy/discogsography)"
+
+# Optional - Circuit Breaker
+DIGGER_CB_WINDOW_SECONDS=300     # Rolling failure-rate window (default: 300)
+DIGGER_CB_FAILURE_PCT=30         # Failure % that opens the breaker (default: 30; >= 10 events required)
+DIGGER_CB_COOLDOWN_SECONDS=1800  # Open-state cooldown before reset (default: 1800)
+
+# Optional - Logging
+LOG_LEVEL=INFO
+```
+
+Health check: http://localhost:8012/health (also exposes Prometheus `/metrics`)
+
+**Notes**: The Digger worker scrapes public Discogs marketplace listing and seller pages, persisting to the `digger.*` PostgreSQL schema and using Redis for the rate-budget token bucket. It does **not** use RabbitMQ and does **not** call the API service. Per-release retries use exponential backoff (capped at 24 h); the global circuit breaker pauses scraping when the recent failure rate is high. The `DIGGER_API_SERVICE_TOKEN` that gates `/api/internal/digger/*` is consumed by the **API service**, not by this worker — see the [API](#api) section. See [Digger Scraping Policy](digger-scraping-policy.md) for the full request and Terms-of-Service posture.
+
 ### MCP Server
 
 ```bash
@@ -999,6 +1032,7 @@ curl http://localhost:8007/health  # Explore
 curl http://localhost:8009/health  # Insights
 curl http://localhost:8010/health  # Brainztableinator
 curl http://localhost:8011/health  # Brainzgraphinator
+curl http://localhost:8012/health  # Digger (also /metrics)
 ```
 
 Expected response for all:

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -1214,6 +1214,183 @@ graph LR
 
 All MusicBrainz-sourced edges carry `source: 'musicbrainz'` for provenance tracking. The existing `MEMBER_OF` relationship is enriched with date information from MusicBrainz.
 
+#### Digger Schema
+
+All Digger marketplace-scraper data lives in a dedicated `digger` schema, owned by `schema-init/digger_schema.py`. M1 actively uses `sellers`, `release_scrape_state`, `listings`, `user_wantlist_priorities`, and `user_digger_settings`; the `reports`, `proposals`, `agent_sessions`, and `agent_messages` tables are scaffolding for the M2 (optimizer) and M3 (agent) milestones.
+
+```sql
+CREATE SCHEMA IF NOT EXISTS digger;
+```
+
+**Enums** — 11 enumerated types scope the domain values:
+
+```sql
+CREATE TYPE digger.priority_tier    AS ENUM ('must', 'nice', 'eventually');
+CREATE TYPE digger.condition        AS ENUM ('M','NM','VG+','VG','G+','G','F','P');
+CREATE TYPE digger.sleeve_condition AS ENUM ('M','NM','VG+','VG','G+','G','F','P','generic','no_cover');
+CREATE TYPE digger.region           AS ENUM ('us','ca','eu','uk','jp','au','other');
+CREATE TYPE digger.cadence          AS ENUM ('off','weekly','biweekly','monthly');
+CREATE TYPE digger.model            AS ENUM ('haiku','sonnet','opus');
+CREATE TYPE digger.report_kind      AS ENUM ('scheduled','interactive');
+CREATE TYPE digger.change_flag      AS ENUM ('significant','none','first_run');
+CREATE TYPE digger.confidence       AS ENUM ('high','low');
+CREATE TYPE digger.proposal_status  AS ENUM ('pending','approved','rejected','expired');
+CREATE TYPE digger.role             AS ENUM ('system','user','assistant','tool');
+```
+
+**digger.sellers** — public Discogs marketplace sellers.
+
+```sql
+CREATE TABLE IF NOT EXISTS digger.sellers (
+    seller_id              BIGINT        PRIMARY KEY,
+    username               TEXT          NOT NULL,
+    country_code           CHAR(2),
+    region                 digger.region NOT NULL DEFAULT 'other',
+    feedback_count         INT,
+    feedback_score         NUMERIC(4,1),
+    ships_internationally  BOOL          NOT NULL DEFAULT FALSE,
+    shipping_policy        JSONB,
+    last_refreshed_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+```
+
+**digger.release_scrape_state** — per-release scrape scheduling and failure tracking. `priority_tier` is recomputed by a trigger on `user_wantlist_priorities` (see below).
+
+```sql
+CREATE TABLE IF NOT EXISTS digger.release_scrape_state (
+    release_id             BIGINT                PRIMARY KEY,
+    priority_tier          digger.priority_tier  NOT NULL DEFAULT 'eventually',
+    last_scraped_at        TIMESTAMPTZ,
+    next_scrape_due_at     TIMESTAMPTZ           NOT NULL DEFAULT NOW(),
+    listings_delta_7d      INT                   NOT NULL DEFAULT 0,
+    consecutive_failures   INT                   NOT NULL DEFAULT 0,
+    next_retry_at          TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_rss_due_tier
+    ON digger.release_scrape_state (priority_tier, next_scrape_due_at);
+```
+
+**digger.listings** — marketplace listings with a soft-delete lifecycle. `first_seen_at` is set once; `last_seen_at` is refreshed on every scrape that re-observes a listing; `removed_at` is set (not deleted) when a previously-seen listing disappears from a scrape. Active-listing queries filter on `removed_at IS NULL` via partial indexes.
+
+```sql
+CREATE TABLE IF NOT EXISTS digger.listings (
+    listing_id          BIGINT                   PRIMARY KEY,
+    release_id          BIGINT                   NOT NULL REFERENCES digger.release_scrape_state(release_id) ON DELETE CASCADE,
+    seller_id           BIGINT                   NOT NULL REFERENCES digger.sellers(seller_id) ON DELETE CASCADE,
+    price_value         NUMERIC(10,2)            NOT NULL,
+    price_currency      CHAR(3)                  NOT NULL,
+    media_condition     digger.condition         NOT NULL,
+    sleeve_condition    digger.sleeve_condition  NOT NULL,
+    comments            TEXT,
+    posted_at           TIMESTAMPTZ,
+    first_seen_at       TIMESTAMPTZ              NOT NULL DEFAULT NOW(),  -- set once, on first observation
+    last_seen_at        TIMESTAMPTZ              NOT NULL DEFAULT NOW(),  -- refreshed each re-observation
+    removed_at          TIMESTAMPTZ                                       -- soft-delete marker (NULL = active)
+);
+
+CREATE INDEX IF NOT EXISTS idx_listings_release_active
+    ON digger.listings (release_id) WHERE removed_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_listings_seller_active
+    ON digger.listings (seller_id) WHERE removed_at IS NULL;
+```
+
+**digger.user_wantlist_priorities** — per-user, per-release priority and minimum-condition / max-price preferences. An `AFTER INSERT OR UPDATE OR DELETE` trigger recomputes `release_scrape_state.priority_tier` to the highest tier any user has assigned to that release.
+
+```sql
+CREATE TABLE IF NOT EXISTS digger.user_wantlist_priorities (
+    user_id              UUID                    NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    release_id           BIGINT                  NOT NULL,
+    tier                 digger.priority_tier    NOT NULL DEFAULT 'nice',
+    min_media_condition  digger.condition        NOT NULL DEFAULT 'VG',
+    min_sleeve_condition digger.sleeve_condition NOT NULL DEFAULT 'VG',
+    max_price_cents      INT,
+    updated_at           TIMESTAMPTZ             NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, release_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_uwp_release ON digger.user_wantlist_priorities (release_id);
+```
+
+The priority-recompute trigger keeps each release's scrape priority in sync with user demand:
+
+```sql
+-- recompute_priority_for_release() sets release_scrape_state.priority_tier to the
+-- highest tier (must > nice > eventually) any user has assigned to the release.
+CREATE OR REPLACE TRIGGER trg_uwp_recompute
+AFTER INSERT OR UPDATE OR DELETE ON digger.user_wantlist_priorities
+FOR EACH ROW EXECUTE FUNCTION digger.uwp_after_change();
+```
+
+> **Note**: `user_wantlist_priorities.release_id` intentionally has **no** foreign key to `release_scrape_state`. Priorities are user-owned and may be seeded before a scrape-state row exists; the trigger's `UPDATE` is a harmless no-op when the parent row is absent, and the worker reconciles scrape state on first encounter.
+
+**digger.user_digger_settings** — per-user Digger configuration (enable flag, locale, scheduled cadence, model preference, daily token caps).
+
+```sql
+CREATE TABLE IF NOT EXISTS digger.user_digger_settings (
+    user_id                       UUID             PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    enabled                       BOOL             NOT NULL DEFAULT FALSE,
+    country_code                  CHAR(2),
+    currency                      CHAR(3)          NOT NULL DEFAULT 'USD',
+    scheduled_cadence             digger.cadence   NOT NULL DEFAULT 'off',
+    next_scheduled_run_at         TIMESTAMPTZ,
+    preferred_model               digger.model     NOT NULL DEFAULT 'sonnet',
+    daily_token_cap_interactive   INT              NOT NULL DEFAULT 200000,
+    daily_token_cap_scheduled     INT              NOT NULL DEFAULT 100000
+);
+```
+
+**digger.reports**, **digger.proposals**, **digger.agent_sessions**, **digger.agent_messages** — scaffolding for the M2 optimizer and M3 agent milestones (not exercised in M1).
+
+```sql
+CREATE TABLE IF NOT EXISTS digger.reports (
+    report_id            UUID                     PRIMARY KEY,
+    user_id              UUID                     NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    kind                 digger.report_kind       NOT NULL,
+    generated_at         TIMESTAMPTZ              NOT NULL DEFAULT NOW(),
+    read_at              TIMESTAMPTZ,
+    title                TEXT                     NOT NULL,
+    summary              JSONB                    NOT NULL,
+    bundles              JSONB                    NOT NULL,
+    watching             JSONB                    NOT NULL DEFAULT '[]'::JSONB,
+    change_flag          digger.change_flag       NOT NULL,
+    shipping_confidence  digger.confidence        NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS digger.proposals (
+    proposal_id  UUID                     PRIMARY KEY,
+    user_id      UUID                     NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    session_id   UUID,
+    created_at   TIMESTAMPTZ              NOT NULL DEFAULT NOW(),
+    status       digger.proposal_status   NOT NULL DEFAULT 'pending',
+    payload      JSONB                    NOT NULL,
+    expires_at   TIMESTAMPTZ              NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS digger.agent_sessions (
+    session_id              UUID           PRIMARY KEY,
+    user_id                 UUID           NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    started_at              TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    last_active_at          TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    model                   digger.model   NOT NULL,
+    total_input_tokens      INT            NOT NULL DEFAULT 0,
+    total_output_tokens     INT            NOT NULL DEFAULT 0,
+    total_cache_read_tokens INT            NOT NULL DEFAULT 0,
+    total_cost_usd          NUMERIC(10,4)  NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS digger.agent_messages (
+    message_id    UUID          PRIMARY KEY,
+    session_id    UUID          NOT NULL REFERENCES digger.agent_sessions(session_id) ON DELETE CASCADE,
+    role          digger.role   NOT NULL,
+    content       JSONB         NOT NULL,
+    token_counts  JSONB,
+    created_at    TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+```
+
+See [Digger Scraping Policy](digger-scraping-policy.md) for how the worker populates `listings`, `sellers`, and `release_scrape_state`.
+
 ### Common Queries
 
 #### Full-text search releases

--- a/docs/digger-scraping-policy.md
+++ b/docs/digger-scraping-policy.md
@@ -1,0 +1,122 @@
+# ⛏️ Digger Scraping Policy
+
+<div align="center">
+
+**How the Digger worker scrapes Discogs marketplace data — responsibly and transparently**
+
+[🏠 Back to Main](../README.md) | [📚 Documentation Index](README.md) | [🏛️ Architecture](architecture.md) | [⚙️ Configuration](configuration.md)
+
+</div>
+
+## Overview
+
+**Digger** is the Discogs marketplace scraper and wantlist-intelligence worker. It tracks marketplace listings for the releases users have prioritised in their wantlist, applying each user's tier, condition, and price preferences. The worker runs on a schedule, reads and writes PostgreSQL (`digger.*` schema) and Redis directly, and exposes health plus Prometheus metrics on port **8012**. It does **not** use RabbitMQ and does **not** call the API service.
+
+This document describes exactly what Digger scrapes, the controls that keep request volume low and well-behaved, and the project's posture toward Discogs' Terms of Service.
+
+## What We Scrape
+
+Digger fetches only **public, unauthenticated** Discogs pages. It never logs in, never holds a Discogs session cookie, and never touches private, member-only, or rate-limited API endpoints.
+
+Digger restricts itself to these public URL patterns:
+
+| Purpose          | URL Pattern                                          | Notes                                              |
+| ---------------- | ---------------------------------------------------- | -------------------------------------------------- |
+| Release listings | `https://www.discogs.com/sell/release/{release_id}`  | Public marketplace listings for a release — the only page fetched in M1 |
+| Seller profiles  | `https://www.discogs.com/seller/{username}`          | Public seller profile (country, feedback, shipping). Parser is implemented but the fetch is **not yet wired in M1** — seller identity uses deterministic placeholder IDs until then |
+
+No other hosts, paths, or authenticated areas are requested. See the [Digger design spec](superpowers/specs/2026-05-14-digger-wantlist-agent-design.md) for the full feature design.
+
+## Rate Budget
+
+All outbound requests pass through a **Redis-backed token bucket** before they are made.
+
+- **Default budget**: **600 requests/hour** (`DIGGER_RATE_BUDGET_PER_HOUR`).
+- **Implementation**: a Redis token bucket using optimistic concurrency (`WATCH`/`MULTI`/`EXEC`) rather than Lua scripts, so it works for the single-worker M1 deployment and scales to multiple workers via the same mechanism.
+- **Refill**: tokens refill continuously at `budget / 3600` tokens per second. When the bucket is empty the worker blocks until the next token is available — it never bursts past the budget.
+
+600 requests/hour is roughly one request every six seconds — deliberately conservative for a public site.
+
+## User-Agent
+
+Every request carries a transparent, identifying User-Agent so Discogs can attribute (and contact about) the traffic:
+
+```
+discogsography-digger/0.1 (github.com/SimplicityGuy/discogsography)
+```
+
+Configurable via `DIGGER_SCRAPER_USER_AGENT`. Requests also send `Accept-Language: en`.
+
+## Per-Release Backoff
+
+When a scrape of a release fails, that release is retried with **exponential backoff**:
+
+- Delay is `2 ** consecutive_failures` hours — failure 0 → 1 h, 1 → 2 h, 2 → 4 h, 3 → 8 h, …
+- Capped at **24 hours** maximum.
+- The counter resets to zero on the next successful scrape.
+
+This is per-release state stored in `digger.release_scrape_state` (`consecutive_failures`, `next_retry_at`), so a single problematic release backs off without affecting healthy ones.
+
+## Circuit Breaker
+
+A global, in-memory circuit breaker protects Discogs (and Digger) from sustained failures:
+
+| Setting          | Default | Env Var                        | Behaviour                                                  |
+| ---------------- | ------- | ------------------------------ | --------------------------------------------------------- |
+| Window           | `300` s | `DIGGER_CB_WINDOW_SECONDS`     | Rolling observation window for outcomes                   |
+| Failure threshold | `30` %  | `DIGGER_CB_FAILURE_PCT`        | Opens when failure rate `>=` threshold (≥10 events needed) |
+| Cooldown         | `1800` s | `DIGGER_CB_COOLDOWN_SECONDS`   | Stays open this long before a success can reset it         |
+
+While the breaker is open the scrape loop pauses (sleeping in short intervals) instead of hammering a struggling endpoint. At least 10 events must be observed in the window before the breaker can trip, so a couple of isolated failures will not open it.
+
+## SSRF Protection
+
+The HTTP client (`digger/scraper/http_client.py`) enforces a strict **hostname allow-list** so the worker can never be redirected to an unintended target:
+
+- **Allowed hosts**: only `www.discogs.com` and `discogs.com`.
+- **Allowed schemes**: `http` and `https` only.
+- **Manual redirect handling**: redirects are *not* followed automatically. Each `Location` hop is resolved against the current URL and **re-validated** against the allow-list before the next request is made. Any disallowed scheme or host raises `BlockedTargetError` and the request is abandoned.
+
+This prevents an attacker-controlled or compromised redirect from steering the worker at internal services or arbitrary hosts.
+
+## Listings Soft-Delete Lifecycle
+
+Digger never hard-deletes marketplace listings. It keeps a complete, time-stamped history so price and availability trends survive across scrapes.
+
+Each scrape of a release runs inside a single PostgreSQL transaction:
+
+1. **Upsert** every listing observed in the scrape via `INSERT … ON CONFLICT (listing_id) DO UPDATE`, refreshing `last_seen_at` and clearing `removed_at`. `first_seen_at` is set once, on first observation, and never changes.
+2. **Soft-delete** any previously-active listing for the release that was *not* seen in this scrape — its `removed_at` is set to `now()` rather than deleting the row.
+3. **Reschedule** the release using an adaptive next-scrape interval.
+
+The adaptive interval starts from a per-tier base and is scaled by recent listing churn (more activity → shorter interval, clamped to a `[0.5, 1.5]×` multiplier):
+
+| Priority Tier | Base Interval |
+| ------------- | ------------- |
+| `must`        | 7 days        |
+| `nice`        | 14 days       |
+| `eventually`  | 28 days       |
+
+Active-listing queries filter on `removed_at IS NULL` (backed by partial indexes), so soft-deleted rows stay out of "what's for sale now" results while remaining available for historical analysis.
+
+## Terms of Service Posture
+
+Digger is designed to be a low-impact, transparent, good-faith consumer of public Discogs data:
+
+- **Public pages only** — listing and seller pages that any logged-out visitor can view. No authenticated, private, or API-rate-limited endpoints.
+- **Well under any reasonable rate** — a default ceiling of 600 requests/hour (≈1 every 6 s), enforced before each request, with exponential per-release backoff and a global circuit breaker that backs off automatically when the site is unhealthy.
+- **Transparent identification** — an honest, project-identifying User-Agent that links back to the source repository.
+- **Respectful of failure signals** — `429` and `5xx` responses count as failures, feeding both per-release backoff and the circuit breaker so the worker eases off rather than retrying aggressively.
+
+Operators deploying Digger are responsible for ensuring their use complies with Discogs' Terms of Service and any applicable law. These controls exist to make compliant, courteous operation the default.
+
+## Related Documentation
+
+- [Architecture Overview](architecture.md) — where Digger fits in the platform
+- [Configuration Guide](configuration.md) — full environment-variable reference
+- [Database Schema](database-schema.md) — the `digger.*` schema
+- [Digger Design Spec](superpowers/specs/2026-05-14-digger-wantlist-agent-design.md) — feature design and milestones
+
+______________________________________________________________________
+
+**Last Updated**: 2026-05-20

--- a/docs/emoji-guide.md
+++ b/docs/emoji-guide.md
@@ -28,6 +28,7 @@ Emojis in Discogsography serve to:
 | 📊    | Dashboard         | Analytics dashboard                            |
 | 📈    | Insights          | Precomputed analytics and music trends         |
 | 🤖    | MCP Server        | AI assistant integration via knowledge graph   |
+| ⛏️    | Digger            | Discogs marketplace scraper and wantlist worker |
 | 🐰    | RabbitMQ          | Message broker                                 |
 
 ### Status Indicators

--- a/justfile
+++ b/justfile
@@ -587,6 +587,7 @@ build:
         brainzgraphinator \
         brainztableinator \
         dashboard \
+        digger \
         explore \
         extractor-discogs \
         extractor-musicbrainz \
@@ -594,6 +595,21 @@ build:
         insights \
         schema-init \
         tableinator
+
+# Start only the digger service (with its dependencies)
+[group('docker')]
+digger-up:
+    docker compose up -d digger
+
+# Follow digger service logs
+[group('docker')]
+digger-logs:
+    docker compose logs -f digger
+
+# Fetch Prometheus metrics from the running digger container
+[group('docker')]
+digger-metrics:
+    curl -s http://localhost:8012/metrics
 
 # Build production Docker images
 [group('docker')]

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -5,3 +5,7 @@
 # re-tests each entry after dependency upgrades and removes resolved ones.
 #
 # Only add entries when no fix is available upstream.
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-183"
+reason = "pyjwt==2.12.1 — disputed weak-encryption advisory; the key length is chosen by the calling application, and there is no upstream fix (2026-05-20)"

--- a/tests/digger/test_digger_m1_smoke.py
+++ b/tests/digger/test_digger_m1_smoke.py
@@ -1,0 +1,305 @@
+"""M1 happy-path smoke test for the digger feature.
+
+This single file wires the REAL digger components together at their seams, with
+mocks only at the I/O boundaries (HTTP via respx, Postgres via a mock pool/cursor).
+Its value over the existing isolated unit tests is that it exercises the genuine
+contracts between components, so a break between any of these pairs is caught here:
+
+    Part 1 (scrape -> persist):
+        DiggerHttpClient (respx) -> ScrapeExecutor -> parse_listings -> _persist SQL
+    Part 2 (persist -> API surface):
+        require_user -> get_wantlist router -> get_wantlist_with_listings_counts ->
+        DiggerWantlistResponse response model
+
+No part of the real parser, executor, router, or query is reimplemented or
+over-mocked: the actual functions run end to end against the mock boundaries.
+
+SCOPE NOTE: A true cross-process E2E (real Postgres, a running stack, a browser)
+is INTENTIONALLY out of scope. This repository has no real-DB test infrastructure
+-- every test, including ones named "*integration*", is mock-based, and the only
+live marker is ``e2e`` (which assumes a running stack). This smoke is therefore
+mock-based and in-process so it runs in normal CI (``just test-digger``) without a
+database, a stack, a browser, or a new marker. It is NOT marked ``e2e`` and runs
+under the default ``-m 'not e2e'`` selection.
+"""
+
+from __future__ import annotations
+
+import base64
+from decimal import Decimal
+import hashlib
+import hmac
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import httpx
+import pytest
+import respx
+
+from api.routers import digger as digger_router
+from digger.scraper.executor import ScrapeExecutor, _placeholder_seller_id
+from digger.scraper.http_client import DiggerHttpClient
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+# Mirrors tests/api/conftest.py so the JWT is minted exactly the same way.
+TEST_JWT_SECRET = "test-jwt-secret-for-unit-tests"
+TEST_USER_ID = "00000000-0000-0000-0000-000000000001"
+TEST_USER_EMAIL = "test@example.com"
+
+
+# ---------------------------------------------------------------------------
+# Part 1 helpers: a mock pool/conn/cursor chain that records the SQL it receives
+# ---------------------------------------------------------------------------
+
+
+def _make_executor_pool(fetchone_return: object = None) -> tuple[MagicMock, AsyncMock]:
+    """Build a mock pool -> conn -> cursor chain for ScrapeExecutor._persist.
+
+    Mirrors the shape used in tests/digger/test_executor.py. Returns (pool, cursor)
+    so the caller can assert on the SQL the executor issued.
+    """
+    cursor = AsyncMock()
+    cursor.__aenter__ = AsyncMock(return_value=cursor)
+    cursor.__aexit__ = AsyncMock(return_value=False)
+    cursor.execute = AsyncMock()
+    cursor.fetchone = AsyncMock(return_value=fetchone_return)
+    cursor.rowcount = 0
+
+    conn = AsyncMock()
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=False)
+    conn.set_autocommit = AsyncMock()
+    conn.cursor = MagicMock(return_value=cursor)
+    tx = AsyncMock()
+    tx.__aenter__ = AsyncMock(return_value=tx)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=tx)
+
+    pool = MagicMock()
+    pool.connection = MagicMock(return_value=conn)
+    return pool, cursor
+
+
+# ---------------------------------------------------------------------------
+# Part 1: scrape -> persist  (real http client + real parser + real executor)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_m1_smoke_scrape_release_persists_parsed_listings() -> None:
+    """Fetch a release page, parse the real HTML, persist via the real executor.
+
+    Asserts the full scrape-one-release contract:
+      (i)   the correct Discogs /sell/release/<id> URL was requested,
+      (ii)  the canned HTML was parsed into >= 1 marketplace listing,
+      (iii) the executor upserted that listing into digger.listings with the
+            price/condition that came out of the parsed HTML,
+      (iv)  the executor set next_scrape_due_at so the queue runner will not
+            immediately re-pop and re-scrape the release.
+    """
+    release_id = 12345
+    html = (FIXTURES / "listing_page_basic.html").read_text()
+
+    listing_url = f"https://www.discogs.com/sell/release/{release_id}"
+    route = respx.get(listing_url).mock(return_value=httpx.Response(200, text=html))
+
+    # New seller -> the executor synthesises a placeholder seller_id.
+    pool, cursor = _make_executor_pool(fetchone_return=None)
+
+    async with DiggerHttpClient(user_agent="digger-smoke/1.0") as http:
+        executor = ScrapeExecutor(http_client=http, pool=pool)
+        result = await executor.scrape_release(release_id)
+
+    assert result is True
+
+    # (i) the correct listing URL was fetched
+    assert route.called
+    requested_url = str(route.calls.last.request.url)
+    assert requested_url == listing_url
+
+    # (ii) the real parser produced listings from the canned HTML. The first
+    # fixture row is listing_id=20001, seller "vinylking", NM/NM, USD 12.99 -- so
+    # a SELECT on that exact username confirms the parsed record reached _persist.
+    select_calls = [c for c in cursor.execute.call_args_list if "SELECT seller_id" in c[0][0]]
+    selected_usernames = {c[0][1][0] for c in select_calls}
+    assert "vinylking" in selected_usernames
+
+    # (iii) the parsed listing was upserted into digger.listings with values
+    # derived from the HTML (listing_id 20001, USD 12.99, NM media condition,
+    # and the placeholder seller_id for the new "vinylking" seller).
+    listing_inserts = [c for c in cursor.execute.call_args_list if "INSERT INTO digger.listings" in c[0][0]]
+    assert listing_inserts, "expected an upsert into digger.listings"
+    insert_sql = listing_inserts[0][0][0]
+    assert "ON CONFLICT (listing_id) DO UPDATE" in insert_sql
+
+    row_20001 = next(c for c in listing_inserts if c[0][1][0] == 20001)
+    params = row_20001[0][1]
+    # Positional params: listing_id, release_id, seller_id, price_value,
+    # price_currency, media_condition, sleeve_condition, comments, posted_at.
+    # Sanity-guard params[0] so a future column reorder fails loudly here.
+    assert params[0] == 20001, f"listing_id should be the first param; got {params!r}"
+    assert params[1] == release_id
+    assert params[2] == _placeholder_seller_id("vinylking")
+    assert params[3] == Decimal("12.99")
+    assert params[4] == "USD"
+    assert params[5] == "NM"
+
+    # (iv) the executor set next_scrape_due_at (and recorded a successful scrape)
+    # so the queue runner will not immediately re-pop this release.
+    state_calls = [c for c in cursor.execute.call_args_list if "release_scrape_state" in c[0][0]]
+    assert state_calls, "expected a release_scrape_state update"
+    state_sql = state_calls[0][0][0]
+    assert "next_scrape_due_at" in state_sql
+    assert "last_scraped_at" in state_sql
+    assert "consecutive_failures = 0" in state_sql
+
+
+# ---------------------------------------------------------------------------
+# Part 2 helpers: mint a JWT + a mock pool whose cursor drives the REAL query
+# ---------------------------------------------------------------------------
+
+
+def _make_test_jwt(
+    user_id: str = TEST_USER_ID,
+    email: str = TEST_USER_EMAIL,
+    exp: int = 9_999_999_999,
+    secret: str = TEST_JWT_SECRET,
+) -> str:
+    """Mint a valid HS256 JWT exactly as tests/api/conftest.make_test_jwt does."""
+
+    def b64url(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+    header = b64url(json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode())
+    body = b64url(json.dumps({"sub": user_id, "email": email, "exp": exp}, separators=(",", ":")).encode())
+    signing_input = f"{header}.{body}".encode("ascii")
+    sig = b64url(hmac.new(secret.encode("utf-8"), signing_input, hashlib.sha256).digest())
+    return f"{header}.{body}.{sig}"
+
+
+def _make_query_pool(rows: list[dict[str, Any]]) -> MagicMock:
+    """Build a mock pool whose cursor returns *rows* from fetchall().
+
+    Shaped so the REAL get_wantlist_with_listings_counts runs unchanged: it opens
+    pool.connection(), calls conn.cursor(row_factory=dict_row), executes, and
+    fetchall()s dict rows. We mock only at that boundary.
+    """
+    cursor = AsyncMock()
+    cursor.__aenter__ = AsyncMock(return_value=cursor)
+    cursor.__aexit__ = AsyncMock(return_value=False)
+    cursor.execute = AsyncMock()
+    cursor.fetchall = AsyncMock(return_value=rows)
+    cursor.fetchone = AsyncMock(return_value=None)
+
+    conn = AsyncMock()
+    conn.__aenter__ = AsyncMock(return_value=conn)
+    conn.__aexit__ = AsyncMock(return_value=False)
+    # cursor() must accept the row_factory=dict_row kwarg the real query passes.
+    conn.cursor = MagicMock(return_value=cursor)
+
+    pool = MagicMock()
+    pool.connection = MagicMock(return_value=conn)
+    return pool
+
+
+@pytest.fixture
+def digger_api_client() -> Iterator[TestClient]:
+    """A minimal FastAPI app mounting the REAL digger router + REAL auth dependency.
+
+    Self-contained: tests/api/conftest fixtures are not visible here (conftest is
+    directory-scoped). We configure api.dependencies with a known JWT secret so the
+    real require_user runs, mount the real router, and restore module state on exit.
+    """
+    import api.dependencies as deps
+
+    original_jwt = deps._jwt_secret
+    original_redis = deps._redis
+    original_pool_deps = deps._pool
+    original_token = deps._digger_api_service_token
+    original_router_pool = digger_router._pool
+
+    # Real require_user only needs the JWT secret; Redis is optional (revocation
+    # checks are skipped when _redis is None).
+    deps.configure(TEST_JWT_SECRET, redis=None, pool=None, digger_api_service_token=None)
+
+    app = FastAPI()
+    app.include_router(digger_router.router)
+
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            yield client
+    finally:
+        deps.configure(original_jwt, redis=original_redis, pool=original_pool_deps, digger_api_service_token=original_token)
+        digger_router._pool = original_router_pool
+
+
+# ---------------------------------------------------------------------------
+# Part 2: persist -> API surface  (real router + real query shaping)
+# ---------------------------------------------------------------------------
+
+
+def test_m1_smoke_scraped_listing_surfaces_through_wantlist_api(digger_api_client: TestClient) -> None:
+    """A "scraped" wantlist row (active_listings >= 1) surfaces through the API.
+
+    Stands up the REAL digger router with a mock pool whose query path returns one
+    wantlist row shaped exactly as get_wantlist_with_listings_counts emits (the
+    SELECT's column aliases). Authenticates with a real JWT (exercising the real
+    require_user), GETs /api/digger/wantlist, and asserts the response item shows
+    active_listings > 0 with the expected tier and release_id -- proving a scraped
+    listing flows through the real query shaping and DiggerWantlistResponse model.
+    """
+    release_id = 12345
+    # Row shape mirrors get_wantlist_with_listings_counts: the SELECT aliases the
+    # active count to "active_listings"; a value >= 1 means this release has been
+    # scraped and has live marketplace listings.
+    scraped_row: dict[str, Any] = {
+        "release_id": release_id,
+        "tier": "must",
+        "min_media_condition": "VG",
+        "min_sleeve_condition": "VG",
+        "max_price_cents": None,
+        "last_scraped_at": None,
+        "active_listings": 3,
+        "title": "Awesome Record",
+        "artist": "The Diggers",
+        "year": 1999,
+    }
+    pool = _make_query_pool([scraped_row])
+    digger_router.configure(pool)
+
+    token = _make_test_jwt()
+    resp = digger_api_client.get("/api/digger/wantlist", headers={"Authorization": f"Bearer {token}"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["items"]) == 1
+    item = body["items"][0]
+    assert item["release_id"] == release_id
+    assert item["tier"] == "must"
+    assert item["active_listings"] == 3  # > 0 => release has live scraped listings
+    assert item["title"] == "Awesome Record"
+
+    # Guard the seam this smoke exists to protect: the real query must open the
+    # cursor with row_factory=dict_row, else the router's r["..."] lookups break.
+    from psycopg.rows import dict_row
+
+    conn = pool.connection.return_value
+    conn.cursor.assert_called_once_with(row_factory=dict_row)
+
+
+def test_m1_smoke_wantlist_requires_authentication(digger_api_client: TestClient) -> None:
+    """The real require_user dependency rejects an unauthenticated wantlist request."""
+    digger_router.configure(_make_query_pool([]))
+    resp = digger_api_client.get("/api/digger/wantlist")
+    assert resp.status_code == 401

--- a/tests/perftest/Dockerfile
+++ b/tests/perftest/Dockerfile
@@ -15,7 +15,7 @@ LABEL org.opencontainers.image.title="Discogsography Performance Test" \
       com.discogsography.service="perftest"
 
 # hadolint ignore=DL3013
-RUN pip install --no-cache-dir httpx pyyaml neo4j psycopg2-binary
+RUN pip install --no-cache-dir httpx pyyaml neo4j psycopg2-binary "psycopg[binary]"
 
 # Create non-root user and directories
 RUN groupadd -r perftest && \

--- a/tests/perftest/README.md
+++ b/tests/perftest/README.md
@@ -44,6 +44,33 @@ The performance test covers all API endpoints that execute database queries (Neo
 | `GET /api/node/{id}`                     | Each artist and label                         | Neo4j      |
 | `GET /api/expand`                        | Each artist (releases), each label (releases) | Neo4j      |
 
+### Authenticated Digger Endpoints (`digger_scenarios`)
+
+The four user-facing `/api/digger/*` endpoints require a logged-in user, so the
+runner mints an HS256 JWT (claims `sub`/`email`/`exp`, signed with
+`JWT_SECRET_KEY`) for a fixed perftest user and attaches it as a `Bearer` token
+for any scenario flagged `auth: true`. Run with `--seed` first so these hit
+real, pre-seeded rows (otherwise `GET /settings` 404s and the wantlist is empty).
+
+| Endpoint                                       | Method | Database   |
+| ---------------------------------------------- | ------ | ---------- |
+| `/api/digger/settings`                         | GET    | PostgreSQL |
+| `/api/digger/wantlist`                         | GET    | PostgreSQL |
+| `/api/digger/wantlist/{release_id}/priority`   | PUT    | PostgreSQL |
+| `/api/digger/wantlist/bulk-tier`               | POST   | PostgreSQL |
+
+`--seed` inserts (idempotently) the perftest `users` row, `digger` settings, a
+`user_wantlists` entry, a `user_wantlist_priorities` row, plus scrape-state /
+seller / listing rows for release `12345` so `active_listings > 0`. Seeding uses
+a synchronous psycopg3 connection to `postgres_url` from the config.
+
+```bash
+# Seed + run only the digger scenarios (requires a running API + Postgres)
+JWT_SECRET_KEY=... uv run python tests/perftest/run_perftest.py \
+  --config tests/perftest/config.yaml --output ./perftest-results \
+  --seed --only digger
+```
+
 ## Prerequisites
 
 The Discogsography stack must be running with data loaded:

--- a/tests/perftest/__init__.py
+++ b/tests/perftest/__init__.py
@@ -1,0 +1,1 @@
+"""Perftest harness tests."""

--- a/tests/perftest/config.yaml
+++ b/tests/perftest/config.yaml
@@ -72,3 +72,40 @@ nlq_scenarios:
     query_params:
       pane: "explore"
     target_p95_ms: 200
+
+# Digger user-facing endpoints (all require an authenticated user).
+# Run with `--seed` so these hit pre-seeded rows for the fixed perftest user.
+# `auth: true` makes the runner attach a minted Bearer token whose `sub` matches
+# the seeded users row. The PUT/bulk-tier scenarios target release_id 12345,
+# which the seed step inserts into the user's wantlist priorities.
+digger_scenarios:
+  - name: digger_settings_get
+    method: GET
+    path: /api/digger/settings
+    auth: true
+    target_p95_ms: 200
+
+  - name: digger_wantlist_get
+    method: GET
+    path: /api/digger/wantlist
+    auth: true
+    target_p95_ms: 500
+
+  - name: digger_wantlist_priority_put
+    method: PUT
+    path: /api/digger/wantlist/{release_id}/priority
+    path_params:
+      release_id: 12345
+    body:
+      tier: nice
+    auth: true
+    target_p95_ms: 300
+
+  - name: digger_wantlist_bulk_tier_post
+    method: POST
+    path: /api/digger/wantlist/bulk-tier
+    body:
+      release_ids: [12345]
+      tier: nice
+    auth: true
+    target_p95_ms: 300

--- a/tests/perftest/run_perftest.py
+++ b/tests/perftest/run_perftest.py
@@ -8,10 +8,14 @@ and writes results to JSON and human-readable report files.
 from __future__ import annotations
 
 import argparse
+import base64
 from datetime import UTC, datetime
+import hashlib
+import hmac
 from itertools import combinations
 import json
 import math
+import os
 from pathlib import Path
 import sys
 import time
@@ -19,6 +23,61 @@ from typing import Any
 
 import httpx
 import yaml
+
+
+# ---------------------------------------------------------------------------
+# Auth: minted JWT for digger (authenticated) scenarios
+# ---------------------------------------------------------------------------
+
+# Fixed perftest user UUID. The minted token's `sub` claim and the seeded
+# `users` row MUST share this value so authenticated digger endpoints resolve
+# to real, pre-seeded rows. Kept in sync with seed_digger_perftest_data().
+PERFTEST_USER_ID = "00000000-0000-0000-0000-0000000d1996"
+PERFTEST_USER_EMAIL = "perftest-digger@example.invalid"
+
+# Release id shared by the seed and the digger PUT/bulk-tier scenarios.
+PERFTEST_RELEASE_ID = 12345
+
+
+def _jwt_secret() -> str:
+    """Return the JWT signing secret from the environment.
+
+    Mirrors the API service: the secret is sourced from JWT_SECRET_KEY (with the
+    standard _FILE secret convention). Never hardcoded.
+    """
+    file_path = os.getenv("JWT_SECRET_KEY_FILE")
+    if file_path:
+        return Path(file_path).read_text().strip()
+    secret = os.getenv("JWT_SECRET_KEY")
+    if not secret:
+        raise RuntimeError("JWT_SECRET_KEY (or JWT_SECRET_KEY_FILE) must be set to run authenticated digger scenarios")
+    return secret
+
+
+def mint_perftest_jwt(
+    user_id: str = PERFTEST_USER_ID,
+    email: str = PERFTEST_USER_EMAIL,
+    *,
+    secret: str | None = None,
+    exp: int = 9_999_999_999,
+) -> str:
+    """Mint an HS256 JWT for the fixed perftest user.
+
+    Claim shape mirrors tests/api/conftest.py make_test_jwt exactly: header
+    {"alg": "HS256", "typ": "JWT"} and body {"sub", "email", "exp"}. require_user
+    only checks `sub` presence and rejects admin tokens, so no other claims are
+    needed.
+    """
+    secret_value = secret if secret is not None else _jwt_secret()
+
+    def b64url(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+    header = b64url(json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode())
+    body = b64url(json.dumps({"sub": user_id, "email": email, "exp": exp}, separators=(",", ":")).encode())
+    signing_input = f"{header}.{body}".encode("ascii")
+    sig = b64url(hmac.new(secret_value.encode("utf-8"), signing_input, hashlib.sha256).digest())
+    return f"{header}.{body}.{sig}"
 
 
 # ---------------------------------------------------------------------------
@@ -88,6 +147,82 @@ def list_postgres_indexes(config: dict[str, Any]) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Seeding for authenticated digger scenarios
+# ---------------------------------------------------------------------------
+
+
+def seed_digger_perftest_data(postgres_url: str) -> None:
+    """Idempotently seed the rows the authenticated digger scenarios need.
+
+    Creates (or leaves untouched, via ON CONFLICT):
+      * a `users` row with the fixed perftest UUID the minted token's `sub`
+        claim points at (required NOT NULL columns: email, hashed_password),
+      * `digger.user_digger_settings` for that user with enabled = true,
+      * a `user_wantlists` row for (user, release) so GET /wantlist has metadata,
+      * `digger.user_wantlist_priorities` for (user, release) so the PUT/bulk
+        endpoints update real rows,
+      * `digger.release_scrape_state` + `digger.sellers` + a `digger.listings`
+        row with removed_at IS NULL so active_listings > 0.
+
+    Uses a synchronous psycopg3 connection — this keeps the runner free of
+    asyncio. Safe to run repeatedly.
+    """
+    import psycopg
+
+    user_id = PERFTEST_USER_ID
+    release_id = PERFTEST_RELEASE_ID
+    seller_id = 999_001
+    listing_id = 999_001
+    # A non-functional placeholder hash in the API's salt:key format. This user
+    # is for read/write digger queries only and never logs in via password.
+    hashed_password = "00" * 32 + ":" + "00" * 32
+
+    print(f"Seeding digger perftest data (user={user_id}, release={release_id}) ...")
+    with psycopg.connect(postgres_url) as conn, conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO users (id, email, hashed_password, is_active, is_admin) "
+            "VALUES (%s, %s, %s, true, false) "
+            "ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email, is_active = true",
+            (user_id, PERFTEST_USER_EMAIL, hashed_password),
+        )
+        cur.execute(
+            "INSERT INTO digger.user_digger_settings (user_id, enabled) VALUES (%s, true) ON CONFLICT (user_id) DO UPDATE SET enabled = true",
+            (user_id,),
+        )
+        cur.execute(
+            "INSERT INTO user_wantlists (user_id, release_id, title, artist, year) "
+            "VALUES (%s, %s, %s, %s, %s) "
+            "ON CONFLICT (user_id, release_id) DO UPDATE SET title = EXCLUDED.title, artist = EXCLUDED.artist, year = EXCLUDED.year",
+            (user_id, release_id, "Perftest Release", "Perftest Artist", 1996),
+        )
+        cur.execute(
+            "INSERT INTO digger.user_wantlist_priorities (user_id, release_id, tier) "
+            "VALUES (%s, %s, 'nice') "
+            "ON CONFLICT (user_id, release_id) DO UPDATE SET tier = EXCLUDED.tier",
+            (user_id, release_id),
+        )
+        cur.execute(
+            "INSERT INTO digger.release_scrape_state (release_id, last_scraped_at) "
+            "VALUES (%s, now()) "
+            "ON CONFLICT (release_id) DO UPDATE SET last_scraped_at = now()",
+            (release_id,),
+        )
+        cur.execute(
+            "INSERT INTO digger.sellers (seller_id, username, region) VALUES (%s, %s, 'us') ON CONFLICT (seller_id) DO NOTHING",
+            (seller_id, "perftest-seller"),
+        )
+        cur.execute(
+            "INSERT INTO digger.listings "
+            "(listing_id, release_id, seller_id, price_value, price_currency, media_condition, sleeve_condition, removed_at) "
+            "VALUES (%s, %s, %s, %s, 'USD', 'VG+', 'VG+', NULL) "
+            "ON CONFLICT (listing_id) DO UPDATE SET removed_at = NULL",
+            (listing_id, release_id, seller_id, 24.99),
+        )
+        conn.commit()
+    print("  Seed complete.")
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -96,6 +231,20 @@ def load_config(path: str) -> dict[str, Any]:
     """Load and return YAML config."""
     with Path(path).open() as f:
         return yaml.safe_load(f)
+
+
+def interpolate_path(path: str, path_params: dict[str, Any] | None) -> str:
+    """Fill `{name}` placeholders in a path from path_params.
+
+    e.g. interpolate_path("/api/digger/wantlist/{release_id}/priority",
+    {"release_id": 12345}) -> "/api/digger/wantlist/12345/priority".
+    """
+    if not path_params:
+        return path
+    out = path
+    for key, value in path_params.items():
+        out = out.replace(f"{{{key}}}", str(value))
+    return out
 
 
 def wait_for_health(url: str, retries: int, interval: int, timeout: int) -> bool:
@@ -147,11 +296,11 @@ def compute_stats(timings: list[float]) -> dict[str, float]:
 # ---------------------------------------------------------------------------
 
 
-def timed_get(client: httpx.Client, url: str, params: dict[str, str] | None = None) -> dict[str, Any]:
+def timed_get(client: httpx.Client, url: str, params: dict[str, str] | None = None, headers: dict[str, str] | None = None) -> dict[str, Any]:
     """Make a GET request and return timing + response metadata."""
     start = time.perf_counter()
     try:
-        resp = client.get(url, params=params)
+        resp = client.get(url, params=params, headers=headers)
         elapsed = time.perf_counter() - start
         return {
             "status": resp.status_code,
@@ -169,11 +318,33 @@ def timed_get(client: httpx.Client, url: str, params: dict[str, str] | None = No
         }
 
 
-def timed_post(client: httpx.Client, url: str, json_body: dict[str, Any] | None = None) -> dict[str, Any]:
+def timed_post(client: httpx.Client, url: str, json_body: dict[str, Any] | None = None, headers: dict[str, str] | None = None) -> dict[str, Any]:
     """Make a POST request and return timing + response metadata."""
     start = time.perf_counter()
     try:
-        resp = client.post(url, json=json_body)
+        resp = client.post(url, json=json_body, headers=headers)
+        elapsed = time.perf_counter() - start
+        return {
+            "status": resp.status_code,
+            "elapsed": round(elapsed, 4),
+            "size": len(resp.content),
+            "error": None,
+        }
+    except Exception as exc:
+        elapsed = time.perf_counter() - start
+        return {
+            "status": 0,
+            "elapsed": round(elapsed, 4),
+            "size": 0,
+            "error": str(exc),
+        }
+
+
+def timed_put(client: httpx.Client, url: str, json_body: dict[str, Any] | None = None, headers: dict[str, str] | None = None) -> dict[str, Any]:
+    """Make a PUT request and return timing + response metadata."""
+    start = time.perf_counter()
+    try:
+        resp = client.put(url, json=json_body, headers=headers)
         elapsed = time.perf_counter() - start
         return {
             "status": resp.status_code,
@@ -200,6 +371,7 @@ def run_endpoint(
     *,
     method: str = "GET",
     json_body: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
     max_429_retries: int = 4,
     base_429_delay: float = 32.0,
     max_429_delay: float = 300.0,
@@ -214,7 +386,12 @@ def run_endpoint(
     for i in range(iterations):
         retries = 0
         while True:
-            result = timed_post(client, url, json_body) if method == "POST" else timed_get(client, url, params)
+            if method == "POST":
+                result = timed_post(client, url, json_body, headers)
+            elif method == "PUT":
+                result = timed_put(client, url, json_body, headers)
+            else:
+                result = timed_get(client, url, params, headers)
             if result["status"] == 429 and retries < max_429_retries:
                 retries += 1
                 delay = min(base_429_delay * (2 ** (retries - 1)), max_429_delay)
@@ -663,6 +840,22 @@ def build_test_plan(
                 }
             )
 
+    # --- Digger scenarios (authenticated; require --seed for meaningful data) ---
+    for scenario in config.get("digger_scenarios", []):
+        method = scenario.get("method", "GET").upper()
+        path = interpolate_path(scenario["path"], scenario.get("path_params"))
+        test: dict[str, Any] = {
+            "name": scenario["name"],
+            "url": f"{base}{path}",
+            "method": method,
+            "auth": bool(scenario.get("auth", False)),
+        }
+        if method in ("POST", "PUT"):
+            test["json_body"] = scenario.get("body")
+        else:
+            test["params"] = scenario.get("query_params")
+        tests.append(test)
+
     return tests
 
 
@@ -792,6 +985,16 @@ def main() -> None:
         default="/results",
         help="Output directory for results (default: /results)",
     )
+    parser.add_argument(
+        "--seed",
+        action="store_true",
+        help="Seed Postgres with perftest digger rows before running (requires a reachable database).",
+    )
+    parser.add_argument(
+        "--only",
+        default=None,
+        help="Only run tests whose name contains this substring (e.g. 'digger').",
+    )
     args = parser.parse_args()
 
     config = load_config(args.config)
@@ -801,6 +1004,15 @@ def main() -> None:
 
     # Verify output directory is writable before running tests
     _verify_output_dir(Path(args.output))
+
+    # Optionally seed Postgres for authenticated digger scenarios.
+    if args.seed:
+        postgres_url = config.get("postgres_url")
+        if not postgres_url:
+            print("ERROR: --seed requires 'postgres_url' in the config. Exiting.")
+            sys.exit(1)
+        seed_digger_perftest_data(postgres_url)
+        print()
 
     # Wait for API to be healthy
     if not wait_for_health(
@@ -845,13 +1057,23 @@ def main() -> None:
 
         # Build test plan
         test_plan = build_test_plan(config, artist_ids, label_ids)
+        if args.only:
+            test_plan = [t for t in test_plan if args.only in t["name"]]
         print(f"Test plan: {len(test_plan)} endpoints")
         print()
+
+        # Mint the auth token only if the (filtered) plan actually contains an
+        # authenticated scenario — so non-digger runs never need JWT_SECRET_KEY.
+        auth_headers: dict[str, str] | None = None
+        if any(t.get("auth") for t in test_plan):
+            token = mint_perftest_jwt()
+            auth_headers = {"Authorization": f"Bearer {token}"}
 
         # Execute tests
         results: list[dict[str, Any]] = []
         for i, test in enumerate(test_plan, 1):
             print(f"[{i}/{len(test_plan)}] {test['name']}")
+            headers = auth_headers if test.get("auth") else None
             result = run_endpoint(
                 client,
                 test["name"],
@@ -860,6 +1082,7 @@ def main() -> None:
                 iterations,
                 method=test.get("method", "GET"),
                 json_body=test.get("json_body"),
+                headers=headers,
             )
             results.append(result)
             print()

--- a/tests/perftest/test_run_perftest.py
+++ b/tests/perftest/test_run_perftest.py
@@ -1,0 +1,107 @@
+"""Unit tests for the perftest harness pure pieces (no live API or DB).
+
+Covers the digger additions: JWT minting parity, path-param interpolation, and
+parsing of `digger_scenarios` into the test plan with auth + body + path_params.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from api.auth import decode_token
+from tests.perftest import run_perftest as rp
+
+
+SECRET = "unit-test-secret"
+
+
+def test_mint_perftest_jwt_decodes_with_secret_and_sub() -> None:
+    """The minted token verifies under the secret and carries the perftest sub/email."""
+    token = rp.mint_perftest_jwt(secret=SECRET)
+    payload = decode_token(token, SECRET)
+    assert payload["sub"] == rp.PERFTEST_USER_ID
+    assert payload["email"] == rp.PERFTEST_USER_EMAIL
+    # Token shape mirrors tests/api/conftest.make_test_jwt: only sub/email/exp.
+    assert set(payload) == {"sub", "email", "exp"}
+
+
+def test_mint_perftest_jwt_rejected_under_wrong_secret() -> None:
+    """A token minted under one secret fails verification under another."""
+    token = rp.mint_perftest_jwt(secret=SECRET)
+    try:
+        decode_token(token, "a-different-secret")
+    except ValueError:
+        pass
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected signature verification to fail")
+
+
+def test_jwt_sub_matches_seed_user_id() -> None:
+    """The minted sub must equal the UUID the seeder uses (auth -> seeded rows)."""
+    payload = decode_token(rp.mint_perftest_jwt(secret=SECRET), SECRET)
+    assert payload["sub"] == rp.PERFTEST_USER_ID == "00000000-0000-0000-0000-0000000d1996"
+
+
+def test_interpolate_path_fills_release_id() -> None:
+    """Path-param interpolation fills {release_id} from path_params."""
+    out = rp.interpolate_path("/api/digger/wantlist/{release_id}/priority", {"release_id": 12345})
+    assert out == "/api/digger/wantlist/12345/priority"
+
+
+def test_interpolate_path_noop_without_params() -> None:
+    """Paths without placeholders (and no path_params) pass through unchanged."""
+    assert rp.interpolate_path("/api/digger/settings", None) == "/api/digger/settings"
+    assert rp.interpolate_path("/api/digger/settings", {}) == "/api/digger/settings"
+
+
+def _digger_config() -> dict[str, Any]:
+    return {
+        "api_base_url": "http://api:8004",
+        "digger_scenarios": [
+            {"name": "digger_settings_get", "method": "GET", "path": "/api/digger/settings", "auth": True},
+            {
+                "name": "digger_wantlist_priority_put",
+                "method": "PUT",
+                "path": "/api/digger/wantlist/{release_id}/priority",
+                "path_params": {"release_id": 12345},
+                "body": {"tier": "nice"},
+                "auth": True,
+            },
+            {
+                "name": "digger_wantlist_bulk_tier_post",
+                "method": "POST",
+                "path": "/api/digger/wantlist/bulk-tier",
+                "body": {"release_ids": [12345], "tier": "nice"},
+                "auth": True,
+            },
+        ],
+    }
+
+
+def test_build_test_plan_parses_digger_scenarios() -> None:
+    """digger_scenarios become plan entries with auth, interpolated paths, and bodies."""
+    plan = rp.build_test_plan(_digger_config(), artist_ids={}, label_ids={})
+    by_name = {t["name"]: t for t in plan}
+
+    get_t = by_name["digger_settings_get"]
+    assert get_t["method"] == "GET"
+    assert get_t["auth"] is True
+    assert get_t["url"] == "http://api:8004/api/digger/settings"
+
+    put_t = by_name["digger_wantlist_priority_put"]
+    assert put_t["method"] == "PUT"
+    assert put_t["auth"] is True
+    assert put_t["url"] == "http://api:8004/api/digger/wantlist/12345/priority"
+    assert put_t["json_body"] == {"tier": "nice"}
+
+    post_t = by_name["digger_wantlist_bulk_tier_post"]
+    assert post_t["method"] == "POST"
+    assert post_t["auth"] is True
+    assert post_t["json_body"] == {"release_ids": [12345], "tier": "nice"}
+
+
+def test_build_test_plan_without_digger_scenarios_is_empty_when_no_entities() -> None:
+    """No digger_scenarios and no entities -> only the static endpoints are present."""
+    plan = rp.build_test_plan({"api_base_url": "http://api:8004"}, artist_ids={}, label_ids={})
+    names = {t["name"] for t in plan}
+    assert not any(n.startswith("digger_") for n in names)


### PR DESCRIPTION
## Summary

PR 5 of 5 — the **integration + docs layer** of Digger M1 (plan Tasks 20–21, 26–29). This wires the existing `digger/` worker into the stack, adds perf-test coverage, an M1 smoke test, and full documentation. **This completes the Digger M1 foundation milestone.**

Built against the real codebase (the plan's Task 26/28 drafts were heavily reconciled — they assumed `X-Service-Token`-vs-Bearer, asyncpg `$1`, and invented fixtures like `fake_discogs_marketplace`/`api_client`/`postgres_pool` that don't exist here).

## What's included

- **Docker Compose** (`docker-compose.yml` + `docker-compose.prod.yml`): a `digger` worker service mirroring the `tableinator` pattern — no `build.args` (the Dockerfile hardcodes `python:3.13-slim`/uid 1001), no exposed ports, full hardening (`read_only`, `cap_drop`, `no-new-privileges`, tmpfs), `digger_logs` volume, healthcheck on 8012, prod overlay with postgres `_FILE` secrets. Env is exactly the `DiggerConfig` set (no `API_BASE_URL`/RabbitMQ/service-token — the M1 worker talks to Postgres/Redis directly). `.env.example` gains the optional `DIGGER_*` tuning vars.
- **justfile**: `digger` added to `build`; new `digger-up` / `digger-logs` / `digger-metrics` recipes.
- **Perf tests** (`tests/perftest/`): extended the (previously auth-less) harness with JWT minting (matches the API's HS256 decode path), PUT + path-param support, a config-driven `digger_scenarios` block, and an idempotent synchronous-psycopg3 **seed** (user + settings + wantlist + priorities + sellers + listings) so the 4 `/api/digger/*` endpoints return real 2xx. Config entries + 7 unit tests covering the pure pieces.
- **M1 smoke** (`tests/digger/test_digger_m1_smoke.py`): a CI-runnable, mock-based happy-path test that wires the **real** components at the seams the unit tests mock out — real parser→executor (respx canned HTML → asserts the listings upsert + `next_scrape_due_at`) and real router→`get_wantlist_with_listings_counts` (asserts a scraped listing surfaces as `active_listings>0`, incl. a real-JWT auth check). A true cross-process real-DB/live-stack E2E is intentionally out of scope (the repo has no real-DB test infra; a full browser E2E was declined).
- **Docs**: new `docs/digger-scraping-policy.md` (accurate rate/backoff/circuit-breaker/SSRF/soft-delete facts), plus `CLAUDE.md` (directory + ports 8012), `docs/architecture.md`, `docs/database-schema.md` (digger schema: 11 enums, 9 tables), `docs/configuration.md`, `docs/README.md`, and an `emoji-guide.md` service identifier.

## Verification

- `just test-digger` **123 passed** (incl. the new smoke), `just test-api` **1575 passed**, `tests/perftest` **7 passed**.
- `just lint-python` clean (ruff + mypy, 135 files). Pre-commit (incl. compose validation) passed on every commit.
- Cross-surface coherence verified: the `DIGGER_*` env set + defaults + port 8012 are consistent across compose / `.env.example` / `configuration.md` / `scraping-policy.md` / `DiggerConfig`.

## CI / manual (not run here — needs Docker + a running stack/DB)

- `just build` / `just up` container smoke and the live perf run (`run_perftest.py --seed --only digger`) require Docker + a live API + Postgres, so they're CI/manual steps (the compose files are schema-validated; the perftest seed/runner is unit-tested).

## Executed via subagent-driven development

Per task: implementer → spec-compliance review → code-quality review → fix loop, then this whole-PR cross-surface consistency pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
