### PR TITLE
feat(digger): M3 Layer E — perf tests, docs, deployment wiring, E2E smoke (completes M3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@
 
 ```
 api/                  API service — all user-facing HTTP endpoints (auth, search, graph, OAuth, insights proxy, MusicBrainz)
+  digger_agent/       Digger LLM agent — Anthropic SDK, system prompt, 9 tools, SSE chat endpoint — see docs/digger-agent.md
 brainzgraphinator/    Brainzgraphinator service — MusicBrainz data → Neo4j enrichment
 brainztableinator/    Brainztableinator service — MusicBrainz data → PostgreSQL
 common/               Shared library — config, models, utilities used by all Python services

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,6 +18,9 @@ secrets:
     file: ./secrets/brevo_api_key.txt
   nlq_api_key:
     file: ./secrets/nlq_api_key.txt
+  # Anthropic API key for the Digger LLM agent (/api/digger/agent/*).
+  anthropic_api_key:
+    file: ./secrets/anthropic_api_key.txt
   postgres_password:
     file: ./secrets/postgres_password.txt
   postgres_username:
@@ -200,6 +203,7 @@ services:
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
       POSTGRES_USERNAME_FILE: /run/secrets/postgres_username
       NLQ_API_KEY_FILE: /run/secrets/nlq_api_key
+      ANTHROPIC_API_KEY_FILE: /run/secrets/anthropic_api_key
       RABBITMQ_PASSWORD_FILE: /run/secrets/rabbitmq_password
       RABBITMQ_USERNAME_FILE: /run/secrets/rabbitmq_username
       DIGGER_API_SERVICE_TOKEN_FILE: /run/secrets/digger_api_service_token
@@ -209,6 +213,7 @@ services:
       - encryption_master_key
       - brevo_api_key
       - nlq_api_key
+      - anthropic_api_key
       - postgres_username
       - postgres_password
       - rabbitmq_username

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -256,6 +256,8 @@ services:
       NLQ_ENABLED: "${NLQ_ENABLED:-false}"
       NLQ_API_KEY: "${NLQ_API_KEY:-}"
       NLQ_MODEL: "${NLQ_MODEL:-claude-sonnet-4-20250514}"
+      # Digger LLM agent — Anthropic API key enabling /api/digger/agent/*
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
       # Email notifications (optional — when not set, reset links are logged instead)
       # BREVO_API_KEY: "${BREVO_API_KEY:-}"
       # BREVO_SENDER_EMAIL: "${BREVO_SENDER_EMAIL:-noreply@discogsography.com}"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -539,6 +539,10 @@ See [Brainztableinator README](../brainztableinator/README.md) for details.
 
 See [Digger README](../digger/README.md) and the [Digger Scraping Policy](digger-scraping-policy.md) for the full request and Terms-of-Service posture. The deterministic bundle optimizer that powers the interactive `POST /api/digger/recommend` endpoint and the scheduled reports is documented in [Digger Optimizer](digger-optimizer.md).
 
+#### Digger LLM agent
+
+On top of the deterministic optimizer, the API hosts a conversational **Digger agent** (`api/digger_agent/`, built on the Anthropic SDK). A single SSE endpoint, `POST /api/digger/agent/message`, orchestrates a tool-using turn — the model calls read/compute/write tools that delegate to the same M2 optimizer, reports, and refresh services — with per-user daily token caps and a one-stream-per-user concurrency lock (both in Redis). Explore exposes it as a chat sub-view, and `mcp-server/` re-exposes four Digger tools so external Claude clients can drive the same engine. It requires `ANTHROPIC_API_KEY` on the API. See [Digger Agent](digger-agent.md) for the tool surface, guardrails, models, and MCP exposure.
+
 ### Explore Service
 
 **Responsibilities**:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -547,6 +547,11 @@ SNAPSHOT_MAX_NODES=100   # Max nodes per snapshot (default: 100)
 # In production, supply via DIGGER_API_SERVICE_TOKEN_FILE (Docker secret).
 DIGGER_API_SERVICE_TOKEN="your-service-token-here"
 
+# Optional — Anthropic API key enabling the Digger LLM agent (/api/digger/agent/*).
+# When unset, the agent endpoints return an error; the rest of the API is unaffected.
+# In production, supply via ANTHROPIC_API_KEY_FILE (Docker secret).
+ANTHROPIC_API_KEY="sk-ant-..."
+
 # Optional
 JWT_EXPIRE_MINUTES=1440
 LOG_LEVEL=INFO
@@ -858,9 +863,15 @@ Health check: http://localhost:8012/health (also exposes Prometheus `/metrics`)
 ```bash
 # Required
 API_BASE_URL="http://api:8004"   # Base URL for the Discogsography API
+
+# Optional — per-user JWT enabling the authenticated Digger tools
+# (digger_get_wantlist_status, digger_run_recommendation, digger_explain_bundle,
+# digger_simulate_what_if). The public knowledge-graph tools need no token; the
+# Digger tools return a clear error when it is unset. See docs/digger-agent.md.
+MCP_API_TOKEN="<a-user-jwt>"
 ```
 
-**Notes**: The MCP server has no direct database dependencies — all data is fetched via the API service over HTTP. It supports `stdio` (default, for local use with Claude Desktop/Cursor/Zed) and `streamable-http` (for hosted deployments) transports.
+**Notes**: The MCP server has no direct database dependencies — all data is fetched via the API service over HTTP. It supports `stdio` (default, for local use with Claude Desktop/Cursor/Zed) and `streamable-http` (for hosted deployments) transports. The Digger tools act on behalf of the single user whose JWT is supplied in `MCP_API_TOKEN`.
 
 ## Environment Templates
 

--- a/docs/digger-agent.md
+++ b/docs/digger-agent.md
@@ -1,0 +1,119 @@
+# Digger LLM Agent
+
+The Digger agent lets a user chat with their record-hunting assistant — interactively
+in Explore or through an external MCP client — to get bundle recommendations,
+what-if scenarios, and agent-proposed wantlist tier changes. It is built on the
+official `anthropic` Python SDK and lives in `api/digger_agent/`.
+
+## Overview
+
+A single endpoint, `POST /api/digger/agent/message`, orchestrates one tool-using
+agent turn and streams typed Server-Sent Events. Tools delegate to the M2
+deterministic services (optimizer, reports, opportunistic refresh) — the model
+decides _which_ tools to call and _how_ to summarize, but never invents numbers.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Explore as Explore chat
+    participant API as POST /api/digger/agent/message
+    participant Redis
+    participant Anthropic
+    participant Tools as Digger tools
+
+    User->>Explore: types a message
+    Explore->>API: SSE request (Bearer JWT)
+    API->>API: settings.enabled? (403 if not)
+    API->>Redis: daily token cap exceeded? (429 if so)
+    API->>Redis: acquire per-user concurrency lock
+    loop up to 8 iterations
+        API->>Anthropic: messages.stream (system+tools cached)
+        Anthropic-->>API: text deltas + tool_use blocks
+        API-->>Explore: event: text / tool_call
+        API->>Tools: dispatch_tool(name, input)
+        Tools-->>API: result JSON
+        API-->>Explore: event: tool_result / bundle_card / proposal_card
+    end
+    API->>API: persist assistant message, roll up tokens + cost
+    API->>Redis: record spend against daily budget
+    API-->>Explore: event: done
+```
+
+## Endpoints
+
+| Method & path | Purpose |
+| --- | --- |
+| `POST /api/digger/agent/message` | Stream one agent turn (SSE). 403 if digger disabled, 429 if the daily interactive token cap is exhausted. |
+| `GET /api/digger/agent/sessions` | List the caller's recent sessions (most recently active first). |
+| `GET /api/digger/proposals` | The caller's pending, unexpired tier-change proposals. |
+| `POST /api/digger/proposals/{id}/approve` | Apply a proposal's tier changes (one transaction); returns the count applied. |
+| `POST /api/digger/proposals/{id}/reject` | Mark a pending proposal rejected. |
+
+### SSE event types
+
+`text` · `tool_call` · `tool_result` · `bundle_card` · `proposal_card` · `done` · `error`
+
+## Tool surface
+
+Nine tools (see `api/digger_agent/tools/schemas.py`):
+
+- **read** — `get_wantlist`, `get_user_settings`, `get_listings_for_release`, `summarize_marketplace_coverage`
+- **compute** — `compute_bundles`, `explain_bundle`
+- **write** — `save_report`, `propose_tier_changes` (records a _pending_ proposal the user approves in the UI)
+- **side-effect** — `request_opportunistic_refresh` (nudges the worker to re-scrape stale releases)
+
+`compute_bundles` never takes a `user_id` — it comes from the JWT via `ToolContext`.
+`explain_bundle` and `save_report` reuse `ctx.last_optimizer_output`; if it is missing
+they return an explicit error string the model can self-correct from.
+
+## Guardrails
+
+- **Daily token cap** per user and kind (interactive / scheduled), counted in Redis and keyed by the UTC date.
+- **One active stream per user** — a Redis `SET NX` lock; a concurrent turn yields an `error` event.
+- **Max 8 tool iterations** per turn.
+- **User-message length** capped at 4000 characters.
+- All tool inputs are validated against their JSON schemas before dispatch.
+
+## Models
+
+- Interactive default: **Sonnet 4.6** (`claude-sonnet-4-6`).
+- Scheduled default: **Haiku 4.5** (`claude-haiku-4-5`).
+- Opus available as `claude-opus-4-7`.
+- User-overridable per call via `model_override` ∈ `{haiku, sonnet, opus}`; the
+  per-user default is `user_digger_settings.preferred_model`.
+
+Model IDs carry **no date suffix** (`_MODEL_IDS` in `api/digger_agent/runtime.py`).
+
+## Prompt caching
+
+The system prompt + tool definitions are sent with a single `cache_control:
+ephemeral` breakpoint, caching the stable tools→system prefix across turns.
+Verify with `usage.cache_read_input_tokens` on multi-turn sessions.
+
+## Cost tracking
+
+`digger.agent_sessions.total_cost_usd` is incremented per turn from token usage
+using the per-million-token rates in `_COST_PER_M` (`api/routers/digger_agent.py`).
+This figure is for display only — it does not gate requests (the token cap does).
+
+## MCP exposure
+
+`mcp-server/mcp_server/digger_tools.py` exposes four tools so an external Claude
+client can drive the same engine over HTTP:
+
+- `digger_get_wantlist_status`, `digger_run_recommendation`,
+  `digger_explain_bundle`, `digger_simulate_what_if`
+
+Unlike the public knowledge-graph tools, these require a **per-user JWT**: set
+`MCP_API_TOKEN` in the MCP server's environment. Without it the tools return a
+clear error rather than a 401. `digger_run_recommendation` / `digger_simulate_what_if`
+consume the `/api/digger/recommend` SSE stream and return its final `result`
+(the optimizer output) as JSON.
+
+## Configuration
+
+- `ANTHROPIC_API_KEY` (API service) — enables `/api/digger/agent/*`. Supports the
+  `_FILE` secret variant in production.
+- `MCP_API_TOKEN` (MCP server) — the per-user JWT the Digger MCP tools authenticate with.
+
+See [configuration.md](configuration.md) for the full environment reference.

--- a/scripts/create-secrets.sh
+++ b/scripts/create-secrets.sh
@@ -38,6 +38,10 @@ write_secret "encryption_master_key.txt" "$(python3 -c 'import base64, os; print
 # When empty, password reset links are logged instead of emailed.
 write_secret "brevo_api_key.txt" "${BREVO_API_KEY:-}"
 
+# Anthropic API key — enables the Digger LLM agent (/api/digger/agent/*).
+# When empty, the agent endpoints return an error; the rest of the API is unaffected.
+write_secret "anthropic_api_key.txt" "${ANTHROPIC_API_KEY:-}"
+
 # PostgreSQL credentials
 write_secret "postgres_username.txt" "discogsography"
 write_secret "postgres_password.txt" "$(openssl rand -base64 24)"

--- a/tests/e2e/test_digger_m3_smoke.py
+++ b/tests/e2e/test_digger_m3_smoke.py
@@ -1,0 +1,94 @@
+"""M3 happy-path E2E smoke for the Digger LLM agent.
+
+Like the M2 smoke (``tests/e2e/test_digger_m2_smoke.py``), this runs against a
+**live stack** with a **real PostgreSQL** and a **real Anthropic key configured
+on the API**. It is marked ``e2e`` (deselected by the default ``-m 'not e2e'``)
+and additionally needs ``ANTHROPIC_API_KEY`` in the environment as the operator's
+signal that the live API is key-configured — so it never runs in regular CI.
+
+It covers the M3 user-facing surface end to end:
+
+    Part 1 (agent chat SSE + session persistence):
+        POST /api/digger/agent/message streams text / tool_call ... done, proving
+        the agent loop runs against the real wantlist/optimizer; the turn then
+        appears in GET /api/digger/agent/sessions.
+    Part 2 (auth):
+        the agent + proposals surfaces reject unauthenticated requests.
+
+Seeding reuses the perftest harness's idempotent seed + JWT mint so the
+authenticated, digger-enabled user (with a wantlist release + live listings)
+exists before the flow runs.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+from tests.perftest.run_perftest import mint_perftest_jwt, seed_digger_perftest_data
+
+
+_DEFAULT_API_URL = "http://localhost:8004"
+
+
+@pytest.fixture(scope="session")
+def digger_m3_e2e() -> tuple[str, dict[str, str]]:
+    """Seed the live database and return (api_base_url, auth_headers), or skip.
+
+    Skips unless the signing secret, a reachable database, and an Anthropic key
+    (the live API's agent dependency) are all present — the agent smoke is
+    meaningless without a key-configured stack.
+    """
+    secret = os.getenv("JWT_SECRET_KEY")
+    postgres_url = os.getenv("DIGGER_E2E_POSTGRES_URL")
+    if not secret or not postgres_url or not os.getenv("ANTHROPIC_API_KEY"):
+        pytest.skip("Digger M3 E2E needs JWT_SECRET_KEY + DIGGER_E2E_POSTGRES_URL + ANTHROPIC_API_KEY (live key-configured stack)")
+
+    seed_digger_perftest_data(postgres_url)
+    token = mint_perftest_jwt(secret=secret)
+    base_url = os.getenv("DIGGER_E2E_API_URL", _DEFAULT_API_URL)
+    return base_url, {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.e2e
+def test_m3_smoke_agent_chat_and_session(digger_m3_e2e: tuple[str, dict[str, str]]) -> None:
+    """A chat turn streams to completion and is recorded as a session."""
+    base_url, headers = digger_m3_e2e
+
+    events: list[str] = []
+    with (
+        httpx.Client(timeout=60.0) as client,
+        client.stream(
+            "POST",
+            f"{base_url}/api/digger/agent/message",
+            headers=headers,
+            json={"user_message": "Summarize my wantlist status."},
+        ) as resp,
+    ):
+        assert resp.status_code == 200, resp.read()
+        for raw in resp.iter_lines():
+            line = raw.strip()
+            if line.startswith("event:"):
+                events.append(line.split(":", 1)[1].strip())
+            if "done" in events or "error" in events:
+                break
+
+    assert "error" not in events, f"agent emitted an error event: {events}"
+    assert "done" in events
+    assert "text" in events or "tool_call" in events
+
+    # The completed turn created a session that the session list now surfaces.
+    sessions = httpx.get(f"{base_url}/api/digger/agent/sessions", headers=headers, timeout=30.0)
+    assert sessions.status_code == 200
+    assert len(sessions.json()["items"]) >= 1
+
+
+@pytest.mark.e2e
+def test_m3_smoke_agent_surfaces_require_authentication(digger_m3_e2e: tuple[str, dict[str, str]]) -> None:
+    """The agent session list and the proposals inbox reject anonymous requests."""
+    base_url, _ = digger_m3_e2e
+    with httpx.Client(timeout=10.0) as client:
+        assert client.get(f"{base_url}/api/digger/agent/sessions").status_code == 401
+        assert client.get(f"{base_url}/api/digger/proposals").status_code == 401

--- a/tests/perftest/config.yaml
+++ b/tests/perftest/config.yaml
@@ -151,3 +151,33 @@ digger_scenarios:
       deadline_seconds: 5
     auth: true
     target_p95_ms: 6000
+
+  # Agent session list — a cheap authenticated GET (newest sessions first).
+  - name: digger_agent_sessions
+    method: GET
+    path: /api/digger/agent/sessions
+    auth: true
+    target_p95_ms: 200
+
+  # Pending tier-change proposals — a cheap authenticated GET.
+  - name: digger_proposals_list
+    method: GET
+    path: /api/digger/proposals
+    auth: true
+    target_p95_ms: 200
+
+  # Interactive agent chat turn (LLM-backed). Streams typed SSE events
+  # (text/tool_call/tool_result/bundle_card/proposal_card/done); like the NLQ +
+  # recommend scenarios the harness issues a plain POST and times the full
+  # response. Requires the API to be configured with ANTHROPIC_API_KEY and the
+  # seeded user to be digger-enabled; without a key the turn errors, which the
+  # harness reports informationally (it does not gate on errors). Operators may
+  # exclude this from routine runs with --only / --skip since each turn calls the
+  # model and incurs cost.
+  - name: digger_agent_message
+    method: POST
+    path: /api/digger/agent/message
+    body:
+      user_message: "summarize my wantlist"
+    auth: true
+    target_p95_ms: 12000

--- a/tests/perftest/test_run_perftest.py
+++ b/tests/perftest/test_run_perftest.py
@@ -200,4 +200,26 @@ def test_real_config_yaml_includes_m2_digger_scenarios() -> None:
 
     assert by_name["digger_reports_get"]["url"].endswith(f"/api/digger/reports/{rp.PERFTEST_REPORT_ID}")
     assert by_name["digger_reports_read"]["url"].endswith(f"/api/digger/reports/{rp.PERFTEST_REPORT_ID}/read")
+
+
+def test_real_config_yaml_includes_m3_digger_scenarios() -> None:
+    """The shipped config.yaml wires the M3 agent + proposals endpoints.
+
+    Guards against config<->runner drift for the agent chat turn, the agent
+    session list, and the proposals list — all authenticated, and the chat turn
+    carrying a user_message body.
+    """
+    config_path = Path(__file__).parent / "config.yaml"
+    config = rp.load_config(str(config_path))
+    plan = rp.build_test_plan(config, artist_ids={}, label_ids={})
+    by_name = {t["name"]: t for t in plan}
+
+    for name in ("digger_agent_sessions", "digger_proposals_list", "digger_agent_message"):
+        assert name in by_name, f"{name} missing from the shipped config plan"
+        assert by_name[name]["auth"] is True
+
+    msg = by_name["digger_agent_message"]
+    assert msg["method"] == "POST"
+    assert msg["url"].endswith("/api/digger/agent/message")
+    assert msg["json_body"] == {"user_message": "summarize my wantlist"}
     assert by_name["digger_recommend"]["json_body"] == {"deadline_seconds": 5}


### PR DESCRIPTION
## Summary

Digger M3 **Layer E** (Tasks 15–18) — the final layer. **Test/docs/config only — zero service production code changed.** Completing this finishes M3 and **all Digger milestones**.

- **Task 15 — perf config.** Added `digger_agent_sessions`, `digger_proposals_list` (cheap authed GETs) and `digger_agent_message` (LLM-backed POST, timed as a plain SSE POST like recommend) to `tests/perftest/config.yaml` in the M1 `digger_scenarios` format, plus a real-config test guarding against config↔runner drift.
- **Task 16 — docs.** New `docs/digger-agent.md` (overview + Mermaid turn sequence, endpoints, SSE event types, the 9-tool surface, guardrails, models with no date-suffix IDs, prompt caching, cost tracking, MCP exposure); `api/digger_agent/` entry in CLAUDE.md; a "Digger LLM agent" subsection in `docs/architecture.md`; `ANTHROPIC_API_KEY` + `MCP_API_TOKEN` in `docs/configuration.md`.
- **Deployment wiring.** `ANTHROPIC_API_KEY` (distinct from `NLQ_API_KEY`) wired into the API service: dev compose passthrough, prod compose `_FILE` secret + secrets list + top-level secret, and `scripts/create-secrets.sh` (empty default, mirroring brevo) so the prod stack starts without manual secret creation.
- **Task 17 — E2E smoke.** `tests/e2e/test_digger_m3_smoke.py` mirroring the M2 smoke: a real agent chat turn streams `text/tool_call ... done` over SSE and then appears in the session list; the agent + proposals surfaces reject anonymous requests. Double-gated (`@pytest.mark.e2e` + `ANTHROPIC_API_KEY`), so it never runs in CI.

## Test Plan
- [x] `just test` — **3482 passed, 20 skipped** (eval runner), e2e deselected.
- [x] `just test-api` — 1685 passed; **all `api/digger_agent/*`, routers, and queries at 100% coverage** (Task 18 ≥80% gate far exceeded).
- [x] `just lint` — all hooks pass (ruff, ruff-format, bandit, mypy, yamllint, compose validation, shellcheck).
- [x] New perftest real-config test + e2e smoke collect cleanly and skip without a live stack.

With this, **M3 is complete** — the Digger LLM agent (core, API, explore chat, MCP tools, evals, perf/docs/e2e) is shipped across PRs #349–#353, finishing the Digger program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)