### PR TITLE
fix(digger): ship digger_agent system prompt in api image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -79,6 +79,9 @@ CLAUDE.md
 # Exclude all markdown files except README.md
 **/*.md
 !README.md
+# Runtime prompt assets (e.g. api/digger_agent/prompts/system.md) are read at
+# import time — keep them in the build context or the image crash-loops.
+!**/prompts/*.md
 
 # Temporary files
 *.tmp


### PR DESCRIPTION
## Problem

`discogsography-api` crash-loops on startup with:

```
FileNotFoundError: [Errno 2] No such file or directory: '/app/api/digger_agent/prompts/system.md'
```

`api/digger_agent/__init__.py` reads `prompts/system.md` at **import time** (module-level `SYSTEM_PROMPT`), but `.dockerignore`'s blanket `**/*.md` rule dropped the file from the build context. The published `api:latest` image shipped without it, so the container never becomes healthy — taking down `discogsography-api` and every service that waits on it via `depends_on … condition: service_healthy` (dashboard, explore, and the homelab deploy's `lux-discogsography` stage).

## Fix

Re-include prompt markdown via `!**/prompts/*.md`, after the `**/*.md` exclude. Runtime prompt assets stay in the image; docs/READMEs remain excluded.

## Verification

Build-context COPY test against `busybox`:

- **Before** (`origin/main`): `COPY api/digger_agent/prompts/system.md` → `"/api/digger_agent/prompts/system.md": not found` (excluded by `.dockerignore`)
- **After** (this branch): same `COPY` succeeds, file present and non-empty

`api/digger_agent/prompts/system.md` is the only runtime-loaded markdown asset in the repo; static `.html`/JS assets (dashboard, explore) were never affected by the `*.md` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)