### PR TITLE
feat(digger): M2 API layer — recommend SSE + reports CRUD + opportunistic refresh

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -41,6 +41,7 @@ import api.routers.auth as _auth_router
 import api.routers.collection as _collection_router
 import api.routers.credits as _credits_router
 import api.routers.digger as _digger_router
+import api.routers.digger_recommend as _digger_recommend_router
 import api.routers.digger_reports as _digger_reports_router
 import api.routers.explore as _explore_router
 import api.routers.extraction_analysis as _extraction_analysis_router
@@ -250,6 +251,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:  # pragma: no cover
     jwt_secret_for_neo4j = _config.jwt_secret_key if _config.neo4j_host else None
     _dependencies.configure(jwt_secret_for_neo4j, _redis, pool=_pool, digger_api_service_token=_config.digger_api_service_token)
     _digger_router.configure(_pool)
+    _digger_recommend_router.configure(_pool, _redis)
     _digger_reports_router.configure(_pool)
     _internal_digger_router.configure(_pool)
     _sync_router.configure(_pool, _neo4j, _config, _running_syncs, _redis)
@@ -399,6 +401,7 @@ async def metrics_middleware(request: Request, call_next: Any) -> Any:
 
 app.include_router(_auth_router.router)
 app.include_router(_digger_router.router)
+app.include_router(_digger_recommend_router.router)
 app.include_router(_digger_reports_router.router)
 app.include_router(_internal_digger_router.router)
 app.include_router(_sync_router.router)

--- a/api/api.py
+++ b/api/api.py
@@ -41,6 +41,7 @@ import api.routers.auth as _auth_router
 import api.routers.collection as _collection_router
 import api.routers.credits as _credits_router
 import api.routers.digger as _digger_router
+import api.routers.digger_reports as _digger_reports_router
 import api.routers.explore as _explore_router
 import api.routers.extraction_analysis as _extraction_analysis_router
 import api.routers.insights as _insights_router
@@ -249,6 +250,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:  # pragma: no cover
     jwt_secret_for_neo4j = _config.jwt_secret_key if _config.neo4j_host else None
     _dependencies.configure(jwt_secret_for_neo4j, _redis, pool=_pool, digger_api_service_token=_config.digger_api_service_token)
     _digger_router.configure(_pool)
+    _digger_reports_router.configure(_pool)
     _internal_digger_router.configure(_pool)
     _sync_router.configure(_pool, _neo4j, _config, _running_syncs, _redis)
     _explore_router.configure(_neo4j, jwt_secret_for_neo4j, _redis)
@@ -397,6 +399,7 @@ async def metrics_middleware(request: Request, call_next: Any) -> Any:
 
 app.include_router(_auth_router.router)
 app.include_router(_digger_router.router)
+app.include_router(_digger_reports_router.router)
 app.include_router(_internal_digger_router.router)
 app.include_router(_sync_router.router)
 app.include_router(_explore_router.router)

--- a/api/digger_refresh/__init__.py
+++ b/api/digger_refresh/__init__.py
@@ -1,0 +1,1 @@
+"""Digger opportunistic-refresh and optimizer-input helpers for the API service."""

--- a/api/digger_refresh/coordinator.py
+++ b/api/digger_refresh/coordinator.py
@@ -1,0 +1,71 @@
+"""Opportunistic refresh: write priority bumps and subscribe to worker progress.
+
+API -> Postgres: set ``next_scrape_due_at = now()`` for stale releases so the
+worker picks them up on its next iteration.
+Worker -> Redis: publishes per-scrape progress to ``digger:refresh:{user_id}``
+(see the scheduler layer); this class consumes those events.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from typing import Any
+
+    import redis.asyncio as aioredis
+
+    from common import AsyncPostgreSQLPool
+
+
+log = logging.getLogger(__name__)
+
+
+class RefreshCoordinator:
+    """Coordinates opportunistic listing refreshes for the recommend flow."""
+
+    def __init__(self, *, pool: AsyncPostgreSQLPool | None, redis: aioredis.Redis) -> None:
+        self._pool = pool
+        self._redis = redis
+
+    async def bump_priorities(self, release_ids: list[int]) -> int:
+        """Mark releases due now so the worker re-scrapes them; returns rows updated."""
+        if not release_ids:
+            return 0
+        if self._pool is None:
+            raise RuntimeError("RefreshCoordinator requires a pool to bump priorities")
+        async with self._pool.connection() as conn, conn.cursor() as cur:
+            await cur.execute(
+                "UPDATE digger.release_scrape_state SET next_scrape_due_at = now() WHERE release_id = ANY(%s)",
+                (release_ids,),
+            )
+            return cur.rowcount
+
+    async def subscribe_progress(self, user_id: str, *, deadline_seconds: float) -> AsyncIterator[dict[str, Any]]:
+        """Yield refresh-progress events for a user until the deadline elapses."""
+        channel = f"digger:refresh:{user_id}"
+        pubsub = self._redis.pubsub()
+        await pubsub.subscribe(channel)
+        try:
+            loop = asyncio.get_running_loop()
+            end = loop.time() + deadline_seconds
+            while True:
+                remaining = end - loop.time()
+                if remaining <= 0:
+                    return
+                msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=remaining)
+                if msg is None:
+                    continue
+                try:
+                    data = json.loads(msg["data"])
+                except (ValueError, TypeError):
+                    continue
+                yield data
+        finally:
+            await pubsub.unsubscribe(channel)
+            await pubsub.aclose()

--- a/api/digger_refresh/coordinator.py
+++ b/api/digger_refresh/coordinator.py
@@ -14,7 +14,7 @@ import logging
 from typing import TYPE_CHECKING
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import AsyncIterator
     from typing import Any
 

--- a/api/digger_refresh/input_builder.py
+++ b/api/digger_refresh/input_builder.py
@@ -1,0 +1,133 @@
+"""Build an OptimizerInput from the digger Postgres state.
+
+Bridges stored wantlist priorities + scraped listings/sellers into the pure
+optimizer's OptimizerInput. Used by the interactive recommend endpoint and
+reusable by scheduled runs. Async psycopg3 throughout.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from psycopg.rows import dict_row
+
+from api.queries.digger_queries import list_wantlist_priorities
+from common.digger_optimizer.models import Listing, OptimizerInput, ReleaseConstraint, Seller, ShippingPolicyRegion
+
+
+if TYPE_CHECKING:
+    import uuid
+
+    from common import AsyncPostgreSQLPool
+
+
+async def build_optimizer_input(
+    pool: AsyncPostgreSQLPool,
+    user_id: uuid.UUID,
+    *,
+    location: str,
+    currency: str = "USD",
+    budget_cap_cents: int | None = None,
+    excluded_sellers: frozenset[int] = frozenset(),
+) -> OptimizerInput:
+    """Assemble the optimizer input for a user from their wantlist + scraped marketplace data."""
+    priorities = await list_wantlist_priorities(pool, user_id)
+
+    must: list[ReleaseConstraint] = []
+    nice: list[ReleaseConstraint] = []
+    eventually: list[ReleaseConstraint] = []
+    release_ids: list[int] = []
+    for p in priorities:
+        rc = ReleaseConstraint(
+            release_id=p.release_id,
+            min_media_condition=p.min_media_condition,  # type: ignore[arg-type]  # DB enum value is a valid Condition
+            min_sleeve_condition=p.min_sleeve_condition,  # type: ignore[arg-type]  # DB enum value is a valid SleeveCondition
+            max_price_cents=p.max_price_cents,
+        )
+        release_ids.append(p.release_id)
+        if p.tier == "must":
+            must.append(rc)
+        elif p.tier == "nice":
+            nice.append(rc)
+        else:
+            eventually.append(rc)
+
+    if not release_ids:
+        return OptimizerInput(
+            user_id=user_id,
+            location=location,
+            currency=currency,
+            must_have_releases=[],
+            nice_have_releases=[],
+            eventually_releases=[],
+            candidate_listings=[],
+            sellers={},
+            budget_cap_cents=budget_cap_cents,
+            excluded_sellers=excluded_sellers,
+        )
+
+    async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            "SELECT listing_id, release_id, seller_id, price_value, price_currency, media_condition, sleeve_condition "
+            "FROM digger.listings WHERE release_id = ANY(%s) AND removed_at IS NULL",
+            (release_ids,),
+        )
+        listing_rows = await cur.fetchall()
+        seller_ids = list({r["seller_id"] for r in listing_rows})
+        if seller_ids:
+            await cur.execute(
+                "SELECT seller_id, region, country_code, shipping_policy, feedback_score FROM digger.sellers WHERE seller_id = ANY(%s)",
+                (seller_ids,),
+            )
+            seller_rows = await cur.fetchall()
+        else:
+            seller_rows = []
+
+    sellers: dict[int, Seller] = {}
+    for r in seller_rows:
+        raw = r["shipping_policy"]
+        policy = (
+            {
+                region: ShippingPolicyRegion(
+                    first_cents=v["first_cents"],
+                    additional_cents=v["additional_cents"],
+                    currency=v.get("currency", "USD"),
+                )
+                for region, v in raw.items()
+            }
+            if raw
+            else None
+        )
+        sellers[r["seller_id"]] = Seller(
+            seller_id=r["seller_id"],
+            region=r["region"],
+            country_code=r["country_code"],
+            shipping_policy=policy,
+            feedback_score=float(r["feedback_score"]) if r["feedback_score"] is not None else None,
+        )
+
+    listings = [
+        Listing(
+            listing_id=r["listing_id"],
+            release_id=r["release_id"],
+            seller_id=r["seller_id"],
+            price_value=r["price_value"],
+            price_currency=r["price_currency"],
+            media_condition=r["media_condition"],
+            sleeve_condition=r["sleeve_condition"],
+        )
+        for r in listing_rows
+    ]
+
+    return OptimizerInput(
+        user_id=user_id,
+        location=location,
+        currency=currency,
+        must_have_releases=must,
+        nice_have_releases=nice,
+        eventually_releases=eventually,
+        candidate_listings=listings,
+        sellers=sellers,
+        budget_cap_cents=budget_cap_cents,
+        excluded_sellers=excluded_sellers,
+    )

--- a/api/digger_refresh/input_builder.py
+++ b/api/digger_refresh/input_builder.py
@@ -15,7 +15,7 @@ from api.queries.digger_queries import list_wantlist_priorities
 from common.digger_optimizer.models import Listing, OptimizerInput, ReleaseConstraint, Seller, ShippingPolicyRegion
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     import uuid
 
     from common import AsyncPostgreSQLPool

--- a/api/queries/digger_reports.py
+++ b/api/queries/digger_reports.py
@@ -14,7 +14,7 @@ from psycopg.rows import dict_row
 from psycopg.types.json import Jsonb
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing import Any
 
     from common import AsyncPostgreSQLPool

--- a/api/queries/digger_reports.py
+++ b/api/queries/digger_reports.py
@@ -1,0 +1,96 @@
+"""SQL helpers for the digger.reports table, used by the reports API router.
+
+Async psycopg3 throughout: pool.connection() -> conn.cursor() -> cur.execute(sql,
+(params,)); %s placeholders, params as tuples. JSONB columns are written with the
+psycopg ``Jsonb`` adapter and returned already parsed (dict_row).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+import uuid
+
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from common import AsyncPostgreSQLPool
+
+
+async def list_reports(pool: AsyncPostgreSQLPool, user_id: uuid.UUID, limit: int = 50) -> list[dict[str, Any]]:
+    """Return a user's reports (newest first) as inbox summaries."""
+    async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            "SELECT report_id, kind, generated_at, read_at, title, summary, change_flag "
+            "FROM digger.reports WHERE user_id = %s ORDER BY generated_at DESC LIMIT %s",
+            (user_id, limit),
+        )
+        rows = await cur.fetchall()
+    return [
+        {
+            "report_id": str(r["report_id"]),
+            "kind": r["kind"],
+            "generated_at": r["generated_at"].isoformat(),
+            "read_at": r["read_at"].isoformat() if r["read_at"] else None,
+            "title": r["title"],
+            "summary": r["summary"],
+            "change_flag": r["change_flag"],
+        }
+        for r in rows
+    ]
+
+
+async def get_report(pool: AsyncPostgreSQLPool, user_id: uuid.UUID, report_id: uuid.UUID) -> dict[str, Any] | None:
+    """Return one full report owned by the user, or None if it does not exist."""
+    async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            "SELECT report_id, user_id, kind, generated_at, read_at, title, summary, bundles, watching, change_flag, shipping_confidence "
+            "FROM digger.reports WHERE report_id = %s AND user_id = %s",
+            (report_id, user_id),
+        )
+        row = await cur.fetchone()
+    if row is None:
+        return None
+    result = dict(row)
+    result["report_id"] = str(result["report_id"])
+    result["user_id"] = str(result["user_id"])
+    result["generated_at"] = result["generated_at"].isoformat()
+    result["read_at"] = result["read_at"].isoformat() if result["read_at"] else None
+    return result
+
+
+async def insert_report(
+    pool: AsyncPostgreSQLPool,
+    user_id: uuid.UUID,
+    *,
+    kind: str,
+    title: str,
+    summary: dict[str, Any],
+    bundles: list[Any],
+    watching: list[int],
+    change_flag: str,
+    shipping_confidence: str,
+) -> uuid.UUID:
+    """Insert a report row and return its new report_id."""
+    report_id = uuid.uuid4()
+    async with pool.connection() as conn, conn.cursor() as cur:
+        await cur.execute(
+            "INSERT INTO digger.reports "
+            "(report_id, user_id, kind, title, summary, bundles, watching, change_flag, shipping_confidence) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)",
+            (report_id, user_id, kind, title, Jsonb(summary), Jsonb(bundles), Jsonb(watching), change_flag, shipping_confidence),
+        )
+    return report_id
+
+
+async def mark_read(pool: AsyncPostgreSQLPool, user_id: uuid.UUID, report_id: uuid.UUID) -> bool:
+    """Mark a report read; return True if a still-unread report was updated."""
+    async with pool.connection() as conn, conn.cursor() as cur:
+        await cur.execute(
+            "UPDATE digger.reports SET read_at = now() WHERE report_id = %s AND user_id = %s AND read_at IS NULL",
+            (report_id, user_id),
+        )
+        return cur.rowcount > 0

--- a/api/routers/digger_recommend.py
+++ b/api/routers/digger_recommend.py
@@ -1,0 +1,152 @@
+"""POST /api/digger/recommend — SSE-streamed interactive recommendation.
+
+Flow:
+1. Confirm the caller has digger enabled.
+2. Identify stale releases (last scrape older than the per-tier half-life).
+3. Bump their scrape priority and subscribe to refresh-progress over Redis.
+4. Stream refresh events as SSE until the deadline or all stale complete.
+5. Build the OptimizerInput, run the optimizer, stream the result.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import json
+import logging
+from typing import TYPE_CHECKING, Annotated, Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from psycopg.rows import dict_row
+from pydantic import BaseModel
+from sse_starlette.sse import EventSourceResponse
+
+from api.dependencies import require_user
+from api.digger_refresh.coordinator import RefreshCoordinator
+from api.digger_refresh.input_builder import build_optimizer_input
+from api.queries import digger_queries as q
+from common.digger_optimizer import pareto_bundles
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import AsyncIterator
+
+    import redis.asyncio as aioredis
+
+    from common import AsyncPostgreSQLPool
+
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/digger", tags=["digger"])
+
+_pool: AsyncPostgreSQLPool | None = None
+_redis: aioredis.Redis | None = None
+
+
+def configure(pool: AsyncPostgreSQLPool, redis: aioredis.Redis) -> None:
+    """Inject the Postgres pool and Redis client at application startup."""
+    global _pool, _redis
+    _pool = pool
+    _redis = redis
+
+
+def _get_pool() -> AsyncPostgreSQLPool:
+    if _pool is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service not ready")
+    return _pool
+
+
+def _get_redis() -> aioredis.Redis:
+    if _redis is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service not ready")
+    return _redis
+
+
+class RecommendIn(BaseModel):
+    deadline_seconds: int = 30
+    budget_cap_cents: int | None = None
+    excluded_sellers: list[int] = []
+
+
+_STALE_TIER_HALF_LIFE: dict[str, timedelta] = {
+    "must": timedelta(days=3, hours=12),
+    "nice": timedelta(days=7),
+    "eventually": timedelta(days=14),
+}
+
+
+async def _refresh_progress_events(
+    coord: RefreshCoordinator, user_id: UUID, stale: list[int], *, deadline_seconds: int
+) -> AsyncIterator[dict[str, str]]:
+    """Bump stale releases, then stream refresh-progress SSE events until done or deadline."""
+    if not stale:
+        return
+    await coord.bump_priorities(stale)
+    stale_set = set(stale)
+    completed: set[int] = set()
+    async for ev in coord.subscribe_progress(str(user_id), deadline_seconds=deadline_seconds):
+        release_id = ev.get("release_id")
+        if release_id is not None:
+            completed.add(release_id)
+        yield {
+            "event": "refresh_progress",
+            "data": json.dumps({"release_id": release_id, "status": ev.get("status"), "remaining": max(0, len(stale) - len(completed))}),
+        }
+        if completed >= stale_set:
+            break
+
+
+async def _identify_stale(pool: AsyncPostgreSQLPool, user_id: UUID) -> list[int]:
+    """Return release_ids whose last scrape is older than the user's per-tier half-life."""
+    async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            "SELECT uwp.release_id, uwp.tier, rs.last_scraped_at "
+            "FROM digger.user_wantlist_priorities uwp "
+            "LEFT JOIN digger.release_scrape_state rs ON rs.release_id = uwp.release_id "
+            "WHERE uwp.user_id = %s",
+            (user_id,),
+        )
+        rows = await cur.fetchall()
+    now = datetime.now(UTC)
+    stale: list[int] = []
+    for r in rows:
+        floor = _STALE_TIER_HALF_LIFE.get(r["tier"], timedelta(days=7))
+        if r["last_scraped_at"] is None or now - r["last_scraped_at"] > floor:
+            stale.append(r["release_id"])
+    return stale
+
+
+@router.post("/recommend")
+async def recommend(body: RecommendIn, current_user: Annotated[dict[str, Any], Depends(require_user)]) -> EventSourceResponse:
+    """Stream an interactive recommendation: opportunistic refresh, then optimizer bundles."""
+    pool = _get_pool()
+    redis = _get_redis()
+    user_id = UUID(current_user["sub"])
+    settings = await q.get_user_settings(pool, user_id)
+
+    async def event_gen() -> AsyncIterator[dict[str, str]]:
+        if settings is None or not settings.enabled:
+            yield {"event": "error", "data": json.dumps({"reason": "digger not enabled"})}
+            return
+
+        coord = RefreshCoordinator(pool=pool, redis=redis)
+        stale = await _identify_stale(pool, user_id)
+        yield {"event": "refresh_started", "data": json.dumps({"stale_count": len(stale)})}
+
+        async for evt in _refresh_progress_events(coord, user_id, stale, deadline_seconds=body.deadline_seconds):
+            yield evt
+
+        inp = await build_optimizer_input(
+            pool,
+            user_id,
+            location=settings.country_code or "US",
+            currency=settings.currency,
+            budget_cap_cents=body.budget_cap_cents,
+            excluded_sellers=frozenset(body.excluded_sellers),
+        )
+        out = pareto_bundles(inp)
+        yield {"event": "result", "data": out.model_dump_json()}
+        yield {"event": "done", "data": "{}"}
+
+    return EventSourceResponse(event_gen())

--- a/api/routers/digger_reports.py
+++ b/api/routers/digger_reports.py
@@ -1,0 +1,115 @@
+"""Digger Reports inbox endpoints: list, read, and persist recommendation reports.
+
+NOTE: `from __future__ import annotations` is intentionally NOT used here — the
+`report_id: UUID` path params must resolve at runtime for FastAPI, and the
+Pydantic request/response models need their field types available at runtime.
+The `_pool` annotation is quoted so the TYPE_CHECKING-only import stays valid.
+(Matches the api/routers/internal_digger.py pattern.)
+"""
+
+from typing import TYPE_CHECKING, Annotated, Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from api.dependencies import require_user
+from api.queries import digger_reports as q
+
+
+if TYPE_CHECKING:
+    from common import AsyncPostgreSQLPool
+
+
+router = APIRouter(prefix="/api/digger/reports", tags=["digger"])
+
+_pool: "AsyncPostgreSQLPool | None" = None
+
+
+def configure(pool: "AsyncPostgreSQLPool") -> None:
+    """Inject the Postgres pool at application startup."""
+    global _pool
+    _pool = pool
+
+
+def _get_pool() -> "AsyncPostgreSQLPool":
+    if _pool is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service not ready")
+    return _pool
+
+
+class ReportListItem(BaseModel):
+    report_id: str
+    kind: str
+    generated_at: str
+    read_at: str | None
+    title: str
+    summary: dict[str, Any]
+    change_flag: str
+
+
+class ReportListResponse(BaseModel):
+    items: list[ReportListItem]
+
+
+class ReportCreateIn(BaseModel):
+    title: str
+    kind: str  # "interactive" | "scheduled"
+    summary: dict[str, Any]
+    bundles: list[Any]
+    watching: list[int]
+    change_flag: str  # "significant" | "none" | "first_run"
+    shipping_confidence: str  # "high" | "low"
+
+
+class ReportCreatedOut(BaseModel):
+    report_id: str
+
+
+@router.get("", response_model=ReportListResponse)
+async def list_reports(current_user: Annotated[dict[str, Any], Depends(require_user)]) -> ReportListResponse:
+    """Return the caller's report inbox, newest first."""
+    pool = _get_pool()
+    user_id = UUID(current_user["sub"])
+    items = await q.list_reports(pool, user_id)
+    return ReportListResponse(items=[ReportListItem(**it) for it in items])
+
+
+@router.get("/{report_id}")
+async def get_report(report_id: UUID, current_user: Annotated[dict[str, Any], Depends(require_user)]) -> dict[str, Any]:
+    """Return one full report owned by the caller."""
+    pool = _get_pool()
+    user_id = UUID(current_user["sub"])
+    report = await q.get_report(pool, user_id, report_id)
+    if report is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="report not found")
+    return report
+
+
+@router.post("", status_code=status.HTTP_201_CREATED, response_model=ReportCreatedOut)
+async def create_report(body: ReportCreateIn, current_user: Annotated[dict[str, Any], Depends(require_user)]) -> ReportCreatedOut:
+    """Persist a report for the caller (used by the interactive recommend flow)."""
+    pool = _get_pool()
+    user_id = UUID(current_user["sub"])
+    report_id = await q.insert_report(
+        pool,
+        user_id,
+        kind=body.kind,
+        title=body.title,
+        summary=body.summary,
+        bundles=body.bundles,
+        watching=body.watching,
+        change_flag=body.change_flag,
+        shipping_confidence=body.shipping_confidence,
+    )
+    return ReportCreatedOut(report_id=str(report_id))
+
+
+@router.post("/{report_id}/read", status_code=status.HTTP_204_NO_CONTENT)
+async def mark_read(report_id: UUID, current_user: Annotated[dict[str, Any], Depends(require_user)]) -> None:
+    """Mark a report read; 404 if it does not exist or was already read."""
+    pool = _get_pool()
+    user_id = UUID(current_user["sub"])
+    ok = await q.mark_read(pool, user_id, report_id)
+    if not ok:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="report not found or already read")

--- a/api/routers/digger_reports.py
+++ b/api/routers/digger_reports.py
@@ -17,7 +17,7 @@ from api.dependencies import require_user
 from api.queries import digger_reports as q
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from common import AsyncPostgreSQLPool
 
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -177,6 +177,7 @@ def test_client(
     import api.routers.admin as _admin_router
     import api.routers.collection as _collection_router
     import api.routers.digger as _digger_router
+    import api.routers.digger_recommend as _digger_recommend_router
     import api.routers.digger_reports as _digger_reports_router
     import api.routers.explore as _explore_router
     import api.routers.internal_digger as _internal_digger_router
@@ -190,6 +191,7 @@ def test_client(
 
     fake_redis = aioredis_fake.FakeRedis(server=fake_redis_server)
     _digger_router.configure(mock_pool)
+    _digger_recommend_router.configure(mock_pool, fake_redis)
     _digger_reports_router.configure(mock_pool)
     _internal_digger_router.configure(mock_pool)
     _sync_router.configure(mock_pool, mock_neo4j, test_api_config, api_module._running_syncs, mock_redis)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -177,6 +177,7 @@ def test_client(
     import api.routers.admin as _admin_router
     import api.routers.collection as _collection_router
     import api.routers.digger as _digger_router
+    import api.routers.digger_reports as _digger_reports_router
     import api.routers.explore as _explore_router
     import api.routers.internal_digger as _internal_digger_router
     import api.routers.label_dna as _label_dna_router
@@ -189,6 +190,7 @@ def test_client(
 
     fake_redis = aioredis_fake.FakeRedis(server=fake_redis_server)
     _digger_router.configure(mock_pool)
+    _digger_reports_router.configure(mock_pool)
     _internal_digger_router.configure(mock_pool)
     _sync_router.configure(mock_pool, mock_neo4j, test_api_config, api_module._running_syncs, mock_redis)
     _explore_router.configure(mock_neo4j, test_api_config.jwt_secret_key, mock_redis)

--- a/tests/api/test_digger_input_builder.py
+++ b/tests/api/test_digger_input_builder.py
@@ -1,0 +1,67 @@
+"""Tests for the digger OptimizerInput builder (Postgres -> OptimizerInput)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+import uuid
+
+import pytest
+
+from api.digger_refresh.input_builder import build_optimizer_input
+from api.queries.digger_queries import WantlistPriorityRow
+from common.digger_optimizer.models import OptimizerInput
+
+
+@pytest.mark.asyncio
+async def test_build_optimizer_input_groups_tiers_and_attaches_listings(mock_pool: object, mock_cur: AsyncMock) -> None:
+    user_id = uuid.uuid4()
+    priorities = [
+        WantlistPriorityRow(release_id=1, tier="must", min_media_condition="VG", min_sleeve_condition="VG", max_price_cents=None),
+        WantlistPriorityRow(release_id=2, tier="nice", min_media_condition="VG", min_sleeve_condition="VG", max_price_cents=500),
+        WantlistPriorityRow(release_id=3, tier="eventually", min_media_condition="VG", min_sleeve_condition="VG", max_price_cents=None),
+    ]
+    listing_rows = [
+        {
+            "listing_id": 101,
+            "release_id": 1,
+            "seller_id": 11,
+            "price_value": Decimal("10.00"),
+            "price_currency": "USD",
+            "media_condition": "NM",
+            "sleeve_condition": "NM",
+        }
+    ]
+    seller_rows = [
+        {
+            "seller_id": 11,
+            "region": "us",
+            "country_code": "US",
+            "shipping_policy": {"us": {"first_cents": 500, "additional_cents": 100, "currency": "USD"}},
+            "feedback_score": Decimal("99.5"),
+        }
+    ]
+    mock_cur.fetchall = AsyncMock(side_effect=[listing_rows, seller_rows])
+
+    with patch("api.digger_refresh.input_builder.list_wantlist_priorities", AsyncMock(return_value=priorities)):
+        inp = await build_optimizer_input(mock_pool, user_id, location="US", currency="USD")
+
+    assert isinstance(inp, OptimizerInput)
+    assert [c.release_id for c in inp.must_have_releases] == [1]
+    assert [c.release_id for c in inp.nice_have_releases] == [2]
+    assert [c.release_id for c in inp.eventually_releases] == [3]
+    assert len(inp.candidate_listings) == 1
+    assert inp.candidate_listings[0].seller_id == 11
+    assert inp.sellers[11].region == "us"
+    assert inp.sellers[11].shipping_policy is not None
+    assert inp.sellers[11].shipping_policy["us"].first_cents == 500
+
+
+@pytest.mark.asyncio
+async def test_build_optimizer_input_empty_wantlist_returns_empty(mock_pool: object) -> None:
+    user_id = uuid.uuid4()
+    with patch("api.digger_refresh.input_builder.list_wantlist_priorities", AsyncMock(return_value=[])):
+        inp = await build_optimizer_input(mock_pool, user_id, location="US")
+    assert inp.must_have_releases == []
+    assert inp.candidate_listings == []
+    assert inp.sellers == {}

--- a/tests/api/test_digger_input_builder.py
+++ b/tests/api/test_digger_input_builder.py
@@ -65,3 +65,15 @@ async def test_build_optimizer_input_empty_wantlist_returns_empty(mock_pool: obj
     assert inp.must_have_releases == []
     assert inp.candidate_listings == []
     assert inp.sellers == {}
+
+
+@pytest.mark.asyncio
+async def test_build_optimizer_input_with_priorities_but_no_listings(mock_pool: object, mock_cur: AsyncMock) -> None:
+    user_id = uuid.uuid4()
+    priorities = [WantlistPriorityRow(release_id=1, tier="must", min_media_condition="VG", min_sleeve_condition="VG", max_price_cents=None)]
+    mock_cur.fetchall = AsyncMock(return_value=[])  # listings query returns nothing -> no sellers fetched
+    with patch("api.digger_refresh.input_builder.list_wantlist_priorities", AsyncMock(return_value=priorities)):
+        inp = await build_optimizer_input(mock_pool, user_id, location="US")
+    assert len(inp.must_have_releases) == 1
+    assert inp.candidate_listings == []
+    assert inp.sellers == {}

--- a/tests/api/test_digger_recommend.py
+++ b/tests/api/test_digger_recommend.py
@@ -1,0 +1,155 @@
+"""Tests for the /api/digger/recommend SSE endpoint."""
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+import json
+from unittest.mock import AsyncMock, patch
+import uuid
+
+import fakeredis.aioredis as aioredis_fake
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+import pytest
+
+from api.digger_refresh.coordinator import RefreshCoordinator
+from api.queries.digger_queries import UserDiggerSettings
+from common.digger_optimizer.models import Listing, OptimizerInput, ReleaseConstraint, Seller
+
+
+def _enabled_settings() -> UserDiggerSettings:
+    return UserDiggerSettings(
+        user_id=uuid.uuid4(),
+        enabled=True,
+        country_code="US",
+        currency="USD",
+        scheduled_cadence="off",
+        preferred_model="sonnet",
+        daily_token_cap_interactive=200_000,
+        daily_token_cap_scheduled=100_000,
+    )
+
+
+def _sample_input() -> OptimizerInput:
+    return OptimizerInput(
+        user_id=uuid.uuid4(),
+        location="US",
+        currency="USD",
+        must_have_releases=[ReleaseConstraint(release_id=1, min_media_condition="VG", min_sleeve_condition="VG")],
+        candidate_listings=[
+            Listing(
+                listing_id=101,
+                release_id=1,
+                seller_id=1,
+                price_value=Decimal("5"),
+                price_currency="USD",
+                media_condition="NM",
+                sleeve_condition="NM",
+            )
+        ],
+        sellers={1: Seller(seller_id=1, region="us", country_code="US")},
+    )
+
+
+def test_recommend_requires_auth(test_client: TestClient) -> None:
+    r = test_client.post("/api/digger/recommend", json={"deadline_seconds": 5})
+    assert r.status_code == 401
+
+
+def test_recommend_streams_result_when_no_stale(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    with (
+        patch("api.routers.digger_recommend.q.get_user_settings", AsyncMock(return_value=_enabled_settings())),
+        patch("api.routers.digger_recommend._identify_stale", AsyncMock(return_value=[])),
+        patch("api.routers.digger_recommend.build_optimizer_input", AsyncMock(return_value=_sample_input())),
+    ):
+        r = test_client.post("/api/digger/recommend", headers=auth_headers, json={"deadline_seconds": 5})
+    assert r.status_code == 200
+    assert "event: refresh_started" in r.text
+    assert "event: result" in r.text
+    assert "event: done" in r.text
+
+
+def test_recommend_emits_error_when_not_enabled(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    with patch("api.routers.digger_recommend.q.get_user_settings", AsyncMock(return_value=None)):
+        r = test_client.post("/api/digger/recommend", headers=auth_headers, json={"deadline_seconds": 5})
+    assert r.status_code == 200
+    assert "event: error" in r.text
+    assert "digger not enabled" in r.text
+
+
+def test_recommend_streams_refresh_progress_when_stale(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    async def fake_events(*_args: object, **_kwargs: object):
+        yield {"event": "refresh_progress", "data": json.dumps({"release_id": 1})}
+
+    with (
+        patch("api.routers.digger_recommend.q.get_user_settings", AsyncMock(return_value=_enabled_settings())),
+        patch("api.routers.digger_recommend._identify_stale", AsyncMock(return_value=[1])),
+        patch("api.routers.digger_recommend._refresh_progress_events", fake_events),
+        patch("api.routers.digger_recommend.build_optimizer_input", AsyncMock(return_value=_sample_input())),
+    ):
+        r = test_client.post("/api/digger/recommend", headers=auth_headers, json={"deadline_seconds": 5})
+    assert r.status_code == 200
+    assert "event: refresh_progress" in r.text
+    assert "event: result" in r.text
+
+
+@pytest.mark.asyncio
+async def test_identify_stale_flags_old_and_unscraped(mock_pool: object, mock_cur: AsyncMock) -> None:
+    from api.routers.digger_recommend import _identify_stale
+
+    now = datetime.now(UTC)
+    mock_cur.fetchall = AsyncMock(
+        return_value=[
+            {"release_id": 1, "tier": "must", "last_scraped_at": None},  # never scraped -> stale
+            {"release_id": 2, "tier": "must", "last_scraped_at": now - timedelta(days=10)},  # old -> stale
+            {"release_id": 3, "tier": "eventually", "last_scraped_at": now - timedelta(days=1)},  # fresh -> not stale
+        ]
+    )
+    stale = await _identify_stale(mock_pool, uuid.uuid4())
+    assert set(stale) == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_refresh_progress_events_empty_when_no_stale() -> None:
+    from api.routers.digger_recommend import _refresh_progress_events
+
+    coord = RefreshCoordinator(pool=None, redis=AsyncMock())
+    out = [e async for e in _refresh_progress_events(coord, uuid.uuid4(), [], deadline_seconds=1)]
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_progress_events_streams_then_stops(mock_pool: object, mock_cur: AsyncMock) -> None:
+    from api.routers.digger_recommend import _refresh_progress_events
+
+    mock_cur.rowcount = 1
+    redis = aioredis_fake.FakeRedis(decode_responses=True)
+    coord = RefreshCoordinator(pool=mock_pool, redis=redis)
+    uid = uuid.uuid4()
+    out: list[dict[str, str]] = []
+
+    async def run() -> None:
+        async for evt in _refresh_progress_events(coord, uid, [1], deadline_seconds=2):
+            out.append(evt)
+
+    task = asyncio.create_task(run())
+    await asyncio.sleep(0.2)
+    await redis.publish(f"digger:refresh:{uid}", json.dumps({"release_id": 1, "status": "ok"}))
+    await asyncio.wait_for(task, timeout=3)
+    assert out and out[0]["event"] == "refresh_progress"
+    await redis.aclose()
+
+
+def test_get_pool_and_redis_raise_when_unconfigured() -> None:
+    import api.routers.digger_recommend as mod
+
+    saved_pool, saved_redis = mod._pool, mod._redis
+    mod._pool = None
+    mod._redis = None
+    try:
+        with pytest.raises(HTTPException):
+            mod._get_pool()
+        with pytest.raises(HTTPException):
+            mod._get_redis()
+    finally:
+        mod._pool, mod._redis = saved_pool, saved_redis

--- a/tests/api/test_digger_refresh_coordinator.py
+++ b/tests/api/test_digger_refresh_coordinator.py
@@ -48,3 +48,42 @@ async def test_subscribe_progress_yields_published_events() -> None:
 
     assert any(e["release_id"] == 1 for e in events)
     await redis.aclose()
+
+
+@pytest.mark.asyncio
+async def test_bump_priorities_requires_pool() -> None:
+    coord = RefreshCoordinator(pool=None, redis=AsyncMock())
+    with pytest.raises(RuntimeError):
+        await coord.bump_priorities([1])
+
+
+@pytest.mark.asyncio
+async def test_subscribe_progress_returns_after_deadline() -> None:
+    redis = aioredis_fake.FakeRedis(decode_responses=True)
+    coord = RefreshCoordinator(pool=None, redis=redis)
+    events = [ev async for ev in coord.subscribe_progress("deadline-user", deadline_seconds=0.3)]
+    assert events == []
+    await redis.aclose()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_progress_skips_invalid_json() -> None:
+    redis = aioredis_fake.FakeRedis(decode_responses=True)
+    coord = RefreshCoordinator(pool=None, redis=redis)
+    user_id = "00000000-0000-0000-0000-000000000002"
+    events: list[dict[str, object]] = []
+
+    async def consume() -> None:
+        async for ev in coord.subscribe_progress(user_id, deadline_seconds=2):
+            events.append(ev)
+            break
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.2)
+    await redis.publish(f"digger:refresh:{user_id}", "not valid json {")  # skipped
+    await asyncio.sleep(0.1)
+    await redis.publish(f"digger:refresh:{user_id}", json.dumps({"release_id": 7}))  # yielded
+    await asyncio.wait_for(task, timeout=3)
+
+    assert events[0]["release_id"] == 7
+    await redis.aclose()

--- a/tests/api/test_digger_refresh_coordinator.py
+++ b/tests/api/test_digger_refresh_coordinator.py
@@ -1,0 +1,50 @@
+"""Tests for the digger opportunistic-refresh coordinator."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock
+
+import fakeredis.aioredis as aioredis_fake
+import pytest
+
+from api.digger_refresh.coordinator import RefreshCoordinator
+
+
+@pytest.mark.asyncio
+async def test_bump_priorities_updates_due_time(mock_pool: object, mock_cur: AsyncMock) -> None:
+    mock_cur.rowcount = 2
+    coord = RefreshCoordinator(pool=mock_pool, redis=AsyncMock())
+    updated = await coord.bump_priorities([1, 2])
+    assert updated == 2
+    sql = mock_cur.execute.await_args.args[0]
+    assert "next_scrape_due_at = now()" in sql
+    assert mock_cur.execute.await_args.args[1] == ([1, 2],)
+
+
+@pytest.mark.asyncio
+async def test_bump_priorities_noop_for_empty(mock_pool: object) -> None:
+    coord = RefreshCoordinator(pool=mock_pool, redis=AsyncMock())
+    assert await coord.bump_priorities([]) == 0
+
+
+@pytest.mark.asyncio
+async def test_subscribe_progress_yields_published_events() -> None:
+    redis = aioredis_fake.FakeRedis(decode_responses=True)
+    coord = RefreshCoordinator(pool=None, redis=redis)
+    user_id = "00000000-0000-0000-0000-000000000001"
+    events: list[dict[str, object]] = []
+
+    async def consume() -> None:
+        async for ev in coord.subscribe_progress(user_id, deadline_seconds=2):
+            events.append(ev)
+            break
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.2)  # let the subscriber attach before publishing
+    await redis.publish(f"digger:refresh:{user_id}", json.dumps({"release_id": 1, "status": "ok", "eta_seconds_remaining": 0}))
+    await asyncio.wait_for(task, timeout=3)
+
+    assert any(e["release_id"] == 1 for e in events)
+    await redis.aclose()

--- a/tests/api/test_digger_reports_queries.py
+++ b/tests/api/test_digger_reports_queries.py
@@ -1,0 +1,93 @@
+"""Tests for digger.reports SQL helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+import uuid
+
+import pytest
+
+from api.queries import digger_reports as q
+
+
+@pytest.mark.asyncio
+async def test_list_reports_formats_rows(mock_pool: object, mock_cur: AsyncMock) -> None:
+    rid = uuid.uuid4()
+    gen = datetime(2026, 5, 21, tzinfo=UTC)
+    mock_cur.fetchall = AsyncMock(
+        return_value=[
+            {
+                "report_id": rid,
+                "kind": "scheduled",
+                "generated_at": gen,
+                "read_at": None,
+                "title": "Weekly",
+                "summary": {"wantlist_size": 5},
+                "change_flag": "significant",
+            }
+        ]
+    )
+    out = await q.list_reports(mock_pool, uuid.uuid4())
+    assert out[0]["report_id"] == str(rid)
+    assert out[0]["generated_at"] == gen.isoformat()
+    assert out[0]["read_at"] is None
+    assert out[0]["summary"] == {"wantlist_size": 5}
+
+
+@pytest.mark.asyncio
+async def test_get_report_returns_none_when_missing(mock_pool: object, mock_cur: AsyncMock) -> None:
+    mock_cur.fetchone = AsyncMock(return_value=None)
+    assert await q.get_report(mock_pool, uuid.uuid4(), uuid.uuid4()) is None
+
+
+@pytest.mark.asyncio
+async def test_get_report_formats_row(mock_pool: object, mock_cur: AsyncMock) -> None:
+    rid = uuid.uuid4()
+    uid = uuid.uuid4()
+    gen = datetime(2026, 5, 21, tzinfo=UTC)
+    mock_cur.fetchone = AsyncMock(
+        return_value={
+            "report_id": rid,
+            "user_id": uid,
+            "kind": "interactive",
+            "generated_at": gen,
+            "read_at": None,
+            "title": "T",
+            "summary": {},
+            "bundles": [],
+            "watching": [],
+            "change_flag": "first_run",
+            "shipping_confidence": "high",
+        }
+    )
+    out = await q.get_report(mock_pool, uid, rid)
+    assert out is not None
+    assert out["report_id"] == str(rid)
+    assert out["user_id"] == str(uid)
+    assert out["generated_at"] == gen.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_insert_report_returns_uuid(mock_pool: object, mock_cur: AsyncMock) -> None:
+    rid = await q.insert_report(
+        mock_pool,
+        uuid.uuid4(),
+        kind="interactive",
+        title="T",
+        summary={"x": 1},
+        bundles=[],
+        watching=[],
+        change_flag="first_run",
+        shipping_confidence="high",
+    )
+    assert isinstance(rid, uuid.UUID)
+    assert mock_cur.execute.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_mark_read_reflects_rowcount(mock_pool: object, mock_cur: AsyncMock) -> None:
+    mock_cur.rowcount = 1
+    assert await q.mark_read(mock_pool, uuid.uuid4(), uuid.uuid4()) is True
+    mock_cur.rowcount = 0
+    assert await q.mark_read(mock_pool, uuid.uuid4(), uuid.uuid4()) is False

--- a/tests/api/test_digger_reports_router.py
+++ b/tests/api/test_digger_reports_router.py
@@ -1,0 +1,74 @@
+"""Tests for the digger reports CRUD router."""
+
+from unittest.mock import AsyncMock, patch
+import uuid
+
+from fastapi.testclient import TestClient
+
+
+def test_list_reports_empty(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    with patch("api.routers.digger_reports.q.list_reports", AsyncMock(return_value=[])):
+        r = test_client.get("/api/digger/reports", headers=auth_headers)
+    assert r.status_code == 200
+    assert r.json()["items"] == []
+
+
+def test_create_report_returns_201_with_id(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    rid = uuid.uuid4()
+    payload = {
+        "title": "Test bundle",
+        "kind": "interactive",
+        "summary": {"wantlist_size": 5},
+        "bundles": [],
+        "watching": [],
+        "change_flag": "first_run",
+        "shipping_confidence": "high",
+    }
+    with patch("api.routers.digger_reports.q.insert_report", AsyncMock(return_value=rid)):
+        r = test_client.post("/api/digger/reports", headers=auth_headers, json=payload)
+    assert r.status_code == 201
+    assert r.json()["report_id"] == str(rid)
+
+
+def test_get_report_404_when_missing(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    with patch("api.routers.digger_reports.q.get_report", AsyncMock(return_value=None)):
+        r = test_client.get(f"/api/digger/reports/{uuid.uuid4()}", headers=auth_headers)
+    assert r.status_code == 404
+
+
+def test_get_report_returns_report(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    rid = uuid.uuid4()
+    report = {
+        "report_id": str(rid),
+        "user_id": str(uuid.uuid4()),
+        "kind": "interactive",
+        "generated_at": "2026-05-21T00:00:00+00:00",
+        "read_at": None,
+        "title": "My report",
+        "summary": {},
+        "bundles": [],
+        "watching": [],
+        "change_flag": "first_run",
+        "shipping_confidence": "high",
+    }
+    with patch("api.routers.digger_reports.q.get_report", AsyncMock(return_value=report)):
+        r = test_client.get(f"/api/digger/reports/{rid}", headers=auth_headers)
+    assert r.status_code == 200
+    assert r.json()["title"] == "My report"
+
+
+def test_mark_read_204(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    with patch("api.routers.digger_reports.q.mark_read", AsyncMock(return_value=True)):
+        r = test_client.post(f"/api/digger/reports/{uuid.uuid4()}/read", headers=auth_headers)
+    assert r.status_code == 204
+
+
+def test_mark_read_404_when_missing(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    with patch("api.routers.digger_reports.q.mark_read", AsyncMock(return_value=False)):
+        r = test_client.post(f"/api/digger/reports/{uuid.uuid4()}/read", headers=auth_headers)
+    assert r.status_code == 404
+
+
+def test_reports_require_auth(test_client: TestClient) -> None:
+    r = test_client.get("/api/digger/reports")
+    assert r.status_code == 401

--- a/tests/api/test_digger_reports_router.py
+++ b/tests/api/test_digger_reports_router.py
@@ -3,7 +3,9 @@
 from unittest.mock import AsyncMock, patch
 import uuid
 
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
+import pytest
 
 
 def test_list_reports_empty(test_client: TestClient, auth_headers: dict[str, str]) -> None:
@@ -72,3 +74,15 @@ def test_mark_read_404_when_missing(test_client: TestClient, auth_headers: dict[
 def test_reports_require_auth(test_client: TestClient) -> None:
     r = test_client.get("/api/digger/reports")
     assert r.status_code == 401
+
+
+def test_get_pool_raises_when_unconfigured() -> None:
+    import api.routers.digger_reports as mod
+
+    saved = mod._pool
+    mod._pool = None
+    try:
+        with pytest.raises(HTTPException):
+            mod._get_pool()
+    finally:
+        mod._pool = saved

--- a/tests/perftest/config.yaml
+++ b/tests/perftest/config.yaml
@@ -109,3 +109,9 @@ digger_scenarios:
       tier: nice
     auth: true
     target_p95_ms: 300
+
+  - name: digger_reports_list
+    method: GET
+    path: /api/digger/reports
+    auth: true
+    target_p95_ms: 200


### PR DESCRIPTION
## Summary

Second layer of **Digger M2**, building on the optimizer library (#344). Wires the optimizer into the API service:

- **`api/digger_refresh/input_builder.py`** — `build_optimizer_input()` assembles an `OptimizerInput` from a user's wantlist priorities + scraped `digger.listings`/`digger.sellers` (psycopg3, reuses `list_wantlist_priorities`).
- **`api/digger_refresh/coordinator.py`** — `RefreshCoordinator`: bumps `release_scrape_state.next_scrape_due_at = now()` for stale releases and streams worker progress from `digger:refresh:{user_id}` (Redis pub/sub) with a deadline.
- **`api/routers/digger_recommend.py`** — `POST /api/digger/recommend`: SSE stream that confirms digger is enabled, identifies stale releases (per-tier half-life), opportunistically refreshes, then runs `pareto_bundles` and streams the result (`refresh_started` → `refresh_progress*` → `result` → `done`, or `error`).
- **`api/routers/digger_reports.py`** + **`api/queries/digger_reports.py`** — Reports inbox CRUD: `GET /api/digger/reports`, `GET /{id}`, `POST` (201), `POST /{id}/read` (204). JSONB via the psycopg `Jsonb` adapter.

Both routers registered in `api/api.py` + `tests/api/conftest.py`. Perf scenario added for the reports list endpoint (`tests/perftest/config.yaml`).

## Conventions (per the plan's VERIFIED note)

psycopg3 throughout (`pool.connection()` → `cursor(row_factory=dict_row)` → `%s` params); routers use `require_user` → `current_user["sub"]` + module-level `configure()`; the reports router mirrors `internal_digger.py`'s no-future-annotations + runtime-`UUID` path-param pattern. Tests are mock-based (`AsyncMock` pool/conn/cursor + `fakeredis` for pub/sub) — no real DB.

## Test Plan

- [x] ~30 new tests; `tests/api` (1605) and `tests/common` (501) all pass — no regressions
- [x] **100% coverage** on all five new Layer B modules
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run mypy api/` — clean (73 files)
- [x] SSE endpoint verified through `TestClient` (happy path, not-enabled error, stale-refresh path)

## Deferred to Layer E (perf/docs/e2e/polish)

The `/api/digger/recommend` perf scenario needs a seeded enabled-settings user + listings (the perf harness's seed step), so meaningful recommend perf testing is grouped with the Layer E perf work. The reports list perf scenario is included here.

## Follow-up layers

- **C** — digger scheduler + worker publish (Tasks 10, 13-14)
- **D** — explore frontend (vanilla JS, Tasks 15-18)
- **E** — perf/docs/e2e/polish (Tasks 19-22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)