### PR TITLE
fix(digger-agent): broaden SSE exception scope to prevent stream aborts

### DIFF
--- a/api/routers/digger_agent.py
+++ b/api/routers/digger_agent.py
@@ -151,8 +151,14 @@ async def message(body: MessageIn, current_user: Annotated[dict[str, Any], Depen
                         cost_usd=cost,
                     )
                     await budget.record(user_id, input_tokens=final_usage["input"], output_tokens=final_usage["output"])
-        except RuntimeError as exc:
-            yield {"event": "error", "data": json.dumps({"reason": str(exc)})}
+        except Exception as exc:
+            # Catch broadly so the SSE stream always yields a typed error event instead
+            # of aborting mid-response (which surfaces as ERR_HTTP2_PROTOCOL_ERROR in the
+            # browser while the access log shows 200). RuntimeError covers ConcurrencyLock
+            # contention; the rest — DB hiccups, Anthropic SDK errors, serialization
+            # failures — would otherwise tear down the HTTP/2 stream.
+            log.exception("agent turn failed for session %s", session_id)
+            yield {"event": "error", "data": json.dumps({"reason": str(exc) or type(exc).__name__})}
 
     return EventSourceResponse(stream_events())
 

--- a/tests/api/test_digger_agent_endpoint.py
+++ b/tests/api/test_digger_agent_endpoint.py
@@ -166,6 +166,27 @@ def test_message_emits_error_event_when_lock_held(test_client: TestClient, auth_
     assert "already running" in r.text
 
 
+def test_message_emits_error_event_on_unexpected_exception(test_client: TestClient, auth_headers: dict[str, str]) -> None:
+    """Non-RuntimeError raised inside the stream must surface as an SSE error event, not abort the response."""
+
+    def _raising_run(**_kwargs: Any) -> Any:
+        async def _gen() -> Any:
+            raise ValueError("boom from inside the agent loop")
+            yield  # pragma: no cover
+
+        return _gen()
+
+    with (
+        patch("api.routers.digger_agent.q.get_user_settings", AsyncMock(return_value=_enabled_settings())),
+        patch("api.routers.digger_agent.run_agent_turn", _raising_run),
+        patch("api.routers.digger_agent.anthropic.AsyncAnthropic", _fake_anthropic([])),
+    ):
+        r = test_client.post("/api/digger/agent/message", headers=auth_headers, json={"user_message": "hi"})
+    assert r.status_code == 200
+    assert "event: error" in r.text
+    assert "boom from inside the agent loop" in r.text
+
+
 def test_message_without_done_skips_persistence(test_client: TestClient, auth_headers: dict[str, str]) -> None:
     with (
         patch("api.routers.digger_agent.q.get_user_settings", AsyncMock(return_value=_enabled_settings())),


### PR DESCRIPTION
## Summary

- `stream_events` in `api/routers/digger_agent.py` only caught `RuntimeError`, so any other exception (DB hiccup, Anthropic SDK error, JSON serialization failure) propagated out of the async generator and aborted the SSE response.
- The access log showed `200 OK` (headers committed before the crash) while the browser saw `ERR_HTTP2_PROTOCOL_ERROR` — exactly the symptom reported by a user during a chat turn.
- Catch `Exception`, `log.exception(...)`, and yield a typed `error` event so the UI can render the failure.

## Test plan

- [x] New regression test raises `ValueError` inside `run_agent_turn` and asserts the SSE stream emits `event: error` rather than collapsing to an empty body
- [x] Test fails on `main` (empty body) and passes with the fix
- [x] `just test-api` — 1686 / 1686 passing, 99% coverage
- [x] `just lint-python` — ruff + mypy clean

## Follow-up (separate issue)

A separate root cause was identified during this investigation: `request_opportunistic_refresh` bumps all wantlist items unconditionally and waits 30s, but the default rate budget (`DIGGER_RATE_BUDGET_PER_HOUR=600`) caps throughput at ~5 scrapes per 30s. The agent then misinterprets `refreshed=0` as "data pipeline broken." Will be filed as a separate issue with a redesign proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)