### PR TITLE
feat(digger): M2 Layer D — explore Reports UI (inbox, viewer, run recommendation)

### DIFF
--- a/explore/__tests__/api-client.test.js
+++ b/explore/__tests__/api-client.test.js
@@ -1640,4 +1640,141 @@ describe('ApiClient', () => {
             expect(result.body).toBeNull();
         });
     });
+
+    describe('getDiggerReports', () => {
+        it('should GET /api/digger/reports with Authorization header', async () => {
+            let capturedUrl, capturedOptions;
+            vi.stubGlobal('fetch', async (url, options) => {
+                capturedUrl = url;
+                capturedOptions = options;
+                return { ok: true, status: 200, json: async () => ({ items: [] }) };
+            });
+
+            await window.apiClient.getDiggerReports('my-token');
+            expect(capturedUrl).toBe('/api/digger/reports');
+            expect(capturedOptions.headers['Authorization']).toBe('Bearer my-token');
+        });
+
+        it('should return { ok:true, status:200, body } with items array on success', async () => {
+            const data = {
+                items: [
+                    {
+                        report_id: 'r1',
+                        kind: 'scheduled',
+                        generated_at: '2026-05-15T00:00:00Z',
+                        read_at: null,
+                        title: 'Weekly dig',
+                        summary: { wantlist_size: 5 },
+                        change_flag: 'significant',
+                    },
+                ],
+            };
+            vi.stubGlobal('fetch', async () => ({ ok: true, status: 200, json: async () => data }));
+
+            const result = await window.apiClient.getDiggerReports('token');
+            expect(result.ok).toBe(true);
+            expect(result.status).toBe(200);
+            expect(result.body).toEqual(data);
+        });
+
+        it('should return { ok:false, status:401, body } on unauthorized', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: false, status: 401, json: async () => ({ detail: 'Unauthorized' }) }));
+
+            const result = await window.apiClient.getDiggerReports('bad-token');
+            expect(result.ok).toBe(false);
+            expect(result.status).toBe(401);
+            expect(result.body).toEqual({ detail: 'Unauthorized' });
+        });
+
+        it('should return body:null when json() throws', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: false, status: 503, json: async () => { throw new Error('no body'); } }));
+
+            const result = await window.apiClient.getDiggerReports('token');
+            expect(result.body).toBeNull();
+        });
+    });
+
+    describe('getDiggerReport', () => {
+        it('should GET /api/digger/reports/{id} with Authorization header', async () => {
+            let capturedUrl, capturedOptions;
+            vi.stubGlobal('fetch', async (url, options) => {
+                capturedUrl = url;
+                capturedOptions = options;
+                return { ok: true, status: 200, json: async () => ({ report_id: 'abc' }) };
+            });
+
+            await window.apiClient.getDiggerReport('my-token', 'abc');
+            expect(capturedUrl).toBe('/api/digger/reports/abc');
+            expect(capturedOptions.headers['Authorization']).toBe('Bearer my-token');
+        });
+
+        it('should URL-encode the report id', async () => {
+            let capturedUrl;
+            vi.stubGlobal('fetch', async (url) => {
+                capturedUrl = url;
+                return { ok: true, status: 200, json: async () => ({}) };
+            });
+
+            await window.apiClient.getDiggerReport('token', 'a/b c');
+            expect(capturedUrl).toBe('/api/digger/reports/a%2Fb%20c');
+        });
+
+        it('should return { ok:true, status:200, body } with the full report on success', async () => {
+            const report = {
+                report_id: 'abc',
+                title: 'Test report',
+                summary: { wantlist_size: 5 },
+                bundles: [{ name: 'cheapest' }],
+                watching: [42],
+                shipping_confidence: 'high',
+                generated_at: '2026-05-15T00:00:00Z',
+            };
+            vi.stubGlobal('fetch', async () => ({ ok: true, status: 200, json: async () => report }));
+
+            const result = await window.apiClient.getDiggerReport('token', 'abc');
+            expect(result.ok).toBe(true);
+            expect(result.body).toEqual(report);
+        });
+
+        it('should return { ok:false, status:404, body } when the report is missing', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: false, status: 404, json: async () => ({ detail: 'report not found' }) }));
+
+            const result = await window.apiClient.getDiggerReport('token', 'nope');
+            expect(result.ok).toBe(false);
+            expect(result.status).toBe(404);
+        });
+    });
+
+    describe('markDiggerReportRead', () => {
+        it('should POST /api/digger/reports/{id}/read with Authorization header', async () => {
+            let capturedUrl, capturedOptions;
+            vi.stubGlobal('fetch', async (url, options) => {
+                capturedUrl = url;
+                capturedOptions = options;
+                return { ok: true, status: 204, json: async () => { throw new Error('no body'); } };
+            });
+
+            await window.apiClient.markDiggerReportRead('my-token', 'abc');
+            expect(capturedUrl).toBe('/api/digger/reports/abc/read');
+            expect(capturedOptions.method).toBe('POST');
+            expect(capturedOptions.headers['Authorization']).toBe('Bearer my-token');
+        });
+
+        it('should return { ok:true, status:204, body:null } on 204 No Content', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: true, status: 204, json: async () => { throw new Error('no body'); } }));
+
+            const result = await window.apiClient.markDiggerReportRead('token', 'abc');
+            expect(result.ok).toBe(true);
+            expect(result.status).toBe(204);
+            expect(result.body).toBeNull();
+        });
+
+        it('should return { ok:false, status:404 } when already read or missing', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: false, status: 404, json: async () => ({ detail: 'already read' }) }));
+
+            const result = await window.apiClient.markDiggerReportRead('token', 'abc');
+            expect(result.ok).toBe(false);
+            expect(result.status).toBe(404);
+        });
+    });
 });

--- a/explore/__tests__/api-client.test.js
+++ b/explore/__tests__/api-client.test.js
@@ -1777,4 +1777,155 @@ describe('ApiClient', () => {
             expect(result.status).toBe(404);
         });
     });
+
+    describe('runDiggerRecommend SSE streaming', () => {
+        function makeReadableStream(chunks) {
+            let index = 0;
+            return {
+                getReader() {
+                    return {
+                        read() {
+                            if (index < chunks.length) {
+                                const chunk = chunks[index++];
+                                return Promise.resolve({ done: false, value: new TextEncoder().encode(chunk) });
+                            }
+                            return Promise.resolve({ done: true, value: undefined });
+                        },
+                    };
+                },
+            };
+        }
+
+        it('should POST /api/digger/recommend with auth + event-stream headers', async () => {
+            let capturedUrl, capturedOptions;
+            vi.stubGlobal('fetch', async (url, options) => {
+                capturedUrl = url;
+                capturedOptions = options;
+                return { ok: true, body: makeReadableStream([]) };
+            });
+
+            window.apiClient.runDiggerRecommend('my-token', {}, {});
+            await new Promise((r) => setTimeout(r, 30));
+
+            expect(capturedUrl).toBe('/api/digger/recommend');
+            expect(capturedOptions.method).toBe('POST');
+            expect(capturedOptions.headers['Authorization']).toBe('Bearer my-token');
+            expect(capturedOptions.headers['Accept']).toBe('text/event-stream');
+            expect(capturedOptions.headers['Content-Type']).toBe('application/json');
+        });
+
+        it('should serialize deadline, budget, and excluded sellers in the body', async () => {
+            let capturedOptions;
+            vi.stubGlobal('fetch', async (_url, options) => {
+                capturedOptions = options;
+                return { ok: true, body: makeReadableStream([]) };
+            });
+
+            window.apiClient.runDiggerRecommend('token', { deadline_seconds: 15, budget_cap_cents: 5000, excluded_sellers: [7] }, {});
+            await new Promise((r) => setTimeout(r, 30));
+
+            expect(JSON.parse(capturedOptions.body)).toEqual({ deadline_seconds: 15, budget_cap_cents: 5000, excluded_sellers: [7] });
+        });
+
+        it('should default deadline and excluded sellers when omitted', async () => {
+            let capturedOptions;
+            vi.stubGlobal('fetch', async (_url, options) => {
+                capturedOptions = options;
+                return { ok: true, body: makeReadableStream([]) };
+            });
+
+            window.apiClient.runDiggerRecommend('token', {}, {});
+            await new Promise((r) => setTimeout(r, 30));
+
+            const parsed = JSON.parse(capturedOptions.body);
+            expect(parsed.deadline_seconds).toBe(30);
+            expect(parsed.excluded_sellers).toEqual([]);
+        });
+
+        it('should invoke onRefreshStarted with the parsed event data', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: true, body: makeReadableStream(['event: refresh_started\ndata: {"stale_count":3}\n\n']) }));
+
+            const onRefreshStarted = vi.fn();
+            window.apiClient.runDiggerRecommend('token', {}, { onRefreshStarted });
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(onRefreshStarted).toHaveBeenCalledWith({ stale_count: 3 });
+        });
+
+        it('should invoke onRefreshProgress with the parsed event data', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: true, body: makeReadableStream(['event: refresh_progress\ndata: {"remaining":2,"status":"done"}\n\n']) }));
+
+            const onRefreshProgress = vi.fn();
+            window.apiClient.runDiggerRecommend('token', {}, { onRefreshProgress });
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(onRefreshProgress).toHaveBeenCalledWith({ remaining: 2, status: 'done' });
+        });
+
+        it('should invoke onResult with the optimizer output', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: true, body: makeReadableStream(['event: result\ndata: {"bundles":[],"watching":[1]}\n\n']) }));
+
+            const onResult = vi.fn();
+            window.apiClient.runDiggerRecommend('token', {}, { onResult });
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(onResult).toHaveBeenCalledWith({ bundles: [], watching: [1] });
+        });
+
+        it('should invoke onDone on the done event', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: true, body: makeReadableStream(['event: done\ndata: {}\n\n']) }));
+
+            const onDone = vi.fn();
+            window.apiClient.runDiggerRecommend('token', {}, { onDone });
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(onDone).toHaveBeenCalled();
+        });
+
+        it('should invoke onError with the parsed error event payload', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: true, body: makeReadableStream(['event: error\ndata: {"reason":"digger not enabled"}\n\n']) }));
+
+            const onError = vi.fn();
+            window.apiClient.runDiggerRecommend('token', {}, { onError });
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(onError).toHaveBeenCalledWith({ reason: 'digger not enabled' });
+        });
+
+        it('should invoke onError with the status when the response is not ok', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: false, status: 503 }));
+
+            const onError = vi.fn();
+            window.apiClient.runDiggerRecommend('token', {}, { onError });
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(onError).toHaveBeenCalled();
+            expect(onError.mock.calls[0][0]).toMatchObject({ status: 503 });
+        });
+
+        it('should invoke onError when the reader rejects mid-stream', async () => {
+            let readCount = 0;
+            const stream = {
+                getReader() {
+                    return {
+                        read() {
+                            readCount++;
+                            if (readCount === 1) {
+                                return Promise.resolve({ done: false, value: new TextEncoder().encode('event: refresh_started\ndata: {"stale_count":1}\n\n') });
+                            }
+                            return Promise.reject(new Error('stream aborted'));
+                        },
+                    };
+                },
+            };
+            vi.stubGlobal('fetch', async () => ({ ok: true, body: stream }));
+
+            const onError = vi.fn();
+            window.apiClient.runDiggerRecommend('token', {}, { onError });
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(onError).toHaveBeenCalled();
+            expect(onError.mock.calls[0][0].message).toBe('stream aborted');
+        });
+    });
 });

--- a/explore/__tests__/digger-reports.test.js
+++ b/explore/__tests__/digger-reports.test.js
@@ -579,5 +579,33 @@ describe('DiggerPane reports — inbox, navigation & viewer', () => {
             await Promise.resolve();
             expect(window.apiClient.runDiggerRecommend).toHaveBeenCalledTimes(1);
         });
+
+        it('updates the progress count on refresh_progress events', async () => {
+            window.apiClient.runDiggerRecommend = vi.fn((token, opts, cbs) => {
+                cbs.onRefreshStarted({ stale_count: 4 });
+                cbs.onRefreshProgress({ remaining: 1 });
+            });
+            await window.diggerPane.init();
+            document.getElementById('diggerHeaderActions').querySelector('.digger-run-btn').click();
+            await Promise.resolve();
+            const body = document.getElementById('diggerBody');
+            expect(body.querySelector('.digger-recommend-progress')).not.toBeNull();
+            expect(body.textContent).toContain('3/4');
+        });
+
+        it('returns to the wantlist from a recommendation result', async () => {
+            window.apiClient.runDiggerRecommend = vi.fn((token, opts, cbs) => {
+                cbs.onResult({ bundles: [], watching: [] });
+                cbs.onDone({});
+            });
+            await window.diggerPane.init();
+            document.getElementById('diggerHeaderActions').querySelector('.digger-run-btn').click();
+            await Promise.resolve();
+            const back = document.getElementById('diggerBody').querySelector('.digger-back-btn');
+            expect(back).not.toBeNull();
+            back.click();
+            await Promise.resolve();
+            expect(window.apiClient.getDiggerWantlist).toHaveBeenCalled();
+        });
     });
 });

--- a/explore/__tests__/digger-reports.test.js
+++ b/explore/__tests__/digger-reports.test.js
@@ -206,3 +206,287 @@ describe('DiggerPane reports — render helpers', () => {
         });
     });
 });
+
+// ---------------------------------------------------------------------- //
+// Reports inbox, header navigation, and the report viewer
+// ---------------------------------------------------------------------- //
+
+const ENABLED_SETTINGS = {
+    ok: true,
+    status: 200,
+    body: {
+        enabled: true,
+        country_code: 'US',
+        currency: 'USD',
+        scheduled_cadence: 'weekly',
+        preferred_model: 'claude-opus',
+        daily_token_cap_interactive: 10000,
+        daily_token_cap_scheduled: 50000,
+    },
+};
+
+function makeInboxItem(overrides = {}) {
+    return {
+        report_id: 'r1',
+        kind: 'scheduled',
+        generated_at: '2026-05-15T00:00:00Z',
+        read_at: null,
+        title: 'Weekly dig',
+        summary: { wantlist_size: 5 },
+        change_flag: 'significant',
+        ...overrides,
+    };
+}
+
+function makeFullReport(overrides = {}) {
+    return {
+        report_id: 'r1',
+        user_id: 'u1',
+        kind: 'scheduled',
+        generated_at: '2026-05-15T00:00:00Z',
+        read_at: null,
+        title: 'Weekly dig',
+        summary: { wantlist_size: 5, currency: 'USD' },
+        bundles: [
+            { name: 'cheapest', seller_orders: [], total_item_cost_cents: 1000, total_shipping_cents: 500, grand_total_cents: 1500, coverage: { must: 1, nice: 0, eventually: 0 }, avg_condition_score: 7, solver: 'ilp', reasoning_hint: 'a' },
+            { name: 'most_coverage', seller_orders: [], total_item_cost_cents: 2000, total_shipping_cents: 500, grand_total_cents: 2500, coverage: { must: 1, nice: 1, eventually: 0 }, avg_condition_score: 7, solver: 'ilp', reasoning_hint: 'b' },
+            { name: 'best_quality', seller_orders: [], total_item_cost_cents: 3000, total_shipping_cents: 500, grand_total_cents: 3500, coverage: { must: 1, nice: 0, eventually: 0 }, avg_condition_score: 8, solver: 'ilp', reasoning_hint: 'c' },
+            { name: 'fewest_sellers', seller_orders: [], total_item_cost_cents: 1800, total_shipping_cents: 300, grand_total_cents: 2100, coverage: { must: 1, nice: 0, eventually: 0 }, avg_condition_score: 7, solver: 'greedy', reasoning_hint: 'd' },
+        ],
+        watching: [42, 99],
+        change_flag: 'significant',
+        shipping_confidence: 'high',
+        ...overrides,
+    };
+}
+
+describe('DiggerPane reports — inbox, navigation & viewer', () => {
+    function setupDOM() {
+        document.body.textContent = '';
+        for (const id of ['diggerPane', 'diggerLoading', 'diggerBody', 'diggerHeaderActions']) {
+            const el = document.createElement('div');
+            el.id = id;
+            document.body.appendChild(el);
+        }
+    }
+
+    beforeEach(() => {
+        setupDOM();
+        delete globalThis.window;
+        globalThis.window = globalThis;
+        window.authManager = {
+            getToken: vi.fn().mockReturnValue('test-token'),
+            isLoggedIn: vi.fn().mockReturnValue(true),
+        };
+        window.apiClient = {
+            getDiggerSettings: vi.fn().mockResolvedValue(ENABLED_SETTINGS),
+            getDiggerWantlist: vi.fn().mockResolvedValue({ ok: true, status: 200, body: { items: [] } }),
+            setDiggerPriority: vi.fn(),
+            getDiggerReports: vi.fn().mockResolvedValue({ ok: true, status: 200, body: { items: [makeInboxItem()] } }),
+            getDiggerReport: vi.fn().mockResolvedValue({ ok: true, status: 200, body: makeFullReport() }),
+            markDiggerReportRead: vi.fn().mockResolvedValue({ ok: true, status: 204, body: null }),
+        };
+        window.exploreApp = undefined;
+        loadScript('digger.js');
+    });
+
+    // ---------------------------------------------------------------- //
+    // Header navigation
+    // ---------------------------------------------------------------- //
+
+    describe('header navigation', () => {
+        it('renders Wantlist and Reports nav buttons when Digger is enabled', async () => {
+            await window.diggerPane.init();
+            const header = document.getElementById('diggerHeaderActions');
+            const navBtns = header.querySelectorAll('.digger-nav-btn');
+            const labels = Array.from(navBtns).map((b) => b.textContent);
+            expect(labels).toContain('Wantlist');
+            expect(labels).toContain('Reports');
+        });
+
+        it('marks the Wantlist nav button active by default', async () => {
+            await window.diggerPane.init();
+            const header = document.getElementById('diggerHeaderActions');
+            const wantlistBtn = header.querySelector('.digger-nav-btn[data-view="wantlist"]');
+            expect(wantlistBtn.classList.contains('active')).toBe(true);
+        });
+
+        it('does not render nav buttons on the onboarding (disabled) path', async () => {
+            window.apiClient.getDiggerSettings.mockResolvedValue({ ok: false, status: 404, body: null });
+            await window.diggerPane.init();
+            const header = document.getElementById('diggerHeaderActions');
+            expect(header.querySelectorAll('.digger-nav-btn')).toHaveLength(0);
+        });
+
+        it('switches to the reports view when the Reports nav button is clicked', async () => {
+            await window.diggerPane.init();
+            const header = document.getElementById('diggerHeaderActions');
+            const reportsBtn = header.querySelector('.digger-nav-btn[data-view="reports"]');
+            reportsBtn.click();
+            await Promise.resolve();
+            await Promise.resolve();
+            expect(window.apiClient.getDiggerReports).toHaveBeenCalledWith('test-token');
+            expect(reportsBtn.classList.contains('active')).toBe(true);
+        });
+
+        it('returns to the wantlist when the Wantlist nav button is clicked', async () => {
+            await window.diggerPane.init();
+            const header = document.getElementById('diggerHeaderActions');
+            header.querySelector('.digger-nav-btn[data-view="reports"]').click();
+            await Promise.resolve();
+            const wantlistBtn = header.querySelector('.digger-nav-btn[data-view="wantlist"]');
+            wantlistBtn.click();
+            await Promise.resolve();
+            expect(window.apiClient.getDiggerWantlist).toHaveBeenCalled();
+            expect(wantlistBtn.classList.contains('active')).toBe(true);
+        });
+    });
+
+    // ---------------------------------------------------------------- //
+    // Reports inbox
+    // ---------------------------------------------------------------- //
+
+    describe('reports inbox', () => {
+        it('does not fetch reports when there is no token', async () => {
+            window.authManager.getToken.mockReturnValue(null);
+            await window.diggerPane._showReports();
+            expect(window.apiClient.getDiggerReports).not.toHaveBeenCalled();
+        });
+
+        it('renders one list item per report', async () => {
+            window.apiClient.getDiggerReports.mockResolvedValue({
+                ok: true, status: 200,
+                body: { items: [makeInboxItem({ report_id: 'a' }), makeInboxItem({ report_id: 'b' })] },
+            });
+            await window.diggerPane._showReports();
+            const items = document.getElementById('diggerBody').querySelectorAll('.digger-report-item');
+            expect(items).toHaveLength(2);
+        });
+
+        it('marks unread reports unread and read reports read', async () => {
+            window.apiClient.getDiggerReports.mockResolvedValue({
+                ok: true, status: 200,
+                body: { items: [
+                    makeInboxItem({ report_id: 'a', read_at: null }),
+                    makeInboxItem({ report_id: 'b', read_at: '2026-05-16T00:00:00Z' }),
+                ] },
+            });
+            await window.diggerPane._showReports();
+            const body = document.getElementById('diggerBody');
+            const unread = body.querySelector('.digger-report-item[data-report-id="a"]');
+            const read = body.querySelector('.digger-report-item[data-report-id="b"]');
+            expect(unread.classList.contains('unread')).toBe(true);
+            expect(read.classList.contains('read')).toBe(true);
+        });
+
+        it('shows the title and change-flag label for a report', async () => {
+            await window.diggerPane._showReports();
+            const item = document.getElementById('diggerBody').querySelector('.digger-report-item');
+            expect(item.textContent).toContain('Weekly dig');
+            expect(item.textContent).toContain('significant');
+        });
+
+        it('renders an empty state when there are no reports', async () => {
+            window.apiClient.getDiggerReports.mockResolvedValue({ ok: true, status: 200, body: { items: [] } });
+            await window.diggerPane._showReports();
+            const body = document.getElementById('diggerBody');
+            expect(body.querySelector('.digger-report-item')).toBeNull();
+            expect(body.querySelector('.user-pane-empty')).not.toBeNull();
+        });
+
+        it('renders an error state when the reports load fails', async () => {
+            window.apiClient.getDiggerReports.mockResolvedValue({ ok: false, status: 500, body: null });
+            await window.diggerPane._showReports();
+            const body = document.getElementById('diggerBody');
+            expect(body.querySelector('.user-pane-empty')).not.toBeNull();
+            expect(body.textContent.toLowerCase()).toContain('could not');
+        });
+
+        it('opens the report when a list item is clicked', async () => {
+            await window.diggerPane._showReports();
+            const item = document.getElementById('diggerBody').querySelector('.digger-report-item button, .digger-report-item .digger-report-link');
+            item.click();
+            await Promise.resolve();
+            await Promise.resolve();
+            expect(window.apiClient.getDiggerReport).toHaveBeenCalledWith('test-token', 'r1');
+        });
+    });
+
+    // ---------------------------------------------------------------- //
+    // Report viewer
+    // ---------------------------------------------------------------- //
+
+    describe('report viewer', () => {
+        it('renders the report title', async () => {
+            await window.diggerPane._openReport('r1');
+            await Promise.resolve();
+            expect(document.getElementById('diggerBody').textContent).toContain('Weekly dig');
+        });
+
+        it('renders one bundle card per bundle', async () => {
+            await window.diggerPane._openReport('r1');
+            await Promise.resolve();
+            const cards = document.getElementById('diggerBody').querySelectorAll('.digger-bundle-card');
+            expect(cards).toHaveLength(4);
+        });
+
+        it('renders the watching list when releases are being watched', async () => {
+            await window.diggerPane._openReport('r1');
+            await Promise.resolve();
+            const body = document.getElementById('diggerBody');
+            const watching = body.querySelector('.digger-watching-list');
+            expect(watching).not.toBeNull();
+            expect(watching.textContent).toContain('42');
+        });
+
+        it('omits the watching list when nothing is watched', async () => {
+            window.apiClient.getDiggerReport.mockResolvedValue({ ok: true, status: 200, body: makeFullReport({ watching: [] }) });
+            await window.diggerPane._openReport('r1');
+            await Promise.resolve();
+            expect(document.getElementById('diggerBody').querySelector('.digger-watching-list')).toBeNull();
+        });
+
+        it('shows the shipping-confidence badge', async () => {
+            await window.diggerPane._openReport('r1');
+            await Promise.resolve();
+            const badge = document.getElementById('diggerBody').querySelector('.digger-confidence-high');
+            expect(badge).not.toBeNull();
+            expect(badge.textContent.toLowerCase()).toContain('shipping');
+        });
+
+        it('marks an unread report read on open', async () => {
+            await window.diggerPane._openReport('r1');
+            await Promise.resolve();
+            await Promise.resolve();
+            expect(window.apiClient.markDiggerReportRead).toHaveBeenCalledWith('test-token', 'r1');
+        });
+
+        it('does not mark an already-read report read again', async () => {
+            window.apiClient.getDiggerReport.mockResolvedValue({
+                ok: true, status: 200, body: makeFullReport({ read_at: '2026-05-16T00:00:00Z' }),
+            });
+            await window.diggerPane._openReport('r1');
+            await Promise.resolve();
+            await Promise.resolve();
+            expect(window.apiClient.markDiggerReportRead).not.toHaveBeenCalled();
+        });
+
+        it('renders an error state when the report fails to load', async () => {
+            window.apiClient.getDiggerReport.mockResolvedValue({ ok: false, status: 404, body: null });
+            await window.diggerPane._openReport('missing');
+            await Promise.resolve();
+            const body = document.getElementById('diggerBody');
+            expect(body.querySelector('.user-pane-empty')).not.toBeNull();
+        });
+
+        it('renders a back control that returns to the inbox', async () => {
+            await window.diggerPane._openReport('r1');
+            await Promise.resolve();
+            const back = document.getElementById('diggerBody').querySelector('.digger-back-btn');
+            expect(back).not.toBeNull();
+            back.click();
+            await Promise.resolve();
+            expect(window.apiClient.getDiggerReports).toHaveBeenCalled();
+        });
+    });
+});

--- a/explore/__tests__/digger-reports.test.js
+++ b/explore/__tests__/digger-reports.test.js
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { loadScript } from './helpers.js';
+
+/**
+ * Create the minimal DOM elements DiggerPane reads in its constructor.
+ */
+function setupDiggerDOM() {
+    document.body.textContent = '';
+    const ids = ['diggerPane', 'diggerLoading', 'diggerBody', 'diggerHeaderActions'];
+    for (const id of ids) {
+        const el = document.createElement('div');
+        el.id = id;
+        document.body.appendChild(el);
+    }
+}
+
+/**
+ * A representative optimizer Bundle (cents-denominated, shape per
+ * common/digger_optimizer/models.py).
+ */
+function makeBundle(overrides = {}) {
+    return {
+        name: 'cheapest',
+        seller_orders: [
+            {
+                seller_id: 1,
+                listings: [
+                    {
+                        listing_id: 11,
+                        release_id: 101,
+                        price_cents: 1000,
+                        currency: 'USD',
+                        media_condition: 'NM',
+                        sleeve_condition: 'NM',
+                    },
+                ],
+                subtotal_item_cents: 1000,
+                shipping_cents: 500,
+            },
+        ],
+        total_item_cost_cents: 1000,
+        total_shipping_cents: 500,
+        grand_total_cents: 1500,
+        coverage: { must: 1, nice: 0, eventually: 0 },
+        avg_condition_score: 7.0,
+        solver: 'ilp',
+        reasoning_hint: '1 must from 1 seller.',
+        ...overrides,
+    };
+}
+
+describe('DiggerPane reports — render helpers', () => {
+    beforeEach(() => {
+        setupDiggerDOM();
+        delete globalThis.window;
+        globalThis.window = globalThis;
+        window.authManager = {
+            getToken: vi.fn().mockReturnValue('test-token'),
+            isLoggedIn: vi.fn().mockReturnValue(true),
+        };
+        window.apiClient = {};
+        window.exploreApp = undefined;
+        loadScript('digger.js');
+    });
+
+    // ------------------------------------------------------------------ //
+    // _formatCents
+    // ------------------------------------------------------------------ //
+
+    describe('_formatCents', () => {
+        it('formats cents as a currency amount', () => {
+            const out = window.diggerPane._formatCents(1500, 'USD');
+            expect(out).toContain('15.00');
+            expect(out).toContain('$');
+        });
+
+        it('formats zero cents', () => {
+            const out = window.diggerPane._formatCents(0, 'USD');
+            expect(out).toContain('0.00');
+        });
+
+        it('defaults missing/invalid cents to zero', () => {
+            const out = window.diggerPane._formatCents(null, 'USD');
+            expect(out).toContain('0.00');
+        });
+
+        it('falls back gracefully on an invalid currency code', () => {
+            const out = window.diggerPane._formatCents(1500, 'not-a-currency');
+            expect(out).toContain('15.00');
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // _buildBundleCard
+    // ------------------------------------------------------------------ //
+
+    describe('_buildBundleCard', () => {
+        it('renders the human-readable bundle name label', () => {
+            const card = window.diggerPane._buildBundleCard(makeBundle(), 'USD');
+            expect(card.textContent).toContain('Cheapest');
+        });
+
+        it('renders the grand total formatted as currency', () => {
+            const card = window.diggerPane._buildBundleCard(makeBundle(), 'USD');
+            expect(card.textContent).toContain('$15.00');
+        });
+
+        it('renders the item + shipping breakdown', () => {
+            const card = window.diggerPane._buildBundleCard(makeBundle(), 'USD');
+            expect(card.textContent).toContain('$10.00');
+            expect(card.textContent).toContain('$5.00');
+            expect(card.textContent.toLowerCase()).toContain('shipping');
+        });
+
+        it('renders coverage counts', () => {
+            const card = window.diggerPane._buildBundleCard(makeBundle(), 'USD');
+            expect(card.textContent).toContain('1 must');
+            expect(card.textContent).toContain('0 nice');
+            expect(card.textContent).toContain('0 eventually');
+        });
+
+        it('renders a singular seller count', () => {
+            const card = window.diggerPane._buildBundleCard(makeBundle(), 'USD');
+            expect(card.textContent).toContain('1 seller');
+            expect(card.textContent).not.toContain('1 sellers');
+        });
+
+        it('renders a plural seller count for multiple sellers', () => {
+            const bundle = makeBundle({
+                seller_orders: [
+                    { seller_id: 1, listings: [], subtotal_item_cents: 1000, shipping_cents: 500 },
+                    { seller_id: 2, listings: [], subtotal_item_cents: 800, shipping_cents: 500 },
+                ],
+            });
+            const card = window.diggerPane._buildBundleCard(bundle, 'USD');
+            expect(card.textContent).toContain('2 sellers');
+        });
+
+        it('renders the reasoning hint', () => {
+            const card = window.diggerPane._buildBundleCard(makeBundle(), 'USD');
+            expect(card.textContent).toContain('1 must from 1 seller.');
+        });
+
+        it('tags the card element with a per-bundle class and data attribute', () => {
+            const card = window.diggerPane._buildBundleCard(makeBundle(), 'USD');
+            expect(card.classList.contains('digger-bundle-card')).toBe(true);
+            expect(card.classList.contains('digger-bundle-cheapest')).toBe(true);
+            expect(card.dataset.bundleName).toBe('cheapest');
+        });
+
+        it('does not show a greedy badge for ILP-solved bundles', () => {
+            const card = window.diggerPane._buildBundleCard(makeBundle({ solver: 'ilp' }), 'USD');
+            expect(card.querySelector('.digger-solver-greedy')).toBeNull();
+        });
+
+        it('shows a greedy badge for greedy-solved bundles', () => {
+            const card = window.diggerPane._buildBundleCard(makeBundle({ solver: 'greedy' }), 'USD');
+            const badge = card.querySelector('.digger-solver-greedy');
+            expect(badge).not.toBeNull();
+            expect(badge.textContent.toLowerCase()).toContain('greedy');
+        });
+
+        it('renders an expandable seller breakdown listing each order line', () => {
+            const card = window.diggerPane._buildBundleCard(makeBundle(), 'USD');
+            const details = card.querySelector('details.digger-bundle-details');
+            expect(details).not.toBeNull();
+            // The single order line references its release id and condition.
+            expect(details.textContent).toContain('101');
+            expect(details.textContent).toContain('NM');
+            // And its price.
+            expect(details.textContent).toContain('$10.00');
+        });
+
+        it('omits the seller breakdown when there are no seller orders', () => {
+            const bundle = makeBundle({ seller_orders: [] });
+            const card = window.diggerPane._buildBundleCard(bundle, 'USD');
+            expect(card.querySelector('details.digger-bundle-details')).toBeNull();
+        });
+    });
+
+    // ------------------------------------------------------------------ //
+    // _buildWatchingList
+    // ------------------------------------------------------------------ //
+
+    describe('_buildWatchingList', () => {
+        it('returns null when there is nothing to watch', () => {
+            expect(window.diggerPane._buildWatchingList([])).toBeNull();
+            expect(window.diggerPane._buildWatchingList(null)).toBeNull();
+        });
+
+        it('builds a list of Discogs release links', () => {
+            const section = window.diggerPane._buildWatchingList([42, 99]);
+            expect(section).not.toBeNull();
+            const links = section.querySelectorAll('a');
+            expect(links).toHaveLength(2);
+            expect(links[0].getAttribute('href')).toBe('https://www.discogs.com/release/42');
+            expect(links[0].textContent).toContain('42');
+            expect(links[1].getAttribute('href')).toBe('https://www.discogs.com/release/99');
+        });
+
+        it('opens release links in a new tab safely', () => {
+            const section = window.diggerPane._buildWatchingList([42]);
+            const link = section.querySelector('a');
+            expect(link.getAttribute('target')).toBe('_blank');
+            expect(link.getAttribute('rel')).toContain('noopener');
+        });
+    });
+});

--- a/explore/__tests__/digger-reports.test.js
+++ b/explore/__tests__/digger-reports.test.js
@@ -285,6 +285,7 @@ describe('DiggerPane reports — inbox, navigation & viewer', () => {
             getDiggerReports: vi.fn().mockResolvedValue({ ok: true, status: 200, body: { items: [makeInboxItem()] } }),
             getDiggerReport: vi.fn().mockResolvedValue({ ok: true, status: 200, body: makeFullReport() }),
             markDiggerReportRead: vi.fn().mockResolvedValue({ ok: true, status: 204, body: null }),
+            runDiggerRecommend: vi.fn(),
         };
         window.exploreApp = undefined;
         loadScript('digger.js');
@@ -487,6 +488,96 @@ describe('DiggerPane reports — inbox, navigation & viewer', () => {
             back.click();
             await Promise.resolve();
             expect(window.apiClient.getDiggerReports).toHaveBeenCalled();
+        });
+    });
+
+    // ---------------------------------------------------------------- //
+    // Run recommendation (SSE-driven)
+    // ---------------------------------------------------------------- //
+
+    describe('run recommendation', () => {
+        it('renders a Run recommendation button when Digger is enabled', async () => {
+            await window.diggerPane.init();
+            const runBtn = document.getElementById('diggerHeaderActions').querySelector('.digger-run-btn');
+            expect(runBtn).not.toBeNull();
+            expect(runBtn.textContent).toContain('Run recommendation');
+        });
+
+        it('does not start a run when there is no token', async () => {
+            window.authManager.getToken.mockReturnValue(null);
+            await window.diggerPane._runRecommendation();
+            expect(window.apiClient.runDiggerRecommend).not.toHaveBeenCalled();
+        });
+
+        it('calls runDiggerRecommend with the token when the button is clicked', async () => {
+            await window.diggerPane.init();
+            document.getElementById('diggerHeaderActions').querySelector('.digger-run-btn').click();
+            await Promise.resolve();
+            expect(window.apiClient.runDiggerRecommend).toHaveBeenCalled();
+            expect(window.apiClient.runDiggerRecommend.mock.calls[0][0]).toBe('test-token');
+        });
+
+        it('shows progress while refreshing stale listings', async () => {
+            window.apiClient.runDiggerRecommend = vi.fn((token, opts, cbs) => {
+                cbs.onRefreshStarted({ stale_count: 3 });
+            });
+            await window.diggerPane.init();
+            document.getElementById('diggerHeaderActions').querySelector('.digger-run-btn').click();
+            await Promise.resolve();
+            const body = document.getElementById('diggerBody');
+            expect(body.querySelector('.digger-recommend-progress')).not.toBeNull();
+            expect(body.textContent).toContain('3');
+        });
+
+        it('renders bundle cards and watching from the result event', async () => {
+            window.apiClient.runDiggerRecommend = vi.fn((token, opts, cbs) => {
+                cbs.onRefreshStarted({ stale_count: 0 });
+                cbs.onResult({ bundles: makeFullReport().bundles, watching: [42], shipping_confidence: 'low' });
+                cbs.onDone({});
+            });
+            await window.diggerPane.init();
+            document.getElementById('diggerHeaderActions').querySelector('.digger-run-btn').click();
+            await Promise.resolve();
+            const body = document.getElementById('diggerBody');
+            expect(body.querySelectorAll('.digger-bundle-card')).toHaveLength(4);
+            expect(body.querySelector('.digger-watching-list').textContent).toContain('42');
+        });
+
+        it('renders an error when the run emits an error event', async () => {
+            window.apiClient.runDiggerRecommend = vi.fn((token, opts, cbs) => {
+                cbs.onError({ reason: 'digger not enabled' });
+            });
+            await window.diggerPane.init();
+            document.getElementById('diggerHeaderActions').querySelector('.digger-run-btn').click();
+            await Promise.resolve();
+            const body = document.getElementById('diggerBody');
+            expect(body.querySelector('.user-pane-empty')).not.toBeNull();
+            expect(body.textContent.toLowerCase()).toContain('digger not enabled');
+        });
+
+        it('re-enables the run button when the stream completes', async () => {
+            window.apiClient.runDiggerRecommend = vi.fn((token, opts, cbs) => {
+                cbs.onResult({ bundles: [], watching: [] });
+                cbs.onDone({});
+            });
+            await window.diggerPane.init();
+            const runBtn = document.getElementById('diggerHeaderActions').querySelector('.digger-run-btn');
+            runBtn.click();
+            await Promise.resolve();
+            expect(runBtn.disabled).toBe(false);
+            expect(window.diggerPane._recommending).toBe(false);
+        });
+
+        it('guards against concurrent runs', async () => {
+            // A run that never completes (no onDone) keeps the in-flight guard set.
+            window.apiClient.runDiggerRecommend = vi.fn((token, opts, cbs) => {
+                cbs.onRefreshStarted({ stale_count: 5 });
+            });
+            await window.diggerPane.init();
+            window.diggerPane._runRecommendation();
+            window.diggerPane._runRecommendation();
+            await Promise.resolve();
+            expect(window.apiClient.runDiggerRecommend).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/explore/static/css/styles.css
+++ b/explore/static/css/styles.css
@@ -2667,3 +2667,293 @@ select option {
     padding: 0.2rem 0.35rem;
     font-size: 0.78rem;
 }
+
+/* ------------------------------------------------------------------ */
+/* Reports — header navigation                                         */
+/* ------------------------------------------------------------------ */
+
+.digger-nav-btn {
+    background: none;
+    border: 1px solid var(--border-color);
+    color: var(--text-mid);
+    font-size: 0.85rem;
+    padding: 0.3rem 0.75rem;
+    border-radius: 0.4rem;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.digger-nav-btn:hover {
+    color: var(--text-high);
+    border-color: var(--blue-accent);
+}
+
+.digger-nav-btn.active {
+    color: var(--text-high);
+    border-color: var(--blue-accent);
+    background: var(--inner-bg);
+}
+
+.digger-run-btn {
+    margin-left: 0.25rem;
+}
+
+/* ------------------------------------------------------------------ */
+/* Reports — inbox list                                                */
+/* ------------------------------------------------------------------ */
+
+.digger-reports {
+    list-style: none;
+    margin: 1rem 1.5rem 1.5rem;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.digger-report-item {
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    background: var(--card-bg);
+}
+
+.digger-report-item.unread {
+    border-left: 3px solid var(--blue-accent);
+}
+
+.digger-report-link {
+    display: block;
+    width: 100%;
+    text-align: left;
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    padding: 0.75rem 1rem;
+}
+
+.digger-report-link:hover {
+    background: var(--bg-hover);
+}
+
+.digger-report-title {
+    color: var(--text-high);
+    font-weight: 600;
+    margin-bottom: 0.2rem;
+}
+
+.digger-report-item.read .digger-report-title {
+    color: var(--text-mid);
+    font-weight: 500;
+}
+
+.digger-report-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-size: 0.8rem;
+    color: var(--text-dim);
+}
+
+/* Change-flag pills */
+.digger-flag {
+    padding: 0.05rem 0.45rem;
+    border-radius: 0.75rem;
+    font-size: 0.72rem;
+    border: 1px solid var(--border-color);
+}
+
+.digger-flag-significant {
+    color: var(--accent-yellow);
+    border-color: rgba(255, 171, 0, 0.4);
+    background: rgba(255, 171, 0, 0.1);
+}
+
+.digger-flag-first_run {
+    color: var(--blue-accent);
+    border-color: rgba(0, 188, 212, 0.4);
+    background: rgba(0, 188, 212, 0.1);
+}
+
+.digger-flag-none {
+    color: var(--text-dim);
+}
+
+/* ------------------------------------------------------------------ */
+/* Reports — viewer                                                    */
+/* ------------------------------------------------------------------ */
+
+.digger-report-viewer {
+    margin: 1rem 1.5rem 1.5rem;
+}
+
+.digger-back-btn {
+    background: none;
+    border: none;
+    color: var(--text-mid);
+    font-size: 0.85rem;
+    cursor: pointer;
+    padding: 0.25rem 0;
+    margin-bottom: 0.75rem;
+    transition: color 0.15s;
+}
+
+.digger-back-btn:hover {
+    color: var(--text-high);
+}
+
+.digger-report-viewer-header {
+    margin-bottom: 1rem;
+}
+
+.digger-report-viewer-header h3 {
+    color: var(--text-high);
+    margin: 0 0 0.4rem;
+}
+
+.digger-confidence-high {
+    color: var(--accent-green);
+    border: 1px solid rgba(0, 230, 118, 0.3);
+    background: rgba(0, 230, 118, 0.1);
+}
+
+.digger-confidence-low {
+    color: var(--accent-yellow);
+    border: 1px solid rgba(255, 171, 0, 0.3);
+    background: rgba(255, 171, 0, 0.1);
+}
+
+/* ------------------------------------------------------------------ */
+/* Reports — bundle cards                                              */
+/* ------------------------------------------------------------------ */
+
+.digger-bundles-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+    gap: 1rem;
+}
+
+.digger-bundle-card {
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    background: var(--card-bg);
+    padding: 1rem;
+}
+
+.digger-bundle-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.digger-bundle-name {
+    margin: 0;
+    font-size: 1rem;
+    color: var(--text-high);
+}
+
+.digger-solver-greedy {
+    color: var(--text-dim);
+    border: 1px solid var(--border-color);
+    background: var(--inner-bg);
+}
+
+.digger-bundle-total {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--blue-accent);
+}
+
+.digger-bundle-breakdown {
+    font-size: 0.8rem;
+    color: var(--text-dim);
+    margin-bottom: 0.5rem;
+}
+
+.digger-bundle-coverage,
+.digger-bundle-sellers {
+    font-size: 0.82rem;
+    color: var(--text-mid);
+}
+
+.digger-bundle-hint {
+    font-size: 0.8rem;
+    color: var(--text-dim);
+    margin: 0.5rem 0 0;
+    font-style: italic;
+}
+
+.digger-bundle-details {
+    margin-top: 0.6rem;
+    font-size: 0.8rem;
+}
+
+.digger-bundle-details summary {
+    cursor: pointer;
+    color: var(--text-mid);
+}
+
+.digger-seller-order {
+    margin-top: 0.4rem;
+    padding-top: 0.4rem;
+    border-top: 1px solid var(--row-border);
+}
+
+.digger-seller-order-head {
+    color: var(--text-mid);
+    margin-bottom: 0.2rem;
+}
+
+.digger-listing-list {
+    list-style: none;
+    margin: 0;
+    padding: 0 0 0 0.75rem;
+    color: var(--text-dim);
+}
+
+/* ------------------------------------------------------------------ */
+/* Reports — watching list                                            */
+/* ------------------------------------------------------------------ */
+
+.digger-watching-list {
+    margin-top: 1.5rem;
+}
+
+.digger-watching-list h4 {
+    color: var(--text-high);
+    font-size: 0.95rem;
+    margin: 0 0 0.5rem;
+}
+
+.digger-watching-list ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+}
+
+.digger-watching-list a {
+    color: var(--blue-accent);
+    font-size: 0.85rem;
+}
+
+/* ------------------------------------------------------------------ */
+/* Reports — interactive run progress                                 */
+/* ------------------------------------------------------------------ */
+
+.digger-recommend-progress {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 3rem 1.5rem;
+}
+
+.digger-recommend-status {
+    color: var(--text-mid);
+    font-size: 0.9rem;
+}

--- a/explore/static/js/api-client.js
+++ b/explore/static/js/api-client.js
@@ -688,6 +688,78 @@ class ApiClient {
     }
 
     /**
+     * Run an interactive Digger recommendation, streaming progress over SSE.
+     * Events: refresh_started, refresh_progress, result, done, error.
+     * @param {string} token - JWT auth token
+     * @param {Object} opts - { deadline_seconds?, budget_cap_cents?, excluded_sellers? }
+     * @param {Object} callbacks - { onRefreshStarted, onRefreshProgress, onResult, onDone, onError }
+     */
+    runDiggerRecommend(token, opts = {}, callbacks = {}) {
+        const { onRefreshStarted, onRefreshProgress, onResult, onDone, onError } = callbacks;
+        const body = {
+            deadline_seconds: opts.deadline_seconds ?? 30,
+            budget_cap_cents: opts.budget_cap_cents ?? null,
+            excluded_sellers: opts.excluded_sellers ?? [],
+        };
+        fetch('/api/digger/recommend', {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'Content-Type': 'application/json',
+                'Accept': 'text/event-stream',
+            },
+            body: JSON.stringify(body),
+        }).then(response => {
+            if (!response.ok) {
+                if (onError) onError({ status: response.status });
+                return;
+            }
+            const reader = response.body.getReader();
+            const decoder = new TextDecoder();
+            let buffer = '';
+            let eventType = null;
+            function processLines(lines) {
+                for (const line of lines) {
+                    if (line.startsWith('event:')) {
+                        eventType = line.slice(6).trim();
+                    } else if (line.startsWith('data:') && eventType) {
+                        let data = null;
+                        try {
+                            data = JSON.parse(line.slice(5).trim());
+                        } catch {
+                            data = null;
+                        }
+                        if (eventType === 'refresh_started' && onRefreshStarted) onRefreshStarted(data || {});
+                        else if (eventType === 'refresh_progress' && onRefreshProgress) onRefreshProgress(data || {});
+                        else if (eventType === 'result' && onResult) onResult(data || {});
+                        else if (eventType === 'error' && onError) onError(data || {});
+                        else if (eventType === 'done' && onDone) onDone(data || {});
+                        eventType = null;
+                    }
+                }
+            }
+            function processChunk() {
+                reader.read().then(({ done, value }) => {
+                    if (done) {
+                        if (buffer.trim()) processLines(buffer.split('\n'));
+                        return;
+                    }
+                    buffer += decoder.decode(value, { stream: true });
+                    const lines = buffer.split('\n');
+                    buffer = lines.pop() || '';
+                    processLines(lines);
+                    processChunk();
+                }).catch(err => {
+                    if (onError) onError(err);
+                });
+            }
+            processChunk();
+        }).catch(err => {
+            if (onError) onError(err);
+        });
+    }
+
+    /**
      * Send a natural language query with SSE streaming.
      * @param {string} query - Natural language question
      * @param {Object|null} context - Optional context

--- a/explore/static/js/api-client.js
+++ b/explore/static/js/api-client.js
@@ -646,6 +646,48 @@ class ApiClient {
     }
 
     /**
+     * Get the Digger reports inbox for the current user (newest first).
+     * @param {string} token - JWT auth token
+     * @returns {Promise<{ok: boolean, status: number, body: Object|null}>} body = { items: [...] }
+     */
+    async getDiggerReports(token) {
+        const response = await fetch('/api/digger/reports', {
+            headers: { 'Authorization': `Bearer ${token}` },
+        });
+        const body = await response.json().catch(() => null);
+        return { ok: response.ok, status: response.status, body };
+    }
+
+    /**
+     * Get one full Digger report (bundles, watching, summary, shipping confidence).
+     * @param {string} token - JWT auth token
+     * @param {string} reportId - Report UUID
+     * @returns {Promise<{ok: boolean, status: number, body: Object|null}>}
+     */
+    async getDiggerReport(token, reportId) {
+        const response = await fetch(`/api/digger/reports/${encodeURIComponent(reportId)}`, {
+            headers: { 'Authorization': `Bearer ${token}` },
+        });
+        const body = await response.json().catch(() => null);
+        return { ok: response.ok, status: response.status, body };
+    }
+
+    /**
+     * Mark a Digger report read.
+     * @param {string} token - JWT auth token
+     * @param {string} reportId - Report UUID
+     * @returns {Promise<{ok: boolean, status: number, body: Object|null}>} 204 → body null
+     */
+    async markDiggerReportRead(token, reportId) {
+        const response = await fetch(`/api/digger/reports/${encodeURIComponent(reportId)}/read`, {
+            method: 'POST',
+            headers: { 'Authorization': `Bearer ${token}` },
+        });
+        const body = await response.json().catch(() => null);
+        return { ok: response.ok, status: response.status, body };
+    }
+
+    /**
      * Send a natural language query with SSE streaming.
      * @param {string} query - Natural language question
      * @param {Object|null} context - Optional context

--- a/explore/static/js/digger.js
+++ b/explore/static/js/digger.js
@@ -9,6 +9,21 @@ const DIGGER_TIERS = ['must', 'nice', 'eventually'];
 const DIGGER_CONDITIONS = ['M', 'NM', 'VG+', 'VG', 'G+', 'G', 'F', 'P'];
 const DIGGER_SLEEVE_CONDITIONS = ['M', 'NM', 'VG+', 'VG', 'G+', 'G', 'F', 'P', 'generic', 'no_cover'];
 
+// Human-readable labels for the four optimizer bundle variants.
+const DIGGER_BUNDLE_LABELS = {
+    cheapest: 'Cheapest',
+    most_coverage: 'Most Coverage',
+    best_quality: 'Best Quality',
+    fewest_sellers: 'Fewest Sellers',
+};
+
+// Human-readable labels for a report's change flag.
+const DIGGER_CHANGE_FLAG_LABELS = {
+    first_run: 'first run',
+    significant: 'significant',
+    none: 'no change',
+};
+
 class DiggerPane {
     constructor() {
         this._settings = null;
@@ -747,6 +762,180 @@ class DiggerPane {
         } catch {
             return 'never';
         }
+    }
+
+    // ------------------------------------------------------------------ //
+    // Reports — bundle rendering helpers
+    // ------------------------------------------------------------------ //
+
+    /**
+     * Format an integer cents amount as a localized currency string.
+     * Money flows through the optimizer in cents; the UI displays currency.
+     * @param {number} cents
+     * @param {string} [currency='USD'] - ISO-4217 currency code
+     * @returns {string}
+     */
+    _formatCents(cents, currency = 'USD') {
+        const amount = (Number(cents) || 0) / 100;
+        try {
+            return new Intl.NumberFormat(undefined, {
+                style: 'currency',
+                currency,
+                currencyDisplay: 'symbol',
+            }).format(amount);
+        } catch {
+            // Invalid currency code — fall back to a plain decimal.
+            return `${currency} ${amount.toFixed(2)}`;
+        }
+    }
+
+    /**
+     * Build a single bundle card showing totals, coverage, and an expandable
+     * per-seller breakdown.
+     * @param {Object} bundle - Optimizer Bundle (cents-denominated)
+     * @param {string} currency - ISO-4217 currency code for display
+     * @returns {HTMLDivElement}
+     */
+    _buildBundleCard(bundle, currency) {
+        const card = document.createElement('div');
+        card.className = `digger-bundle-card digger-bundle-${bundle.name}`;
+        card.dataset.bundleName = bundle.name;
+
+        // Header — name label + optional greedy-solver badge.
+        const header = document.createElement('header');
+        header.className = 'digger-bundle-header';
+
+        const title = document.createElement('h4');
+        title.className = 'digger-bundle-name';
+        title.textContent = DIGGER_BUNDLE_LABELS[bundle.name] || bundle.name;
+        header.appendChild(title);
+
+        if (bundle.solver === 'greedy') {
+            const badge = document.createElement('span');
+            badge.className = 'badge digger-solver-greedy';
+            badge.textContent = 'greedy';
+            badge.title = 'Computed with the greedy fallback solver';
+            header.appendChild(badge);
+        }
+        card.appendChild(header);
+
+        // Grand total.
+        const total = document.createElement('div');
+        total.className = 'digger-bundle-total';
+        total.textContent = this._formatCents(bundle.grand_total_cents, currency);
+        card.appendChild(total);
+
+        // Item + shipping breakdown.
+        const breakdown = document.createElement('div');
+        breakdown.className = 'digger-bundle-breakdown';
+        breakdown.textContent =
+            `${this._formatCents(bundle.total_item_cost_cents, currency)} items` +
+            ` + ${this._formatCents(bundle.total_shipping_cents, currency)} shipping`;
+        card.appendChild(breakdown);
+
+        // Coverage counts.
+        const cov = bundle.coverage || { must: 0, nice: 0, eventually: 0 };
+        const coverage = document.createElement('div');
+        coverage.className = 'digger-bundle-coverage';
+        coverage.textContent = `${cov.must} must · ${cov.nice} nice · ${cov.eventually} eventually`;
+        card.appendChild(coverage);
+
+        // Seller count.
+        const orders = bundle.seller_orders || [];
+        const sellers = document.createElement('div');
+        sellers.className = 'digger-bundle-sellers';
+        sellers.textContent = `${orders.length} seller${orders.length === 1 ? '' : 's'}`;
+        card.appendChild(sellers);
+
+        // Reasoning hint.
+        if (bundle.reasoning_hint) {
+            const hint = document.createElement('p');
+            hint.className = 'digger-bundle-hint';
+            hint.textContent = bundle.reasoning_hint;
+            card.appendChild(hint);
+        }
+
+        // Expandable per-seller breakdown (only when there are orders).
+        if (orders.length > 0) {
+            card.appendChild(this._buildSellerBreakdown(bundle, currency));
+        }
+
+        return card;
+    }
+
+    /**
+     * Build the collapsible per-seller order breakdown for a bundle card.
+     * @param {Object} bundle
+     * @param {string} currency
+     * @returns {HTMLDetailsElement}
+     */
+    _buildSellerBreakdown(bundle, currency) {
+        const details = document.createElement('details');
+        details.className = 'digger-bundle-details';
+
+        const summary = document.createElement('summary');
+        summary.textContent = 'Seller breakdown';
+        details.appendChild(summary);
+
+        for (const order of bundle.seller_orders || []) {
+            const block = document.createElement('div');
+            block.className = 'digger-seller-order';
+
+            const head = document.createElement('div');
+            head.className = 'digger-seller-order-head';
+            head.textContent =
+                `Seller ${order.seller_id} — ` +
+                `${this._formatCents(order.subtotal_item_cents, currency)} items` +
+                ` + ${this._formatCents(order.shipping_cents, currency)} shipping`;
+            block.appendChild(head);
+
+            const list = document.createElement('ul');
+            list.className = 'digger-listing-list';
+            for (const line of order.listings || []) {
+                const li = document.createElement('li');
+                li.textContent =
+                    `Release ${line.release_id} — ` +
+                    `${line.media_condition}/${line.sleeve_condition} — ` +
+                    `${this._formatCents(line.price_cents, currency)}`;
+                list.appendChild(li);
+            }
+            block.appendChild(list);
+            details.appendChild(block);
+        }
+
+        return details;
+    }
+
+    /**
+     * Build the "Watching" section listing releases with no qualifying listing.
+     * Returns null when there is nothing to watch.
+     * @param {number[]} releaseIds
+     * @returns {HTMLElement|null}
+     */
+    _buildWatchingList(releaseIds) {
+        if (!releaseIds || releaseIds.length === 0) return null;
+
+        const section = document.createElement('section');
+        section.className = 'digger-watching-list';
+
+        const heading = document.createElement('h4');
+        heading.textContent = 'Watching — no qualifying listings yet';
+        section.appendChild(heading);
+
+        const list = document.createElement('ul');
+        for (const id of releaseIds) {
+            const li = document.createElement('li');
+            const link = document.createElement('a');
+            link.href = `https://www.discogs.com/release/${id}`;
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+            link.textContent = `release ${id}`;
+            li.appendChild(link);
+            list.appendChild(li);
+        }
+        section.appendChild(list);
+
+        return section;
     }
 }
 

--- a/explore/static/js/digger.js
+++ b/explore/static/js/digger.js
@@ -36,8 +36,15 @@ class DiggerPane {
         this._hideNoListings = false;        // hide items with active_listings === 0
         this._bulkApplying = false;          // in-flight guard for bulk-tier Apply
 
+        // M2 — reports view state.
+        this._view = 'wantlist';             // 'wantlist' | 'reports' | 'report' | 'recommend'
+        this._reports = [];                  // inbox summaries
+        this._currentReport = null;          // full report being viewed
+        this._recommending = false;          // in-flight guard for Run recommendation
+
         this._loading = document.getElementById('diggerLoading');
         this._body = document.getElementById('diggerBody');
+        this._headerActions = document.getElementById('diggerHeaderActions');
     }
 
     /**
@@ -61,8 +68,10 @@ class DiggerPane {
                 this._settings = res.body || null;
                 this._renderOnboarding();
             } else if (res.ok && res.body) {
-                // Digger enabled — load wantlist
+                // Digger enabled — render the view navigation and load the wantlist.
                 this._settings = res.body;
+                this._view = 'wantlist';
+                this._renderHeaderActions();
                 await this._loadWantlist(token);
             } else {
                 // Unexpected error
@@ -94,6 +103,9 @@ class DiggerPane {
     // ------------------------------------------------------------------ //
 
     _renderOnboarding() {
+        // No view navigation while Digger is disabled.
+        if (this._headerActions) this._headerActions.textContent = '';
+
         if (!this._body) return;
         this._body.textContent = '';
 
@@ -936,6 +948,309 @@ class DiggerPane {
         section.appendChild(list);
 
         return section;
+    }
+
+    // ------------------------------------------------------------------ //
+    // Reports — header navigation
+    // ------------------------------------------------------------------ //
+
+    /**
+     * Render the in-pane view navigation (Wantlist / Reports) into the header.
+     * Only shown when Digger is enabled.
+     */
+    _renderHeaderActions() {
+        if (!this._headerActions) return;
+        this._headerActions.textContent = '';
+
+        this._headerActions.appendChild(this._buildNavButton('Wantlist', 'wantlist'));
+        this._headerActions.appendChild(this._buildNavButton('Reports', 'reports'));
+
+        this._updateNavActiveState();
+    }
+
+    /**
+     * Build a single header navigation button.
+     * @param {string} label
+     * @param {'wantlist'|'reports'} view
+     * @returns {HTMLButtonElement}
+     */
+    _buildNavButton(label, view) {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'digger-nav-btn';
+        btn.dataset.view = view;
+        btn.textContent = label;
+        btn.addEventListener('click', () => {
+            if (view === 'wantlist') {
+                this._showWantlist();
+            } else if (view === 'reports') {
+                this._showReports();
+            }
+        });
+        return btn;
+    }
+
+    /**
+     * Reflect the current view on the navigation buttons. The report viewer is
+     * part of the Reports section, so it keeps the Reports button active.
+     */
+    _updateNavActiveState() {
+        if (!this._headerActions) return;
+        const navBtns = this._headerActions.querySelectorAll('.digger-nav-btn');
+        for (const btn of navBtns) {
+            const view = btn.dataset.view;
+            const isActive =
+                (view === 'wantlist' && this._view === 'wantlist') ||
+                (view === 'reports' && (this._view === 'reports' || this._view === 'report'));
+            btn.classList.toggle('active', isActive);
+            btn.setAttribute('aria-pressed', String(isActive));
+        }
+    }
+
+    /**
+     * Switch back to the wantlist view and reload it.
+     */
+    async _showWantlist() {
+        this._view = 'wantlist';
+        this._updateNavActiveState();
+        const token = window.authManager.getToken();
+        if (!token) return;
+        await this._loadWantlist(token);
+    }
+
+    // ------------------------------------------------------------------ //
+    // Reports — inbox
+    // ------------------------------------------------------------------ //
+
+    /**
+     * Switch to the reports inbox, fetching the latest summaries.
+     */
+    async _showReports() {
+        this._view = 'reports';
+        this._updateNavActiveState();
+        const token = window.authManager.getToken();
+        if (!token) return;
+
+        const res = await window.apiClient.getDiggerReports(token);
+        if (res.ok && res.body) {
+            this._reports = res.body.items || [];
+            this._renderReportsList();
+        } else {
+            this._renderError('Could not load your Digger reports. Please try again later.');
+        }
+    }
+
+    /**
+     * Render the reports inbox list (or an empty state).
+     */
+    _renderReportsList() {
+        if (!this._body) return;
+        this._body.textContent = '';
+
+        if (!this._reports || this._reports.length === 0) {
+            this._renderReportsEmpty();
+            return;
+        }
+
+        const list = document.createElement('ul');
+        list.className = 'digger-reports';
+        for (const item of this._reports) {
+            list.appendChild(this._buildReportListItem(item));
+        }
+        this._body.appendChild(list);
+    }
+
+    /**
+     * Render the empty-inbox placeholder.
+     */
+    _renderReportsEmpty() {
+        const empty = document.createElement('div');
+        empty.className = 'user-pane-empty';
+
+        const icon = document.createElement('span');
+        icon.className = 'material-symbols-outlined icon-3x mb-3';
+        icon.textContent = 'inbox';
+        empty.appendChild(icon);
+
+        const msg = document.createElement('p');
+        msg.textContent = 'No reports yet — run a recommendation to generate your first one.';
+        empty.appendChild(msg);
+
+        this._body.appendChild(empty);
+    }
+
+    /**
+     * Build a single inbox list item.
+     * @param {Object} item - Report summary
+     * @returns {HTMLLIElement}
+     */
+    _buildReportListItem(item) {
+        const li = document.createElement('li');
+        li.className = `digger-report-item ${item.read_at ? 'read' : 'unread'}`;
+        li.dataset.reportId = item.report_id;
+
+        const link = document.createElement('button');
+        link.type = 'button';
+        link.className = 'digger-report-link';
+        link.addEventListener('click', () => this._openReport(item.report_id));
+
+        const title = document.createElement('div');
+        title.className = 'digger-report-title';
+        title.textContent = item.title;
+        link.appendChild(title);
+
+        const meta = document.createElement('div');
+        meta.className = 'digger-report-meta';
+
+        const when = document.createElement('span');
+        when.className = 'digger-report-when';
+        when.textContent = this._formatDateTime(item.generated_at);
+        meta.appendChild(when);
+
+        const flag = document.createElement('span');
+        flag.className = `digger-flag digger-flag-${item.change_flag}`;
+        flag.textContent = this._changeFlagLabel(item.change_flag);
+        meta.appendChild(flag);
+
+        link.appendChild(meta);
+        li.appendChild(link);
+        return li;
+    }
+
+    /**
+     * Human-readable label for a change flag.
+     * @param {string} flag
+     * @returns {string}
+     */
+    _changeFlagLabel(flag) {
+        return DIGGER_CHANGE_FLAG_LABELS[flag] || (flag || '').replace(/_/g, ' ');
+    }
+
+    /**
+     * Format an ISO timestamp as a locale date-time string, or '' on failure.
+     * @param {string|null} iso
+     * @returns {string}
+     */
+    _formatDateTime(iso) {
+        if (!iso) return '';
+        try {
+            return new Date(iso).toLocaleString();
+        } catch {
+            return '';
+        }
+    }
+
+    // ------------------------------------------------------------------ //
+    // Reports — viewer
+    // ------------------------------------------------------------------ //
+
+    /**
+     * Open a full report: fetch it, render the viewer, and mark it read.
+     * @param {string} reportId
+     */
+    async _openReport(reportId) {
+        this._view = 'report';
+        this._updateNavActiveState();
+        const token = window.authManager.getToken();
+        if (!token) return;
+
+        const res = await window.apiClient.getDiggerReport(token, reportId);
+        if (!res.ok || !res.body) {
+            this._renderError('Could not load this report. Please try again later.');
+            return;
+        }
+
+        this._currentReport = res.body;
+        this._renderReportViewer(this._currentReport);
+
+        // Mark unread reports read (fire-and-forget); reflect locally so the
+        // inbox shows the updated state on return.
+        if (!this._currentReport.read_at) {
+            window.apiClient
+                .markDiggerReportRead(token, reportId)
+                .then(() => {
+                    const summary = this._reports.find((r) => r.report_id === reportId);
+                    if (summary) summary.read_at = new Date().toISOString();
+                })
+                .catch(() => { /* read state is non-critical */ });
+        }
+    }
+
+    /**
+     * Render the report viewer (4 bundle cards + watching list).
+     * @param {Object} report - Full report payload
+     */
+    _renderReportViewer(report) {
+        const currency =
+            (report.summary && report.summary.currency) ||
+            (this._settings && this._settings.currency) ||
+            'USD';
+        this._renderBundlesView({
+            title: report.title,
+            generatedAt: report.generated_at,
+            shippingConfidence: report.shipping_confidence,
+            bundles: report.bundles || [],
+            watching: report.watching || [],
+            currency,
+            onBack: () => this._showReports(),
+        });
+    }
+
+    /**
+     * Shared renderer for a set of bundles + watching list. Used by both the
+     * stored-report viewer and the interactive recommendation result.
+     * @param {Object} opts
+     */
+    _renderBundlesView(opts) {
+        if (!this._body) return;
+        this._body.textContent = '';
+
+        const viewer = document.createElement('div');
+        viewer.className = 'digger-report-viewer';
+
+        if (opts.onBack) {
+            const back = document.createElement('button');
+            back.type = 'button';
+            back.className = 'digger-back-btn';
+            back.textContent = opts.backLabel || '← Back to reports';
+            back.addEventListener('click', () => opts.onBack());
+            viewer.appendChild(back);
+        }
+
+        const header = document.createElement('div');
+        header.className = 'digger-report-viewer-header';
+
+        const heading = document.createElement('h3');
+        heading.textContent = opts.title;
+        header.appendChild(heading);
+
+        const meta = document.createElement('div');
+        meta.className = 'digger-report-meta';
+        if (opts.generatedAt) {
+            const when = document.createElement('span');
+            when.textContent = this._formatDateTime(opts.generatedAt);
+            meta.appendChild(when);
+        }
+        if (opts.shippingConfidence) {
+            const conf = document.createElement('span');
+            conf.className = `badge digger-confidence-${opts.shippingConfidence}`;
+            conf.textContent = `${opts.shippingConfidence} shipping confidence`;
+            meta.appendChild(conf);
+        }
+        header.appendChild(meta);
+        viewer.appendChild(header);
+
+        const grid = document.createElement('div');
+        grid.className = 'digger-bundles-grid';
+        for (const bundle of opts.bundles || []) {
+            grid.appendChild(this._buildBundleCard(bundle, opts.currency));
+        }
+        viewer.appendChild(grid);
+
+        const watching = this._buildWatchingList(opts.watching);
+        if (watching) viewer.appendChild(watching);
+
+        this._body.appendChild(viewer);
     }
 }
 

--- a/explore/static/js/digger.js
+++ b/explore/static/js/digger.js
@@ -965,6 +965,14 @@ class DiggerPane {
         this._headerActions.appendChild(this._buildNavButton('Wantlist', 'wantlist'));
         this._headerActions.appendChild(this._buildNavButton('Reports', 'reports'));
 
+        const runBtn = document.createElement('button');
+        runBtn.type = 'button';
+        runBtn.className = 'btn-primary digger-run-btn';
+        runBtn.textContent = 'Run recommendation';
+        runBtn.addEventListener('click', () => this._runRecommendation());
+        this._runBtn = runBtn;
+        this._headerActions.appendChild(runBtn);
+
         this._updateNavActiveState();
     }
 
@@ -1251,6 +1259,103 @@ class DiggerPane {
         if (watching) viewer.appendChild(watching);
 
         this._body.appendChild(viewer);
+    }
+
+    // ------------------------------------------------------------------ //
+    // Reports — interactive "Run recommendation" (SSE)
+    // ------------------------------------------------------------------ //
+
+    /**
+     * Run an interactive recommendation, streaming refresh progress then the
+     * resulting bundles. Guards against concurrent runs.
+     */
+    async _runRecommendation() {
+        if (this._recommending) return; // in-flight guard
+        const token = window.authManager.getToken();
+        if (!token) return;
+
+        this._recommending = true;
+        if (this._runBtn) this._runBtn.disabled = true;
+        this._view = 'recommend';
+        this._updateNavActiveState();
+        this._renderRecommendProgress('Starting recommendation…');
+
+        let staleCount = 0;
+        window.apiClient.runDiggerRecommend(token, {}, {
+            onRefreshStarted: (data) => {
+                staleCount = (data && data.stale_count) || 0;
+                this._renderRecommendProgress(
+                    staleCount === 0 ? 'Computing bundles…' : `Refreshing ${staleCount} stale listings…`,
+                );
+            },
+            onRefreshProgress: (data) => {
+                const remaining = data && data.remaining != null ? data.remaining : staleCount;
+                const done = Math.max(0, staleCount - remaining);
+                this._renderRecommendProgress(`Refreshing listings… ${done}/${staleCount}`);
+            },
+            onResult: (data) => {
+                this._renderRecommendResult(data || {});
+            },
+            onError: (err) => {
+                const reason = (err && (err.reason || err.detail)) || 'Something went wrong.';
+                this._renderError(`Recommendation failed: ${reason}`);
+                this._finishRecommendation();
+            },
+            onDone: () => {
+                this._finishRecommendation();
+            },
+        });
+    }
+
+    /**
+     * Clear the in-flight guard and re-enable the run button.
+     */
+    _finishRecommendation() {
+        this._recommending = false;
+        if (this._runBtn) this._runBtn.disabled = false;
+    }
+
+    /**
+     * Render a spinner + status line while a recommendation is in progress.
+     * @param {string} message
+     */
+    _renderRecommendProgress(message) {
+        if (!this._body) return;
+        this._body.textContent = '';
+
+        const wrap = document.createElement('div');
+        wrap.className = 'digger-recommend-progress';
+
+        const spinner = document.createElement('div');
+        spinner.className = 'spinner';
+        spinner.setAttribute('role', 'status');
+        wrap.appendChild(spinner);
+
+        const status = document.createElement('p');
+        status.className = 'digger-recommend-status';
+        status.textContent = message;
+        wrap.appendChild(status);
+
+        this._body.appendChild(wrap);
+    }
+
+    /**
+     * Render the interactive recommendation result (same layout as the report
+     * viewer), with a back control returning to the wantlist.
+     * @param {Object} out - OptimizerOutput payload
+     */
+    _renderRecommendResult(out) {
+        const currency = (this._settings && this._settings.currency) || 'USD';
+        this._renderBundlesView({
+            title: 'New recommendation',
+            generatedAt: null,
+            shippingConfidence: out.shipping_confidence,
+            bundles: out.bundles || [],
+            watching: out.watching || [],
+            currency,
+            onBack: () => this._showWantlist(),
+            backLabel: '← Back to wantlist',
+        });
     }
 }
 


### PR DESCRIPTION
## Summary

Layer D of Digger M2 — the explore **Reports frontend**, the user-facing surface for the deterministic bundle optimizer (Layer A #344) + scheduled reports (Layer C #346) + reports API (Layer B #345).

Built as **vanilla classic-script JS** extending `explore/static/js/digger.js` (Alpine/imperative-DOM patterns, no React/router — the plan's `.tsx`/`react-router-dom` snippets were adapted to the real explore conventions). Tested with **vitest + jsdom** in `explore/__tests__/`.

### What's included (plan Tasks 15–18)
- **Header view-nav** (Wantlist / Reports) rendered into `#diggerHeaderActions` when Digger is enabled; cleared on the onboarding path. Active state tracks the current view.
- **Reports inbox** (Task 15): list of report summaries with read/unread state, title, generated-at, and change-flag pills; empty + error states.
- **Bundle card** (Task 16): per-variant card showing grand total, item+shipping breakdown, coverage (must/nice/eventually), seller count, reasoning hint, a greedy-solver badge, and an expandable per-seller order breakdown. Money is cents → currency via `Intl.NumberFormat`.
- **Report viewer** (Task 17): title, shipping-confidence badge, the four optimizer bundle cards, and the watching list (Discogs release links). Marks unread reports read on open (reflected locally).
- **Run recommendation** (Task 18): header button + SSE consumer (`api-client.runDiggerRecommend`, mirroring `askNlqStream`) streaming `refresh_started` / `refresh_progress` / `result` / `done` / `error`; renders live progress then the resulting bundles (back control → wantlist). In-flight guard prevents concurrent runs.
- **api-client helpers**: `getDiggerReports`, `getDiggerReport`, `markDiggerReportRead`, `runDiggerRecommend`.
- **Styling** for all new components using the existing explore design tokens.

Bundle/report shapes match `common/digger_optimizer/models.py` and the Layer B endpoints (`api/routers/digger_reports.py`, `api/routers/digger_recommend.py`).

### Adaptation note
In the single-pane explore app there is no router, so the plan's separate "inbox page" and "viewer page" are implemented as in-pane sub-views of the Digger pane (inbox ⇄ viewer with a back control) and shipped together.

## Test plan
- [x] `just test-js` — 29 files, 1215 tests, 0 failures
- [x] `just test-js-cov` — digger.js 99% lines / 98.6% funcs, api-client.js 100% funcs
- [x] `just lint` — all pre-commit hooks pass
- [x] No regressions (existing 97 digger + 147 api-client tests intact)
- [x] Inbox + viewer + run-recommendation render against mocked API responses (vitest + jsdom)

Diff is JS/CSS only (5 files); no Python touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)