### PR TITLE
feat(digger): M2 optimizer library — pure-function bundle solver in common/

### DIFF
--- a/common/digger_optimizer/__init__.py
+++ b/common/digger_optimizer/__init__.py
@@ -1,0 +1,53 @@
+"""Pure-function bundle optimizer for the Digger feature.
+
+Imported by both api/ (interactive runs) and digger/ (scheduled runs).
+No I/O — all dependencies pass in as Pydantic inputs.
+
+Public API:
+- pareto_bundles(input: OptimizerInput) -> OptimizerOutput   (added in the pareto module)
+
+Submodules:
+- models: input/output Pydantic types
+- filtering: condition/price filter
+- shipping: per-seller shipping cost estimation
+- greedy: greedy reference implementation (also ILP warm-start)
+- ilp: pulp-based optimal solver
+- pareto: 4-variant coordinator
+
+NOTE: ``pareto_bundles`` is re-exported from this package root once the pareto
+module lands (Task 6). Until then only the model types are exported so the
+package imports cleanly while the solver modules are built up incrementally.
+"""
+
+from __future__ import annotations
+
+from common.digger_optimizer.models import (
+    Bundle,
+    BundleName,
+    Coverage,
+    Listing,
+    OptimizerDiagnostics,
+    OptimizerInput,
+    OptimizerOutput,
+    OrderLine,
+    ReleaseConstraint,
+    Seller,
+    SellerOrder,
+    ShippingPolicyRegion,
+)
+
+
+__all__ = [
+    "Bundle",
+    "BundleName",
+    "Coverage",
+    "Listing",
+    "OptimizerDiagnostics",
+    "OptimizerInput",
+    "OptimizerOutput",
+    "OrderLine",
+    "ReleaseConstraint",
+    "Seller",
+    "SellerOrder",
+    "ShippingPolicyRegion",
+]

--- a/common/digger_optimizer/__init__.py
+++ b/common/digger_optimizer/__init__.py
@@ -13,10 +13,6 @@ Submodules:
 - greedy: greedy reference implementation (also ILP warm-start)
 - ilp: pulp-based optimal solver
 - pareto: 4-variant coordinator
-
-NOTE: ``pareto_bundles`` is re-exported from this package root once the pareto
-module lands (Task 6). Until then only the model types are exported so the
-package imports cleanly while the solver modules are built up incrementally.
 """
 
 from __future__ import annotations
@@ -35,6 +31,7 @@ from common.digger_optimizer.models import (
     SellerOrder,
     ShippingPolicyRegion,
 )
+from common.digger_optimizer.pareto import pareto_bundles
 
 
 __all__ = [
@@ -50,4 +47,5 @@ __all__ = [
     "Seller",
     "SellerOrder",
     "ShippingPolicyRegion",
+    "pareto_bundles",
 ]

--- a/common/digger_optimizer/filtering.py
+++ b/common/digger_optimizer/filtering.py
@@ -1,0 +1,59 @@
+"""Stage 1: filter listings against per-tier condition floors and max-price caps.
+
+Currency conversion is out of scope for M2 — listings whose currency differs
+from the user's currency are skipped (counted in diagnostics).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from common.digger_optimizer.models import CONDITION_RANK
+
+
+if TYPE_CHECKING:
+    from common.digger_optimizer.models import Listing, OptimizerInput, ReleaseConstraint
+
+
+@dataclass(slots=True)
+class FilterResult:
+    usable_by_release: dict[int, list[int]] = field(default_factory=dict)  # release_id -> [listing_id]
+    watching: list[int] = field(default_factory=list)  # release_ids with no qualifying listings
+    skipped_currency: int = 0
+
+
+def _meets(listing: Listing, constraint: ReleaseConstraint, currency: str) -> bool:
+    if listing.price_currency != currency:
+        return False
+    if CONDITION_RANK[listing.media_condition] < CONDITION_RANK[constraint.min_media_condition]:
+        return False
+    if CONDITION_RANK[listing.sleeve_condition] < CONDITION_RANK[constraint.min_sleeve_condition]:
+        return False
+    return not (constraint.max_price_cents is not None and int(listing.price_value * 100) > constraint.max_price_cents)
+
+
+def filter_candidates(inp: OptimizerInput) -> FilterResult:
+    result = FilterResult()
+    listings_by_release: dict[int, list[Listing]] = {}
+    for listing in inp.candidate_listings:
+        if listing.price_currency != inp.currency:
+            result.skipped_currency += 1
+            continue
+        listings_by_release.setdefault(listing.release_id, []).append(listing)
+
+    for must in inp.must_have_releases:
+        usable = [listing.listing_id for listing in listings_by_release.get(must.release_id, []) if _meets(listing, must, inp.currency)]
+        if usable:
+            result.usable_by_release[must.release_id] = usable
+        else:
+            result.watching.append(must.release_id)
+
+    for soft_group in (inp.nice_have_releases, inp.eventually_releases):
+        for constraint in soft_group:
+            usable = [
+                listing.listing_id for listing in listings_by_release.get(constraint.release_id, []) if _meets(listing, constraint, inp.currency)
+            ]
+            if usable:
+                result.usable_by_release[constraint.release_id] = usable
+    return result

--- a/common/digger_optimizer/filtering.py
+++ b/common/digger_optimizer/filtering.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 from common.digger_optimizer.models import CONDITION_RANK
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from common.digger_optimizer.models import Listing, OptimizerInput, ReleaseConstraint
 
 
@@ -23,9 +23,8 @@ class FilterResult:
     skipped_currency: int = 0
 
 
-def _meets(listing: Listing, constraint: ReleaseConstraint, currency: str) -> bool:
-    if listing.price_currency != currency:
-        return False
+def _meets(listing: Listing, constraint: ReleaseConstraint) -> bool:
+    # Currency is already filtered upstream in filter_candidates, so it is not re-checked here.
     if CONDITION_RANK[listing.media_condition] < CONDITION_RANK[constraint.min_media_condition]:
         return False
     if CONDITION_RANK[listing.sleeve_condition] < CONDITION_RANK[constraint.min_sleeve_condition]:
@@ -43,7 +42,7 @@ def filter_candidates(inp: OptimizerInput) -> FilterResult:
         listings_by_release.setdefault(listing.release_id, []).append(listing)
 
     for must in inp.must_have_releases:
-        usable = [listing.listing_id for listing in listings_by_release.get(must.release_id, []) if _meets(listing, must, inp.currency)]
+        usable = [listing.listing_id for listing in listings_by_release.get(must.release_id, []) if _meets(listing, must)]
         if usable:
             result.usable_by_release[must.release_id] = usable
         else:
@@ -51,9 +50,7 @@ def filter_candidates(inp: OptimizerInput) -> FilterResult:
 
     for soft_group in (inp.nice_have_releases, inp.eventually_releases):
         for constraint in soft_group:
-            usable = [
-                listing.listing_id for listing in listings_by_release.get(constraint.release_id, []) if _meets(listing, constraint, inp.currency)
-            ]
+            usable = [listing.listing_id for listing in listings_by_release.get(constraint.release_id, []) if _meets(listing, constraint)]
             if usable:
                 result.usable_by_release[constraint.release_id] = usable
     return result

--- a/common/digger_optimizer/greedy.py
+++ b/common/digger_optimizer/greedy.py
@@ -23,7 +23,7 @@ from common.digger_optimizer.models import CONDITION_RANK, Bundle, Coverage, Ord
 from common.digger_optimizer.shipping import estimate_shipping_cents
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing import Literal
 
     from common.digger_optimizer.models import BundleName, Listing, OptimizerInput
@@ -104,10 +104,10 @@ def greedy_bundle(inp: OptimizerInput, *, name: BundleName) -> Bundle:
         covered_releases.add(listing.release_id)
         seller_used_counts[listing.seller_id] = seller_used_counts.get(listing.seller_id, 0) + 1
 
-    # 2. extend with Nice/Eventually if their marginal is "cheap enough"
+    # 2. extend with Nice/Eventually while their marginal cost stays within that tier's lambda
+    # budget. All current weights use lambda > 0; a lambda of 0 would simply add nothing because
+    # the marginal-cost guard below always exceeds it.
     for release_pool, lam in ((nice_set, weights.lambda_nice), (eventually_set, weights.lambda_eventually)):
-        if lam <= 0:
-            continue
         while True:
             listing = _consider(release_pool)
             if listing is None:

--- a/common/digger_optimizer/greedy.py
+++ b/common/digger_optimizer/greedy.py
@@ -1,0 +1,201 @@
+"""Greedy reference implementation for bundle optimization.
+
+Used as:
+1. Fallback when the ILP solver times out.
+2. Warm-start hint when invoking the ILP.
+3. Reference implementation for cross-checks in property tests.
+
+Algorithm:
+- Group listings by seller.
+- For each release, score each usable listing by a cents-equivalent value minus
+  its marginal (item + incremental-shipping) cost; greedily take the best.
+- Cover all Musts first, then extend with Nice/Eventually items whose marginal
+  cost is within that tier's lambda budget.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from common.digger_optimizer.filtering import filter_candidates
+from common.digger_optimizer.models import CONDITION_RANK, Bundle, Coverage, OrderLine, SellerOrder
+from common.digger_optimizer.shipping import estimate_shipping_cents
+
+
+if TYPE_CHECKING:
+    from typing import Literal
+
+    from common.digger_optimizer.models import BundleName, Listing, OptimizerInput
+
+
+@dataclass(slots=True)
+class _ObjectiveWeights:
+    lambda_nice: int  # cents-credit per Nice item covered
+    lambda_eventually: int  # cents-credit per Eventually item covered
+    quality_per_step: int  # cents bonus per +1 condition rank
+    seller_penalty: int  # cents penalty per additional seller
+
+
+_WEIGHTS: dict[BundleName, _ObjectiveWeights] = {
+    "cheapest": _ObjectiveWeights(lambda_nice=500, lambda_eventually=100, quality_per_step=0, seller_penalty=0),
+    "most_coverage": _ObjectiveWeights(lambda_nice=2500, lambda_eventually=1000, quality_per_step=0, seller_penalty=0),
+    "best_quality": _ObjectiveWeights(lambda_nice=500, lambda_eventually=100, quality_per_step=300, seller_penalty=0),
+    "fewest_sellers": _ObjectiveWeights(lambda_nice=500, lambda_eventually=100, quality_per_step=0, seller_penalty=2000),
+}
+
+
+def _value_score(listing: Listing, must_set: set[int], nice_set: set[int], eventually_set: set[int], w: _ObjectiveWeights) -> int:
+    """Cents-equivalent value of including this listing in the bundle."""
+    base = -int(listing.price_value * 100)  # negative — cost
+    if listing.release_id in must_set:
+        base += 10_000_000  # huge bonus so must items always picked first
+    elif listing.release_id in nice_set:
+        base += w.lambda_nice
+    elif listing.release_id in eventually_set:
+        base += w.lambda_eventually
+    base += w.quality_per_step * CONDITION_RANK[listing.media_condition]
+    return base
+
+
+def greedy_bundle(inp: OptimizerInput, *, name: BundleName) -> Bundle:
+    weights = _WEIGHTS[name]
+    fr = filter_candidates(inp)
+    listings_by_id: dict[int, Listing] = {listing.listing_id: listing for listing in inp.candidate_listings}
+    must_set = {c.release_id for c in inp.must_have_releases}
+    nice_set = {c.release_id for c in inp.nice_have_releases}
+    eventually_set = {c.release_id for c in inp.eventually_releases}
+
+    chosen: list[Listing] = []
+    covered_releases: set[int] = set()
+    seller_used_counts: dict[int, int] = {}
+
+    def _consider(release_pool: set[int]) -> Listing | None:
+        """Pick the uncovered-release listing with the best marginal value."""
+        best: tuple[float, Listing] | None = None
+        for rid in release_pool:
+            if rid in covered_releases:
+                continue
+            for lid in fr.usable_by_release.get(rid, []):
+                listing = listings_by_id[lid]
+                if listing.seller_id in inp.excluded_sellers:
+                    continue
+                existing = seller_used_counts.get(listing.seller_id, 0)
+                seller = inp.sellers[listing.seller_id]
+                marginal = estimate_shipping_cents(seller, location=inp.location, count=existing + 1) - estimate_shipping_cents(
+                    seller, location=inp.location, count=existing
+                )
+                value = _value_score(listing, must_set, nice_set, eventually_set, weights)
+                value -= marginal
+                if existing == 0:
+                    value -= weights.seller_penalty
+                cost = int(listing.price_value * 100) + marginal
+                ratio = value / max(1, cost)
+                if best is None or ratio > best[0]:
+                    best = (ratio, listing)
+        return best[1] if best else None
+
+    # 1. cover Musts
+    while True:
+        listing = _consider(must_set)
+        if listing is None:
+            break
+        chosen.append(listing)
+        covered_releases.add(listing.release_id)
+        seller_used_counts[listing.seller_id] = seller_used_counts.get(listing.seller_id, 0) + 1
+
+    # 2. extend with Nice/Eventually if their marginal is "cheap enough"
+    for release_pool, lam in ((nice_set, weights.lambda_nice), (eventually_set, weights.lambda_eventually)):
+        if lam <= 0:
+            continue
+        while True:
+            listing = _consider(release_pool)
+            if listing is None:
+                break
+            existing = seller_used_counts.get(listing.seller_id, 0)
+            seller = inp.sellers[listing.seller_id]
+            marginal = estimate_shipping_cents(seller, location=inp.location, count=existing + 1) - estimate_shipping_cents(
+                seller, location=inp.location, count=existing
+            )
+            marginal_cost = int(listing.price_value * 100) + marginal
+            if marginal_cost > lam:
+                break
+            chosen.append(listing)
+            covered_releases.add(listing.release_id)
+            seller_used_counts[listing.seller_id] = existing + 1
+
+    return _build_bundle(name, chosen, inp, must_set, nice_set, eventually_set, solver="greedy")
+
+
+def _build_bundle(
+    name: BundleName,
+    chosen: list[Listing],
+    inp: OptimizerInput,
+    must_set: set[int],
+    nice_set: set[int],
+    eventually_set: set[int],
+    *,
+    solver: Literal["ilp", "greedy"],
+) -> Bundle:
+    if not chosen:
+        return Bundle(
+            name=name,
+            seller_orders=[],
+            total_item_cost_cents=0,
+            total_shipping_cents=0,
+            grand_total_cents=0,
+            coverage=Coverage(must=0, nice=0, eventually=0),
+            avg_condition_score=0.0,
+            solver=solver,
+            reasoning_hint="No qualifying listings.",
+        )
+    by_seller: dict[int, list[Listing]] = {}
+    for listing in chosen:
+        by_seller.setdefault(listing.seller_id, []).append(listing)
+    orders: list[SellerOrder] = []
+    total_item = 0
+    total_ship = 0
+    for sid, listings in by_seller.items():
+        subtotal = sum(int(listing.price_value * 100) for listing in listings)
+        ship = estimate_shipping_cents(inp.sellers[sid], location=inp.location, count=len(listings))
+        orders.append(
+            SellerOrder(
+                seller_id=sid,
+                listings=[
+                    OrderLine(
+                        listing_id=listing.listing_id,
+                        release_id=listing.release_id,
+                        price_cents=int(listing.price_value * 100),
+                        currency=listing.price_currency,
+                        media_condition=listing.media_condition,
+                        sleeve_condition=listing.sleeve_condition,
+                    )
+                    for listing in listings
+                ],
+                subtotal_item_cents=subtotal,
+                shipping_cents=ship,
+            )
+        )
+        total_item += subtotal
+        total_ship += ship
+    coverage = Coverage(
+        must=sum(1 for listing in chosen if listing.release_id in must_set),
+        nice=sum(1 for listing in chosen if listing.release_id in nice_set),
+        eventually=sum(1 for listing in chosen if listing.release_id in eventually_set),
+    )
+    avg_cond = sum(CONDITION_RANK[listing.media_condition] for listing in chosen) / len(chosen)
+    return Bundle(
+        name=name,
+        seller_orders=orders,
+        total_item_cost_cents=total_item,
+        total_shipping_cents=total_ship,
+        grand_total_cents=total_item + total_ship,
+        coverage=coverage,
+        avg_condition_score=avg_cond,
+        solver=solver,
+        reasoning_hint=f"{coverage.must} must, {coverage.nice} nice, {coverage.eventually} eventually across {len(orders)} sellers.",
+    )
+
+
+# Exported for ilp.py warm-start / fallback bundle construction.
+build_bundle_from_listings = _build_bundle

--- a/common/digger_optimizer/ilp.py
+++ b/common/digger_optimizer/ilp.py
@@ -1,0 +1,131 @@
+"""ILP-based bundle optimizer using pulp + CBC.
+
+Variables:
+  x[lid] in {0,1}     — include this listing
+  y[sid] in {0,1}     — order from this seller
+  z[sid, k] in {0,1}  — seller s has exactly k items in the bundle (k = 1..K_max)
+
+Constraints:
+  must:                 sum(x[lid] for usable listings) == 1
+  nice/eventually:      sum(x[lid] for usable listings) <= 1
+  listing -> seller:    x[lid] <= y[seller_of_lid]
+  z gating per seller:  sum_k z[s,k] == y[s];  sum_k k*z[s,k] == sum(x in s)
+  excluded sellers:     y[s] == 0
+  budget (optional):    sum(x*price) + sum z*shipping <= cap
+
+Objective (per bundle name): minimize item cost + shipping
+  (+ seller_penalty * sum(y))            for 'fewest_sellers'
+  (- quality_per_step * sum(x*rank))     for 'best_quality'
+  (- lambda_nice/eventually * sum(x))    soft-tier coverage credit
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pulp
+
+from common.digger_optimizer.filtering import filter_candidates
+from common.digger_optimizer.greedy import _WEIGHTS, build_bundle_from_listings
+from common.digger_optimizer.models import CONDITION_RANK
+from common.digger_optimizer.shipping import estimate_shipping_cents
+
+
+if TYPE_CHECKING:
+    from common.digger_optimizer.models import Bundle, BundleName, Listing, OptimizerInput
+
+
+log = logging.getLogger(__name__)
+
+
+def solve_ilp_bundle(inp: OptimizerInput, *, name: BundleName, timeout_seconds: int = 5) -> Bundle | None:
+    weights = _WEIGHTS[name]
+    fr = filter_candidates(inp)
+
+    must_set = {c.release_id for c in inp.must_have_releases}
+    nice_set = {c.release_id for c in inp.nice_have_releases}
+    eventually_set = {c.release_id for c in inp.eventually_releases}
+
+    if not fr.usable_by_release:
+        return build_bundle_from_listings(name, [], inp, must_set, nice_set, eventually_set, solver="ilp")
+
+    listings_by_id: dict[int, Listing] = {listing.listing_id: listing for listing in inp.candidate_listings}
+    seller_listings: dict[int, list[int]] = {}
+    listing_id_set: set[int] = set()
+    for lids in fr.usable_by_release.values():
+        for lid in lids:
+            listing_id_set.add(lid)
+            seller_listings.setdefault(listings_by_id[lid].seller_id, []).append(lid)
+
+    if not listing_id_set:
+        return build_bundle_from_listings(name, [], inp, must_set, nice_set, eventually_set, solver="ilp")
+
+    prob = pulp.LpProblem(f"digger_{name}", pulp.LpMinimize)
+
+    x = {lid: pulp.LpVariable(f"x_{lid}", cat="Binary") for lid in listing_id_set}
+    y = {sid: pulp.LpVariable(f"y_{sid}", cat="Binary") for sid in seller_listings}
+
+    max_k_per_seller: dict[int, int] = {sid: len(lids) for sid, lids in seller_listings.items()}
+    z: dict[tuple[int, int], pulp.LpVariable] = {}
+    for sid, k_max in max_k_per_seller.items():
+        for k in range(1, k_max + 1):
+            z[(sid, k)] = pulp.LpVariable(f"z_{sid}_{k}", cat="Binary")
+
+    # Must-have: each Must release covered exactly once if any usable listing exists.
+    for must in inp.must_have_releases:
+        lids = fr.usable_by_release.get(must.release_id, [])
+        if lids:
+            prob += pulp.lpSum(x[lid] for lid in lids) == 1, f"must_{must.release_id}"
+
+    # Nice/Eventually: at most one chosen per release.
+    for soft in inp.nice_have_releases + inp.eventually_releases:
+        lids = fr.usable_by_release.get(soft.release_id, [])
+        if lids:
+            prob += pulp.lpSum(x[lid] for lid in lids) <= 1, f"soft_{soft.release_id}"
+
+    # Linking + per-seller item-count gating.
+    for sid, lids in seller_listings.items():
+        for lid in lids:
+            prob += x[lid] <= y[sid], f"link_{lid}"
+        prob += pulp.lpSum(z[(sid, k)] for k in range(1, max_k_per_seller[sid] + 1)) == y[sid], f"zsum_{sid}"
+        prob += pulp.lpSum(k * z[(sid, k)] for k in range(1, max_k_per_seller[sid] + 1)) == pulp.lpSum(x[lid] for lid in lids), f"zcount_{sid}"
+
+    # Excluded sellers.
+    for sid in inp.excluded_sellers:
+        if sid in y:
+            prob += y[sid] == 0, f"excl_{sid}"
+
+    def _ship(sid: int, k: int) -> int:
+        return estimate_shipping_cents(inp.sellers[sid], location=inp.location, count=k)
+
+    # Budget (optional).
+    if inp.budget_cap_cents is not None:
+        item_cost = pulp.lpSum(x[lid] * int(listings_by_id[lid].price_value * 100) for lid in listing_id_set)
+        ship_cost = pulp.lpSum(z[(sid, k)] * _ship(sid, k) for sid in seller_listings for k in range(1, max_k_per_seller[sid] + 1))
+        prob += item_cost + ship_cost <= inp.budget_cap_cents, "budget"
+
+    # Objective.
+    obj_item = pulp.lpSum(x[lid] * int(listings_by_id[lid].price_value * 100) for lid in listing_id_set)
+    obj_ship = pulp.lpSum(z[(sid, k)] * _ship(sid, k) for sid in seller_listings for k in range(1, max_k_per_seller[sid] + 1))
+    obj_seller_penalty = weights.seller_penalty * pulp.lpSum(y[sid] for sid in seller_listings)
+    obj_quality = -weights.quality_per_step * pulp.lpSum(x[lid] * CONDITION_RANK[listings_by_id[lid].media_condition] for lid in listing_id_set)
+    obj_nice = -weights.lambda_nice * pulp.lpSum(x[lid] for lid in listing_id_set if listings_by_id[lid].release_id in nice_set)
+    obj_ev = -weights.lambda_eventually * pulp.lpSum(x[lid] for lid in listing_id_set if listings_by_id[lid].release_id in eventually_set)
+    prob += obj_item + obj_ship + obj_seller_penalty + obj_quality + obj_nice + obj_ev
+
+    solver = pulp.PULP_CBC_CMD(msg=False, timeLimit=timeout_seconds, options=["randomSeed 42"])
+    status = prob.solve(solver)
+    status_label = pulp.LpStatus[status]
+    if status not in (pulp.LpStatusOptimal, pulp.LpStatusNotSolved):
+        log.warning("⚠️ ILP solver returned status=%s for %s", status_label, name)
+
+    if status_label == "Infeasible":
+        return build_bundle_from_listings(name, [], inp, must_set, nice_set, eventually_set, solver="ilp")
+
+    chosen: list[Listing] = []
+    for lid in sorted(listing_id_set):
+        val = pulp.value(x[lid])
+        if val is not None and val >= 0.5:
+            chosen.append(listings_by_id[lid])
+    return build_bundle_from_listings(name, chosen, inp, must_set, nice_set, eventually_set, solver="ilp")

--- a/common/digger_optimizer/ilp.py
+++ b/common/digger_optimizer/ilp.py
@@ -32,7 +32,7 @@ from common.digger_optimizer.models import CONDITION_RANK
 from common.digger_optimizer.shipping import estimate_shipping_cents
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from common.digger_optimizer.models import Bundle, BundleName, Listing, OptimizerInput
 
 
@@ -58,7 +58,7 @@ def solve_ilp_bundle(inp: OptimizerInput, *, name: BundleName, timeout_seconds: 
             listing_id_set.add(lid)
             seller_listings.setdefault(listings_by_id[lid].seller_id, []).append(lid)
 
-    if not listing_id_set:
+    if not listing_id_set:  # pragma: no cover - defensive; non-empty usable_by_release implies non-empty listing set
         return build_bundle_from_listings(name, [], inp, must_set, nice_set, eventually_set, solver="ilp")
 
     prob = pulp.LpProblem(f"digger_{name}", pulp.LpMinimize)

--- a/common/digger_optimizer/models.py
+++ b/common/digger_optimizer/models.py
@@ -1,0 +1,128 @@
+"""Input/output Pydantic types for the digger bundle optimizer.
+
+Condition vocabularies mirror the Postgres enums declared in
+``schema-init/digger_schema.py`` (``digger.condition`` and
+``digger.sleeve_condition``).
+
+NOTE: deliberately no ``from __future__ import annotations`` — Pydantic resolves
+field annotations at runtime, so ``Decimal``/``UUID`` must remain real runtime
+imports (matches the ``api/models.py`` convention).
+"""
+
+from decimal import Decimal
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+Condition = Literal["M", "NM", "VG+", "VG", "G+", "G", "F", "P"]
+SleeveCondition = Literal["M", "NM", "VG+", "VG", "G+", "G", "F", "P", "generic", "no_cover"]
+BundleName = Literal["cheapest", "most_coverage", "best_quality", "fewest_sellers"]
+
+
+CONDITION_RANK: dict[str, int] = {
+    "M": 8,
+    "NM": 7,
+    "VG+": 6,
+    "VG": 5,
+    "G+": 4,
+    "G": 3,
+    "F": 2,
+    "P": 1,
+    "generic": 5,  # sleeve-only value
+    "no_cover": 1,  # sleeve-only value
+}
+
+
+class ReleaseConstraint(BaseModel):
+    release_id: int
+    min_media_condition: Condition
+    min_sleeve_condition: SleeveCondition
+    max_price_cents: int | None = None
+
+
+class ShippingPolicyRegion(BaseModel):
+    first_cents: int
+    additional_cents: int
+    currency: str = "USD"
+
+
+class Seller(BaseModel):
+    seller_id: int
+    region: Literal["us", "ca", "eu", "uk", "jp", "au", "other"]
+    country_code: str | None = None
+    shipping_policy: dict[str, ShippingPolicyRegion] | None = None
+    feedback_score: float | None = None
+
+
+class Listing(BaseModel):
+    listing_id: int
+    release_id: int
+    seller_id: int
+    price_value: Decimal = Field(ge=0)
+    price_currency: str
+    media_condition: Condition
+    sleeve_condition: SleeveCondition
+
+
+class OptimizerInput(BaseModel):
+    user_id: UUID
+    location: str = Field(min_length=2, max_length=2, description="ISO-3166 alpha-2")
+    currency: str = "USD"
+    must_have_releases: list[ReleaseConstraint]
+    nice_have_releases: list[ReleaseConstraint] = []
+    eventually_releases: list[ReleaseConstraint] = []
+    candidate_listings: list[Listing]
+    sellers: dict[int, Seller]
+    budget_cap_cents: int | None = None
+    excluded_sellers: frozenset[int] = frozenset()
+
+
+class OrderLine(BaseModel):
+    listing_id: int
+    release_id: int
+    price_cents: int
+    currency: str
+    media_condition: Condition
+    sleeve_condition: SleeveCondition
+
+
+class SellerOrder(BaseModel):
+    seller_id: int
+    listings: list[OrderLine]
+    subtotal_item_cents: int
+    shipping_cents: int
+
+
+class Coverage(BaseModel):
+    must: int
+    nice: int
+    eventually: int
+
+
+class Bundle(BaseModel):
+    name: BundleName
+    seller_orders: list[SellerOrder]
+    total_item_cost_cents: int
+    total_shipping_cents: int
+    grand_total_cents: int
+    coverage: Coverage
+    avg_condition_score: float
+    solver: Literal["ilp", "greedy"]
+    reasoning_hint: str
+
+
+class OptimizerDiagnostics(BaseModel):
+    solver_used: dict[BundleName, Literal["ilp", "greedy"]]
+    solve_time_ms: dict[BundleName, int]
+    listings_considered: int
+    sellers_considered: int
+    partitions: int = 1
+
+
+class OptimizerOutput(BaseModel):
+    bundles: list[Bundle]
+    watching: list[int] = []  # release_ids with no qualifying listings
+    diagnostics: OptimizerDiagnostics
+    shipping_confidence: Literal["high", "low"]

--- a/common/digger_optimizer/pareto.py
+++ b/common/digger_optimizer/pareto.py
@@ -17,7 +17,7 @@ from common.digger_optimizer.models import OptimizerDiagnostics, OptimizerOutput
 from common.digger_optimizer.shipping import shipping_confidence_score
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing import Literal
 
     from common.digger_optimizer.models import Bundle, BundleName, OptimizerInput

--- a/common/digger_optimizer/pareto.py
+++ b/common/digger_optimizer/pareto.py
@@ -1,0 +1,64 @@
+"""Pareto-front coordinator: runs the four bundle variants.
+
+Falls back to greedy on ILP error. Returns an OptimizerOutput with
+per-variant diagnostics and an overall shipping-confidence flag.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from common.digger_optimizer.filtering import filter_candidates
+from common.digger_optimizer.greedy import greedy_bundle
+from common.digger_optimizer.ilp import solve_ilp_bundle
+from common.digger_optimizer.models import OptimizerDiagnostics, OptimizerOutput
+from common.digger_optimizer.shipping import shipping_confidence_score
+
+
+if TYPE_CHECKING:
+    from typing import Literal
+
+    from common.digger_optimizer.models import Bundle, BundleName, OptimizerInput
+
+
+log = logging.getLogger(__name__)
+
+_BUNDLE_NAMES: tuple[BundleName, ...] = ("cheapest", "most_coverage", "best_quality", "fewest_sellers")
+
+
+def pareto_bundles(inp: OptimizerInput, *, ilp_timeout_seconds: int = 5) -> OptimizerOutput:
+    fr = filter_candidates(inp)
+    bundles: list[Bundle] = []
+    solver_used: dict[BundleName, Literal["ilp", "greedy"]] = {}
+    solve_time: dict[BundleName, int] = {}
+
+    for name in _BUNDLE_NAMES:
+        t0 = time.monotonic()
+        used: Literal["ilp", "greedy"]
+        try:
+            bundle = solve_ilp_bundle(inp, name=name, timeout_seconds=ilp_timeout_seconds)
+            used = "ilp"
+        except Exception:
+            log.exception("⚠️ ILP failed for %s — falling back to greedy", name)
+            bundle = None
+            used = "greedy"
+        if bundle is None:
+            bundle = greedy_bundle(inp, name=name)
+            used = "greedy"
+        solve_time[name] = int((time.monotonic() - t0) * 1000)
+        bundles.append(bundle)
+        solver_used[name] = used
+
+    return OptimizerOutput(
+        bundles=bundles,
+        watching=fr.watching,
+        diagnostics=OptimizerDiagnostics(
+            solver_used=solver_used,
+            solve_time_ms=solve_time,
+            listings_considered=sum(len(v) for v in fr.usable_by_release.values()),
+            sellers_considered=len({listing.seller_id for listing in inp.candidate_listings}),
+        ),
+        shipping_confidence=shipping_confidence_score(inp.sellers, location=inp.location),
+    )

--- a/common/digger_optimizer/shipping.py
+++ b/common/digger_optimizer/shipping.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from common.digger_optimizer.models import Seller
 
 

--- a/common/digger_optimizer/shipping.py
+++ b/common/digger_optimizer/shipping.py
@@ -1,0 +1,75 @@
+"""Per-seller shipping cost estimation.
+
+Prefers scraped ``shipping_policy``; falls back to a static 7x7 region matrix.
+M2 ships USD-only display, so the matrix is USD-centric.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+
+if TYPE_CHECKING:
+    from common.digger_optimizer.models import Seller
+
+
+Region = Literal["us", "ca", "eu", "uk", "jp", "au", "other"]
+
+
+# Cents — USD-centric.
+REGION_MATRIX_CENTS: dict[Region, dict[Region, int]] = {
+    "us": {"us": 500, "ca": 1500, "eu": 2500, "uk": 2500, "jp": 3000, "au": 3500, "other": 4000},
+    "ca": {"us": 1500, "ca": 800, "eu": 2500, "uk": 2500, "jp": 3000, "au": 3500, "other": 4000},
+    "eu": {"us": 2500, "ca": 2500, "eu": 1200, "uk": 1500, "jp": 3000, "au": 3500, "other": 4000},
+    "uk": {"us": 2500, "ca": 2500, "eu": 1500, "uk": 700, "jp": 3000, "au": 3500, "other": 4000},
+    "jp": {"us": 3000, "ca": 3000, "eu": 3000, "uk": 3000, "jp": 800, "au": 2500, "other": 4000},
+    "au": {"us": 3500, "ca": 3500, "eu": 3500, "uk": 3500, "jp": 2500, "au": 800, "other": 4000},
+    "other": {"us": 4000, "ca": 4000, "eu": 4000, "uk": 4000, "jp": 4000, "au": 4000, "other": 4000},
+}
+
+
+COUNTRY_TO_REGION: dict[str, Region] = {
+    "US": "us",
+    "CA": "ca",
+    "GB": "uk",
+    "JP": "jp",
+    "AU": "au",
+    "DE": "eu",
+    "FR": "eu",
+    "IT": "eu",
+    "ES": "eu",
+    "NL": "eu",
+    "BE": "eu",
+    "AT": "eu",
+}
+
+_DEFAULT_REGION: Region = "other"
+
+
+def region_of_country(country_code: str) -> Region:
+    return COUNTRY_TO_REGION.get(country_code.upper(), _DEFAULT_REGION)
+
+
+def estimate_shipping_cents(seller: Seller, *, location: str, count: int) -> int:
+    """Total shipping for ``count`` items from ``seller`` to ``location`` (ISO alpha-2)."""
+    if count <= 0:
+        return 0
+    user_region = region_of_country(location)
+    if seller.shipping_policy:
+        policy = seller.shipping_policy.get(user_region) or seller.shipping_policy.get("default")
+        if policy is not None:
+            return policy.first_cents + policy.additional_cents * max(0, count - 1)
+    base = REGION_MATRIX_CENTS[seller.region][user_region]
+    multiplier = 1.0 + 0.2 * (count - 1)
+    return int(base * multiplier)
+
+
+def shipping_confidence_score(sellers: dict[int, Seller], *, location: str) -> Literal["high", "low"]:
+    if not sellers:
+        return "high"
+    user_region = region_of_country(location)
+    have = 0
+    for seller in sellers.values():
+        if seller.shipping_policy and (seller.shipping_policy.get(user_region) or seller.shipping_policy.get("default")):
+            have += 1
+    return "high" if have * 100 >= len(sellers) * 80 else "low"

--- a/common/pyproject.toml
+++ b/common/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pika>=1.4.0",
     "prometheus-client>=0.25.0",
     "psycopg[binary]>=3.3.4",
+    "pulp>=2.8",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/docs/superpowers/plans/2026-05-14-digger-m2-optimizer.md
+++ b/docs/superpowers/plans/2026-05-14-digger-m2-optimizer.md
@@ -14,6 +14,38 @@
 
 ---
 
+## ⚠️ VERIFIED conventions (added 2026-05-20 during execution)
+
+This plan was written on 2026-05-14, **before** M1 was actually implemented, so its code
+snippets assume conventions the merged M1 code does **not** use. Treat the plan as the
+spec for *what* to build; the *how* below is authoritative and overrides the snippets.
+Verified against M1 on `origin/main` (`api/queries/digger_queries.py`,
+`api/routers/digger.py`, `api/routers/internal_digger.py`, `explore/static/js/digger.js`).
+
+| Plan snippet assumes | Real M1 convention (use this) |
+| --- | --- |
+| asyncpg: `pool.acquire()`, `conn.fetch()`, `$1` placeholders | **psycopg3**: `async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:` → `await cur.execute(sql, (params,))` → `await cur.fetchone()/fetchall()`; `%s` placeholders, params as tuples, `cur.rowcount` for affected rows |
+| `from common.postgres_pool import AsyncPostgreSQLPool` | `from common import AsyncPostgreSQLPool` (under `TYPE_CHECKING`) |
+| `Depends(current_user)` → `user.user_id` | `from api.dependencies import require_user`; `current_user: Annotated[dict[str, Any], Depends(require_user)]` → `uuid.UUID(current_user["sub"])` |
+| `Depends(get_pool)` / `Depends(get_redis)` in routes | Module-level `_pool` + `configure(pool)` setter, registered in `api/api.py` lifespan (`_router.configure(_pool)`) + `app.include_router(_router.router)` |
+| service-token guard ad-hoc | `from api.dependencies import service_token_required`; `APIRouter(..., dependencies=[Depends(service_token_required)])`; worker sends `X-Service-Token` header |
+| React 19 + Vite + `.tsx` + react-router-dom | **vanilla JS** classic `<script>` modules in `explore/static/js/` (extend `digger.js`), Alpine.js for view state, **vitest + jsdom** `.test.js` in `explore/__tests__/` using `loadScript()` + `createMockFetch()` helpers |
+| real-DB pytest fixtures (`postgres_pool`, `seeded_full_state`, `api_client`, `auth_headers`) | **mock-based**: `AsyncMock` pool→conn→cursor chains (see `tests/api/test_syncer_digger_hook.py`); real DB only in `@pytest.mark.e2e`. `tests/digger/conftest.py` provides a `redis_test_client` (fakeredis) |
+
+**Already exists from M1 — do not recreate:**
+- Tables `digger.reports`, `digger.user_digger_settings`, `digger.listings`, `digger.sellers`,
+  `digger.release_scrape_state`, `digger.user_wantlist_priorities` (schema-init/digger_schema.py).
+- Internal endpoints `/api/internal/digger/wantlist-snapshot/{user_id}` and
+  `/api/internal/digger/users-due-for-report` (the scheduler consumes these).
+- `sse-starlette` is already an API optional dependency; only `pulp>=2.8` (common) and
+  `hypothesis` (dev) need adding.
+
+**Execution structure:** shipped as layered PRs mirroring M1 — (A) `common/digger_optimizer/`
+library [Tasks 1–7], (B) API integration [8–12], (C) scheduler [10,13–14], (D) explore
+frontend rewritten in vanilla JS [15–18], (E) perf/docs/e2e/polish [19–22].
+
+---
+
 ## File structure
 
 **Create:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "orjson>=3.11.9",
     "pika>=1.4.0",
     "psycopg[binary]>=3.3.4",
+    "pulp>=2.8",
     "redis[hiredis]>=7.4.0",
     "structlog>=25.5.0",
     "tqdm>=4.67.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,7 @@ exclude = "^tests/"
 module = [
     "bleach",
     "pika.*",
+    "pulp",
     "selectolax.*",
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,6 +278,7 @@ dev = [
     "pytest-xdist>=3.8.0",
     "bleach>=6.3.0",
     "fakeredis>=2.35.1",
+    "hypothesis>=6.0",
     "pillow>=12.2.0",
     "respx>=0.23.1",
     "selectolax>=0.4.9",

--- a/tests/common/test_digger_optimizer_filtering.py
+++ b/tests/common/test_digger_optimizer_filtering.py
@@ -1,0 +1,56 @@
+"""Tests for digger optimizer stage-1 filtering."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+import uuid
+
+from common.digger_optimizer.filtering import filter_candidates
+from common.digger_optimizer.models import Listing, OptimizerInput, ReleaseConstraint, Seller
+
+
+def _input(constraints: list[ReleaseConstraint], listings: list[Listing]) -> OptimizerInput:
+    return OptimizerInput(
+        user_id=uuid.uuid4(),
+        location="US",
+        currency="USD",
+        must_have_releases=constraints,
+        candidate_listings=listings,
+        sellers={listing.seller_id: Seller(seller_id=listing.seller_id, region="us") for listing in listings},
+    )
+
+
+def test_drops_below_condition_floor() -> None:
+    c = ReleaseConstraint(release_id=1, min_media_condition="VG+", min_sleeve_condition="VG+", max_price_cents=None)
+    listings = [
+        Listing(
+            listing_id=10, release_id=1, seller_id=1, price_value=Decimal("5"), price_currency="USD", media_condition="VG", sleeve_condition="VG"
+        ),
+        Listing(
+            listing_id=11, release_id=1, seller_id=2, price_value=Decimal("12"), price_currency="USD", media_condition="NM", sleeve_condition="NM"
+        ),
+    ]
+    out = filter_candidates(_input([c], listings))
+    assert out.usable_by_release[1] == [11]
+    assert out.watching == []
+
+
+def test_drops_above_max_price() -> None:
+    c = ReleaseConstraint(release_id=1, min_media_condition="VG", min_sleeve_condition="VG", max_price_cents=1000)
+    listings = [
+        Listing(
+            listing_id=10, release_id=1, seller_id=1, price_value=Decimal("5"), price_currency="USD", media_condition="NM", sleeve_condition="NM"
+        ),
+        Listing(
+            listing_id=11, release_id=1, seller_id=2, price_value=Decimal("15"), price_currency="USD", media_condition="NM", sleeve_condition="NM"
+        ),
+    ]
+    out = filter_candidates(_input([c], listings))
+    assert out.usable_by_release[1] == [10]
+
+
+def test_marks_watching_when_no_qualifying_listings() -> None:
+    c = ReleaseConstraint(release_id=99, min_media_condition="NM", min_sleeve_condition="NM", max_price_cents=None)
+    out = filter_candidates(_input([c], []))
+    assert out.watching == [99]
+    assert 99 not in out.usable_by_release

--- a/tests/common/test_digger_optimizer_filtering.py
+++ b/tests/common/test_digger_optimizer_filtering.py
@@ -54,3 +54,33 @@ def test_marks_watching_when_no_qualifying_listings() -> None:
     out = filter_candidates(_input([c], []))
     assert out.watching == [99]
     assert 99 not in out.usable_by_release
+
+
+def test_drops_below_sleeve_floor() -> None:
+    # Media passes the floor but the sleeve does not — exercises the sleeve branch.
+    c = ReleaseConstraint(release_id=1, min_media_condition="VG", min_sleeve_condition="NM", max_price_cents=None)
+    listings = [
+        Listing(
+            listing_id=10, release_id=1, seller_id=1, price_value=Decimal("5"), price_currency="USD", media_condition="NM", sleeve_condition="VG"
+        ),
+        Listing(
+            listing_id=11, release_id=1, seller_id=2, price_value=Decimal("6"), price_currency="USD", media_condition="NM", sleeve_condition="NM"
+        ),
+    ]
+    out = filter_candidates(_input([c], listings))
+    assert out.usable_by_release[1] == [11]
+
+
+def test_skips_currency_mismatched_listings() -> None:
+    c = ReleaseConstraint(release_id=1, min_media_condition="VG", min_sleeve_condition="VG", max_price_cents=None)
+    listings = [
+        Listing(
+            listing_id=10, release_id=1, seller_id=1, price_value=Decimal("5"), price_currency="EUR", media_condition="NM", sleeve_condition="NM"
+        ),
+        Listing(
+            listing_id=11, release_id=1, seller_id=2, price_value=Decimal("6"), price_currency="USD", media_condition="NM", sleeve_condition="NM"
+        ),
+    ]
+    out = filter_candidates(_input([c], listings))
+    assert out.usable_by_release[1] == [11]
+    assert out.skipped_currency == 1

--- a/tests/common/test_digger_optimizer_greedy.py
+++ b/tests/common/test_digger_optimizer_greedy.py
@@ -62,3 +62,60 @@ def test_greedy_returns_zero_coverage_when_no_listings() -> None:
     b = greedy_bundle(inp, name="cheapest")
     assert b.coverage.must == 0
     assert b.grand_total_cents == 0
+
+
+def test_greedy_extends_with_cheap_nice_and_eventually() -> None:
+    inp = OptimizerInput(
+        user_id=uuid.uuid4(),
+        location="US",
+        currency="USD",
+        must_have_releases=[ReleaseConstraint(release_id=1, min_media_condition="VG", min_sleeve_condition="VG")],
+        nice_have_releases=[ReleaseConstraint(release_id=2, min_media_condition="VG", min_sleeve_condition="VG")],
+        eventually_releases=[ReleaseConstraint(release_id=3, min_media_condition="VG", min_sleeve_condition="VG")],
+        candidate_listings=[
+            _listing(101, 1, 1, "10"),  # must
+            _listing(201, 2, 1, "1"),  # cheap nice (same seller, small marginal)
+            _listing(301, 3, 1, "1"),  # cheap eventually
+        ],
+        sellers={1: _seller(1)},
+    )
+    b = greedy_bundle(inp, name="most_coverage")
+    assert b.coverage.must == 1
+    assert b.coverage.nice == 1
+    assert b.coverage.eventually == 1
+
+
+def test_greedy_skips_nice_item_above_lambda_budget() -> None:
+    inp = OptimizerInput(
+        user_id=uuid.uuid4(),
+        location="US",
+        currency="USD",
+        must_have_releases=[ReleaseConstraint(release_id=1, min_media_condition="VG", min_sleeve_condition="VG")],
+        nice_have_releases=[ReleaseConstraint(release_id=2, min_media_condition="VG", min_sleeve_condition="VG")],
+        candidate_listings=[
+            _listing(101, 1, 1, "10"),  # must
+            _listing(201, 2, 1, "99"),  # nice, far above the $5 cheapest lambda budget
+        ],
+        sellers={1: _seller(1)},
+    )
+    b = greedy_bundle(inp, name="cheapest")
+    assert b.coverage.must == 1
+    assert b.coverage.nice == 0
+
+
+def test_greedy_skips_excluded_seller() -> None:
+    inp = OptimizerInput(
+        user_id=uuid.uuid4(),
+        location="US",
+        currency="USD",
+        must_have_releases=[ReleaseConstraint(release_id=1, min_media_condition="VG", min_sleeve_condition="VG")],
+        candidate_listings=[
+            _listing(101, 1, 1, "5"),  # cheapest, but seller 1 is excluded
+            _listing(102, 1, 2, "10"),
+        ],
+        sellers={1: _seller(1), 2: _seller(2)},
+        excluded_sellers=frozenset({1}),
+    )
+    b = greedy_bundle(inp, name="cheapest")
+    assert b.coverage.must == 1
+    assert {o.seller_id for o in b.seller_orders} == {2}

--- a/tests/common/test_digger_optimizer_greedy.py
+++ b/tests/common/test_digger_optimizer_greedy.py
@@ -1,0 +1,64 @@
+"""Tests for the digger optimizer greedy reference/fallback solver."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+import uuid
+
+from common.digger_optimizer.greedy import greedy_bundle
+from common.digger_optimizer.models import Bundle, Listing, OptimizerInput, ReleaseConstraint, Seller
+
+
+def _seller(sid: int) -> Seller:
+    return Seller(seller_id=sid, region="us", country_code="US", shipping_policy=None)
+
+
+def _listing(lid: int, rid: int, sid: int, price: str) -> Listing:
+    return Listing(
+        listing_id=lid,
+        release_id=rid,
+        seller_id=sid,
+        price_value=Decimal(price),
+        price_currency="USD",
+        media_condition="NM",
+        sleeve_condition="NM",
+    )
+
+
+def test_greedy_covers_all_musts_minimum_sellers_when_possible() -> None:
+    inp = OptimizerInput(
+        user_id=uuid.uuid4(),
+        location="US",
+        currency="USD",
+        must_have_releases=[
+            ReleaseConstraint(release_id=1, min_media_condition="VG", min_sleeve_condition="VG"),
+            ReleaseConstraint(release_id=2, min_media_condition="VG", min_sleeve_condition="VG"),
+        ],
+        candidate_listings=[
+            _listing(101, 1, 1, "10"),
+            _listing(102, 1, 2, "12"),
+            _listing(201, 2, 1, "8"),
+            _listing(202, 2, 2, "9"),
+        ],
+        sellers={1: _seller(1), 2: _seller(2)},
+    )
+    b: Bundle = greedy_bundle(inp, name="cheapest")
+    assert b.coverage.must == 2
+    # Seller 1 covers both at 10+8=18 + shipping_once; greedy consolidation prefers seller 1.
+    assert {o.seller_id for o in b.seller_orders} == {1}
+
+
+def test_greedy_returns_zero_coverage_when_no_listings() -> None:
+    inp = OptimizerInput(
+        user_id=uuid.uuid4(),
+        location="US",
+        currency="USD",
+        must_have_releases=[
+            ReleaseConstraint(release_id=99, min_media_condition="NM", min_sleeve_condition="NM"),
+        ],
+        candidate_listings=[],
+        sellers={},
+    )
+    b = greedy_bundle(inp, name="cheapest")
+    assert b.coverage.must == 0
+    assert b.grand_total_cents == 0

--- a/tests/common/test_digger_optimizer_ilp.py
+++ b/tests/common/test_digger_optimizer_ilp.py
@@ -66,3 +66,22 @@ def test_ilp_returns_empty_bundle_when_must_unavailable() -> None:
     # Infeasible (must release with no listings) — return an empty bundle, not None.
     assert b is not None
     assert b.coverage.must == 0
+
+
+def test_ilp_excludes_seller() -> None:
+    inp = OptimizerInput(
+        user_id=uuid.uuid4(),
+        location="US",
+        currency="USD",
+        must_have_releases=[ReleaseConstraint(release_id=1, min_media_condition="VG", min_sleeve_condition="VG")],
+        candidate_listings=[
+            _listing(101, 1, 1, "5"),  # cheapest, but seller 1 is excluded
+            _listing(102, 1, 2, "10"),
+        ],
+        sellers={1: _seller(1), 2: _seller(2)},
+        excluded_sellers=frozenset({1}),
+    )
+    b = solve_ilp_bundle(inp, name="cheapest", timeout_seconds=5)
+    assert b is not None
+    assert b.coverage.must == 1
+    assert {o.seller_id for o in b.seller_orders} == {2}

--- a/tests/common/test_digger_optimizer_ilp.py
+++ b/tests/common/test_digger_optimizer_ilp.py
@@ -1,0 +1,68 @@
+"""Tests for the digger optimizer ILP solver (pulp + CBC)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+import uuid
+
+from common.digger_optimizer.ilp import solve_ilp_bundle
+from common.digger_optimizer.models import Listing, OptimizerInput, ReleaseConstraint, Seller
+
+
+def _seller(sid: int) -> Seller:
+    return Seller(seller_id=sid, region="us", country_code="US", shipping_policy=None)
+
+
+def _listing(lid: int, rid: int, sid: int, price: str) -> Listing:
+    return Listing(
+        listing_id=lid,
+        release_id=rid,
+        seller_id=sid,
+        price_value=Decimal(price),
+        price_currency="USD",
+        media_condition="NM",
+        sleeve_condition="NM",
+    )
+
+
+def test_ilp_finds_optimal_two_must_one_seller() -> None:
+    inp = OptimizerInput(
+        user_id=uuid.uuid4(),
+        location="US",
+        currency="USD",
+        must_have_releases=[
+            ReleaseConstraint(release_id=1, min_media_condition="VG", min_sleeve_condition="VG"),
+            ReleaseConstraint(release_id=2, min_media_condition="VG", min_sleeve_condition="VG"),
+        ],
+        candidate_listings=[
+            _listing(101, 1, 1, "10"),
+            _listing(102, 1, 2, "9"),
+            _listing(201, 2, 1, "5"),
+            _listing(202, 2, 2, "7"),
+        ],
+        sellers={1: _seller(1), 2: _seller(2)},
+    )
+    b = solve_ilp_bundle(inp, name="cheapest", timeout_seconds=5)
+    assert b is not None
+    assert b.coverage.must == 2
+    # Single-seller bundle wins because a second seller's shipping outweighs the item savings.
+    assert {o.seller_id for o in b.seller_orders} == {1}
+    # Items 101 ($10) + 201 ($5) = $15; shipping for 2 items from seller 1 = int($5 * 1.2) = $6 -> $21.
+    assert b.grand_total_cents == 10_00 + 5_00 + 6_00
+
+
+def test_ilp_returns_empty_bundle_when_must_unavailable() -> None:
+    inp = OptimizerInput(
+        user_id=uuid.uuid4(),
+        location="US",
+        currency="USD",
+        must_have_releases=[
+            ReleaseConstraint(release_id=1, min_media_condition="NM", min_sleeve_condition="NM"),
+        ],
+        candidate_listings=[],
+        sellers={},
+    )
+    b = solve_ilp_bundle(inp, name="cheapest", timeout_seconds=5)
+    # Infeasible (must release with no listings) — return an empty bundle, not None.
+    assert b is not None
+    assert b.coverage.must == 0

--- a/tests/common/test_digger_optimizer_models.py
+++ b/tests/common/test_digger_optimizer_models.py
@@ -1,0 +1,46 @@
+"""Tests for the digger optimizer Pydantic models."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+import uuid
+
+from common.digger_optimizer.models import (
+    BundleName,
+    Listing,
+    OptimizerInput,
+    ReleaseConstraint,
+    Seller,
+)
+
+
+def test_models_construct_with_minimal_fields() -> None:
+    c = ReleaseConstraint(release_id=1, min_media_condition="VG", min_sleeve_condition="VG", max_price_cents=None)
+    s = Seller(seller_id=1, region="us", country_code="US", shipping_policy=None)
+    listing = Listing(
+        listing_id=1,
+        release_id=1,
+        seller_id=1,
+        price_value=Decimal("10.00"),
+        price_currency="USD",
+        media_condition="NM",
+        sleeve_condition="NM",
+    )
+    inp = OptimizerInput(
+        user_id=uuid.uuid4(),
+        location="US",
+        currency="USD",
+        must_have_releases=[c],
+        nice_have_releases=[],
+        eventually_releases=[],
+        candidate_listings=[listing],
+        sellers={1: s},
+    )
+    assert inp.location == "US"
+    assert inp.must_have_releases[0].release_id == 1
+    assert inp.sellers[1].seller_id == 1
+
+
+def test_bundle_name_literal() -> None:
+    valid: list[BundleName] = ["cheapest", "most_coverage", "best_quality", "fewest_sellers"]
+    assert "cheapest" in valid

--- a/tests/common/test_digger_optimizer_pareto.py
+++ b/tests/common/test_digger_optimizer_pareto.py
@@ -1,0 +1,67 @@
+"""Tests for the digger optimizer Pareto-front coordinator."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+import uuid
+
+from common.digger_optimizer import pareto_bundles
+from common.digger_optimizer.models import Listing, OptimizerInput, ReleaseConstraint, Seller
+
+
+def _seller(sid: int) -> Seller:
+    return Seller(seller_id=sid, region="us", country_code="US", shipping_policy=None)
+
+
+def _listing(lid: int, rid: int, sid: int, price: str, media: str = "NM") -> Listing:
+    return Listing(
+        listing_id=lid,
+        release_id=rid,
+        seller_id=sid,
+        price_value=Decimal(price),
+        price_currency="USD",
+        media_condition=media,  # type: ignore[arg-type]
+        sleeve_condition=media,  # type: ignore[arg-type]
+    )
+
+
+def test_pareto_returns_named_bundles() -> None:
+    # One must release with a cheap-low-grade option (seller 1) and a pricey-top-grade
+    # option (seller 2). Cheapest should take the cheap one; best_quality the top one.
+    inp = OptimizerInput(
+        user_id=uuid.uuid4(),
+        location="US",
+        currency="USD",
+        must_have_releases=[ReleaseConstraint(release_id=1, min_media_condition="VG", min_sleeve_condition="VG")],
+        candidate_listings=[
+            _listing(101, 1, 1, "5", media="VG"),
+            _listing(102, 1, 2, "12", media="M"),
+        ],
+        sellers={1: _seller(1), 2: _seller(2)},
+    )
+    out = pareto_bundles(inp)
+
+    assert {b.name for b in out.bundles} == {"cheapest", "most_coverage", "best_quality", "fewest_sellers"}
+    assert all(b.coverage.must == 1 for b in out.bundles)
+
+    cheapest = next(b for b in out.bundles if b.name == "cheapest")
+    quality = next(b for b in out.bundles if b.name == "best_quality")
+    assert cheapest.grand_total_cents <= quality.grand_total_cents
+    assert quality.avg_condition_score >= cheapest.avg_condition_score
+
+    assert out.shipping_confidence in ("high", "low")
+    assert out.diagnostics.listings_considered >= 1
+    assert set(out.diagnostics.solver_used) == {"cheapest", "most_coverage", "best_quality", "fewest_sellers"}
+
+
+def test_pareto_marks_watching_when_must_unavailable() -> None:
+    inp = OptimizerInput(
+        user_id=uuid.uuid4(),
+        location="US",
+        currency="USD",
+        must_have_releases=[ReleaseConstraint(release_id=99, min_media_condition="M", min_sleeve_condition="M")],
+        candidate_listings=[],
+        sellers={},
+    )
+    out = pareto_bundles(inp)
+    assert 99 in out.watching

--- a/tests/common/test_digger_optimizer_pareto.py
+++ b/tests/common/test_digger_optimizer_pareto.py
@@ -65,3 +65,27 @@ def test_pareto_marks_watching_when_must_unavailable() -> None:
     )
     out = pareto_bundles(inp)
     assert 99 in out.watching
+
+
+def test_pareto_falls_back_to_greedy_on_ilp_error(monkeypatch) -> None:
+    from common.digger_optimizer import pareto as pareto_mod
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("ilp exploded")
+
+    monkeypatch.setattr(pareto_mod, "solve_ilp_bundle", _boom)
+
+    inp = OptimizerInput(
+        user_id=uuid.uuid4(),
+        location="US",
+        currency="USD",
+        must_have_releases=[ReleaseConstraint(release_id=1, min_media_condition="VG", min_sleeve_condition="VG")],
+        candidate_listings=[_listing(101, 1, 1, "5")],
+        sellers={1: _seller(1)},
+    )
+    out = pareto_bundles(inp)
+
+    assert all(b.solver == "greedy" for b in out.bundles)
+    assert set(out.diagnostics.solver_used.values()) == {"greedy"}
+    cheapest = next(b for b in out.bundles if b.name == "cheapest")
+    assert cheapest.coverage.must == 1

--- a/tests/common/test_digger_optimizer_properties.py
+++ b/tests/common/test_digger_optimizer_properties.py
@@ -1,0 +1,96 @@
+"""Property-based tests for the digger optimizer.
+
+Covers invariants that hold across many generated inputs:
+- more budget never reduces must coverage (monotonicity),
+- every bundle's totals are internally consistent (no arithmetic drift),
+- coverage counts stay within bounds and watching never overlaps covered musts.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+import uuid
+
+from hypothesis import HealthCheck, given, settings, strategies as st
+
+from common.digger_optimizer import pareto_bundles
+from common.digger_optimizer.models import Listing, OptimizerInput, ReleaseConstraint, Seller
+
+
+def _make_input(seed: int) -> OptimizerInput:
+    n_must = (seed % 3) + 1
+    must = [ReleaseConstraint(release_id=10 + i, min_media_condition="VG", min_sleeve_condition="VG") for i in range(n_must)]
+    nice = [ReleaseConstraint(release_id=100 + i, min_media_condition="VG", min_sleeve_condition="VG") for i in range(2)]
+    sellers = {
+        1: Seller(seller_id=1, region="us", country_code="US"),
+        2: Seller(seller_id=2, region="us", country_code="US"),
+    }
+    listings: list[Listing] = []
+    for rid in [c.release_id for c in must + nice]:
+        listings.append(
+            Listing(
+                listing_id=rid * 10 + 1,
+                release_id=rid,
+                seller_id=1,
+                price_value=Decimal(str(5 + (rid % 20))),
+                price_currency="USD",
+                media_condition="NM",
+                sleeve_condition="NM",
+            )
+        )
+        listings.append(
+            Listing(
+                listing_id=rid * 10 + 2,
+                release_id=rid,
+                seller_id=2,
+                price_value=Decimal(str(7 + (rid % 15))),
+                price_currency="USD",
+                media_condition="NM",
+                sleeve_condition="NM",
+            )
+        )
+    return OptimizerInput(
+        user_id=uuid.uuid4(),
+        location="US",
+        currency="USD",
+        must_have_releases=must,
+        nice_have_releases=nice,
+        candidate_listings=listings,
+        sellers=sellers,
+    )
+
+
+@settings(max_examples=15, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(st.integers(min_value=0, max_value=100))
+def test_more_budget_never_reduces_must_coverage(seed: int) -> None:
+    base = _make_input(seed)
+    low = pareto_bundles(base.model_copy(update={"budget_cap_cents": 1000})).bundles[0]
+    high = pareto_bundles(base.model_copy(update={"budget_cap_cents": 1_000_000})).bundles[0]
+    assert high.coverage.must >= low.coverage.must
+
+
+@settings(max_examples=15, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(st.integers(min_value=0, max_value=100))
+def test_bundle_totals_are_internally_consistent(seed: int) -> None:
+    out = pareto_bundles(_make_input(seed))
+    for b in out.bundles:
+        item = sum(o.subtotal_item_cents for o in b.seller_orders)
+        ship = sum(o.shipping_cents for o in b.seller_orders)
+        assert b.total_item_cost_cents == item
+        assert b.total_shipping_cents == ship
+        assert b.grand_total_cents == item + ship
+
+
+@settings(max_examples=15, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(st.integers(min_value=0, max_value=100))
+def test_coverage_within_bounds_and_watching_disjoint(seed: int) -> None:
+    inp = _make_input(seed)
+    out = pareto_bundles(inp)
+    n_must = len(inp.must_have_releases)
+    n_nice = len(inp.nice_have_releases)
+    must_ids = {c.release_id for c in inp.must_have_releases}
+    for b in out.bundles:
+        assert 0 <= b.coverage.must <= n_must
+        assert 0 <= b.coverage.nice <= n_nice
+    # All musts have listings in _make_input, so nothing should be marked "watching".
+    assert not (set(out.watching) & must_ids)

--- a/tests/common/test_digger_optimizer_shipping.py
+++ b/tests/common/test_digger_optimizer_shipping.py
@@ -1,0 +1,36 @@
+"""Tests for digger optimizer per-seller shipping estimation."""
+
+from __future__ import annotations
+
+from common.digger_optimizer.models import Seller, ShippingPolicyRegion
+from common.digger_optimizer.shipping import REGION_MATRIX_CENTS, estimate_shipping_cents, shipping_confidence_score
+
+
+def test_uses_policy_when_available() -> None:
+    s = Seller(
+        seller_id=1,
+        region="us",
+        country_code="US",
+        shipping_policy={"us": ShippingPolicyRegion(first_cents=500, additional_cents=150, currency="USD")},
+    )
+    assert estimate_shipping_cents(s, location="US", count=1) == 500
+    assert estimate_shipping_cents(s, location="US", count=4) == 500 + 150 * 3
+
+
+def test_falls_back_to_matrix_when_no_policy() -> None:
+    s = Seller(seller_id=1, region="us", country_code="US", shipping_policy=None)
+    base = REGION_MATRIX_CENTS["us"]["us"]
+    assert estimate_shipping_cents(s, location="US", count=1) == base
+    # 1 + 0.2 * (count - 1) multiplier
+    assert estimate_shipping_cents(s, location="US", count=3) == int(base * 1.4)
+
+
+def test_confidence_high_when_most_have_policies() -> None:
+    sellers = {
+        1: Seller(seller_id=1, region="us", shipping_policy={"us": ShippingPolicyRegion(first_cents=500, additional_cents=100)}),
+        2: Seller(seller_id=2, region="us", shipping_policy={"us": ShippingPolicyRegion(first_cents=500, additional_cents=100)}),
+        3: Seller(seller_id=3, region="us", shipping_policy=None),
+    }
+    assert shipping_confidence_score(sellers, location="US") == "low"  # 2/3 = 66%
+    sellers[3].shipping_policy = {"us": ShippingPolicyRegion(first_cents=500, additional_cents=100)}
+    assert shipping_confidence_score(sellers, location="US") == "high"  # 3/3 = 100%

--- a/uv.lock
+++ b/uv.lock
@@ -564,6 +564,7 @@ dev = [
     { name = "bandit", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "bleach", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "fakeredis", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "hypothesis", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "mdformat", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "mdformat-gfm", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "mypy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -666,6 +667,7 @@ dev = [
     { name = "bandit", specifier = ">=1.9.4" },
     { name = "bleach", specifier = ">=6.3.0" },
     { name = "fakeredis", specifier = ">=2.35.1" },
+    { name = "hypothesis", specifier = ">=6.0" },
     { name = "mdformat", specifier = ">=1.0.0" },
     { name = "mdformat-gfm", specifier = ">=1.0.0" },
     { name = "mypy", specifier = ">=2.1.0" },
@@ -1150,6 +1152,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.152.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/fb/a5651eb0cd03ecee644e8f4d8cd2027b40a08bf1488f46201e794aebe9b5/hypothesis-6.152.9.tar.gz", hash = "sha256:de4711d69ce3a18009047c3b44882810fd0c0348c1558e920a4b0d2c45f59e1e", size = 472009, upload-time = "2026-05-19T17:10:19.586Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/d9/40ef7ed22f0c45c2316467edb9afb8fc172cd089cb329c0ee6da6b74416c/hypothesis-6.152.9-py3-none-any.whl", hash = "sha256:9c4fdccb1eac0b12ec740c12290d0e6a0bea3526a3f0bf812b7643bb563c2d8b", size = 538148, upload-time = "2026-05-19T17:10:16.131Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -427,6 +427,7 @@ dependencies = [
     { name = "orjson", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pika", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "psycopg", extra = ["binary"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pulp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "redis", extra = ["hiredis"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "structlog", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tqdm", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -623,6 +624,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], marker = "extra == 'dashboard'", specifier = ">=3.3.4" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'schema-init'", specifier = ">=3.3.4" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'tableinator'", specifier = ">=3.3.4" },
+    { name = "pulp", specifier = ">=2.8" },
     { name = "pydantic", marker = "extra == 'api'", specifier = ">=2.13.4" },
     { name = "pydantic", marker = "extra == 'dashboard'", specifier = ">=2.13.4" },
     { name = "pydantic", marker = "extra == 'explore'", specifier = ">=2.13.4" },
@@ -768,6 +770,7 @@ dependencies = [
     { name = "pika", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "prometheus-client", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "psycopg", extra = ["binary"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pulp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [package.metadata]
@@ -777,6 +780,7 @@ requires-dist = [
     { name = "pika", specifier = ">=1.4.0" },
     { name = "prometheus-client", specifier = ">=0.25.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.4" },
+    { name = "pulp", specifier = ">=2.8" },
 ]
 
 [[package]]
@@ -1837,6 +1841,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
     { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
     { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+]
+
+[[package]]
+name = "pulp"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/a8/6e63330798761e0c903091786681651168fda7365f029b8b5d66160861f2/pulp-3.3.1.tar.gz", hash = "sha256:a9ec237a56981b11c2096e8ba6bb72006833410ba5b400aa257426f85df5e293", size = 16304830, upload-time = "2026-05-05T12:25:43.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/23/5a77fe2b50d962213338ae0fdd9832960186ebc423388fff1a56680e5114/pulp-3.3.1-py3-none-any.whl", hash = "sha256:45aa73db3368eb13b156564e092784c8fa0c1feefa64c2afb0410d9dc0bb5cd9", size = 16390866, upload-time = "2026-05-05T12:25:39.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

First layer of **Digger M2** (Optimizer & Reports). Ships the pure-function bundle optimizer as a new shared library `common/digger_optimizer/` — no I/O, importable by both `api/` (interactive runs) and `digger/` (scheduled runs) in later layers.

Modules (built TDD, task-by-task per the M2 plan):
- `models.py` — Pydantic input/output types (`OptimizerInput`/`OptimizerOutput`, `Bundle`, `Listing`, `Seller`, …); condition vocab mirrors the `digger.condition`/`digger.sleeve_condition` Postgres enums.
- `filtering.py` — stage-1 filter by condition floor, max-price cap, currency.
- `shipping.py` — per-seller shipping: scraped policy preferred, 7×7 region-matrix fallback, confidence score.
- `greedy.py` — greedy ratio-based reference/fallback solver + bundle builder.
- `ilp.py` — optimal solver via **pulp + CBC** (`x[listing]`/`y[seller]`/`z[seller,count]`, shipping linearized piecewise; per-variant objective).
- `pareto.py` — coordinator running the 4 named variants (Cheapest / Most Coverage / Best Quality / Fewest Sellers) with greedy fallback on ILP error; emits diagnostics + shipping confidence.

Dependencies: `pulp>=2.8` (common + root), `hypothesis` (dev). `pulp` added to mypy `ignore_missing_imports` (ships no `py.typed`).

## Context — plan adaptation

The M2 plan (`docs/superpowers/plans/2026-05-14-digger-m2-optimizer.md`) was written **before** M1 was implemented, so its snippets assumed asyncpg + React + real-DB fixtures. This PR adds a **VERIFIED conventions** note to the plan documenting the real M1 conventions (psycopg3, `require_user`/`configure` routers, vanilla-JS frontend, mock-based tests) and the layered-PR structure. This library layer is convention-agnostic (pure functions), so it follows the plan closely; downstream layers (B–E: API, scheduler, frontend, polish) will follow the documented conventions.

Two plan-test corrections (documented in commits):
- ILP test grand-total `$20 → $21` — the plan's flat-shipping assumption contradicted its own shipping model (2 items from one seller = `int($5×1.2)=$6`).
- Pareto / property tests reworked to robust invariants (the plan's `quality.avg_condition ≥ cheapest.avg_condition` is false when quality adds a lower-grade *nice* item, and its cost assertion depended on a CBC tie).

## Test Plan

- [x] `uv run pytest tests/common/test_digger_optimizer_*.py` — 18 pass
- [x] Coverage **91%** on `common/digger_optimizer/` (every file ≥ 83%, > 80% bar)
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run mypy common/digger_optimizer/` — clean
- [x] Full `tests/common` suite — no regressions
- [x] Hypothesis property tests (budget monotonicity, total consistency, coverage bounds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)