### PR TITLE
feat(digger): M3 Layer C — explore chat UI (streaming, proposals, sessions)

### DIFF
--- a/explore/__tests__/api-client.test.js
+++ b/explore/__tests__/api-client.test.js
@@ -1352,6 +1352,51 @@ describe('ApiClient', () => {
         });
     });
 
+    describe('digger proposal methods', () => {
+        it('getDiggerProposals GETs /api/digger/proposals with auth header', async () => {
+            let capturedUrl;
+            let capturedOptions;
+            vi.stubGlobal('fetch', async (url, options) => {
+                capturedUrl = url;
+                capturedOptions = options;
+                return { ok: true, status: 200, json: async () => ({ items: [] }) };
+            });
+            const res = await window.apiClient.getDiggerProposals('tok');
+            expect(capturedUrl).toBe('/api/digger/proposals');
+            expect(capturedOptions.headers.Authorization).toBe('Bearer tok');
+            expect(res).toEqual({ ok: true, status: 200, body: { items: [] } });
+        });
+
+        it('approveDiggerProposal POSTs to the approve endpoint and returns the applied count', async () => {
+            let capturedUrl;
+            let capturedOptions;
+            vi.stubGlobal('fetch', async (url, options) => {
+                capturedUrl = url;
+                capturedOptions = options;
+                return { ok: true, status: 200, json: async () => ({ applied: 2 }) };
+            });
+            const res = await window.apiClient.approveDiggerProposal('tok', 'p1');
+            expect(capturedUrl).toBe('/api/digger/proposals/p1/approve');
+            expect(capturedOptions.method).toBe('POST');
+            expect(capturedOptions.headers.Authorization).toBe('Bearer tok');
+            expect(res).toEqual({ ok: true, status: 200, body: { applied: 2 } });
+        });
+
+        it('rejectDiggerProposal POSTs to the reject endpoint (204 → body null)', async () => {
+            let capturedUrl;
+            let capturedOptions;
+            vi.stubGlobal('fetch', async (url, options) => {
+                capturedUrl = url;
+                capturedOptions = options;
+                return { ok: true, status: 204, json: async () => { throw new Error('no body'); } };
+            });
+            const res = await window.apiClient.rejectDiggerProposal('tok', 'p1');
+            expect(capturedUrl).toBe('/api/digger/proposals/p1/reject');
+            expect(capturedOptions.method).toBe('POST');
+            expect(res).toEqual({ ok: true, status: 204, body: null });
+        });
+    });
+
     describe('2FA methods', () => {
         it('twoFactorSetup should POST to /api/auth/2fa/setup with Authorization header', async () => {
             let capturedUrl, capturedOptions;

--- a/explore/__tests__/api-client.test.js
+++ b/explore/__tests__/api-client.test.js
@@ -1215,6 +1215,143 @@ describe('ApiClient', () => {
         });
     });
 
+    describe('streamDiggerAgent SSE streaming', () => {
+        function makeReadableStream(chunks) {
+            let index = 0;
+            return {
+                getReader() {
+                    return {
+                        read() {
+                            if (index < chunks.length) {
+                                const chunk = chunks[index++];
+                                return Promise.resolve({ done: false, value: new TextEncoder().encode(chunk) });
+                            }
+                            return Promise.resolve({ done: true, value: undefined });
+                        },
+                    };
+                },
+            };
+        }
+
+        it('forwards text and done events to callbacks', async () => {
+            const stream = makeReadableStream([
+                'event: text\ndata: {"delta":"hel"}\n\n',
+                'event: text\ndata: {"delta":"lo"}\n\n',
+                'event: done\ndata: {"session_id":"s1","usage":{"input":5,"output":2,"cache_read":0}}\n\n',
+            ]);
+            let capturedUrl;
+            let capturedOptions;
+            vi.stubGlobal('fetch', async (url, options) => {
+                capturedUrl = url;
+                capturedOptions = options;
+                return { ok: true, body: stream };
+            });
+
+            const onText = vi.fn();
+            const onDone = vi.fn();
+            window.apiClient.streamDiggerAgent('tok', { user_message: 'hi', session_id: null }, { onText, onDone });
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(capturedUrl).toBe('/api/digger/agent/message');
+            expect(capturedOptions.method).toBe('POST');
+            expect(capturedOptions.headers.Authorization).toBe('Bearer tok');
+            expect(JSON.parse(capturedOptions.body)).toEqual({ user_message: 'hi', session_id: null });
+            expect(onText).toHaveBeenCalledTimes(2);
+            expect(onText.mock.calls[0][0]).toEqual({ delta: 'hel' });
+            expect(onDone).toHaveBeenCalledWith({ session_id: 's1', usage: { input: 5, output: 2, cache_read: 0 } });
+        });
+
+        it('forwards tool_call, tool_result, bundle_card, and proposal_card events', async () => {
+            const stream = makeReadableStream([
+                'event: tool_call\ndata: {"id":"t1","name":"compute_bundles","input":{}}\n\n',
+                'event: tool_result\ndata: {"id":"t1","name":"compute_bundles","output":{"bundles":[]}}\n\n',
+                'event: bundle_card\ndata: {"bundle":{"name":"cheapest"}}\n\n',
+                'event: proposal_card\ndata: {"proposal":{"proposal_id":"p1","count":1}}\n\n',
+                'event: done\ndata: {"session_id":"s1","usage":{"input":1,"output":1,"cache_read":0}}\n\n',
+            ]);
+            vi.stubGlobal('fetch', async () => ({ ok: true, body: stream }));
+
+            const onToolCall = vi.fn();
+            const onToolResult = vi.fn();
+            const onBundleCard = vi.fn();
+            const onProposalCard = vi.fn();
+            window.apiClient.streamDiggerAgent('tok', {}, { onToolCall, onToolResult, onBundleCard, onProposalCard });
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(onToolCall).toHaveBeenCalledWith({ id: 't1', name: 'compute_bundles', input: {} });
+            expect(onToolResult).toHaveBeenCalledWith({ id: 't1', name: 'compute_bundles', output: { bundles: [] } });
+            expect(onBundleCard).toHaveBeenCalledWith({ bundle: { name: 'cheapest' } });
+            expect(onProposalCard).toHaveBeenCalledWith({ proposal: { proposal_id: 'p1', count: 1 } });
+        });
+
+        it('forwards error events to onError', async () => {
+            const stream = makeReadableStream(['event: error\ndata: {"reason":"daily token cap exceeded"}\n\n']);
+            vi.stubGlobal('fetch', async () => ({ ok: true, body: stream }));
+
+            const onError = vi.fn();
+            window.apiClient.streamDiggerAgent('tok', {}, { onError });
+            await new Promise((r) => setTimeout(r, 50));
+
+            expect(onError).toHaveBeenCalledWith({ reason: 'daily token cap exceeded' });
+        });
+
+        it('calls onError with the status on a non-ok response', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: false, status: 429, body: null }));
+            const onError = vi.fn();
+            window.apiClient.streamDiggerAgent('tok', {}, { onError });
+            await new Promise((r) => setTimeout(r, 50));
+            expect(onError).toHaveBeenCalledWith({ status: 429 });
+        });
+
+        it('calls onError when reader.read() rejects mid-stream', async () => {
+            let readCount = 0;
+            const stream = {
+                getReader() {
+                    return {
+                        read() {
+                            readCount++;
+                            if (readCount === 1) {
+                                return Promise.resolve({ done: false, value: new TextEncoder().encode('event: text\ndata: {"delta":"x"}\n\n') });
+                            }
+                            return Promise.reject(new Error('stream aborted'));
+                        },
+                    };
+                },
+            };
+            vi.stubGlobal('fetch', async () => ({ ok: true, body: stream }));
+            const onError = vi.fn();
+            window.apiClient.streamDiggerAgent('tok', {}, { onError });
+            await new Promise((r) => setTimeout(r, 50));
+            expect(onError).toHaveBeenCalled();
+            expect(onError.mock.calls[0][0].message).toBe('stream aborted');
+        });
+
+        it('flushes a trailing buffered event on stream completion', async () => {
+            const stream = makeReadableStream(['event: done\ndata: {"session_id":"s2","usage":{"input":0,"output":0,"cache_read":0}}']);
+            vi.stubGlobal('fetch', async () => ({ ok: true, body: stream }));
+            const onDone = vi.fn();
+            window.apiClient.streamDiggerAgent('tok', {}, { onDone });
+            await new Promise((r) => setTimeout(r, 50));
+            expect(onDone).toHaveBeenCalledWith({ session_id: 's2', usage: { input: 0, output: 0, cache_read: 0 } });
+        });
+    });
+
+    describe('getDiggerAgentSessions', () => {
+        it('GETs /api/digger/agent/sessions with auth header', async () => {
+            let capturedUrl;
+            let capturedOptions;
+            vi.stubGlobal('fetch', async (url, options) => {
+                capturedUrl = url;
+                capturedOptions = options;
+                return { ok: true, status: 200, json: async () => ({ items: [] }) };
+            });
+            const res = await window.apiClient.getDiggerAgentSessions('tok');
+            expect(capturedUrl).toBe('/api/digger/agent/sessions');
+            expect(capturedOptions.headers.Authorization).toBe('Bearer tok');
+            expect(res).toEqual({ ok: true, status: 200, body: { items: [] } });
+        });
+    });
+
     describe('2FA methods', () => {
         it('twoFactorSetup should POST to /api/auth/2fa/setup with Authorization header', async () => {
             let capturedUrl, capturedOptions;

--- a/explore/__tests__/digger-chat.test.js
+++ b/explore/__tests__/digger-chat.test.js
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { loadScript } from './helpers.js';
+
+/**
+ * Create the minimal DOM elements DiggerPane reads in its constructor.
+ */
+function setupDiggerDOM() {
+    document.body.textContent = '';
+    const ids = ['diggerPane', 'diggerLoading', 'diggerBody', 'diggerHeaderActions'];
+    for (const id of ids) {
+        const el = document.createElement('div');
+        el.id = id;
+        document.body.appendChild(el);
+    }
+}
+
+const ENABLED_SETTINGS = { ok: true, status: 200, body: { enabled: true, currency: 'USD' } };
+
+function makeBundle(overrides = {}) {
+    return {
+        name: 'cheapest',
+        seller_orders: [],
+        total_item_cost_cents: 1000,
+        total_shipping_cents: 500,
+        grand_total_cents: 1500,
+        coverage: { must: 1, nice: 0, eventually: 0 },
+        avg_condition_score: 7.0,
+        solver: 'ilp',
+        reasoning_hint: '1 must from 1 seller.',
+        ...overrides,
+    };
+}
+
+describe('DiggerPane chat', () => {
+    beforeEach(() => {
+        setupDiggerDOM();
+        delete globalThis.window;
+        globalThis.window = globalThis;
+        window.authManager = {
+            getToken: vi.fn().mockReturnValue('test-token'),
+            isLoggedIn: vi.fn().mockReturnValue(true),
+        };
+        window.apiClient = {
+            getDiggerSettings: vi.fn().mockResolvedValue(ENABLED_SETTINGS),
+            getDiggerWantlist: vi.fn().mockResolvedValue({ ok: true, status: 200, body: { items: [] } }),
+            getDiggerReports: vi.fn().mockResolvedValue({ ok: true, status: 200, body: { items: [] } }),
+            getDiggerAgentSessions: vi.fn().mockResolvedValue({ ok: true, status: 200, body: { items: [] } }),
+            streamDiggerAgent: vi.fn(),
+        };
+        window.exploreApp = undefined;
+        loadScript('digger.js');
+    });
+
+    // ---------------------------------------------------------------- //
+    // Navigation
+    // ---------------------------------------------------------------- //
+
+    it('renders a Chat nav button when Digger is enabled', async () => {
+        await window.diggerPane.init();
+        const header = document.getElementById('diggerHeaderActions');
+        const labels = Array.from(header.querySelectorAll('.digger-nav-btn')).map((b) => b.textContent);
+        expect(labels).toContain('Chat');
+    });
+
+    it('marks the Chat nav button active in the chat view', async () => {
+        await window.diggerPane.init();
+        await window.diggerPane._showChat();
+        const chatBtn = document.getElementById('diggerHeaderActions').querySelector('.digger-nav-btn[data-view="chat"]');
+        expect(chatBtn.classList.contains('active')).toBe(true);
+    });
+
+    it('switches to the chat view when the Chat nav button is clicked', async () => {
+        await window.diggerPane.init();
+        document.getElementById('diggerHeaderActions').querySelector('.digger-nav-btn[data-view="chat"]').click();
+        await Promise.resolve();
+        expect(window.diggerPane._view).toBe('chat');
+    });
+
+    // ---------------------------------------------------------------- //
+    // Chat view scaffold
+    // ---------------------------------------------------------------- //
+
+    it('renders a message list and composer', async () => {
+        await window.diggerPane.init();
+        await window.diggerPane._showChat();
+        const body = document.getElementById('diggerBody');
+        expect(body.querySelector('.digger-chat-messages')).not.toBeNull();
+        expect(body.querySelector('.digger-chat-input')).not.toBeNull();
+        expect(body.querySelector('.digger-chat-send')).not.toBeNull();
+    });
+
+    // ---------------------------------------------------------------- //
+    // Sending + streaming
+    // ---------------------------------------------------------------- //
+
+    it('renders the user message and streamed assistant text, capturing the session id', async () => {
+        window.apiClient.streamDiggerAgent = vi.fn((token, body, cbs) => {
+            cbs.onText({ delta: 'Hel' });
+            cbs.onText({ delta: 'lo' });
+            cbs.onDone({ session_id: 's1', usage: { input: 1, output: 1, cache_read: 0 } });
+        });
+        await window.diggerPane.init();
+        await window.diggerPane._showChat();
+        window.diggerPane._chatInput.value = 'find me a deal';
+        await window.diggerPane._sendChatMessage();
+
+        const body = document.getElementById('diggerBody');
+        expect(body.querySelector('.digger-chat-msg-user').textContent).toContain('find me a deal');
+        expect(body.querySelector('.digger-chat-msg-assistant').textContent).toContain('Hello');
+        expect(window.diggerPane._chatSessionId).toBe('s1');
+        // payload carried the (initially null) session id
+        expect(window.apiClient.streamDiggerAgent).toHaveBeenCalledWith(
+            'test-token',
+            { user_message: 'find me a deal', session_id: null },
+            expect.any(Object),
+        );
+    });
+
+    it('ignores empty drafts and concurrent sends', async () => {
+        window.apiClient.streamDiggerAgent = vi.fn();
+        await window.diggerPane.init();
+        await window.diggerPane._showChat();
+        window.diggerPane._chatInput.value = '   ';
+        await window.diggerPane._sendChatMessage();
+        expect(window.apiClient.streamDiggerAgent).not.toHaveBeenCalled();
+
+        // concurrent guard
+        window.diggerPane._chatInput.value = 'hi';
+        window.diggerPane._chatBusy = true;
+        await window.diggerPane._sendChatMessage();
+        expect(window.apiClient.streamDiggerAgent).not.toHaveBeenCalled();
+    });
+
+    it('renders tool-call pills and tool-result details', async () => {
+        window.apiClient.streamDiggerAgent = vi.fn((token, body, cbs) => {
+            cbs.onToolCall({ id: 't1', name: 'compute_bundles', input: { budget_cap_cents: 20000 } });
+            cbs.onToolResult({ id: 't1', name: 'compute_bundles', output: { bundles: [] } });
+            cbs.onDone({ session_id: 's1', usage: {} });
+        });
+        await window.diggerPane.init();
+        await window.diggerPane._showChat();
+        window.diggerPane._chatInput.value = 'deals?';
+        await window.diggerPane._sendChatMessage();
+
+        const body = document.getElementById('diggerBody');
+        expect(body.querySelector('.digger-tool-pill')).not.toBeNull();
+        expect(body.querySelector('.digger-tool-pill').textContent).toContain('compute_bundles');
+        const details = body.querySelector('details.digger-tool-result');
+        expect(details).not.toBeNull();
+        expect(details.querySelector('pre').textContent).toContain('bundles');
+    });
+
+    it('renders a bundle card for bundle_card events', async () => {
+        window.apiClient.streamDiggerAgent = vi.fn((token, body, cbs) => {
+            cbs.onBundleCard({ bundle: makeBundle() });
+            cbs.onDone({ session_id: 's1', usage: {} });
+        });
+        await window.diggerPane.init();
+        await window.diggerPane._showChat();
+        window.diggerPane._chatInput.value = 'bundle please';
+        await window.diggerPane._sendChatMessage();
+
+        expect(document.getElementById('diggerBody').querySelector('.digger-bundle-card')).not.toBeNull();
+    });
+
+    it('renders an error bubble on error events and re-enables sending', async () => {
+        window.apiClient.streamDiggerAgent = vi.fn((token, body, cbs) => {
+            cbs.onError({ reason: 'daily token cap exceeded' });
+        });
+        await window.diggerPane.init();
+        await window.diggerPane._showChat();
+        window.diggerPane._chatInput.value = 'hi';
+        await window.diggerPane._sendChatMessage();
+
+        const body = document.getElementById('diggerBody');
+        expect(body.querySelector('.digger-chat-msg-error')).not.toBeNull();
+        expect(body.textContent).toContain('daily token cap exceeded');
+        expect(window.diggerPane._chatBusy).toBe(false);
+        expect(window.diggerPane._chatSendBtn.disabled).toBe(false);
+    });
+
+    it('sends on Enter (without shift) from the composer', async () => {
+        window.apiClient.streamDiggerAgent = vi.fn((token, body, cbs) => cbs.onDone({ session_id: 's1', usage: {} }));
+        await window.diggerPane.init();
+        await window.diggerPane._showChat();
+        const input = window.diggerPane._chatInput;
+        input.value = 'hello';
+        input.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        await Promise.resolve();
+        expect(window.apiClient.streamDiggerAgent).toHaveBeenCalled();
+    });
+});

--- a/explore/__tests__/digger-chat.test.js
+++ b/explore/__tests__/digger-chat.test.js
@@ -268,4 +268,88 @@ describe('DiggerPane chat', () => {
         expect(card.textContent).toContain('Could not approve');
         expect(card.querySelector('.digger-proposal-actions')).not.toBeNull();
     });
+
+    // ---------------------------------------------------------------- //
+    // Cost indicator + session list
+    // ---------------------------------------------------------------- //
+
+    it('cost indicator shows used and remaining tokens', () => {
+        const el = window.diggerPane._buildCostIndicator(5000, 200000);
+        expect(el.textContent).toContain('5,000');
+        expect(el.textContent).toContain('195,000');
+    });
+
+    it('cost indicator treats a zero cap as 1 to avoid divide-by-zero', () => {
+        const el = window.diggerPane._buildCostIndicator(0, 0);
+        expect(el.querySelector('.digger-cost-bar-fill').style.width).toBe('0%');
+    });
+
+    it('surfaces a reject failure without collapsing the actions', async () => {
+        window.apiClient.getDiggerProposals = vi.fn().mockResolvedValue({ ok: true, status: 200, body: { items: [makeProposal()] } });
+        window.apiClient.rejectDiggerProposal = vi.fn().mockResolvedValue({ ok: false, status: 404, body: null });
+
+        await streamProposalAndSettle();
+
+        const card = document.getElementById('diggerBody').querySelector('.digger-proposal-card[data-proposal-id="p1"]');
+        card.querySelectorAll('.digger-proposal-actions button')[1].click();
+        await new Promise((r) => setTimeout(r, 0));
+        expect(card.textContent).toContain('Could not reject');
+        expect(card.querySelector('.digger-proposal-actions')).not.toBeNull();
+    });
+
+    it('renders a session list, new-chat button, and cost indicator in the sidebar', async () => {
+        window.apiClient.getDiggerAgentSessions = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            body: {
+                items: [
+                    { session_id: 'sess-1', started_at: '2026-05-20T00:00:00+00:00', last_active_at: '2026-05-21T00:00:00+00:00', total_cost_usd: 0.01 },
+                ],
+            },
+        });
+        await window.diggerPane.init();
+        await window.diggerPane._showChat();
+        const body = document.getElementById('diggerBody');
+        expect(body.querySelector('.digger-chat-new')).not.toBeNull();
+        expect(body.querySelector('.digger-cost-indicator')).not.toBeNull();
+        expect(body.querySelectorAll('.digger-session-item')).toHaveLength(1);
+    });
+
+    it('continues a past session when its list item is clicked', async () => {
+        window.apiClient.getDiggerAgentSessions = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            body: { items: [{ session_id: 'sess-1', started_at: '2026-05-20T00:00:00+00:00', last_active_at: '2026-05-21T00:00:00+00:00', total_cost_usd: 0 }] },
+        });
+        await window.diggerPane.init();
+        await window.diggerPane._showChat();
+        document.querySelector('.digger-session-item .digger-session-link').click();
+        await Promise.resolve();
+        expect(window.diggerPane._chatSessionId).toBe('sess-1');
+        expect(document.querySelector('.digger-session-item').classList.contains('active')).toBe(true);
+    });
+
+    it('accumulates used tokens from done events and updates the cost indicator', async () => {
+        window.apiClient.streamDiggerAgent = vi.fn((token, body, cbs) => cbs.onDone({ session_id: 's1', usage: { input: 1000, output: 500, cache_read: 0 } }));
+        await window.diggerPane.init();
+        await window.diggerPane._showChat();
+        window.diggerPane._chatInput.value = 'hi';
+        await window.diggerPane._sendChatMessage();
+        expect(window.diggerPane._chatUsedTokens).toBe(1500);
+        expect(document.querySelector('.digger-cost-indicator').textContent).toContain('1,500');
+    });
+
+    it('starts a new chat, clearing the session id and messages', async () => {
+        window.apiClient.streamDiggerAgent = vi.fn((token, body, cbs) => cbs.onDone({ session_id: 's1', usage: {} }));
+        await window.diggerPane.init();
+        await window.diggerPane._showChat();
+        window.diggerPane._chatInput.value = 'hi';
+        await window.diggerPane._sendChatMessage();
+        expect(window.diggerPane._chatSessionId).toBe('s1');
+
+        document.querySelector('.digger-chat-new').click();
+        await Promise.resolve();
+        expect(window.diggerPane._chatSessionId).toBeNull();
+        expect(document.querySelectorAll('.digger-chat-msg')).toHaveLength(0);
+    });
 });

--- a/explore/__tests__/digger-chat.test.js
+++ b/explore/__tests__/digger-chat.test.js
@@ -189,4 +189,83 @@ describe('DiggerPane chat', () => {
         await Promise.resolve();
         expect(window.apiClient.streamDiggerAgent).toHaveBeenCalled();
     });
+
+    // ---------------------------------------------------------------- //
+    // Proposal cards
+    // ---------------------------------------------------------------- //
+
+    function makeProposal(overrides = {}) {
+        return {
+            proposal_id: 'p1',
+            created_at: '2026-05-22T00:00:00+00:00',
+            status: 'pending',
+            payload: [{ release_id: 1, current_tier: 'nice', proposed_tier: 'must', reason: 'rare press' }],
+            ...overrides,
+        };
+    }
+
+    async function streamProposalAndSettle() {
+        window.apiClient.streamDiggerAgent = vi.fn((token, body, cbs) => {
+            cbs.onProposalCard({ proposal: { proposal_id: 'p1', count: 1 } });
+            cbs.onDone({ session_id: 's1', usage: {} });
+        });
+        await window.diggerPane.init();
+        await window.diggerPane._showChat();
+        window.diggerPane._chatInput.value = 'should I bump anything?';
+        await window.diggerPane._sendChatMessage();
+        await new Promise((r) => setTimeout(r, 0)); // let the proposal fetch + render settle
+    }
+
+    it('renders a proposal card from a proposal_card event and approves it', async () => {
+        window.apiClient.getDiggerProposals = vi.fn().mockResolvedValue({ ok: true, status: 200, body: { items: [makeProposal()] } });
+        window.apiClient.approveDiggerProposal = vi.fn().mockResolvedValue({ ok: true, status: 200, body: { applied: 1 } });
+
+        await streamProposalAndSettle();
+
+        const body = document.getElementById('diggerBody');
+        const card = body.querySelector('.digger-proposal-card[data-proposal-id="p1"]');
+        expect(card).not.toBeNull();
+        expect(card.textContent).toContain('rare press');
+        expect(card.textContent).toContain('must');
+
+        card.querySelectorAll('.digger-proposal-actions button')[0].click(); // Approve
+        await new Promise((r) => setTimeout(r, 0));
+        expect(window.apiClient.approveDiggerProposal).toHaveBeenCalledWith('test-token', 'p1');
+        expect(card.textContent).toContain('Applied 1 change');
+        expect(card.querySelector('.digger-proposal-actions')).toBeNull();
+    });
+
+    it('rejects a proposal from the card', async () => {
+        window.apiClient.getDiggerProposals = vi.fn().mockResolvedValue({ ok: true, status: 200, body: { items: [makeProposal()] } });
+        window.apiClient.rejectDiggerProposal = vi.fn().mockResolvedValue({ ok: true, status: 204, body: null });
+
+        await streamProposalAndSettle();
+
+        const card = document.getElementById('diggerBody').querySelector('.digger-proposal-card[data-proposal-id="p1"]');
+        card.querySelectorAll('.digger-proposal-actions button')[1].click(); // Reject
+        await new Promise((r) => setTimeout(r, 0));
+        expect(window.apiClient.rejectDiggerProposal).toHaveBeenCalledWith('test-token', 'p1');
+        expect(card.textContent).toContain('Rejected');
+    });
+
+    it('shows a note when the proposal is no longer available', async () => {
+        window.apiClient.getDiggerProposals = vi.fn().mockResolvedValue({ ok: true, status: 200, body: { items: [] } });
+
+        await streamProposalAndSettle();
+
+        expect(document.getElementById('diggerBody').textContent).toContain('no longer available');
+    });
+
+    it('surfaces an approve failure without collapsing the actions', async () => {
+        window.apiClient.getDiggerProposals = vi.fn().mockResolvedValue({ ok: true, status: 200, body: { items: [makeProposal()] } });
+        window.apiClient.approveDiggerProposal = vi.fn().mockResolvedValue({ ok: false, status: 404, body: null });
+
+        await streamProposalAndSettle();
+
+        const card = document.getElementById('diggerBody').querySelector('.digger-proposal-card[data-proposal-id="p1"]');
+        card.querySelectorAll('.digger-proposal-actions button')[0].click();
+        await new Promise((r) => setTimeout(r, 0));
+        expect(card.textContent).toContain('Could not approve');
+        expect(card.querySelector('.digger-proposal-actions')).not.toBeNull();
+    });
 });

--- a/explore/static/css/styles.css
+++ b/explore/static/css/styles.css
@@ -2957,3 +2957,113 @@ select option {
     color: var(--text-mid);
     font-size: 0.9rem;
 }
+
+/* ---- Digger agent chat (M3) ---- */
+
+.digger-chat {
+    display: flex;
+    gap: 1rem;
+    height: 100%;
+    min-height: 0;
+}
+
+.digger-chat-main {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-width: 0;
+    gap: 0.75rem;
+}
+
+.digger-chat-messages {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    overflow-y: auto;
+    flex: 1 1 auto;
+}
+
+.digger-chat-msg {
+    max-width: 90%;
+}
+
+.digger-chat-msg-user {
+    align-self: flex-end;
+}
+
+.digger-chat-msg-user .digger-chat-text {
+    background: var(--blue-accent);
+    color: #fff;
+    border-radius: 0.75rem 0.75rem 0 0.75rem;
+    padding: 0.5rem 0.75rem;
+    white-space: pre-wrap;
+}
+
+.digger-chat-msg-assistant .digger-chat-text {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    color: var(--text-high);
+    border-radius: 0.75rem 0.75rem 0.75rem 0;
+    padding: 0.5rem 0.75rem;
+    white-space: pre-wrap;
+}
+
+.digger-tool-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.8rem;
+    color: var(--text-dim);
+    border: 1px solid var(--border-color);
+    background: var(--inner-bg);
+    border-radius: 1rem;
+    padding: 0.15rem 0.6rem;
+}
+
+.digger-tool-pill .material-symbols-outlined {
+    font-size: 1rem;
+}
+
+.digger-tool-result {
+    font-size: 0.8rem;
+    color: var(--text-mid);
+}
+
+.digger-tool-result pre {
+    overflow-x: auto;
+    background: var(--inner-bg);
+    border-radius: 0.5rem;
+    padding: 0.5rem;
+}
+
+.digger-chat-msg-error {
+    color: var(--red-accent, #e5484d);
+    border: 1px solid var(--red-accent, #e5484d);
+    border-radius: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.9rem;
+}
+
+.digger-chat-composer {
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-end;
+}
+
+.digger-chat-input {
+    flex: 1 1 auto;
+    resize: vertical;
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    background: var(--inner-bg);
+    color: var(--text-high);
+    padding: 0.5rem 0.75rem;
+    font: inherit;
+}
+
+.digger-chat-send {
+    flex: 0 0 auto;
+}

--- a/explore/static/css/styles.css
+++ b/explore/static/css/styles.css
@@ -3067,3 +3067,50 @@ select option {
 .digger-chat-send {
     flex: 0 0 auto;
 }
+
+.digger-proposal-card {
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    background: var(--card-bg);
+    padding: 0.75rem 1rem;
+}
+
+.digger-proposal-card.approved {
+    border-color: var(--green-accent, #30a46c);
+}
+
+.digger-proposal-card.rejected {
+    border-color: var(--border-color);
+    opacity: 0.7;
+}
+
+.digger-proposal-card h4 {
+    margin: 0 0 0.5rem;
+    font-size: 0.95rem;
+    color: var(--text-high);
+}
+
+.digger-proposal-changes {
+    list-style: none;
+    margin: 0 0 0.75rem;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.digger-proposal-reason {
+    font-size: 0.8rem;
+    color: var(--text-dim);
+}
+
+.digger-proposal-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.digger-proposal-status {
+    margin-top: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--text-mid);
+}

--- a/explore/static/css/styles.css
+++ b/explore/static/css/styles.css
@@ -3114,3 +3114,76 @@ select option {
     font-size: 0.85rem;
     color: var(--text-mid);
 }
+
+/* ---- Digger chat sidebar (sessions + cost) ---- */
+
+.digger-chat-sidebar {
+    flex: 0 0 14rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    border-right: 1px solid var(--border-color);
+    padding-right: 1rem;
+    overflow-y: auto;
+}
+
+.digger-chat-sidebar h3 {
+    margin: 0;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-dim);
+}
+
+.digger-session-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    flex: 1 1 auto;
+}
+
+.digger-session-link {
+    width: 100%;
+    text-align: left;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 0.4rem;
+    color: var(--text-mid);
+    padding: 0.35rem 0.5rem;
+    font: inherit;
+    cursor: pointer;
+}
+
+.digger-session-link:hover {
+    background: var(--inner-bg);
+}
+
+.digger-session-item.active .digger-session-link {
+    border-color: var(--blue-accent);
+    color: var(--text-high);
+}
+
+.digger-cost-indicator {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    font-size: 0.8rem;
+    color: var(--text-dim);
+    border-top: 1px solid var(--border-color);
+    padding-top: 0.5rem;
+}
+
+.digger-cost-bar {
+    height: 0.35rem;
+    border-radius: 0.2rem;
+    background: var(--inner-bg);
+    overflow: hidden;
+}
+
+.digger-cost-bar-fill {
+    height: 100%;
+    background: var(--blue-accent);
+}

--- a/explore/static/js/api-client.js
+++ b/explore/static/js/api-client.js
@@ -760,6 +760,88 @@ class ApiClient {
     }
 
     /**
+     * Get the Digger agent session list for the current user (most recently active first).
+     * @param {string} token - JWT auth token
+     * @returns {Promise<{ok: boolean, status: number, body: Object|null}>} body = { items: [...] }
+     */
+    async getDiggerAgentSessions(token) {
+        const response = await fetch('/api/digger/agent/sessions', {
+            headers: { 'Authorization': `Bearer ${token}` },
+        });
+        const body = await response.json().catch(() => null);
+        return { ok: response.ok, status: response.status, body };
+    }
+
+    /**
+     * Stream one Digger agent turn over SSE.
+     * Events: text, tool_call, tool_result, bundle_card, proposal_card, done, error.
+     * @param {string} token - JWT auth token
+     * @param {Object} body - { user_message, session_id?, model_override? }
+     * @param {Object} callbacks - { onText, onToolCall, onToolResult, onBundleCard, onProposalCard, onDone, onError }
+     */
+    streamDiggerAgent(token, body, callbacks = {}) {
+        const { onText, onToolCall, onToolResult, onBundleCard, onProposalCard, onDone, onError } = callbacks;
+        fetch('/api/digger/agent/message', {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'Content-Type': 'application/json',
+                'Accept': 'text/event-stream',
+            },
+            body: JSON.stringify(body),
+        }).then(response => {
+            if (!response.ok) {
+                if (onError) onError({ status: response.status });
+                return;
+            }
+            const reader = response.body.getReader();
+            const decoder = new TextDecoder();
+            let buffer = '';
+            let eventType = null;
+            function processLines(lines) {
+                for (const line of lines) {
+                    if (line.startsWith('event:')) {
+                        eventType = line.slice(6).trim();
+                    } else if (line.startsWith('data:') && eventType) {
+                        let data = null;
+                        try {
+                            data = JSON.parse(line.slice(5).trim());
+                        } catch {
+                            data = null;
+                        }
+                        if (eventType === 'text' && onText) onText(data || {});
+                        else if (eventType === 'tool_call' && onToolCall) onToolCall(data || {});
+                        else if (eventType === 'tool_result' && onToolResult) onToolResult(data || {});
+                        else if (eventType === 'bundle_card' && onBundleCard) onBundleCard(data || {});
+                        else if (eventType === 'proposal_card' && onProposalCard) onProposalCard(data || {});
+                        else if (eventType === 'error' && onError) onError(data || {});
+                        else if (eventType === 'done' && onDone) onDone(data || {});
+                        eventType = null;
+                    }
+                }
+            }
+            function processChunk() {
+                reader.read().then(({ done, value }) => {
+                    if (done) {
+                        if (buffer.trim()) processLines(buffer.split('\n'));
+                        return;
+                    }
+                    buffer += decoder.decode(value, { stream: true });
+                    const lines = buffer.split('\n');
+                    buffer = lines.pop() || '';
+                    processLines(lines);
+                    processChunk();
+                }).catch(err => {
+                    if (onError) onError(err);
+                });
+            }
+            processChunk();
+        }).catch(err => {
+            if (onError) onError(err);
+        });
+    }
+
+    /**
      * Send a natural language query with SSE streaming.
      * @param {string} query - Natural language question
      * @param {Object|null} context - Optional context

--- a/explore/static/js/api-client.js
+++ b/explore/static/js/api-client.js
@@ -773,6 +773,49 @@ class ApiClient {
     }
 
     /**
+     * Get the current user's pending Digger tier-change proposals.
+     * @param {string} token - JWT auth token
+     * @returns {Promise<{ok: boolean, status: number, body: Object|null}>} body = { items: [...] }
+     */
+    async getDiggerProposals(token) {
+        const response = await fetch('/api/digger/proposals', {
+            headers: { 'Authorization': `Bearer ${token}` },
+        });
+        const body = await response.json().catch(() => null);
+        return { ok: response.ok, status: response.status, body };
+    }
+
+    /**
+     * Approve a Digger tier-change proposal, applying its changes.
+     * @param {string} token - JWT auth token
+     * @param {string} proposalId - Proposal UUID
+     * @returns {Promise<{ok: boolean, status: number, body: Object|null}>} body = { applied: n }
+     */
+    async approveDiggerProposal(token, proposalId) {
+        const response = await fetch(`/api/digger/proposals/${encodeURIComponent(proposalId)}/approve`, {
+            method: 'POST',
+            headers: { 'Authorization': `Bearer ${token}` },
+        });
+        const body = await response.json().catch(() => null);
+        return { ok: response.ok, status: response.status, body };
+    }
+
+    /**
+     * Reject a Digger tier-change proposal.
+     * @param {string} token - JWT auth token
+     * @param {string} proposalId - Proposal UUID
+     * @returns {Promise<{ok: boolean, status: number, body: Object|null}>} 204 → body null
+     */
+    async rejectDiggerProposal(token, proposalId) {
+        const response = await fetch(`/api/digger/proposals/${encodeURIComponent(proposalId)}/reject`, {
+            method: 'POST',
+            headers: { 'Authorization': `Bearer ${token}` },
+        });
+        const body = await response.json().catch(() => null);
+        return { ok: response.ok, status: response.status, body };
+    }
+
+    /**
      * Stream one Digger agent turn over SSE.
      * Events: text, tool_call, tool_result, bundle_card, proposal_card, done, error.
      * @param {string} token - JWT auth token

--- a/explore/static/js/digger.js
+++ b/explore/static/js/digger.js
@@ -37,10 +37,15 @@ class DiggerPane {
         this._bulkApplying = false;          // in-flight guard for bulk-tier Apply
 
         // M2 — reports view state.
-        this._view = 'wantlist';             // 'wantlist' | 'reports' | 'report' | 'recommend'
+        this._view = 'wantlist';             // 'wantlist' | 'reports' | 'report' | 'recommend' | 'chat'
         this._reports = [];                  // inbox summaries
         this._currentReport = null;          // full report being viewed
         this._recommending = false;          // in-flight guard for Run recommendation
+
+        // M3 — agent chat sub-view state.
+        this._chatSessionId = null;          // current agent session (null = new conversation)
+        this._chatBusy = false;              // in-flight guard for a streaming turn
+        this._chatMessages = null;           // <ul> the message bubbles are appended to
 
         this._loading = document.getElementById('diggerLoading');
         this._body = document.getElementById('diggerBody');
@@ -964,6 +969,7 @@ class DiggerPane {
 
         this._headerActions.appendChild(this._buildNavButton('Wantlist', 'wantlist'));
         this._headerActions.appendChild(this._buildNavButton('Reports', 'reports'));
+        this._headerActions.appendChild(this._buildNavButton('Chat', 'chat'));
 
         const runBtn = document.createElement('button');
         runBtn.type = 'button';
@@ -979,7 +985,7 @@ class DiggerPane {
     /**
      * Build a single header navigation button.
      * @param {string} label
-     * @param {'wantlist'|'reports'} view
+     * @param {'wantlist'|'reports'|'chat'} view
      * @returns {HTMLButtonElement}
      */
     _buildNavButton(label, view) {
@@ -993,6 +999,8 @@ class DiggerPane {
                 this._showWantlist();
             } else if (view === 'reports') {
                 this._showReports();
+            } else if (view === 'chat') {
+                this._showChat();
             }
         });
         return btn;
@@ -1009,7 +1017,8 @@ class DiggerPane {
             const view = btn.dataset.view;
             const isActive =
                 (view === 'wantlist' && this._view === 'wantlist') ||
-                (view === 'reports' && (this._view === 'reports' || this._view === 'report'));
+                (view === 'reports' && (this._view === 'reports' || this._view === 'report')) ||
+                (view === 'chat' && this._view === 'chat');
             btn.classList.toggle('active', isActive);
             btn.setAttribute('aria-pressed', String(isActive));
         }
@@ -1356,6 +1365,196 @@ class DiggerPane {
             onBack: () => this._showWantlist(),
             backLabel: '← Back to wantlist',
         });
+    }
+
+    // ------------------------------------------------------------------ //
+    // Chat — interactive agent conversation (SSE)
+    // ------------------------------------------------------------------ //
+
+    /**
+     * Switch to the chat view and render the message list + composer.
+     */
+    async _showChat() {
+        this._view = 'chat';
+        this._updateNavActiveState();
+        this._renderChatView();
+    }
+
+    /**
+     * Render the chat sub-view: a scrolling message list above a composer.
+     */
+    _renderChatView() {
+        if (!this._body) return;
+        this._body.textContent = '';
+
+        const chat = document.createElement('div');
+        chat.className = 'digger-chat';
+
+        const main = document.createElement('div');
+        main.className = 'digger-chat-main';
+
+        const messages = document.createElement('ul');
+        messages.className = 'digger-chat-messages';
+        this._chatMessages = messages;
+        main.appendChild(messages);
+
+        const composer = document.createElement('div');
+        composer.className = 'digger-chat-composer';
+
+        const input = document.createElement('textarea');
+        input.className = 'digger-chat-input';
+        input.placeholder = 'Ask Digger…';
+        input.rows = 2;
+        input.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                this._sendChatMessage();
+            }
+        });
+        this._chatInput = input;
+        composer.appendChild(input);
+
+        const send = document.createElement('button');
+        send.type = 'button';
+        send.className = 'btn-primary digger-chat-send';
+        send.textContent = 'Send';
+        send.addEventListener('click', () => this._sendChatMessage());
+        this._chatSendBtn = send;
+        composer.appendChild(send);
+
+        main.appendChild(composer);
+        chat.appendChild(main);
+        this._body.appendChild(chat);
+    }
+
+    /**
+     * Send the composer draft as one agent turn, streaming the reply into the
+     * message list. Guards against empty drafts and concurrent turns.
+     */
+    async _sendChatMessage() {
+        if (this._chatBusy) return;
+        const draft = ((this._chatInput && this._chatInput.value) || '').trim();
+        if (!draft) return;
+        const token = window.authManager.getToken();
+        if (!token) return;
+
+        this._chatBusy = true;
+        if (this._chatSendBtn) this._chatSendBtn.disabled = true;
+        if (this._chatInput) this._chatInput.value = '';
+
+        this._appendChatUserMessage(draft);
+        const assistantText = this._appendChatAssistantShell();
+
+        window.apiClient.streamDiggerAgent(
+            token,
+            { user_message: draft, session_id: this._chatSessionId },
+            {
+                onText: (data) => {
+                    assistantText.textContent += (data && data.delta) || '';
+                    this._scrollChatToEnd();
+                },
+                onToolCall: (data) => this._appendChatToolCall(data),
+                onToolResult: (data) => this._appendChatToolResult(data),
+                onBundleCard: (data) => this._appendChatBundleCard(data),
+                onDone: (data) => {
+                    if (data && data.session_id) this._chatSessionId = data.session_id;
+                    this._finishChat();
+                },
+                onError: (err) => {
+                    this._appendChatError((err && (err.reason || err.detail)) || 'Something went wrong.');
+                    this._finishChat();
+                },
+            },
+        );
+    }
+
+    /**
+     * Clear the in-flight guard and re-enable the composer.
+     */
+    _finishChat() {
+        this._chatBusy = false;
+        if (this._chatSendBtn) this._chatSendBtn.disabled = false;
+    }
+
+    /**
+     * Append an empty chat bubble <li> with the given role class and return it.
+     * @param {string} roleClass
+     * @returns {HTMLLIElement}
+     */
+    _appendChatMessageItem(roleClass) {
+        const li = document.createElement('li');
+        li.className = `digger-chat-msg ${roleClass}`;
+        if (this._chatMessages) this._chatMessages.appendChild(li);
+        return li;
+    }
+
+    _appendChatUserMessage(text) {
+        const li = this._appendChatMessageItem('digger-chat-msg-user');
+        const div = document.createElement('div');
+        div.className = 'digger-chat-text';
+        div.textContent = text;
+        li.appendChild(div);
+    }
+
+    /**
+     * Append an empty assistant bubble and return its text node for streaming.
+     * @returns {HTMLDivElement}
+     */
+    _appendChatAssistantShell() {
+        const li = this._appendChatMessageItem('digger-chat-msg-assistant');
+        const div = document.createElement('div');
+        div.className = 'digger-chat-text';
+        li.appendChild(div);
+        return div;
+    }
+
+    _appendChatToolCall(data) {
+        const li = this._appendChatMessageItem('digger-chat-msg-tool');
+        const pill = document.createElement('div');
+        pill.className = 'digger-tool-pill';
+        const icon = document.createElement('span');
+        icon.className = 'material-symbols-outlined';
+        icon.textContent = 'build';
+        pill.appendChild(icon);
+        const label = document.createElement('span');
+        label.textContent = (data && data.name) || 'tool';
+        pill.appendChild(label);
+        li.appendChild(pill);
+        this._scrollChatToEnd();
+    }
+
+    _appendChatToolResult(data) {
+        const li = this._appendChatMessageItem('digger-chat-msg-tool');
+        const details = document.createElement('details');
+        details.className = 'digger-tool-result';
+        const summary = document.createElement('summary');
+        summary.textContent = `${(data && data.name) || 'tool'} result`;
+        details.appendChild(summary);
+        const pre = document.createElement('pre');
+        pre.textContent = JSON.stringify((data && data.output) ?? {}, null, 2);
+        details.appendChild(pre);
+        li.appendChild(details);
+        this._scrollChatToEnd();
+    }
+
+    _appendChatBundleCard(data) {
+        const li = this._appendChatMessageItem('digger-chat-msg-assistant');
+        const currency = (this._settings && this._settings.currency) || 'USD';
+        li.appendChild(this._buildBundleCard((data && data.bundle) || {}, currency));
+        this._scrollChatToEnd();
+    }
+
+    _appendChatError(message) {
+        const li = this._appendChatMessageItem('digger-chat-msg-error');
+        li.textContent = message;
+        this._scrollChatToEnd();
+    }
+
+    /**
+     * Keep the newest message in view as content streams in.
+     */
+    _scrollChatToEnd() {
+        if (this._chatMessages) this._chatMessages.scrollTop = this._chatMessages.scrollHeight;
     }
 }
 

--- a/explore/static/js/digger.js
+++ b/explore/static/js/digger.js
@@ -1456,6 +1456,7 @@ class DiggerPane {
                 onToolCall: (data) => this._appendChatToolCall(data),
                 onToolResult: (data) => this._appendChatToolResult(data),
                 onBundleCard: (data) => this._appendChatBundleCard(data),
+                onProposalCard: (data) => this._appendChatProposalCard(data),
                 onDone: (data) => {
                     if (data && data.session_id) this._chatSessionId = data.session_id;
                     this._finishChat();
@@ -1548,6 +1549,126 @@ class DiggerPane {
         const li = this._appendChatMessageItem('digger-chat-msg-error');
         li.textContent = message;
         this._scrollChatToEnd();
+    }
+
+    /**
+     * Append a proposal card placeholder, then fill it with the fetched proposal.
+     * The stream only carries {proposal_id, count}; the full payload is fetched
+     * from the proposals endpoint so the card can show the tier changes.
+     */
+    _appendChatProposalCard(data) {
+        const proposal = (data && data.proposal) || {};
+        const li = this._appendChatMessageItem('digger-chat-msg-assistant');
+        this._populateProposalCard(li, proposal.proposal_id);
+        this._scrollChatToEnd();
+    }
+
+    async _populateProposalCard(container, proposalId) {
+        const token = window.authManager.getToken();
+        if (!token || !proposalId) return;
+        const res = await window.apiClient.getDiggerProposals(token);
+        const items = (res && res.ok && res.body && res.body.items) || [];
+        const proposal = items.find((p) => p.proposal_id === proposalId);
+        if (!proposal) {
+            const note = document.createElement('div');
+            note.className = 'digger-proposal-card';
+            note.textContent = 'Proposal no longer available.';
+            container.appendChild(note);
+            return;
+        }
+        container.appendChild(this._buildProposalCard(proposal));
+        this._scrollChatToEnd();
+    }
+
+    /**
+     * Build a tier-change proposal card with Approve / Reject actions.
+     * @param {Object} proposal - { proposal_id, payload: [{release_id,current_tier,proposed_tier,reason}] }
+     * @returns {HTMLDivElement}
+     */
+    _buildProposalCard(proposal) {
+        const card = document.createElement('div');
+        card.className = 'digger-proposal-card';
+        card.dataset.proposalId = proposal.proposal_id;
+
+        const heading = document.createElement('h4');
+        heading.textContent = 'Tier-change proposal';
+        card.appendChild(heading);
+
+        const list = document.createElement('ul');
+        list.className = 'digger-proposal-changes';
+        for (const change of proposal.payload || []) {
+            const item = document.createElement('li');
+            const desc = document.createElement('div');
+            desc.textContent = `release ${change.release_id}: ${change.current_tier} → ${change.proposed_tier}`;
+            item.appendChild(desc);
+            if (change.reason) {
+                const reason = document.createElement('div');
+                reason.className = 'digger-proposal-reason';
+                reason.textContent = change.reason;
+                item.appendChild(reason);
+            }
+            list.appendChild(item);
+        }
+        card.appendChild(list);
+
+        const actions = document.createElement('div');
+        actions.className = 'digger-proposal-actions';
+
+        const approveBtn = document.createElement('button');
+        approveBtn.type = 'button';
+        approveBtn.className = 'btn-primary';
+        approveBtn.textContent = 'Approve';
+        actions.appendChild(approveBtn);
+
+        const rejectBtn = document.createElement('button');
+        rejectBtn.type = 'button';
+        rejectBtn.className = 'btn-secondary';
+        rejectBtn.textContent = 'Reject';
+        actions.appendChild(rejectBtn);
+
+        card.appendChild(actions);
+
+        const status = document.createElement('div');
+        status.className = 'digger-proposal-status';
+        card.appendChild(status);
+
+        const setBusy = (busy) => {
+            approveBtn.disabled = busy;
+            rejectBtn.disabled = busy;
+        };
+
+        approveBtn.addEventListener('click', async () => {
+            const token = window.authManager.getToken();
+            if (!token) return;
+            setBusy(true);
+            const res = await window.apiClient.approveDiggerProposal(token, proposal.proposal_id);
+            if (res && res.ok) {
+                const applied = (res.body && res.body.applied) || 0;
+                actions.remove();
+                status.textContent = `Applied ${applied} change${applied === 1 ? '' : 's'}`;
+                card.classList.add('approved');
+            } else {
+                setBusy(false);
+                status.textContent = 'Could not approve. Please try again.';
+            }
+        });
+
+        rejectBtn.addEventListener('click', async () => {
+            const token = window.authManager.getToken();
+            if (!token) return;
+            setBusy(true);
+            const res = await window.apiClient.rejectDiggerProposal(token, proposal.proposal_id);
+            if (res && res.ok) {
+                actions.remove();
+                status.textContent = 'Rejected';
+                card.classList.add('rejected');
+            } else {
+                setBusy(false);
+                status.textContent = 'Could not reject. Please try again.';
+            }
+        });
+
+        return card;
     }
 
     /**

--- a/explore/static/js/digger.js
+++ b/explore/static/js/digger.js
@@ -46,6 +46,9 @@ class DiggerPane {
         this._chatSessionId = null;          // current agent session (null = new conversation)
         this._chatBusy = false;              // in-flight guard for a streaming turn
         this._chatMessages = null;           // <ul> the message bubbles are appended to
+        this._sessions = [];                 // recent agent session summaries (sidebar)
+        this._chatUsedTokens = 0;            // running token total for the cost indicator
+        this._chatCostEl = null;             // cost-indicator node (replaced on update)
 
         this._loading = document.getElementById('diggerLoading');
         this._body = document.getElementById('diggerBody');
@@ -1372,16 +1375,22 @@ class DiggerPane {
     // ------------------------------------------------------------------ //
 
     /**
-     * Switch to the chat view and render the message list + composer.
+     * Switch to the chat view, load the session list, and render the chat.
      */
     async _showChat() {
         this._view = 'chat';
         this._updateNavActiveState();
+        const token = window.authManager.getToken();
+        if (token) {
+            const res = await window.apiClient.getDiggerAgentSessions(token);
+            this._sessions = (res && res.ok && res.body && res.body.items) || [];
+        }
         this._renderChatView();
     }
 
     /**
-     * Render the chat sub-view: a scrolling message list above a composer.
+     * Render the chat sub-view: a session/cost sidebar beside a scrolling
+     * message list above a composer.
      */
     _renderChatView() {
         if (!this._body) return;
@@ -1389,6 +1398,8 @@ class DiggerPane {
 
         const chat = document.createElement('div');
         chat.className = 'digger-chat';
+
+        chat.appendChild(this._buildChatSidebar());
 
         const main = document.createElement('div');
         main.className = 'digger-chat-main';
@@ -1459,6 +1470,10 @@ class DiggerPane {
                 onProposalCard: (data) => this._appendChatProposalCard(data),
                 onDone: (data) => {
                     if (data && data.session_id) this._chatSessionId = data.session_id;
+                    if (data && data.usage) {
+                        this._chatUsedTokens += (data.usage.input || 0) + (data.usage.output || 0);
+                        this._updateCostIndicator();
+                    }
                     this._finishChat();
                 },
                 onError: (err) => {
@@ -1676,6 +1691,134 @@ class DiggerPane {
      */
     _scrollChatToEnd() {
         if (this._chatMessages) this._chatMessages.scrollTop = this._chatMessages.scrollHeight;
+    }
+
+    // ------------------------------------------------------------------ //
+    // Chat — sidebar (session list + cost indicator)
+    // ------------------------------------------------------------------ //
+
+    /**
+     * Build the chat sidebar: a "New chat" button, the recent-session list,
+     * and the daily-token cost indicator.
+     * @returns {HTMLElement}
+     */
+    _buildChatSidebar() {
+        const sidebar = document.createElement('nav');
+        sidebar.className = 'digger-chat-sidebar';
+
+        const newBtn = document.createElement('button');
+        newBtn.type = 'button';
+        newBtn.className = 'btn-secondary digger-chat-new';
+        newBtn.textContent = 'New chat';
+        newBtn.addEventListener('click', () => this._startNewChat());
+        sidebar.appendChild(newBtn);
+
+        const heading = document.createElement('h3');
+        heading.textContent = 'Sessions';
+        sidebar.appendChild(heading);
+
+        const list = document.createElement('ul');
+        list.className = 'digger-session-list';
+        for (const session of this._sessions || []) {
+            list.appendChild(this._buildSessionListItem(session));
+        }
+        sidebar.appendChild(list);
+
+        const cost = this._buildCostIndicator(this._chatUsedTokens, this._chatTokenCap());
+        this._chatCostEl = cost;
+        sidebar.appendChild(cost);
+
+        return sidebar;
+    }
+
+    /**
+     * Build a single session list item; clicking continues that session.
+     * @param {Object} session - { session_id, last_active_at, ... }
+     * @returns {HTMLLIElement}
+     */
+    _buildSessionListItem(session) {
+        const li = document.createElement('li');
+        li.className = 'digger-session-item';
+        li.dataset.sessionId = session.session_id;
+        if (session.session_id === this._chatSessionId) li.classList.add('active');
+
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'digger-session-link';
+        btn.textContent = this._formatDateTime(session.last_active_at);
+        btn.addEventListener('click', () => this._continueSession(session.session_id));
+        li.appendChild(btn);
+        return li;
+    }
+
+    /**
+     * The caller's daily interactive token cap (falls back to the default).
+     * @returns {number}
+     */
+    _chatTokenCap() {
+        return (this._settings && this._settings.daily_token_cap_interactive) || 200000;
+    }
+
+    /**
+     * Continue an existing session: adopt its id and reset the message list.
+     * @param {string} sessionId
+     */
+    _continueSession(sessionId) {
+        this._chatSessionId = sessionId;
+        this._renderChatView();
+    }
+
+    /**
+     * Start a fresh conversation: clear the session id and message list.
+     */
+    _startNewChat() {
+        this._chatSessionId = null;
+        this._renderChatView();
+    }
+
+    /**
+     * Build a token cost indicator showing used + remaining tokens for the day.
+     * @param {number} used
+     * @param {number} cap
+     * @returns {HTMLDivElement}
+     */
+    _buildCostIndicator(used, cap) {
+        const wrap = document.createElement('div');
+        wrap.className = 'digger-cost-indicator';
+
+        const safeCap = cap || 1;
+        const remaining = Math.max(0, safeCap - used);
+        const pct = Math.min(100, Math.round((used / safeCap) * 100));
+
+        const usedLine = document.createElement('span');
+        usedLine.className = 'digger-cost-used';
+        usedLine.textContent = `${used.toLocaleString()} tokens used`;
+        wrap.appendChild(usedLine);
+
+        const remainingLine = document.createElement('span');
+        remainingLine.className = 'digger-cost-remaining';
+        remainingLine.textContent = `${remaining.toLocaleString()} remaining today`;
+        wrap.appendChild(remainingLine);
+
+        const bar = document.createElement('div');
+        bar.className = 'digger-cost-bar';
+        const fill = document.createElement('div');
+        fill.className = 'digger-cost-bar-fill';
+        fill.style.width = `${pct}%`;
+        bar.appendChild(fill);
+        wrap.appendChild(bar);
+
+        return wrap;
+    }
+
+    /**
+     * Replace the cost indicator in place with one reflecting current usage.
+     */
+    _updateCostIndicator() {
+        if (!this._chatCostEl || !this._chatCostEl.parentNode) return;
+        const fresh = this._buildCostIndicator(this._chatUsedTokens, this._chatTokenCap());
+        this._chatCostEl.replaceWith(fresh);
+        this._chatCostEl = fresh;
     }
 }
 


### PR DESCRIPTION
## Summary

Digger M3 **Layer C** (Tasks 10–12 of the M3 agent plan) — the explore chat UI on top of the Layer B API surface (#350). One layer = one PR.

The plan drafted these as React/TSX; per the repo's verified conventions this is implemented as **vanilla JS extending `DiggerPane`** (`explore/static/js/digger.js`), mirroring the M2 in-pane reports view — no React/router. Three commits:

- **Task 10 — chat sub-view + SSE consumer.** `api-client.streamDiggerAgent()` consumes the `/api/digger/agent/message` SSE stream (text, tool_call, tool_result, bundle_card, proposal_card, done, error), modeled on `runDiggerRecommend`; `getDiggerAgentSessions()` lists sessions. A new **Chat** header-nav button opens `_showChat`: a scrolling message list + composer (Enter to send). Streamed text fills the assistant bubble; tool calls render as pills, tool results as collapsible `<details>`, and optimizer bundles reuse `_buildBundleCard`. The `done` event captures the session id for continuation; errors render inline.
- **Task 11 — proposal cards.** `getDiggerProposals` / `approveDiggerProposal` / `rejectDiggerProposal`. A `proposal_card` event appends a card that fetches the full proposal (the stream carries only id + count), shows the tier changes, and offers **Approve** (shows applied count) / **Reject**; failures surface inline and a resolved/expired proposal shows a "no longer available" note.
- **Task 12 — session sidebar + cost indicator.** A sidebar with a recent-session list (click to continue, "New chat" to reset) and a daily-token cost indicator (used + remaining vs `daily_token_cap_interactive`), updated live from each `done` event's usage.

CSS for the chat layout, bubbles, tool pills, proposal cards, sidebar, and cost bar is added to `styles.css`.

## Test Plan
- [x] Vitest: `streamDiggerAgent` SSE consumer + REST helpers (`api-client.test.js`) and the full chat view — nav, streaming text/tools/bundles, proposal approve/reject/error/not-found, session list/continue/new-chat, and cost math (`digger-chat.test.js`).
- [x] `just test-js` — **1246 passed** (30 files), no regressions.
- [x] `just test-js-cov` — `digger.js` 99.3% lines, `api-client.js` 100% funcs (new chat code fully covered).
- [x] `just lint` — all hooks pass.

Layer D (MCP tools + eval harness) and Layer E (perf/docs/e2e/polish) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)