### PR TITLE
fix(common): support REDIS_PASSWORD for authenticated Redis connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ POSTGRES_USERNAME=discogsography
 POSTGRES_PASSWORD=discogsography
 POSTGRES_DATABASE=discogsography
 REDIS_HOST=localhost
+# REDIS_PORT=6379
+# Set only if your Redis enforces auth (requirepass). Supports REDIS_PASSWORD_FILE for Docker secrets.
+# REDIS_PASSWORD=
 DISCOGS_ROOT=/discogs-data
 
 # Production Configuration (docker-compose.prod.yml)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ Core variables used across services (individual components, not composite URLs):
 - `NEO4J_TLS_ENABLED`, `NEO4J_TLS_VERIFY` — opt-in Bolt TLS (default off; certificate verification on when enabled)
 - `POSTGRES_HOST`, `POSTGRES_USERNAME`, `POSTGRES_PASSWORD`, `POSTGRES_DATABASE` — PostgreSQL connection
 - `RABBITMQ_HOST`, `RABBITMQ_USERNAME`, `RABBITMQ_PASSWORD` — RabbitMQ connection
-- `REDIS_HOST` — Redis hostname
+- `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD` — Redis connection (`REDIS_PASSWORD` optional; only needed when Redis enforces `requirepass`)
 - `JWT_SECRET_KEY` — HMAC-SHA256 signing secret (API only)
 - `ENCRYPTION_MASTER_KEY` — HKDF master key for OAuth + TOTP encryption (API only)
 - `API_BASE_URL` — API service URL (used by Explore, Insights, MCP Server)

--- a/common/config.py
+++ b/common/config.py
@@ -73,9 +73,18 @@ def _build_postgres_connstr() -> str:
 
 
 def _build_redis_url() -> str:
-    """Build Redis connection URL from plain hostname environment variable."""
+    """Build Redis connection URL from component secrets and environment variables.
+
+    Reads the password via the standard _FILE secret convention (Docker secrets),
+    falling back to the plain REDIS_PASSWORD environment variable. The auth segment
+    is omitted when no password is set so password-less local Redis keeps working.
+    """
+    password = get_secret("REDIS_PASSWORD")
     host = getenv("REDIS_HOST", "localhost")
-    return f"redis://{host}:6379/0"
+    port = getenv("REDIS_PORT", "6379")
+    if password:
+        return f"redis://:{_url_quote(password, safe='')}@{host}:{port}/0"
+    return f"redis://{host}:{port}/0"
 
 
 def neo4j_security_kwargs() -> dict[str, Any]:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -275,28 +275,37 @@ POSTGRES_COMMAND_TIMEOUT=30
 
 ### Redis Configuration
 
-| Variable     | Description    | Default     | Required                               |
-| ------------ | -------------- | ----------- | -------------------------------------- |
-| `REDIS_HOST` | Redis hostname | `localhost` | Yes (Dashboard, API, Insights, Digger) |
+| Variable         | Description                            | Default     | Required                               |
+| ---------------- | -------------------------------------- | ----------- | -------------------------------------- |
+| `REDIS_HOST`     | Redis hostname                         | `localhost` | Yes (Dashboard, API, Insights, Digger) |
+| `REDIS_PORT`     | Redis port                             | `6379`      | No                                     |
+| `REDIS_PASSWORD` | Redis password (`requirepass`)         | _(none)_    | No (required if Redis enforces auth)   |
 
 **Used By**: Dashboard, API, Insights, Digger
 
 **Connection Details**:
 
 - Protocol: Redis protocol
-- Default port: 6379
+- Default port: 6379 (override with `REDIS_PORT`)
 - Database: 0 (default)
+- Authentication: when `REDIS_PASSWORD` is set it is embedded in the connection URL (`redis://:<password>@host:port/0`); omitted entirely when unset. Supports the `_FILE` secret convention (`REDIS_PASSWORD_FILE`).
 - Connection pool: Automatic
 - Retry logic: Exponential backoff
 
 **Examples**:
 
 ```bash
-# Local development
+# Local development (no auth)
 REDIS_HOST="localhost"
 
 # Docker Compose
 REDIS_HOST="redis"
+
+# Authenticated Redis (e.g. requirepass enabled)
+REDIS_HOST="redis"
+REDIS_PASSWORD="<password>"
+# or, via Docker secret:
+REDIS_PASSWORD_FILE="/run/secrets/redis_password"
 ```
 
 **Cache Configuration**:

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -533,6 +533,71 @@ class TestApiConfig:
         assert config.jwt_expire_minutes == 60
         assert config.discogs_user_agent == "CustomAgent/2.0"
 
+    def test_redis_password_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """REDIS_PASSWORD is embedded in the redis_host URL for authenticated Redis."""
+        from common.config import ApiConfig
+
+        monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+        monkeypatch.setenv("REDIS_HOST", "myredis")
+        monkeypatch.setenv("REDIS_PASSWORD", "s3cr3t")
+
+        config = ApiConfig.from_env()
+
+        assert config.redis_host == "redis://:s3cr3t@myredis:6379/0"
+
+    def test_redis_password_from_file(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """REDIS_PASSWORD_FILE is read via the _FILE secret convention (Docker secrets)."""
+        from common.config import ApiConfig
+
+        pass_file = tmp_path / "redis_password"
+        pass_file.write_text("file-secret\n")
+        monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+        monkeypatch.setenv("REDIS_HOST", "myredis")
+        monkeypatch.setenv("REDIS_PASSWORD_FILE", str(pass_file))
+        monkeypatch.delenv("REDIS_PASSWORD", raising=False)
+
+        config = ApiConfig.from_env()
+
+        assert config.redis_host == "redis://:file-secret@myredis:6379/0"
+
+    def test_redis_password_url_encoded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Special characters in REDIS_PASSWORD are URL-encoded so the URL stays valid."""
+        from common.config import ApiConfig
+
+        monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+        monkeypatch.setenv("REDIS_HOST", "myredis")
+        monkeypatch.setenv("REDIS_PASSWORD", "p@ss:w/rd")
+
+        config = ApiConfig.from_env()
+
+        assert config.redis_host == "redis://:p%40ss%3Aw%2Frd@myredis:6379/0"
+
+    def test_redis_port_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """REDIS_PORT overrides the default 6379."""
+        from common.config import ApiConfig
+
+        monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+        monkeypatch.setenv("REDIS_HOST", "myredis")
+        monkeypatch.setenv("REDIS_PORT", "6380")
+        monkeypatch.delenv("REDIS_PASSWORD", raising=False)
+
+        config = ApiConfig.from_env()
+
+        assert config.redis_host == "redis://myredis:6380/0"
+
+    def test_redis_no_password_omits_auth(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without REDIS_PASSWORD the URL has no auth segment (password-less local Redis)."""
+        from common.config import ApiConfig
+
+        monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+        monkeypatch.setenv("REDIS_HOST", "myredis")
+        monkeypatch.delenv("REDIS_PASSWORD", raising=False)
+        monkeypatch.delenv("REDIS_PASSWORD_FILE", raising=False)
+
+        config = ApiConfig.from_env()
+
+        assert config.redis_host == "redis://myredis:6379/0"
+
     def test_from_env_invalid_jwt_expire_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that invalid JWT_EXPIRE_MINUTES falls back to 30."""
         from common.config import ApiConfig


### PR DESCRIPTION
## Problem

On the lux/homelab deployment, Redis runs with `requirepass` enabled, but the discogsography app connected with `redis://{host}:6379/0` and **no password**. Every Redis call failed with:

```
redis.exceptions.AuthenticationError: Authentication required.
```

This surfaced as opaque `500`s — e.g. `GET /api/oauth/authorize/discogs` (which runs `_get_current_user` → `_redis.get("revoked:jti:...")`), shown to the user as a generic "Could not start Discogs authorization."

`_build_redis_url()` in `common/config.py` was the **only** connection builder that ignored the `get_secret()` `_FILE` convention already used by Neo4j, Postgres, and RabbitMQ.

## Fix

- Read `REDIS_PASSWORD` (and `REDIS_PASSWORD_FILE`) via `get_secret()` and embed it **URL-encoded** in the connection string.
- Add `REDIS_PORT` override (defaults to `6379`).
- Omit the auth segment entirely when no password is set → **password-less local Redis is unchanged** (backward compatible; the repo's own `docker-compose.yml`/`prod` overlay run Redis without auth).
- The API's existing host-logging line already strips the `user:pass@` prefix, so the password never reaches logs (verified).

## Tests

Added 5 tests to `tests/common/test_config.py::TestApiConfig`:
- password from env, password from `_FILE`, URL-encoding of special chars, `REDIS_PORT` override, and the no-password (no auth segment) path.

`uv run pytest tests/common/` → **518 passed**; API auth/oauth/redis subset → **221 passed**. ruff, ruff-format, mypy, bandit all clean.

> Deployment note: the matching homelab change wires `REDIS_PASSWORD_FILE: /run/secrets/redis_password` into the `discogsography-api` + `dashboard` services. This must merge and republish `:latest` images before the homelab change takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)