### PR TITLE
feat(digger): M3 Layer B — agent API surface (SSE chat + proposals)

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -41,6 +41,7 @@ import api.routers.auth as _auth_router
 import api.routers.collection as _collection_router
 import api.routers.credits as _credits_router
 import api.routers.digger as _digger_router
+import api.routers.digger_agent as _digger_agent_router
 import api.routers.digger_recommend as _digger_recommend_router
 import api.routers.digger_reports as _digger_reports_router
 import api.routers.explore as _explore_router
@@ -251,6 +252,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:  # pragma: no cover
     jwt_secret_for_neo4j = _config.jwt_secret_key if _config.neo4j_host else None
     _dependencies.configure(jwt_secret_for_neo4j, _redis, pool=_pool, digger_api_service_token=_config.digger_api_service_token)
     _digger_router.configure(_pool)
+    _digger_agent_router.configure(_pool, _redis, _config.anthropic_api_key)
     _digger_recommend_router.configure(_pool, _redis)
     _digger_reports_router.configure(_pool)
     _internal_digger_router.configure(_pool)
@@ -401,6 +403,7 @@ async def metrics_middleware(request: Request, call_next: Any) -> Any:
 
 app.include_router(_auth_router.router)
 app.include_router(_digger_router.router)
+app.include_router(_digger_agent_router.router)
 app.include_router(_digger_recommend_router.router)
 app.include_router(_digger_reports_router.router)
 app.include_router(_internal_digger_router.router)

--- a/api/api.py
+++ b/api/api.py
@@ -42,6 +42,7 @@ import api.routers.collection as _collection_router
 import api.routers.credits as _credits_router
 import api.routers.digger as _digger_router
 import api.routers.digger_agent as _digger_agent_router
+import api.routers.digger_proposals as _digger_proposals_router
 import api.routers.digger_recommend as _digger_recommend_router
 import api.routers.digger_reports as _digger_reports_router
 import api.routers.explore as _explore_router
@@ -253,6 +254,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:  # pragma: no cover
     _dependencies.configure(jwt_secret_for_neo4j, _redis, pool=_pool, digger_api_service_token=_config.digger_api_service_token)
     _digger_router.configure(_pool)
     _digger_agent_router.configure(_pool, _redis, _config.anthropic_api_key)
+    _digger_proposals_router.configure(_pool)
     _digger_recommend_router.configure(_pool, _redis)
     _digger_reports_router.configure(_pool)
     _internal_digger_router.configure(_pool)
@@ -404,6 +406,7 @@ async def metrics_middleware(request: Request, call_next: Any) -> Any:
 app.include_router(_auth_router.router)
 app.include_router(_digger_router.router)
 app.include_router(_digger_agent_router.router)
+app.include_router(_digger_proposals_router.router)
 app.include_router(_digger_recommend_router.router)
 app.include_router(_digger_reports_router.router)
 app.include_router(_internal_digger_router.router)

--- a/api/queries/digger_agent_queries.py
+++ b/api/queries/digger_agent_queries.py
@@ -66,6 +66,27 @@ async def list_messages(pool: AsyncPostgreSQLPool, session_id: uuid.UUID) -> lis
     return [{"role": r["role"], "content": r["content"]} for r in rows]
 
 
+async def list_sessions(pool: AsyncPostgreSQLPool, user_id: uuid.UUID, limit: int = 50) -> list[dict[str, Any]]:
+    """Return a user's agent sessions (most recently active first) for the session list UI."""
+    async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            "SELECT session_id, started_at, last_active_at, total_cost_usd "
+            "FROM digger.agent_sessions WHERE user_id = %s "
+            "ORDER BY last_active_at DESC LIMIT %s",
+            (user_id, limit),
+        )
+        rows = await cur.fetchall()
+    return [
+        {
+            "session_id": str(r["session_id"]),
+            "started_at": r["started_at"].isoformat(),
+            "last_active_at": r["last_active_at"].isoformat(),
+            "total_cost_usd": float(r["total_cost_usd"]),
+        }
+        for r in rows
+    ]
+
+
 async def update_token_totals(
     pool: AsyncPostgreSQLPool,
     session_id: uuid.UUID,

--- a/api/queries/digger_proposals.py
+++ b/api/queries/digger_proposals.py
@@ -1,0 +1,83 @@
+"""SQL helpers for the digger.proposals table, used by the proposals API router.
+
+Async psycopg3 throughout: pool.connection() -> conn.cursor() -> cur.execute(sql,
+(params,)); %s placeholders, params as tuples. JSONB ``payload`` is returned
+already parsed (dict_row). Approving a proposal applies its tier changes and
+flips its status in a single transaction (autocommit disabled, FOR UPDATE lock).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from psycopg.rows import dict_row
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from typing import Any
+    import uuid
+
+    from common import AsyncPostgreSQLPool
+
+
+async def list_pending_proposals(pool: AsyncPostgreSQLPool, user_id: uuid.UUID) -> list[dict[str, Any]]:
+    """Return a user's pending, unexpired proposals (newest first)."""
+    async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            "SELECT proposal_id, created_at, status, payload FROM digger.proposals "
+            "WHERE user_id = %s AND status = 'pending' AND expires_at > now() "
+            "ORDER BY created_at DESC",
+            (user_id,),
+        )
+        rows = await cur.fetchall()
+    return [
+        {
+            "proposal_id": str(r["proposal_id"]),
+            "created_at": r["created_at"].isoformat(),
+            "status": r["status"],
+            "payload": r["payload"],
+        }
+        for r in rows
+    ]
+
+
+async def approve_proposal(pool: AsyncPostgreSQLPool, proposal_id: uuid.UUID, user_id: uuid.UUID) -> int | None:
+    """Apply a pending proposal's tier changes and mark it approved, in one transaction.
+
+    Returns the number of wantlist rows actually updated (releases still in the
+    wantlist), or ``None`` if the proposal does not exist, is not owned by the
+    user, or is no longer pending.
+    """
+    async with pool.connection() as conn:
+        await conn.set_autocommit(False)
+        async with conn.transaction(), conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                "SELECT payload FROM digger.proposals WHERE proposal_id = %s AND user_id = %s AND status = 'pending' FOR UPDATE",
+                (proposal_id, user_id),
+            )
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            applied = 0
+            for change in row["payload"]:
+                await cur.execute(
+                    "UPDATE digger.user_wantlist_priorities SET tier = %s, updated_at = now() WHERE user_id = %s AND release_id = %s",
+                    (change["proposed_tier"], user_id, change["release_id"]),
+                )
+                if cur.rowcount > 0:
+                    applied += 1
+            await cur.execute(
+                "UPDATE digger.proposals SET status = 'approved' WHERE proposal_id = %s",
+                (proposal_id,),
+            )
+        return applied
+
+
+async def reject_proposal(pool: AsyncPostgreSQLPool, proposal_id: uuid.UUID, user_id: uuid.UUID) -> bool:
+    """Mark a pending proposal rejected; return True if one was updated."""
+    async with pool.connection() as conn, conn.cursor() as cur:
+        await cur.execute(
+            "UPDATE digger.proposals SET status = 'rejected' WHERE proposal_id = %s AND user_id = %s AND status = 'pending'",
+            (proposal_id, user_id),
+        )
+        return cur.rowcount > 0

--- a/api/routers/digger_agent.py
+++ b/api/routers/digger_agent.py
@@ -1,0 +1,177 @@
+"""POST /api/digger/agent/message — SSE-streamed agent chat turn + session list.
+
+Flow for a turn:
+1. Confirm the caller has digger enabled (403 otherwise).
+2. Reject if the caller's daily interactive token cap is exhausted (429).
+3. Acquire a per-user concurrency lock and run one agent turn, streaming typed
+   SSE events (text, tool_call, tool_result, bundle_card, proposal_card, done).
+4. On completion, persist the assistant message, roll up token totals + cost,
+   and record the spend against the daily budget.
+
+DI mirrors ``api/routers/digger_recommend.py``: module-global pool/redis injected
+via ``configure()`` with 503-guard accessors (not FastAPI ``Depends``).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+import json
+import logging
+from typing import TYPE_CHECKING, Annotated, Any
+from uuid import UUID
+
+import anthropic
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sse_starlette.sse import EventSourceResponse
+
+from api.dependencies import require_user
+from api.digger_agent.guardrails import ConcurrencyLock, TokenBudget
+from api.digger_agent.memory import build_message_history
+from api.digger_agent.runtime import run_agent_turn
+from api.digger_agent.tools.context import ToolContext
+from api.queries import digger_agent_queries as aq, digger_queries as q
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import AsyncIterator
+
+    import redis.asyncio as aioredis
+
+    from common import AsyncPostgreSQLPool
+
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/digger/agent", tags=["digger-agent"])
+
+_pool: AsyncPostgreSQLPool | None = None
+_redis: aioredis.Redis | None = None
+_anthropic_api_key: str | None = None
+
+
+def configure(pool: AsyncPostgreSQLPool, redis: aioredis.Redis, anthropic_api_key: str | None = None) -> None:
+    """Inject the Postgres pool, Redis client, and Anthropic API key at startup."""
+    global _pool, _redis, _anthropic_api_key
+    _pool = pool
+    _redis = redis
+    _anthropic_api_key = anthropic_api_key
+
+
+def _get_pool() -> AsyncPostgreSQLPool:
+    if _pool is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service not ready")
+    return _pool
+
+
+def _get_redis() -> aioredis.Redis:
+    if _redis is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service not ready")
+    return _redis
+
+
+class MessageIn(BaseModel):
+    user_message: str = Field(min_length=1, max_length=4000)
+    session_id: UUID | None = None
+    model_override: str | None = None
+
+
+# USD per 1M tokens, by model alias (display-only; feeds agent_sessions.total_cost_usd).
+_COST_PER_M = {
+    "haiku": {"in": 1.0, "out": 5.0, "cache_read": 0.10},
+    "sonnet": {"in": 3.0, "out": 15.0, "cache_read": 0.30},
+    "opus": {"in": 15.0, "out": 75.0, "cache_read": 1.50},
+}
+
+
+def _estimate_cost_usd(model: str, usage: dict[str, Any]) -> Decimal:
+    """Estimate this turn's spend in USD from token usage (unknown models bill as sonnet)."""
+    p = _COST_PER_M.get(model, _COST_PER_M["sonnet"])
+    return (
+        Decimal(usage["input"]) * Decimal(str(p["in"])) / 1_000_000
+        + Decimal(usage["output"]) * Decimal(str(p["out"])) / 1_000_000
+        + Decimal(usage["cache_read"]) * Decimal(str(p["cache_read"])) / 1_000_000
+    )
+
+
+@router.post("/message")
+async def message(body: MessageIn, current_user: Annotated[dict[str, Any], Depends(require_user)]) -> EventSourceResponse:
+    """Run one agent turn for the caller, streaming typed SSE events."""
+    pool = _get_pool()
+    redis = _get_redis()
+    user_id = UUID(current_user["sub"])
+
+    settings_row = await q.get_user_settings(pool, user_id)
+    if settings_row is None or not settings_row.enabled:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="digger not enabled")
+
+    model = body.model_override or settings_row.preferred_model
+    budget = TokenBudget(redis=redis, daily_cap=settings_row.daily_token_cap_interactive, kind="interactive")
+    if await budget.is_exceeded(user_id):
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="daily token cap exceeded")
+
+    lock = ConcurrencyLock(redis=redis)
+    client = anthropic.AsyncAnthropic(api_key=_anthropic_api_key)
+
+    session_id = body.session_id or await aq.create_session(pool, user_id, model=model)
+    await aq.append_message(pool, session_id, role="user", content=[{"type": "text", "text": body.user_message}])
+
+    async def stream_events() -> AsyncIterator[dict[str, str]]:
+        try:
+            async with lock.acquire(user_id):
+                history, anchor = await build_message_history(pool, session_id, client=client)
+                messages: list[dict[str, Any]] = []
+                if anchor is not None:
+                    messages.append(anchor)
+                messages.extend(history)
+
+                ctx = ToolContext(pool=pool, redis=redis, user_id=user_id, session_id=session_id)
+                final_messages: list[dict[str, Any]] | None = None
+                final_usage: dict[str, Any] | None = None
+                async for ev in run_agent_turn(client=client, model=model, ctx=ctx, messages=messages, max_iterations=8):
+                    if ev["type"] == "done":
+                        final_messages = ev["messages_after"]
+                        final_usage = ev["usage"]
+                        yield {"event": "done", "data": json.dumps({"session_id": str(session_id), "usage": final_usage})}
+                    else:
+                        yield {"event": ev["type"], "data": json.dumps({k: v for k, v in ev.items() if k != "type"})}
+
+                if final_messages is not None:
+                    last = final_messages[-1]
+                    if last["role"] == "assistant":
+                        await aq.append_message(pool, session_id, role="assistant", content=last["content"], token_counts=final_usage)
+                if final_usage is not None:
+                    cost = _estimate_cost_usd(model, final_usage)
+                    await aq.update_token_totals(
+                        pool,
+                        session_id,
+                        input_tokens=final_usage["input"],
+                        output_tokens=final_usage["output"],
+                        cache_read=final_usage["cache_read"],
+                        cost_usd=cost,
+                    )
+                    await budget.record(user_id, input_tokens=final_usage["input"], output_tokens=final_usage["output"])
+        except RuntimeError as exc:
+            yield {"event": "error", "data": json.dumps({"reason": str(exc)})}
+
+    return EventSourceResponse(stream_events())
+
+
+class AgentSessionItem(BaseModel):
+    session_id: str
+    started_at: str
+    last_active_at: str
+    total_cost_usd: float
+
+
+class AgentSessionList(BaseModel):
+    items: list[AgentSessionItem]
+
+
+@router.get("/sessions", response_model=AgentSessionList)
+async def list_sessions(current_user: Annotated[dict[str, Any], Depends(require_user)]) -> AgentSessionList:
+    """Return the caller's recent agent sessions, most recently active first."""
+    pool = _get_pool()
+    user_id = UUID(current_user["sub"])
+    items = await aq.list_sessions(pool, user_id)
+    return AgentSessionList(items=[AgentSessionItem(**it) for it in items])

--- a/api/routers/digger_proposals.py
+++ b/api/routers/digger_proposals.py
@@ -1,0 +1,79 @@
+"""Digger proposal endpoints: list pending, approve (apply tier changes), reject.
+
+NOTE: `from __future__ import annotations` is intentionally NOT used here — the
+`proposal_id: UUID` path params must resolve at runtime for FastAPI, and the
+Pydantic response models need their field types available at runtime. The
+`_pool` annotation is quoted so the TYPE_CHECKING-only import stays valid.
+(Matches the api/routers/digger_reports.py pattern.)
+"""
+
+from typing import TYPE_CHECKING, Annotated, Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from api.dependencies import require_user
+from api.queries import digger_proposals as q
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from common import AsyncPostgreSQLPool
+
+
+router = APIRouter(prefix="/api/digger/proposals", tags=["digger"])
+
+_pool: "AsyncPostgreSQLPool | None" = None
+
+
+def configure(pool: "AsyncPostgreSQLPool") -> None:
+    """Inject the Postgres pool at application startup."""
+    global _pool
+    _pool = pool
+
+
+def _get_pool() -> "AsyncPostgreSQLPool":
+    if _pool is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service not ready")
+    return _pool
+
+
+class ProposalItem(BaseModel):
+    proposal_id: str
+    created_at: str
+    status: str
+    payload: list[dict[str, Any]]
+
+
+class ProposalList(BaseModel):
+    items: list[ProposalItem]
+
+
+@router.get("", response_model=ProposalList)
+async def list_proposals(current_user: Annotated[dict[str, Any], Depends(require_user)]) -> ProposalList:
+    """Return the caller's pending, unexpired proposals."""
+    pool = _get_pool()
+    user_id = UUID(current_user["sub"])
+    items = await q.list_pending_proposals(pool, user_id)
+    return ProposalList(items=[ProposalItem(**it) for it in items])
+
+
+@router.post("/{proposal_id}/approve")
+async def approve(proposal_id: UUID, current_user: Annotated[dict[str, Any], Depends(require_user)]) -> dict[str, int]:
+    """Approve a pending proposal, applying its tier changes; 404 if already resolved."""
+    pool = _get_pool()
+    user_id = UUID(current_user["sub"])
+    applied = await q.approve_proposal(pool, proposal_id, user_id)
+    if applied is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="proposal not found or already resolved")
+    return {"applied": applied}
+
+
+@router.post("/{proposal_id}/reject", status_code=status.HTTP_204_NO_CONTENT)
+async def reject(proposal_id: UUID, current_user: Annotated[dict[str, Any], Depends(require_user)]) -> None:
+    """Reject a pending proposal; 404 if it does not exist or was already resolved."""
+    pool = _get_pool()
+    user_id = UUID(current_user["sub"])
+    ok = await q.reject_proposal(pool, proposal_id, user_id)
+    if not ok:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="proposal not found or already resolved")

--- a/common/config.py
+++ b/common/config.py
@@ -518,6 +518,9 @@ class ApiConfig:
     # Digger internal service token — shared secret between the API and the digger worker
     digger_api_service_token: str | None = None
 
+    # Anthropic API key for the Digger LLM agent (ANTHROPIC_API_KEY, _FILE supported)
+    anthropic_api_key: str | None = None
+
     # Admin dashboard — extractor connection
     extractor_host: str = "extractor"
     extractor_health_port: int = 8000
@@ -598,6 +601,7 @@ class ApiConfig:
         brevo_sender_email = getenv("BREVO_SENDER_EMAIL", "noreply@discogsography.com")
         brevo_sender_name = getenv("BREVO_SENDER_NAME", "Discogsography")
         digger_api_service_token = get_secret("DIGGER_API_SERVICE_TOKEN") or None
+        anthropic_api_key = get_secret("ANTHROPIC_API_KEY") or None
 
         metrics_retention_days_str = getenv("METRICS_RETENTION_DAYS", "366")
         try:
@@ -640,6 +644,7 @@ class ApiConfig:
             metrics_retention_days=metrics_retention_days,
             metrics_collection_interval=metrics_collection_interval,
             digger_api_service_token=digger_api_service_token,
+            anthropic_api_key=anthropic_api_key,
         )
 
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -177,6 +177,7 @@ def test_client(
     import api.routers.admin as _admin_router
     import api.routers.collection as _collection_router
     import api.routers.digger as _digger_router
+    import api.routers.digger_agent as _digger_agent_router
     import api.routers.digger_recommend as _digger_recommend_router
     import api.routers.digger_reports as _digger_reports_router
     import api.routers.explore as _explore_router
@@ -191,6 +192,7 @@ def test_client(
 
     fake_redis = aioredis_fake.FakeRedis(server=fake_redis_server)
     _digger_router.configure(mock_pool)
+    _digger_agent_router.configure(mock_pool, fake_redis)
     _digger_recommend_router.configure(mock_pool, fake_redis)
     _digger_reports_router.configure(mock_pool)
     _internal_digger_router.configure(mock_pool)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -178,6 +178,7 @@ def test_client(
     import api.routers.collection as _collection_router
     import api.routers.digger as _digger_router
     import api.routers.digger_agent as _digger_agent_router
+    import api.routers.digger_proposals as _digger_proposals_router
     import api.routers.digger_recommend as _digger_recommend_router
     import api.routers.digger_reports as _digger_reports_router
     import api.routers.explore as _explore_router
@@ -193,6 +194,7 @@ def test_client(
     fake_redis = aioredis_fake.FakeRedis(server=fake_redis_server)
     _digger_router.configure(mock_pool)
     _digger_agent_router.configure(mock_pool, fake_redis)
+    _digger_proposals_router.configure(mock_pool)
     _digger_recommend_router.configure(mock_pool, fake_redis)
     _digger_reports_router.configure(mock_pool)
     _internal_digger_router.configure(mock_pool)

--- a/tests/api/test_digger_agent_endpoint.py
+++ b/tests/api/test_digger_agent_endpoint.py
@@ -1,0 +1,267 @@
+"""Tests for the /api/digger/agent SSE message endpoint and session list.
+
+The Anthropic client is faked: ``anthropic.AsyncAnthropic`` is patched so the
+runtime drives a fake streaming client (``_FakeStream``). The SSE response is
+exercised end-to-end via the sync ``TestClient`` — the EventSourceResponse
+generator runs to completion and the full body is asserted on (M2 precedent).
+"""
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+import uuid
+
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+import pytest
+
+from api.queries.digger_queries import UserDiggerSettings
+
+
+def _enabled_settings(*, cap: int = 200_000, model: str = "sonnet") -> UserDiggerSettings:
+    return UserDiggerSettings(
+        user_id=uuid.uuid4(),
+        enabled=True,
+        country_code="US",
+        currency="USD",
+        scheduled_cadence="off",
+        preferred_model=model,  # type: ignore[arg-type]
+        daily_token_cap_interactive=cap,
+        daily_token_cap_scheduled=100_000,
+    )
+
+
+def _text_delta(text: str) -> SimpleNamespace:
+    return SimpleNamespace(type="content_block_delta", delta=SimpleNamespace(type="text_delta", text=text))
+
+
+def _text_block(text: str) -> SimpleNamespace:
+    return SimpleNamespace(type="text", text=text)
+
+
+def _usage(inp: int = 5, out: int = 1, cache_read: int = 0) -> SimpleNamespace:
+    return SimpleNamespace(input_tokens=inp, output_tokens=out, cache_read_input_tokens=cache_read)
+
+
+def _final(stop_reason: str, content: list[Any]) -> SimpleNamespace:
+    return SimpleNamespace(stop_reason=stop_reason, content=content, usage=_usage())
+
+
+class _FakeStream:
+    def __init__(self, events: list[Any], final: SimpleNamespace) -> None:
+        self._events = events
+        self._final = final
+
+    async def __aenter__(self) -> "_FakeStream":
+        return self
+
+    async def __aexit__(self, *_: object) -> bool:
+        return False
+
+    async def __aiter__(self) -> Any:
+        for event in self._events:
+            yield event
+
+    async def get_final_message(self) -> SimpleNamespace:
+        return self._final
+
+
+def _fake_anthropic(streams: list[_FakeStream]) -> MagicMock:
+    """Patch target for anthropic.AsyncAnthropic — returns a client driving the given streams."""
+    client = MagicMock()
+    client.messages.stream = MagicMock(side_effect=streams)
+    return MagicMock(return_value=client)
+
+
+def _fake_run(events: list[dict[str, Any]]) -> Any:
+    """Build a run_agent_turn replacement that yields the given events."""
+
+    async def _gen(**_kwargs: Any) -> Any:
+        for ev in events:
+            yield ev
+
+    return _gen
+
+
+# --- guard / auth paths ----------------------------------------------------
+
+
+def test_message_requires_auth(test_client: TestClient) -> None:
+    r = test_client.post("/api/digger/agent/message", json={"user_message": "hi"})
+    assert r.status_code == 401
+
+
+def test_message_403_when_no_settings(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    with patch("api.routers.digger_agent.q.get_user_settings", AsyncMock(return_value=None)):
+        r = test_client.post("/api/digger/agent/message", headers=auth_headers, json={"user_message": "hi"})
+    assert r.status_code == 403
+
+
+def test_message_403_when_disabled(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    settings = _enabled_settings()
+    settings.enabled = False
+    with patch("api.routers.digger_agent.q.get_user_settings", AsyncMock(return_value=settings)):
+        r = test_client.post("/api/digger/agent/message", headers=auth_headers, json={"user_message": "hi"})
+    assert r.status_code == 403
+
+
+def test_message_429_when_cap_exceeded(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    # cap=0 -> remaining is 0 -> is_exceeded True without touching Redis counters.
+    with patch("api.routers.digger_agent.q.get_user_settings", AsyncMock(return_value=_enabled_settings(cap=0))):
+        r = test_client.post("/api/digger/agent/message", headers=auth_headers, json={"user_message": "hi"})
+    assert r.status_code == 429
+
+
+# --- streaming paths -------------------------------------------------------
+
+
+def test_message_streams_text_and_done(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    streams = [_FakeStream([_text_delta("hello")], _final("end_turn", [_text_block("hello")]))]
+    with (
+        patch("api.routers.digger_agent.q.get_user_settings", AsyncMock(return_value=_enabled_settings())),
+        patch("api.routers.digger_agent.anthropic.AsyncAnthropic", _fake_anthropic(streams)),
+    ):
+        r = test_client.post("/api/digger/agent/message", headers=auth_headers, json={"user_message": "hi"})
+    assert r.status_code == 200
+    assert "event: text" in r.text
+    assert "event: done" in r.text
+
+
+def test_message_prepends_anchor(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    streams = [_FakeStream([_text_delta("ok")], _final("end_turn", [_text_block("ok")]))]
+    anchor = {"role": "user", "content": [{"type": "text", "text": "[prior context summary]: ..."}]}
+    history = [{"role": "user", "content": [{"type": "text", "text": "earlier"}]}]
+    with (
+        patch("api.routers.digger_agent.q.get_user_settings", AsyncMock(return_value=_enabled_settings())),
+        patch("api.routers.digger_agent.build_message_history", AsyncMock(return_value=(history, anchor))),
+        patch("api.routers.digger_agent.anthropic.AsyncAnthropic", _fake_anthropic(streams)),
+    ):
+        r = test_client.post("/api/digger/agent/message", headers=auth_headers, json={"user_message": "hi"})
+    assert r.status_code == 200
+    assert "event: done" in r.text
+
+
+def test_message_emits_error_event_when_lock_held(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    class _RaisingLock:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            pass
+
+        def acquire(self, *_a: object, **_k: object) -> Any:
+            @asynccontextmanager
+            async def _cm() -> Any:
+                raise RuntimeError("another agent session is already running for this user")
+                yield  # pragma: no cover
+
+            return _cm()
+
+    with (
+        patch("api.routers.digger_agent.q.get_user_settings", AsyncMock(return_value=_enabled_settings())),
+        patch("api.routers.digger_agent.ConcurrencyLock", _RaisingLock),
+        patch("api.routers.digger_agent.anthropic.AsyncAnthropic", _fake_anthropic([])),
+    ):
+        r = test_client.post("/api/digger/agent/message", headers=auth_headers, json={"user_message": "hi"})
+    assert r.status_code == 200
+    assert "event: error" in r.text
+    assert "already running" in r.text
+
+
+def test_message_without_done_skips_persistence(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    with (
+        patch("api.routers.digger_agent.q.get_user_settings", AsyncMock(return_value=_enabled_settings())),
+        patch("api.routers.digger_agent.anthropic.AsyncAnthropic", _fake_anthropic([])),
+        patch("api.routers.digger_agent.run_agent_turn", _fake_run([{"type": "text", "delta": "hi"}])),
+        patch("api.routers.digger_agent.aq.append_message", AsyncMock()) as append_mock,
+        patch("api.routers.digger_agent.aq.update_token_totals", AsyncMock()) as totals_mock,
+    ):
+        r = test_client.post("/api/digger/agent/message", headers=auth_headers, json={"user_message": "hi"})
+    assert r.status_code == 200
+    assert "event: text" in r.text
+    assert "event: done" not in r.text
+    # The user message is appended before streaming; no assistant append and no totals update.
+    assert append_mock.await_count == 1
+    totals_mock.assert_not_awaited()
+
+
+def test_message_done_with_trailing_tool_results_skips_assistant_append(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    done_event = {
+        "type": "done",
+        "usage": {"input": 5, "output": 1, "cache_read": 0},
+        "messages_after": [{"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "{}"}]}],
+    }
+    with (
+        patch("api.routers.digger_agent.q.get_user_settings", AsyncMock(return_value=_enabled_settings())),
+        patch("api.routers.digger_agent.anthropic.AsyncAnthropic", _fake_anthropic([])),
+        patch("api.routers.digger_agent.run_agent_turn", _fake_run([done_event])),
+        patch("api.routers.digger_agent.aq.append_message", AsyncMock()) as append_mock,
+        patch("api.routers.digger_agent.aq.update_token_totals", AsyncMock()) as totals_mock,
+    ):
+        r = test_client.post("/api/digger/agent/message", headers=auth_headers, json={"user_message": "hi"})
+    assert r.status_code == 200
+    assert "event: done" in r.text
+    # Only the initial user message append; the trailing message is not an assistant turn.
+    assert append_mock.await_count == 1
+    totals_mock.assert_awaited_once()
+
+
+# --- cost helper -----------------------------------------------------------
+
+
+def test_estimate_cost_usd_known_model() -> None:
+    from decimal import Decimal
+
+    from api.routers.digger_agent import _estimate_cost_usd
+
+    cost = _estimate_cost_usd("haiku", {"input": 1_000_000, "output": 1_000_000, "cache_read": 0})
+    assert cost == Decimal("1.0") + Decimal("5.0")
+
+
+def test_estimate_cost_usd_unknown_model_falls_back_to_sonnet() -> None:
+    from api.routers.digger_agent import _estimate_cost_usd
+
+    fallback = _estimate_cost_usd("bogus", {"input": 1_000_000, "output": 0, "cache_read": 0})
+    sonnet = _estimate_cost_usd("sonnet", {"input": 1_000_000, "output": 0, "cache_read": 0})
+    assert fallback == sonnet
+
+
+# --- sessions list ---------------------------------------------------------
+
+
+def test_list_sessions_requires_auth(test_client: TestClient) -> None:
+    r = test_client.get("/api/digger/agent/sessions")
+    assert r.status_code == 401
+
+
+def test_list_sessions_returns_items(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    items = [
+        {
+            "session_id": str(uuid.uuid4()),
+            "started_at": "2026-05-21T00:00:00+00:00",
+            "last_active_at": "2026-05-22T00:00:00+00:00",
+            "total_cost_usd": 0.0123,
+        }
+    ]
+    with patch("api.routers.digger_agent.aq.list_sessions", AsyncMock(return_value=items)):
+        r = test_client.get("/api/digger/agent/sessions", headers=auth_headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["items"]) == 1
+    assert body["items"][0]["total_cost_usd"] == 0.0123
+
+
+# --- DI guards -------------------------------------------------------------
+
+
+def test_get_pool_and_redis_raise_when_unconfigured() -> None:
+    import api.routers.digger_agent as mod
+
+    saved_pool, saved_redis = mod._pool, mod._redis
+    mod._pool = None
+    mod._redis = None
+    try:
+        with pytest.raises(HTTPException):
+            mod._get_pool()
+        with pytest.raises(HTTPException):
+            mod._get_redis()
+    finally:
+        mod._pool, mod._redis = saved_pool, saved_redis

--- a/tests/api/test_digger_agent_queries.py
+++ b/tests/api/test_digger_agent_queries.py
@@ -1,5 +1,6 @@
 """Tests for the digger agent session/message persistence queries (mock-based)."""
 
+from datetime import UTC, datetime
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 import uuid
@@ -11,6 +12,7 @@ from api.queries.digger_agent_queries import (
     append_message,
     create_session,
     list_messages,
+    list_sessions,
     update_token_totals,
 )
 
@@ -75,3 +77,27 @@ async def test_update_token_totals_increments(mock_pool: MagicMock, mock_cur: As
     sql, params = mock_cur.execute.await_args.args
     assert "total_input_tokens = total_input_tokens + %s" in sql
     assert params == (10, 5, 3, Decimal("0.001"), session_id)
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_formats_rows(mock_pool: MagicMock, mock_cur: AsyncMock) -> None:
+    sid = uuid.uuid4()
+    started = datetime(2026, 5, 21, tzinfo=UTC)
+    active = datetime(2026, 5, 22, tzinfo=UTC)
+    mock_cur.fetchall.return_value = [
+        {"session_id": sid, "started_at": started, "last_active_at": active, "total_cost_usd": Decimal("0.0123")},
+    ]
+    user_id = uuid.uuid4()
+    out = await list_sessions(mock_pool, user_id)
+    assert out == [
+        {
+            "session_id": str(sid),
+            "started_at": started.isoformat(),
+            "last_active_at": active.isoformat(),
+            "total_cost_usd": 0.0123,
+        }
+    ]
+    sql, params = mock_cur.execute.await_args.args
+    assert "FROM digger.agent_sessions WHERE user_id = %s" in sql
+    assert "ORDER BY last_active_at DESC" in sql
+    assert params == (user_id, 50)

--- a/tests/api/test_digger_proposals_queries.py
+++ b/tests/api/test_digger_proposals_queries.py
@@ -1,0 +1,90 @@
+"""Tests for the digger.proposals SQL helpers (mock-based)."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+import uuid
+
+import pytest
+
+from api.queries import digger_proposals as q
+
+
+def _txn_pool(mock_cur: AsyncMock) -> MagicMock:
+    """Build a pool whose connection supports set_autocommit + transaction() + cursor()."""
+    conn = AsyncMock()
+    conn.set_autocommit = AsyncMock()
+
+    txn_ctx = AsyncMock()
+    txn_ctx.__aenter__ = AsyncMock(return_value=None)
+    txn_ctx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=txn_ctx)
+
+    cur_ctx = AsyncMock()
+    cur_ctx.__aenter__ = AsyncMock(return_value=mock_cur)
+    cur_ctx.__aexit__ = AsyncMock(return_value=False)
+    conn.cursor = MagicMock(return_value=cur_ctx)
+
+    conn_ctx = AsyncMock()
+    conn_ctx.__aenter__ = AsyncMock(return_value=conn)
+    conn_ctx.__aexit__ = AsyncMock(return_value=False)
+    pool = MagicMock()
+    pool.connection = MagicMock(return_value=conn_ctx)
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_list_pending_proposals_formats_rows(mock_pool: MagicMock, mock_cur: AsyncMock) -> None:
+    pid = uuid.uuid4()
+    created = datetime(2026, 5, 21, tzinfo=UTC)
+    payload = [{"release_id": 1, "current_tier": "nice", "proposed_tier": "must", "reason": "rare"}]
+    mock_cur.fetchall.return_value = [{"proposal_id": pid, "created_at": created, "status": "pending", "payload": payload}]
+    user_id = uuid.uuid4()
+    out = await q.list_pending_proposals(mock_pool, user_id)
+    assert out == [{"proposal_id": str(pid), "created_at": created.isoformat(), "status": "pending", "payload": payload}]
+    sql, params = mock_cur.execute.await_args.args
+    assert "status = 'pending'" in sql
+    assert "expires_at > now()" in sql
+    assert params == (user_id,)
+
+
+@pytest.mark.asyncio
+async def test_approve_proposal_returns_none_when_missing(mock_cur: AsyncMock) -> None:
+    mock_cur.fetchone = AsyncMock(return_value=None)
+    pool = _txn_pool(mock_cur)
+    result = await q.approve_proposal(pool, uuid.uuid4(), uuid.uuid4())
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_approve_proposal_applies_matching_changes(mock_cur: AsyncMock) -> None:
+    payload = [
+        {"release_id": 1, "proposed_tier": "must"},
+        {"release_id": 2, "proposed_tier": "nice"},
+    ]
+    mock_cur.fetchone = AsyncMock(return_value={"payload": payload})
+    mock_cur.rowcount = 1
+    pool = _txn_pool(mock_cur)
+    user_id = uuid.uuid4()
+    applied = await q.approve_proposal(pool, uuid.uuid4(), user_id)
+    assert applied == 2
+    sqls = [c.args[0] for c in mock_cur.execute.await_args_list]
+    assert any("FOR UPDATE" in s for s in sqls)
+    assert any("UPDATE digger.user_wantlist_priorities" in s for s in sqls)
+    assert any("status = 'approved'" in s for s in sqls)
+
+
+@pytest.mark.asyncio
+async def test_approve_proposal_skips_unmatched_releases(mock_cur: AsyncMock) -> None:
+    mock_cur.fetchone = AsyncMock(return_value={"payload": [{"release_id": 99, "proposed_tier": "must"}]})
+    mock_cur.rowcount = 0  # release no longer in the wantlist -> no row updated
+    pool = _txn_pool(mock_cur)
+    applied = await q.approve_proposal(pool, uuid.uuid4(), uuid.uuid4())
+    assert applied == 0
+
+
+@pytest.mark.asyncio
+async def test_reject_proposal_reflects_rowcount(mock_pool: MagicMock, mock_cur: AsyncMock) -> None:
+    mock_cur.rowcount = 1
+    assert await q.reject_proposal(mock_pool, uuid.uuid4(), uuid.uuid4()) is True
+    mock_cur.rowcount = 0
+    assert await q.reject_proposal(mock_pool, uuid.uuid4(), uuid.uuid4()) is False

--- a/tests/api/test_digger_proposals_router.py
+++ b/tests/api/test_digger_proposals_router.py
@@ -1,0 +1,73 @@
+"""Tests for the digger proposals router (list / approve / reject)."""
+
+from unittest.mock import AsyncMock, patch
+import uuid
+
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+import pytest
+
+
+def test_list_proposals_empty(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    with patch("api.routers.digger_proposals.q.list_pending_proposals", AsyncMock(return_value=[])):
+        r = test_client.get("/api/digger/proposals", headers=auth_headers)
+    assert r.status_code == 200
+    assert r.json()["items"] == []
+
+
+def test_list_proposals_returns_items(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    pid = str(uuid.uuid4())
+    item = {
+        "proposal_id": pid,
+        "created_at": "2026-05-21T00:00:00+00:00",
+        "status": "pending",
+        "payload": [{"release_id": 1, "current_tier": "nice", "proposed_tier": "must", "reason": "rare"}],
+    }
+    with patch("api.routers.digger_proposals.q.list_pending_proposals", AsyncMock(return_value=[item])):
+        r = test_client.get("/api/digger/proposals", headers=auth_headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["items"][0]["proposal_id"] == pid
+    assert body["items"][0]["payload"][0]["proposed_tier"] == "must"
+
+
+def test_approve_returns_applied_count(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    with patch("api.routers.digger_proposals.q.approve_proposal", AsyncMock(return_value=2)):
+        r = test_client.post(f"/api/digger/proposals/{uuid.uuid4()}/approve", headers=auth_headers)
+    assert r.status_code == 200
+    assert r.json()["applied"] == 2
+
+
+def test_approve_404_when_missing(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    with patch("api.routers.digger_proposals.q.approve_proposal", AsyncMock(return_value=None)):
+        r = test_client.post(f"/api/digger/proposals/{uuid.uuid4()}/approve", headers=auth_headers)
+    assert r.status_code == 404
+
+
+def test_reject_204(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    with patch("api.routers.digger_proposals.q.reject_proposal", AsyncMock(return_value=True)):
+        r = test_client.post(f"/api/digger/proposals/{uuid.uuid4()}/reject", headers=auth_headers)
+    assert r.status_code == 204
+
+
+def test_reject_404_when_missing(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    with patch("api.routers.digger_proposals.q.reject_proposal", AsyncMock(return_value=False)):
+        r = test_client.post(f"/api/digger/proposals/{uuid.uuid4()}/reject", headers=auth_headers)
+    assert r.status_code == 404
+
+
+def test_proposals_require_auth(test_client: TestClient) -> None:
+    r = test_client.get("/api/digger/proposals")
+    assert r.status_code == 401
+
+
+def test_get_pool_raises_when_unconfigured() -> None:
+    import api.routers.digger_proposals as mod
+
+    saved = mod._pool
+    mod._pool = None
+    try:
+        with pytest.raises(HTTPException):
+            mod._get_pool()
+    finally:
+        mod._pool = saved

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -737,6 +737,20 @@ class TestApiConfigNewFields:
         monkeypatch.setenv("ENCRYPTION_MASTER_KEY", "my-master-key")
         assert ApiConfig.from_env().encryption_master_key == "my-master-key"
 
+    def test_anthropic_api_key_none_when_not_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from common.config import ApiConfig
+
+        monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert ApiConfig.from_env().anthropic_api_key is None
+
+    def test_anthropic_api_key_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from common.config import ApiConfig
+
+        monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        assert ApiConfig.from_env().anthropic_api_key == "sk-ant-test"
+
     def test_jwt_algorithm_non_hs256_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from common.config import ApiConfig
 


### PR DESCRIPTION
## Summary

Digger M3 **Layer B** (Tasks 8–9 of the M3 agent plan) — the user-facing API surface on top of the Layer A agent core (#349). One layer = one PR.

- **`POST /api/digger/agent/message`** (SSE) — streams one tool-using agent turn as typed SSE events (`text`, `tool_call`, `tool_result`, `bundle_card`, `proposal_card`, `done`, `error`). Enforces digger-enabled (**403**) and the daily interactive token cap (**429**) before streaming, runs under a per-user Redis concurrency lock, and on completion persists the assistant message, rolls up token totals + an estimated USD cost, and records spend against the daily budget.
- **`GET /api/digger/agent/sessions`** — lists the caller's recent agent sessions.
- **`GET /api/digger/proposals`** — the caller's pending, unexpired tier-change proposals.
- **`POST /api/digger/proposals/{id}/approve`** — applies the proposal's tier changes to the wantlist and flips status to `approved` in one `FOR UPDATE` transaction; returns the count applied (404 if already resolved).
- **`POST /api/digger/proposals/{id}/reject`** — marks a pending proposal `rejected` (404 if already resolved).
- **`anthropic_api_key`** added to `ApiConfig` (`ANTHROPIC_API_KEY`, `_FILE` secret variant; defaults to `None`).

### Conventions
- Routers use module-global `_pool`/`_redis` + `configure()` + 503-guard accessors (not `Depends`), mirroring `digger_recommend`. Auth via `require_user` → `UUID(current_user["sub"])`.
- SQL lives in the queries layer (`digger_agent_queries.list_sessions`, new `digger_proposals` module); routers delegate. Proposals router uses runtime UUID path params (no `from __future__ import annotations`), mirroring `digger_reports`.
- Async psycopg3 throughout; the approve path disables autocommit before its transaction.
- Both routers registered in `api/api.py` (import + `configure` + `include_router`) and the `tests/api/conftest.py` `test_client` fixture (agent router gets the fakeredis client).
- Perf tests deferred to Layer E (Task 15), consistent with M1/M2.

## Test Plan
- [x] New mock-based tests at **100% coverage** on all four new modules (`api/routers/digger_agent.py`, `api/routers/digger_proposals.py`, `api/queries/digger_agent_queries.py`, `api/queries/digger_proposals.py`).
- [x] SSE endpoint exercised end-to-end via `TestClient` with a fake streaming Anthropic client (`_FakeStream`); covers guard (403/429), streaming, anchor, concurrency-error, persistence, and cost paths.
- [x] `uv run pytest tests/api` — **1685 passed**, no regressions.
- [x] `just lint` — all hooks pass (ruff, ruff-format, bandit, mypy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)