### PR TITLE
feat(digger): M2 Layer E — perf tests, optimizer docs, E2E smoke (completes M2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ api/                  API service — all user-facing HTTP endpoints (auth, sear
 brainzgraphinator/    Brainzgraphinator service — MusicBrainz data → Neo4j enrichment
 brainztableinator/    Brainztableinator service — MusicBrainz data → PostgreSQL
 common/               Shared library — config, models, utilities used by all Python services
+  digger_optimizer/   Pure-function ILP bundle optimizer for Digger (shared by api + digger) — see docs/digger-optimizer.md
 dashboard/            Dashboard service — real-time monitoring UI
 digger/               Digger service — Discogs marketplace scraper for wantlist listings (scheduled worker)
 explore/              Explore service — static file serving for graph exploration frontend (Vitest for JS tests)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -537,7 +537,7 @@ See [Brainztableinator README](../brainztableinator/README.md) for details.
 - `DIGGER_SCRAPER_USER_AGENT`: User-Agent header for scrape requests
 - `DIGGER_CB_WINDOW_SECONDS`, `DIGGER_CB_FAILURE_PCT`, `DIGGER_CB_COOLDOWN_SECONDS`: Circuit-breaker tuning
 
-See [Digger README](../digger/README.md) and the [Digger Scraping Policy](digger-scraping-policy.md) for the full request and Terms-of-Service posture.
+See [Digger README](../digger/README.md) and the [Digger Scraping Policy](digger-scraping-policy.md) for the full request and Terms-of-Service posture. The deterministic bundle optimizer that powers the interactive `POST /api/digger/recommend` endpoint and the scheduled reports is documented in [Digger Optimizer](digger-optimizer.md).
 
 ### Explore Service
 

--- a/docs/digger-optimizer.md
+++ b/docs/digger-optimizer.md
@@ -1,0 +1,225 @@
+# Digger Optimizer
+
+The Digger optimizer turns a user's wantlist (with per-release tier, condition, and
+price preferences) plus the scraped marketplace state into **3–4 named, Pareto-optimal
+seller bundles** with shipping-aware total costs:
+
+| Bundle | Optimizes for |
+| ------ | ------------- |
+| **Cheapest** | Lowest grand total (items + shipping) |
+| **Most Coverage** | Most wantlist items satisfied |
+| **Best Quality** | Higher media/sleeve conditions |
+| **Fewest Sellers** | Fewest separate orders (less shipping, less hassle) |
+
+It lives in `common/digger_optimizer/` as a **pure-function library** — no I/O, no
+database, no network. Every input is passed in as a Pydantic model and the result is a
+Pydantic model. This lets the same code run in two places:
+
+- **`api/`** — the interactive `POST /api/digger/recommend` endpoint (real-time, SSE).
+- **`digger/`** — the scheduled report worker (`digger/scheduler/runner.py`).
+
+## Public API
+
+```python
+from common.digger_optimizer import pareto_bundles, OptimizerInput, OptimizerOutput
+
+out: OptimizerOutput = pareto_bundles(inp)  # inp: OptimizerInput
+for bundle in out.bundles:
+    print(bundle.name, bundle.grand_total_cents, bundle.coverage)
+print("watching (no qualifying listings):", out.watching)
+```
+
+`pareto_bundles(inp, *, ilp_timeout_seconds=5)` is the only entry point. It returns an
+`OptimizerOutput` with the bundles, a `watching` list (must-have releases that currently
+have no qualifying listing), per-variant `diagnostics`, and an overall
+`shipping_confidence` flag.
+
+## Modules
+
+| Module | Responsibility |
+| ------ | -------------- |
+| `models.py` | Pydantic input/output types + the `CONDITION_RANK` table |
+| `filtering.py` | Stage 1 — drop listings below the condition floor / over max price / wrong currency |
+| `shipping.py` | Per-seller shipping estimation (scraped policy, else region matrix) |
+| `greedy.py` | Greedy reference solver — ILP fallback and warm-start hint |
+| `ilp.py` | `pulp` + CBC integer program (the optimal solver) |
+| `pareto.py` | Coordinator — runs the four variants, assembles diagnostics |
+
+## Pipeline
+
+```mermaid
+flowchart TD
+    A[OptimizerInput<br/>wantlist tiers + listings + sellers] --> B[Stage 1: filtering]
+    B -->|usable listings per release| C{pareto_bundles<br/>per variant}
+    B -->|releases with no listing| W[watching list]
+    C --> D[ilp.solve_ilp_bundle<br/>pulp + CBC]
+    D -->|optimal| F[Bundle]
+    D -->|error / exception| E[greedy.greedy_bundle]
+    E --> F
+    D -. shipping cost .-> S[shipping.estimate_shipping_cents]
+    E -. shipping cost .-> S
+    F --> G[OptimizerOutput<br/>4 bundles + diagnostics + shipping_confidence]
+    W --> G
+```
+
+### Stage 1 — Filtering (`filtering.py`)
+
+For each release the user wants, keep only listings that:
+
+1. match the user's currency (cross-currency conversion is **out of scope** — mismatches
+   are counted in diagnostics and skipped),
+2. meet the per-tier **media** condition floor (`CONDITION_RANK[listing] >= CONDITION_RANK[floor]`),
+3. meet the per-tier **sleeve** condition floor,
+4. fall at or under the per-release `max_price_cents` cap (when set).
+
+A **must-have** release with zero qualifying listings goes onto the `watching` list rather
+than making the whole problem infeasible.
+
+### Shipping (`shipping.py`)
+
+Per-seller shipping is computed two ways, in priority order:
+
+1. **Scraped policy** — if the seller's `shipping_policy` covers the buyer's region (or a
+   `default`), cost is `first_cents + additional_cents * (count - 1)`.
+2. **Region matrix fallback** — a static 7×7 origin→destination matrix
+   (`REGION_MATRIX_CENTS`, USD-centric) with a diminishing-returns multiplier
+   `1.0 + 0.2 * (count - 1)` for consolidated multi-item orders.
+
+`shipping_confidence_score()` reports **`high`** when ≥80% of candidate sellers have a
+usable scraped policy for the buyer's region, otherwise **`low`** — surfaced to the user so
+they know whether totals are precise or estimated.
+
+### ILP solver (`ilp.py`)
+
+The optimal solver is an integer program built with [`pulp`](https://github.com/coin-or/pulp)
+(which ships the CBC binary):
+
+- **Variables:** `x[listing] ∈ {0,1}` (include listing), `y[seller] ∈ {0,1}` (order from
+  seller), `z[seller, k] ∈ {0,1}` (seller has exactly `k` items — linearizes the per-seller
+  shipping step function in item count).
+- **Constraints:** each must-have covered exactly once (if any listing qualifies); each
+  nice/eventually at most once; `x[listing] ≤ y[seller]`; the `z` gating that ties item
+  count to shipping tier; excluded sellers forced off; optional budget cap.
+- **Objective:** minimize item cost + shipping, with per-variant adjustments (seller
+  penalty for *Fewest Sellers*, a quality bonus for *Best Quality*, and nice/eventually
+  coverage credits).
+
+The solver runs with a per-variant timeout (default **5 s**, `randomSeed 42` for
+determinism). On infeasibility it returns an empty bundle; on an exception the coordinator
+falls back to greedy.
+
+### Greedy fallback (`greedy.py`)
+
+The greedy solver is a ratio-based heuristic (best value-per-marginal-cost, accounting for
+marginal shipping and a seller-consolidation bonus). It is used as the fallback when the
+ILP raises, and as a reference implementation for the property tests. It is bounded and
+fast — typically within 5–15% of the ILP optimum.
+
+### Bundle variants (`pareto.py` + `greedy._WEIGHTS`)
+
+The four variants are the same model solved with different objective weights (cents):
+
+| Variant | Nice credit | Eventually credit | Quality bonus / rank step | Extra-seller penalty |
+| ------- | ----------- | ----------------- | ------------------------- | -------------------- |
+| `cheapest` | $5 | $1 | — | — |
+| `most_coverage` | $25 | $10 | — | — |
+| `best_quality` | $5 | $1 | $3 | — |
+| `fewest_sellers` | $5 | $1 | — | $20 |
+
+The coordinator records, per variant, which solver actually produced the bundle
+(`ilp` or `greedy`) and its wall-clock solve time in `diagnostics`.
+
+## Interactive flow — `POST /api/digger/recommend` (SSE)
+
+The interactive endpoint streams progress while it opportunistically refreshes stale
+listings, then streams the optimizer result. Events are Server-Sent Events
+(`sse-starlette`): `refresh_started`, `refresh_progress` (repeated), `result`, `done`, and
+`error`.
+
+```mermaid
+sequenceDiagram
+    participant UI as Explore (Reports UI)
+    participant API as API /api/digger/recommend
+    participant PG as PostgreSQL (digger.*)
+    participant R as Redis pub/sub
+    participant W as Digger worker
+    participant OPT as common.digger_optimizer
+
+    UI->>API: POST /recommend {deadline_seconds, budget_cap, excluded_sellers}
+    API->>PG: identify stale releases (per-tier half-life)
+    API-->>UI: event: refresh_started {stale_count}
+    API->>PG: bump scrape priority for stale releases
+    API->>R: subscribe digger:refresh:{user_id}
+    W->>PG: scrape + persist listings
+    W->>R: publish progress per release
+    R-->>API: progress message
+    API-->>UI: event: refresh_progress {release_id, status, remaining}
+    Note over API: until all stale done OR deadline reached
+    API->>PG: build OptimizerInput from wantlist + listings + sellers
+    API->>OPT: pareto_bundles(inp)
+    OPT-->>API: OptimizerOutput
+    API-->>UI: event: result {bundles, watching, diagnostics}
+    API-->>UI: event: done
+```
+
+Staleness uses a per-tier half-life — **must** 3.5 days, **nice** 7 days, **eventually**
+14 days. `deadline_seconds` caps how long the refresh wait can run before the optimizer is
+invoked with whatever has arrived; fresh wantlists skip the refresh wait entirely.
+
+## Scheduled flow — `digger/scheduler/runner.py`
+
+The Digger worker runs a scheduler loop that generates reports on each user's configured
+cadence (`weekly` / `biweekly` / `monthly`). The loop **only starts when
+`DIGGER_API_SERVICE_TOKEN` is set**, polling every `DIGGER_SCHEDULER_POLL_SECONDS`
+(default 300). The worker reads its own tables directly but fetches wantlist priorities
+over HTTP from the API's internal endpoints — it never imports from `api/`.
+
+```mermaid
+sequenceDiagram
+    participant S as Scheduler loop (digger)
+    participant API as API /api/internal/digger/*
+    participant PG as PostgreSQL (digger.*)
+    participant OPT as common.digger_optimizer
+
+    loop every DIGGER_SCHEDULER_POLL_SECONDS
+        S->>API: GET users-due-for-report (X-Service-Token)
+        API-->>S: [{user_id, cadence, country, currency}]
+        loop per due user
+            S->>API: GET wantlist-snapshot/{user_id} (X-Service-Token)
+            API-->>S: {must, nice, eventually}
+            S->>PG: read active listings + sellers + last report
+            S->>OPT: pareto_bundles(inp)
+            OPT-->>S: OptimizerOutput
+            S->>PG: INSERT digger.reports + advance next_scheduled_run_at (one tx)
+        end
+    end
+```
+
+### Change detection
+
+Each scheduled run is classified relative to the user's most recent report:
+
+- **`first_run`** — no prior report exists.
+- **`significant`** — the symmetric difference of chosen `listing_id`s between the new run
+  and the prior report is **≥ 3** (`_SIGNIFICANT_CHANGE_THRESHOLD`, inclusive boundary).
+- **`none`** — fewer than 3 listings changed.
+
+The flag drives the Reports inbox so users can skip "nothing changed" reports. An empty
+wantlist advances the schedule without writing a report.
+
+## Performance
+
+- Roughly **~1000 listings × 200 sellers → < 2 s per variant** on a modern CPU.
+- **5 s** per-variant ILP timeout; ~20 s worst case across all four variants.
+- Greedy fallback is bounded and usually within **5–15%** of the ILP optimum.
+
+Perf coverage for the API surface lives in `tests/perftest/` (`digger_recommend`,
+`digger_reports_*`). Optimizer correctness is covered by unit + `hypothesis` property
+tests in `tests/common/test_digger_optimizer_*`.
+
+## Related
+
+- [Architecture](architecture.md) — where Digger and the optimizer sit in the platform.
+- [Digger Scraping Policy](digger-scraping-policy.md) — how listings/sellers are sourced.
+- [Configuration](configuration.md) — `DIGGER_API_SERVICE_TOKEN`, `API_BASE_URL`,
+  `DIGGER_SCHEDULER_POLL_SECONDS`, and the other Digger worker variables.

--- a/tests/e2e/test_digger_m2_smoke.py
+++ b/tests/e2e/test_digger_m2_smoke.py
@@ -1,0 +1,137 @@
+"""M2 happy-path E2E smoke for the Digger optimizer + reports pipeline.
+
+Unlike the M1 smoke (``tests/digger/test_digger_m1_smoke.py``), which wires the
+real components together in-process against mock I/O boundaries, this smoke runs
+against a **live stack** with a **real PostgreSQL** — the only place this repo
+exercises real-DB behaviour. It is therefore marked ``e2e`` and is deselected by
+the default ``-m 'not e2e'`` selection (``just test``); it only runs when an
+operator points it at a running stack.
+
+It mirrors the M1 smoke's structure (clear, contract-focused parts) at the
+live-stack level, covering the two M2 user-facing surfaces end to end:
+
+    Part 1 (recommend SSE):
+        POST /api/digger/recommend streams refresh_started -> result -> done,
+        proving the opportunistic-refresh + optimizer pipeline runs against real
+        wantlist/listing/seller rows.
+    Part 2 (reports CRUD):
+        POST -> GET (list) -> GET (by id) -> POST .../read (204) -> 404 (one-shot),
+        proving the reports inbox round-trips through the real router + query +
+        digger.reports table.
+
+Requirements (skips cleanly if absent):
+  * JWT_SECRET_KEY            — signs a token the live API will accept.
+  * DIGGER_E2E_POSTGRES_URL   — the live database, for idempotent seeding.
+  * DIGGER_E2E_API_URL        — live API base URL (default http://localhost:8004).
+
+Seeding reuses the perftest harness's idempotent seed + JWT mint so the
+authenticated user, its enabled digger settings, a wantlist release with live
+listings/sellers, and an unread report all exist before the flows run.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+from tests.perftest.run_perftest import mint_perftest_jwt, seed_digger_perftest_data
+
+
+_DEFAULT_API_URL = "http://localhost:8004"
+
+
+@pytest.fixture(scope="session")
+def digger_e2e() -> tuple[str, dict[str, str]]:
+    """Seed the live database and return (api_base_url, auth_headers).
+
+    Skips the whole module unless both the signing secret and a reachable
+    database URL are provided, since this smoke is meaningless without a stack.
+    """
+    secret = os.getenv("JWT_SECRET_KEY")
+    postgres_url = os.getenv("DIGGER_E2E_POSTGRES_URL")
+    if not secret or not postgres_url:
+        pytest.skip("Digger M2 E2E needs JWT_SECRET_KEY + DIGGER_E2E_POSTGRES_URL (live stack)")
+
+    seed_digger_perftest_data(postgres_url)
+    token = mint_perftest_jwt(secret=secret)
+    base_url = os.getenv("DIGGER_E2E_API_URL", _DEFAULT_API_URL)
+    return base_url, {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.e2e
+def test_m2_smoke_recommend_streams_sse(digger_e2e: tuple[str, dict[str, str]]) -> None:
+    """POST /api/digger/recommend streams the refresh -> result -> done SSE sequence."""
+    base_url, headers = digger_e2e
+
+    events: list[str] = []
+    with (
+        httpx.Client(timeout=30.0) as client,
+        client.stream(
+            "POST",
+            f"{base_url}/api/digger/recommend",
+            headers=headers,
+            json={"deadline_seconds": 5},
+        ) as resp,
+    ):
+        assert resp.status_code == 200
+        for raw in resp.iter_lines():
+            line = raw.strip()
+            if line.startswith("event:"):
+                events.append(line.split(":", 1)[1].strip())
+            if "done" in events or "error" in events:
+                break
+
+    # The seeded user is digger-enabled, so the optimizer path must run cleanly.
+    assert "error" not in events, f"recommend emitted an error event: {events}"
+    assert "refresh_started" in events
+    assert "result" in events
+    assert "done" in events
+
+
+@pytest.mark.e2e
+def test_m2_smoke_reports_crud_roundtrip(digger_e2e: tuple[str, dict[str, str]]) -> None:
+    """A report can be created, listed, fetched, and marked read exactly once."""
+    base_url, headers = digger_e2e
+
+    with httpx.Client(timeout=30.0) as client:
+        created = client.post(
+            f"{base_url}/api/digger/reports",
+            headers=headers,
+            json={
+                "title": "E2E smoke report",
+                "kind": "interactive",
+                "summary": {"note": "e2e"},
+                "bundles": [],
+                "watching": [],
+                "change_flag": "first_run",
+                "shipping_confidence": "low",
+            },
+        )
+        assert created.status_code == 201, created.text
+        report_id = created.json()["report_id"]
+
+        listed = client.get(f"{base_url}/api/digger/reports", headers=headers)
+        assert listed.status_code == 200
+        listed_ids = {item["report_id"] for item in listed.json()["items"]}
+        assert report_id in listed_ids
+
+        fetched = client.get(f"{base_url}/api/digger/reports/{report_id}", headers=headers)
+        assert fetched.status_code == 200
+        assert fetched.json()["report_id"] == report_id
+
+        first_read = client.post(f"{base_url}/api/digger/reports/{report_id}/read", headers=headers)
+        assert first_read.status_code == 204
+        # mark_read is one-shot (UPDATE ... WHERE read_at IS NULL): a second call 404s.
+        second_read = client.post(f"{base_url}/api/digger/reports/{report_id}/read", headers=headers)
+        assert second_read.status_code == 404
+
+
+@pytest.mark.e2e
+def test_m2_smoke_reports_require_authentication(digger_e2e: tuple[str, dict[str, str]]) -> None:
+    """The reports inbox rejects an unauthenticated request."""
+    base_url, _ = digger_e2e
+    with httpx.Client(timeout=10.0) as client:
+        resp = client.get(f"{base_url}/api/digger/reports")
+    assert resp.status_code == 401

--- a/tests/perftest/config.yaml
+++ b/tests/perftest/config.yaml
@@ -115,3 +115,39 @@ digger_scenarios:
     path: /api/digger/reports
     auth: true
     target_p95_ms: 200
+
+  # Fetch one report by id. The --seed step inserts a digger.reports row carrying
+  # this fixed UUID (owned by the perftest user) so this resolves a real report.
+  - name: digger_reports_get
+    method: GET
+    path: /api/digger/reports/{report_id}
+    path_params:
+      report_id: 00000000-0000-0000-0000-0000000d2222
+    auth: true
+    target_p95_ms: 100
+
+  # Mark that report read. mark_read is one-shot (UPDATE ... WHERE read_at IS NULL):
+  # the seed resets read_at to NULL each run, so the first of the N iterations is a
+  # 204 and the rest are 404 (already read). Both measure the same UPDATE round-trip;
+  # the harness reports errors informationally and does not fail on them.
+  - name: digger_reports_read
+    method: POST
+    path: /api/digger/reports/{report_id}/read
+    path_params:
+      report_id: 00000000-0000-0000-0000-0000000d2222
+    auth: true
+    target_p95_ms: 100
+
+  # Interactive recommendation. Streams Server-Sent Events (refresh_started ->
+  # refresh_progress* -> result -> done); like the NLQ scenarios above, the harness
+  # issues a plain POST and times the full response (the EventSourceResponse closes
+  # once the generator completes). The seed keeps the wantlist release fresh
+  # (last_scraped_at = now()) so there is no opportunistic-refresh wait and the
+  # deadline only caps the worst case.
+  - name: digger_recommend
+    method: POST
+    path: /api/digger/recommend
+    body:
+      deadline_seconds: 5
+    auth: true
+    target_p95_ms: 6000

--- a/tests/perftest/run_perftest.py
+++ b/tests/perftest/run_perftest.py
@@ -38,6 +38,11 @@ PERFTEST_USER_EMAIL = "perftest-digger@example.invalid"
 # Release id shared by the seed and the digger PUT/bulk-tier scenarios.
 PERFTEST_RELEASE_ID = 12345
 
+# Fixed report UUID shared by the seed and the digger reports get/read scenarios.
+# The seed inserts a digger.reports row carrying this id (reset to unread each run)
+# so GET /reports/{id} and POST /reports/{id}/read hit a real, owned report.
+PERFTEST_REPORT_ID = "00000000-0000-0000-0000-0000000d2222"
+
 
 def _jwt_secret() -> str:
     """Return the JWT signing secret from the environment.
@@ -162,15 +167,20 @@ def seed_digger_perftest_data(postgres_url: str) -> None:
       * `digger.user_wantlist_priorities` for (user, release) so the PUT/bulk
         endpoints update real rows,
       * `digger.release_scrape_state` + `digger.sellers` + a `digger.listings`
-        row with removed_at IS NULL so active_listings > 0.
+        row with removed_at IS NULL so active_listings > 0,
+      * a `digger.reports` row with the fixed perftest report id (reset to unread
+        on every run) so GET /reports/{id} and POST /reports/{id}/read hit a real,
+        owned report.
 
     Uses a synchronous psycopg3 connection — this keeps the runner free of
     asyncio. Safe to run repeatedly.
     """
     import psycopg
+    from psycopg.types.json import Jsonb
 
     user_id = PERFTEST_USER_ID
     release_id = PERFTEST_RELEASE_ID
+    report_id = PERFTEST_REPORT_ID
     seller_id = 999_001
     listing_id = 999_001
     # A non-functional placeholder hash in the API's salt:key format. This user
@@ -217,6 +227,24 @@ def seed_digger_perftest_data(postgres_url: str) -> None:
             "VALUES (%s, %s, %s, %s, 'USD', 'VG+', 'VG+', NULL) "
             "ON CONFLICT (listing_id) DO UPDATE SET removed_at = NULL",
             (listing_id, release_id, seller_id, 24.99),
+        )
+        # A pre-generated report so the reports get/read scenarios target a real,
+        # owned row. read_at is reset to NULL each run so the first mark-read hits
+        # the success (204) path; later iterations are 404 (already read) — both
+        # measure the same UPDATE round-trip latency.
+        cur.execute(
+            "INSERT INTO digger.reports "
+            "(report_id, user_id, kind, title, summary, bundles, watching, change_flag, shipping_confidence) "
+            "VALUES (%s, %s, 'interactive', %s, %s, %s, %s, 'first_run', 'low') "
+            "ON CONFLICT (report_id) DO UPDATE SET read_at = NULL, generated_at = now()",
+            (
+                report_id,
+                user_id,
+                "Perftest Report",
+                Jsonb({"bundle_count": 0, "watching_count": 0}),
+                Jsonb([]),
+                Jsonb([]),
+            ),
         )
         conn.commit()
     print("  Seed complete.")

--- a/tests/perftest/test_run_perftest.py
+++ b/tests/perftest/test_run_perftest.py
@@ -6,6 +6,7 @@ parsing of `digger_scenarios` into the test plan with auth + body + path_params.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from api.auth import decode_token
@@ -40,6 +41,20 @@ def test_jwt_sub_matches_seed_user_id() -> None:
     """The minted sub must equal the UUID the seeder uses (auth -> seeded rows)."""
     payload = decode_token(rp.mint_perftest_jwt(secret=SECRET), SECRET)
     assert payload["sub"] == rp.PERFTEST_USER_ID == "00000000-0000-0000-0000-0000000d1996"
+
+
+def test_perftest_report_id_is_a_distinct_valid_uuid() -> None:
+    """The seeded report UUID (used by the reports get/read scenarios) is valid and distinct.
+
+    The reports-by-id and mark-read perftest scenarios target this fixed UUID, so the
+    seeder must insert a digger.reports row carrying it. It must not collide with the
+    perftest user UUID.
+    """
+    import uuid
+
+    parsed = uuid.UUID(rp.PERFTEST_REPORT_ID)
+    assert str(parsed) == rp.PERFTEST_REPORT_ID
+    assert rp.PERFTEST_REPORT_ID != rp.PERFTEST_USER_ID
 
 
 def test_interpolate_path_fills_release_id() -> None:
@@ -105,3 +120,84 @@ def test_build_test_plan_without_digger_scenarios_is_empty_when_no_entities() ->
     plan = rp.build_test_plan({"api_base_url": "http://api:8004"}, artist_ids={}, label_ids={})
     names = {t["name"] for t in plan}
     assert not any(n.startswith("digger_") for n in names)
+
+
+def _digger_m2_config() -> dict[str, Any]:
+    """A config exercising the M2 reports + recommend scenarios."""
+    return {
+        "api_base_url": "http://api:8004",
+        "digger_scenarios": [
+            {"name": "digger_reports_list", "method": "GET", "path": "/api/digger/reports", "auth": True},
+            {
+                "name": "digger_reports_get",
+                "method": "GET",
+                "path": "/api/digger/reports/{report_id}",
+                "path_params": {"report_id": rp.PERFTEST_REPORT_ID},
+                "auth": True,
+            },
+            {
+                "name": "digger_reports_read",
+                "method": "POST",
+                "path": "/api/digger/reports/{report_id}/read",
+                "path_params": {"report_id": rp.PERFTEST_REPORT_ID},
+                "auth": True,
+            },
+            {
+                "name": "digger_recommend",
+                "method": "POST",
+                "path": "/api/digger/recommend",
+                "body": {"deadline_seconds": 5},
+                "auth": True,
+            },
+        ],
+    }
+
+
+def test_build_test_plan_parses_reports_get_by_id() -> None:
+    """The reports-by-id GET interpolates {report_id} and carries no body."""
+    plan = rp.build_test_plan(_digger_m2_config(), artist_ids={}, label_ids={})
+    get_t = {t["name"]: t for t in plan}["digger_reports_get"]
+    assert get_t["method"] == "GET"
+    assert get_t["auth"] is True
+    assert get_t["url"] == f"http://api:8004/api/digger/reports/{rp.PERFTEST_REPORT_ID}"
+    assert "json_body" not in get_t
+
+
+def test_build_test_plan_parses_report_read_post_path_param_no_body() -> None:
+    """The mark-read POST interpolates {report_id} and sends no body (json_body is None)."""
+    plan = rp.build_test_plan(_digger_m2_config(), artist_ids={}, label_ids={})
+    read_t = {t["name"]: t for t in plan}["digger_reports_read"]
+    assert read_t["method"] == "POST"
+    assert read_t["auth"] is True
+    assert read_t["url"] == f"http://api:8004/api/digger/reports/{rp.PERFTEST_REPORT_ID}/read"
+    assert read_t["json_body"] is None
+
+
+def test_build_test_plan_parses_recommend_post_with_body() -> None:
+    """The recommend POST (SSE) carries its JSON body and is authenticated."""
+    plan = rp.build_test_plan(_digger_m2_config(), artist_ids={}, label_ids={})
+    rec_t = {t["name"]: t for t in plan}["digger_recommend"]
+    assert rec_t["method"] == "POST"
+    assert rec_t["auth"] is True
+    assert rec_t["url"] == "http://api:8004/api/digger/recommend"
+    assert rec_t["json_body"] == {"deadline_seconds": 5}
+
+
+def test_real_config_yaml_includes_m2_digger_scenarios() -> None:
+    """The shipped config.yaml wires the M2 reports + recommend endpoints end-to-end.
+
+    Guards against config<->runner drift: the new scenarios must parse through the
+    real load path and the reports get/read scenarios must target the seeded report
+    UUID so the --seed step and the path params stay in sync.
+    """
+    config_path = Path(__file__).parent / "config.yaml"
+    config = rp.load_config(str(config_path))
+    plan = rp.build_test_plan(config, artist_ids={}, label_ids={})
+    by_name = {t["name"]: t for t in plan}
+
+    for name in ("digger_reports_list", "digger_reports_get", "digger_reports_read", "digger_recommend"):
+        assert name in by_name, f"{name} missing from the shipped config plan"
+
+    assert by_name["digger_reports_get"]["url"].endswith(f"/api/digger/reports/{rp.PERFTEST_REPORT_ID}")
+    assert by_name["digger_reports_read"]["url"].endswith(f"/api/digger/reports/{rp.PERFTEST_REPORT_ID}/read")
+    assert by_name["digger_recommend"]["json_body"] == {"deadline_seconds": 5}


### PR DESCRIPTION
## Summary

Final layer (E) of Digger **M2**, completing the milestone. This layer is
test/docs/config only — **no service production code changed**. Builds on the
merged Layers A–D (optimizer #344, API #345, scheduler #346, Reports UI #347).

- **Perf tests** (`tests/perftest/`): add the three new M2 user-facing endpoints
  to the harness in the M1 `digger_scenarios` format —
  `GET /api/digger/reports/{id}`, `POST /api/digger/reports/{id}/read`, and
  `POST /api/digger/recommend` (SSE; timed as a plain POST, mirroring the NLQ
  scenarios — the `EventSourceResponse` closes once the generator completes).
  The seed now inserts a fixed-UUID `digger.reports` row (reset to unread each
  run) so the reports get/read scenarios resolve a real, owned report. New unit +
  real-config integration tests lock the new scenario parsing.
- **Docs**: new `docs/digger-optimizer.md` (Mermaid diagrams for the
  filtering → shipping → greedy/ILP → pareto pipeline, the recommend SSE flow,
  and the scheduler/reports pipeline with change-flag logic). Register
  `common/digger_optimizer/` in CLAUDE.md's directory structure and link the doc
  from `docs/architecture.md`. (Layer C env vars were already documented in
  `docs/configuration.md`.)
- **E2E smoke** (`tests/e2e/test_digger_m2_smoke.py`, `@pytest.mark.e2e`): a
  live-stack smoke covering the recommend SSE flow + reports CRUD round-trip.
  Self-contained (reuses the perftest seed + JWT mint), skips cleanly unless the
  live-stack env is present, and is deselected by `-m 'not e2e'`.

## Test Plan

- [x] `just lint` — all pre-commit hooks pass
- [x] `just test` — 3367 passed (non-e2e; +5 new perftest tests)
- [x] `just test-js` — 1215 passed
- [x] `just test-js-cov` — passes (digger.js 98% line)
- [x] `just test-common` — 504 passed; `common/digger_optimizer/*` 100%
- [x] `just test-api` — 1605 passed; recommend/reports/refresh/queries 100%
- [x] `just test-digger` — 143 passed; `digger/scheduler/runner.py` 100%
- [ ] E2E smoke (`tests/e2e/test_digger_m2_smoke.py`) requires a live stack +
      `JWT_SECRET_KEY`/`DIGGER_E2E_POSTGRES_URL`; not run here (no stack), matching
      the M1 precedent that live perf/E2E are CI/manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)