### PR TITLE
feat(schema-init): app_tokens table for third-party app authorization (v2-gruvax P2)

### DIFF
--- a/.planning/v2-gruvax/PLAN.md
+++ b/.planning/v2-gruvax/PLAN.md
@@ -1,0 +1,181 @@
+# Plan: App Tokens + Collection API for GRUVAX v2.0
+
+**Workflow:** One worktree per phase, one PR per phase. Atomic commits within. Each phase ends with a green CI run before next phase starts. PRs link back to this PLAN.md and SPEC.md.
+
+**Phase numbering follows brief §5.** P1 (spike) is done — see SPEC.md §4.
+
+## P2 — `app_tokens` schema
+
+**Branch:** `feat/app-tokens-schema`
+
+- `schema-init/postgres_schema.py` — append the table + 2 partial indexes from brief §3.2 to `POSTGRES_STATEMENTS` (CREATE-IF-NOT-EXISTS pattern matches existing entries).
+- Verify roundtrip (`just rebuild` or local schema-init container run) — no live DB needed for tests since this repo uses mocks, but eyeball schema-init logs on the e2e stack.
+- Tests in `tests/schema_init/` if any exist for postgres_schema; otherwise rely on the existing schema-init e2e smoke.
+
+**Acceptance:**
+- [ ] `schema-init` boots clean against fresh PG.
+- [ ] Partial indexes exist: `idx_app_tokens_user_active`, `idx_app_tokens_token_lookup`.
+- [ ] Tombstone semantics documented in postgres_schema.py comment.
+
+## P3 — `require_app_token` dependency + tests
+
+**Branch:** `feat/require-app-token-dep`
+
+- New file `api/app_tokens.py`:
+  - `mint_token(user_id, name, scopes)` → returns `(token_id, plaintext_dscg_token)`. Plaintext format: `dscg_` + 32 bytes `secrets.token_urlsafe` (base64url, no `=`).
+  - `hash_token(plaintext)` → SHA-256 hex.
+  - `require_app_token(scopes: list[str])` → dependency factory. Reads `Authorization: Bearer ...`, looks up by `token_hash` + `revoked_at IS NULL`, checks scope, returns `AppTokenAuth(user_id, token_id, scopes, name)`. Schedules `last_used_at` update via `asyncio.create_task` — failure must NOT fail the request.
+  - Constant-time scope check using `secrets.compare_digest` on hash lookup (defense in depth).
+- `api/dependencies.py` — re-export `require_app_token` symbol (consistent with existing `require_user` location).
+- Tests in `tests/api/test_app_token_auth.py` (NEW):
+  - missing `Authorization` → 401
+  - malformed header (e.g. `Bearer ` empty, `Token foo`, no `Bearer`) → 401
+  - unknown token → 401
+  - revoked token → 401
+  - valid token, missing scope → 403
+  - valid token, sufficient scope → 200 + `AppTokenAuth` populated
+  - `last_used_at` update raises → request still succeeds, error logged
+  - Two valid tokens with same plaintext (impossible by construction) — collision-safe note
+
+**Acceptance:**
+- [ ] All 7 failure-mode tests green.
+- [ ] No plaintext token in any log line (grep CI step or test).
+- [ ] `require_user` tests unchanged and still pass.
+- [ ] mypy + ruff clean.
+
+## P4 — Settings UI for mint/list/revoke
+
+**Branch:** `feat/app-tokens-settings-ui`
+
+**Backend** (`api/routers/app_tokens.py`, NEW) — all under `Depends(require_user)`:
+- `POST /api/user/app-tokens` — body `{name, scopes}`. Returns `{token_id, token, name, scopes, created_at}`. Plaintext only this once.
+- `GET /api/user/app-tokens` — returns `{active: [...], revoked: [...]}`. Active rows: `{id, name, scopes, created_at, last_used_at}`. Revoked rows: `{id, name, revoked_at}`.
+- `DELETE /api/user/app-tokens/{id}` — sets `revoked_at = NOW()`. 404 if not owned by current user. 204 on success.
+- Wire router in `api/api.py` next to existing user routers.
+
+**Frontend** (`explore/`) — vanilla classic-script JS per memory `project_digger_m1_execution`:
+- New page `explore/static/settings/apps.html` + `explore/static/settings/apps.js` + CSS.
+- Route in `explore/app.py` (or equivalent) serving the page.
+- List: active + revoked sections.
+- Mint form: name input, scope multiselect (only `collection:read` for v1).
+- Reveal screen: large code block with plaintext, "Copy" button, prominent warning, "Done" returns to list (plaintext discarded from DOM).
+- Revoke: confirm modal → DELETE call → list refresh.
+- Tests in `explore/static/__tests__/apps.test.js` (Vitest) with FAKE TIMERS (per memory — leaked-timer flake).
+
+**Acceptance:**
+- [ ] User flow: mint → copy → list shows row with `last_used_at: never` → revoke → row moves to revoked tombstones section.
+- [ ] Plaintext NEVER appears after navigating away from reveal screen.
+- [ ] Vitest covers mint flow, list rendering, revoke confirmation.
+- [ ] Python tests cover all 3 backend endpoints + ownership 404 case.
+
+## P5 — Apply auth + rate limits to /api/user/collection endpoints
+
+**Branch:** `feat/app-token-collection-auth`
+
+- Decision: support BOTH `require_user` (first-party JWT) AND `require_app_token` on the three endpoints — they're additive. Use a `require_user_or_app_token(scopes=[...])` helper that returns a unified `AuthContext` exposing `user_id`. This avoids duplicating endpoint code paths.
+- Update `api/routers/user.py` lines 69, 158, 169 to use the unified dep.
+- Add response field `user_id` (UUID string) to all three responses — required by brief §3.5.
+- Rate limits via existing `api/limiter.py` (slowapi):
+  - `60/minute` per token (key derived from `token_id` for app-token; `sub` for JWT — fall back to IP if neither).
+  - `600/hour` per token.
+  - 429 sets `Retry-After`.
+- Tests:
+  - First-party JWT path still works (regression).
+  - App-token path returns user's collection.
+  - Rate-limit headers present at boundary.
+  - 429 with `Retry-After` when limit exceeded (use slowapi test helper).
+  - `user_id` field present in all three responses.
+
+**Acceptance:**
+- [ ] `curl -H 'Authorization: Bearer dscg_...' /api/user/collection` returns user's collection.
+- [ ] Same endpoint with first-party JWT still works (regression).
+- [ ] Existing collection endpoint tests still pass.
+- [ ] Rate limit test green.
+
+## P6 — `catalog_number` everywhere (no schema migrations)
+
+**Branch:** `feat/catalog-number-everywhere`
+
+Approach B-everywhere per SPEC.md §4.3. No PG schema migration.
+
+### P6.1 — Sync path (`api/syncer.py`)
+
+- Lines 147–167: extract `catno = labels[0].get("catno") if labels else None` per item.
+- PG upsert (line 180-ish): change the `metadata` slot from literal `None` to `Jsonb({"catno": catno}) if catno else None`. The column is already `JSONB` (postgres_schema.py:180). Use `psycopg.types.json.Jsonb`.
+- Neo4j cypher around line 200 — verify whether the existing cypher MATCHes Release by id (does not MERGE) and whether bulk-extracted Release nodes already exist before sync runs. If Release pre-exists, add `SET r.catalog_number = rel.catno` (guard with `WHERE rel.catno IS NOT NULL` so we never overwrite existing catno with null).
+- Add `catno: rel.catno` to the Cypher `UNWIND $releases AS rel` payload.
+
+### P6.2 — Graphinator path (`graphinator/batch_processor.py`)
+
+- On the Release MERGE arm, extract `catno = msg.data.get("labels", [{}])[0].get("catno")` (defensive on empty labels).
+- Add `SET r.catalog_number = $catno` to the Release MERGE cypher (guarded `WHERE $catno IS NOT NULL` if Cypher syntax permits, otherwise conditional in Python).
+- This populates catno on Release nodes from bulk extraction going forward.
+
+### P6.3 — Tableinator path
+
+**No change.** The full entity payload including `labels[].catno` is already persisted into `data JSONB` at `tableinator/batch_processor.py:418` via `Jsonb(msg.data)`. Verified during P1 spike.
+
+### P6.4 — Query layer (`api/queries/user_queries.py`)
+
+- `get_user_collection` (line ~42): add `r.catalog_number AS catalog_number` to RETURN.
+- `get_user_wantlist` (line ~82): same.
+- Check `get_user_collection_stats` and `get_user_collection_timeline` — likely no change needed (these aggregate, don't return per-release catno) but verify.
+
+### P6.5 — Tests
+
+- `tests/api/test_syncer.py`: catno extracted and persisted to both stores (mocked Discogs response with `labels[].catno`).
+- `tests/api/test_syncer.py`: null-safe — items where `labels` is empty or `catno` is missing → catno=None, metadata=None.
+- `tests/graphinator/test_graphinator.py`: graphinator MERGE writes catno on Release node (mocked Neo4j session, assert cypher parameters).
+- `tests/api/test_user_queries.py` (or wherever queries are tested): `get_user_collection` returns `catalog_number` in each item.
+
+### Backfill (operational, not a code change)
+
+- For active users: trigger one re-sync via existing endpoint. Most users will hit "Re-sync" voluntarily.
+- For unowned releases on Release nodes: nothing to do — wait for next Discogs monthly bulk re-ingest (graphinator will then write catno).
+- GRUVAX positions OWNED records → sync-path coverage is sufficient at cutover.
+
+**Acceptance:**
+- [ ] Synced collection items expose `catalog_number` (non-null where Discogs has it) on both `/api/user/collection` and `/api/user/wantlist`.
+- [ ] Null-safe: items where Discogs returns no `catno` → `catalog_number: null`, no errors.
+- [ ] Graphinator writes `r.catalog_number` on Release MERGE going forward.
+- [ ] Tableinator unchanged and tests still green.
+- [ ] No PG schema migration in this phase. (`postgres_schema.py` diff is zero.)
+- [ ] `user_collections.metadata` rows for catno-bearing items contain `{"catno": "..."}` (verifiable via direct SELECT in e2e).
+
+## P7 — Cross-repo contract artifact
+
+**Branch:** `feat/v2-gruvax-contract-doc`
+
+- Write `docs/specs/v2-gruvax-integration.md` with all sections from brief §3.7:
+  - P1 spike outcome (cite outcome (c) + chosen approach B + final field name `catalog_number`)
+  - OpenAPI fragment (YAML) for the three endpoints under app-token auth
+  - Example request + response with `catalog_number` populated
+  - Scope vocabulary (`collection:read`)
+  - Error shapes (401/403/429)
+  - Plaintext token format (`dscg_<base64url>`)
+  - `user_id` location: response envelope top-level field
+  - Rate-limit thresholds and `Retry-After` semantics
+  - Versioning / deprecation note (when contract changes, what GRUVAX does)
+- Mention this file is the *cross-repo contract* and changes require GRUVAX coordination.
+
+**Acceptance:**
+- [ ] All hand-off criteria from brief §6 demonstrably true.
+- [ ] Document accurately reflects live API (cross-checked against actual response JSON from running the e2e stack).
+
+## Ordering
+
+P2 → P3 → P4 → P5 → P6 → P7. Within each, one worktree, one branch, one PR.
+
+P6 *could* theoretically come earlier (the field is independent of auth), but landing it later means the contract artifact in P7 already shows the catalog_number-enabled responses, which keeps the contract document drafting linear.
+
+## Worktree convention (per project memory)
+
+```bash
+WORKTREE=.worktrees/$BRANCH
+git worktree add -b $BRANCH $WORKTREE origin/main
+# work in $WORKTREE
+# atomic commits
+gh pr create --base main
+```
+
+Each PR description references this PLAN.md path and the P# it implements.

--- a/.planning/v2-gruvax/SPEC.md
+++ b/.planning/v2-gruvax/SPEC.md
@@ -1,0 +1,123 @@
+# Milestone: App Tokens + Collection API for GRUVAX v2.0
+
+**Status:** Drafting (P1 spike complete — catalog# decision pending user input)
+**Origin brief:** External (GRUVAX repo, 2026-05-26) — pasted into session, not checked into either repo
+**Cross-repo contract artifact (deliverable):** `docs/specs/v2-gruvax-integration.md` (written in P7)
+**Scope:** Self-contained discogsography milestone. After it ships, GRUVAX v2.0 work begins (GRUVAX agrees to wait).
+
+---
+
+## 1. What GRUVAX needs from discogsography
+
+GRUVAX v2.0 must integrate with discogsography over **HTTP API** (not direct DB read), fetching a specific *authorized user's* collection. Each GRUVAX user must **authorize** GRUVAX to read their collection. A GRUVAX deployment supports multiple per-user profiles.
+
+This milestone adds a generic, scoped, revocable third-party app authorization mechanism — usable by GRUVAX now, and by other future third parties.
+
+## 2. Deliverables
+
+1. **`app_tokens` table** — third-party app authorization records (id, user_id, name, scope[], token_hash, created_at, last_used_at, revoked_at).
+2. **`require_app_token` FastAPI dependency** — Bearer-token auth, scope check, async `last_used_at` update.
+3. **Settings UI** — `/settings/apps` page in `explore/`: mint (one-time reveal), list active + revoked, revoke.
+4. **App-token auth on three endpoints:**
+   - `GET /api/user/collection`
+   - `GET /api/user/collection/stats`
+   - `GET /api/user/collection/timeline`
+5. **Rate limits** on those endpoints: 60/min/token, 600/hr/token, 429 with `Retry-After`.
+6. **`catalog_number` exposed per collection item** — see §4 spike findings; PENDING user input on approach.
+7. **Cross-repo contract:** `docs/specs/v2-gruvax-integration.md`.
+
+## 3. Out of scope (per brief §2)
+
+- Building GRUVAX-side code.
+- OAuth2 device-authorization grant (PAT-style token is sufficient).
+- Per-app permissions UI beyond a flat scope list.
+- `collection:write` scope.
+- Webhooks to GRUVAX.
+- Refactoring existing first-party JWT auth (`require_user`) or Discogs OAuth flow.
+
+## 4. P1 spike findings (verification)
+
+Three claims to verify per brief §3.1:
+
+### 4.1 Are the three target endpoints already exposed?
+
+**YES** — at `api/routers/user.py`:
+
+| Endpoint | Line | Source |
+|---|---|---|
+| `GET /api/user/collection` | 69 | Neo4j (`get_user_collection`) |
+| `GET /api/user/collection/stats` | 158 | Neo4j (`get_user_collection_stats`) |
+| `GET /api/user/collection/timeline` | 169 | Neo4j (`get_user_collection_timeline`) |
+
+All use `Depends(require_user)` today (first-party JWT only). Response shapes from `api/queries/user_queries.py`:
+
+```jsonc
+// /api/user/collection
+{
+  "releases": [
+    { "id", "title", "year", "artist", "label", "genres", "styles",
+      "rating", "date_added", "folder_id" }
+  ],
+  "total": N, "offset": 0, "limit": 50, "has_more": bool
+}
+```
+
+No `catalog_number`, no `user_id`. Both must be added for the GRUVAX contract.
+
+### 4.2 Is `catalog_number` stored anywhere?
+
+**NO — outcome (c).** Per brief §3.1 escalation policy, this requires user confirmation before scope expansion.
+
+Verified by code inspection (read-only — no live DB query in spike):
+
+- **`user_collections` table** (`schema-init/postgres_schema.py:165`) — no `catalog_number` column. `metadata` JSONB is "reserved for future use" (syncer comment `api/syncer.py:165`).
+- **Discogs collection syncer** (`api/syncer.py:147`) — Discogs API returns `labels[]` with `catno` per item. Syncer only reads `labels[0]["name"]` (line 148), discards `catno`.
+- **Neo4j Release node** (referenced by `r.title`, `r.year`, `r.id` throughout `api/queries/user_queries.py`) — no `r.catalog_number`.
+- **Graphinator** (`graphinator/graphinator.py`, `batch_processor.py`) — `grep catno catalog` returns zero matches. Bulk pipeline messages contain `catno` (preserved by Rust extractor — see `extractor/src/tests/normalize_tests.rs:304`), but graphinator drops it.
+- **Tableinator** — same: zero matches.
+
+Catalog numbers ARE in the upstream data (both Discogs API responses and bulk XML dumps), but neither persists them anywhere downstream.
+
+### 4.3 Decision — Approach B-everywhere (no PG schema migrations)
+
+**User decision (2026-05-26):** Approach B-everywhere with no schema changes.
+
+| Layer | Action | Schema migration? |
+|---|---|---|
+| `api/syncer.py` (Discogs API → Neo4j + PG, per-user sync) | Extract `labels[0].get("catno")` per item. Neo4j: `SET r.catalog_number = $catno` on the existing Release MATCH. PG: include `{"catno": "..."}` in `user_collections.metadata` JSONB upsert (column already exists, currently always written as `None`). | None |
+| `graphinator/batch_processor.py` (bulk Discogs XML → Neo4j) | On Release MERGE, also `SET r.catalog_number` from `msg.data.labels[0].catno` (Rust extractor already preserves it — verified in `extractor/src/tests/normalize_tests.rs:304`). | None |
+| `tableinator/batch_processor.py` (bulk Discogs XML → PG) | **No code change required.** Table shape is `{data_id, hash, data JSONB, updated_at}` (postgres_schema.py:684); the full entity payload including `labels[].catno` is already written via `Jsonb(msg.data)` at `batch_processor.py:418`. | None |
+| `api/queries/user_queries.py` | Add `r.catalog_number AS catalog_number` to `RETURN` for collection + wantlist + stats/timeline where relevant. | None |
+
+**Why this works without schema changes:**
+- Neo4j is schemaless on node properties — first write creates `r.catalog_number`.
+- `user_collections.metadata JSONB` already exists (postgres_schema.py:180) — was always written as `None`; switch to `Jsonb({"catno": catno})` when catno present.
+- Tableinator already stores the full payload.
+
+**Backfill strategy:**
+- Owned releases (most important for GRUVAX): one re-sync per active user via existing Discogs sync endpoint. Cheap (Discogs API only).
+- Unowned releases: populated organically by next bulk Discogs ingest (graphinator will then write catno on MERGE). Discogs ships monthly XML dumps; no forced re-ingest required.
+- For the immediate GRUVAX cutover, owned-release catno (via sync) is sufficient — GRUVAX only positions records the user owns.
+
+**The only schema migration this milestone introduces is the new `app_tokens` table** (P2). That table cannot be expressed via JSONB without losing partial-index lookups by `token_hash` (the critical hot path for `require_app_token`).
+
+## 5. Open §7 questions from the brief
+
+| # | Question | Resolution |
+|---|---|---|
+| 1 | `catalog_number` not stored — scope expansion OK? | **Resolved 2026-05-26:** Approach B-everywhere with no PG schema changes. See §4.3. |
+| 2 | `user_id` location — header vs response envelope | **Response envelope** (`"user_id": "<uuid>"` as a top-level field alongside `releases`/`total`/`offset`/`limit`/`has_more`). Discoverable, JSON-typed, doesn't depend on caller reading headers. |
+| 3 | Scope naming — `collection:read` or `read:collection`? | Match repo conventions — check `MCP_API_TOKEN` flow and `X-Service-Token` guard for existing scope naming. If none found, default to brief's suggestion `collection:read`. |
+| 4 | Token format prefix `dscg_` | Accept — no existing identifier convention conflicts on inspection. |
+| 5 | Anything in §2 (out of scope) that seems mandatory? | None identified. |
+
+## 6. Non-goals beyond brief §2
+
+- Re-architecting `/api/user/collection` source-of-truth (stays on Neo4j).
+- Adding `collection:read` to the existing MCP server flow (orthogonal — MCP uses `MCP_API_TOKEN`, separate auth path).
+- Forcing a full bulk re-ingest to backfill catalog# on unowned releases (let it happen organically at next monthly Discogs dump).
+- Adding a top-level `catalog_number` column to `user_collections` (we'll use existing `metadata` JSONB instead).
+
+---
+
+**Approved by user:** 2026-05-26 — Approach B-everywhere, JSONB metadata reuse, no PG schema migrations beyond `app_tokens`.

--- a/schema-init/postgres_schema.py
+++ b/schema-init/postgres_schema.py
@@ -149,6 +149,33 @@ _USER_TABLES: list[tuple[str, str]] = [
         )
         """,
     ),
+    # app_tokens: revocable Bearer tokens for third-party app authorization
+    # (e.g. GRUVAX kiosk). Plaintext shown ONCE at mint time; only the SHA-256
+    # hex hash is persisted. Revoked rows are tombstones — never deleted, so
+    # the audit trail is preserved. See docs/specs/v2-gruvax-integration.md.
+    (
+        "app_tokens table",
+        """
+        CREATE TABLE IF NOT EXISTS app_tokens (
+            id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id      UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            name         VARCHAR(255) NOT NULL,
+            scope        TEXT[] NOT NULL,
+            token_hash   VARCHAR(64) NOT NULL,
+            created_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+            last_used_at TIMESTAMP WITH TIME ZONE,
+            revoked_at   TIMESTAMP WITH TIME ZONE
+        )
+        """,
+    ),
+    (
+        "idx_app_tokens_user_active",
+        "CREATE INDEX IF NOT EXISTS idx_app_tokens_user_active ON app_tokens (user_id) WHERE revoked_at IS NULL",
+    ),
+    (
+        "idx_app_tokens_token_lookup",
+        "CREATE INDEX IF NOT EXISTS idx_app_tokens_token_lookup ON app_tokens (token_hash) WHERE revoked_at IS NULL",
+    ),
     (
         "app_config table",
         """

--- a/tests/schema-init/test_postgres_schema.py
+++ b/tests/schema-init/test_postgres_schema.py
@@ -107,6 +107,69 @@ class TestInsightsSchema:
         assert "insights.computation_log table" in table_names
 
 
+class TestAppTokensTable:
+    """Schema-shape tests for the app_tokens third-party auth table."""
+
+    def _user_tables_dict(self) -> dict[str, str]:
+        return dict(_USER_TABLES)
+
+    def test_app_tokens_table_defined(self) -> None:
+        assert "app_tokens table" in self._user_tables_dict()
+
+    def test_app_tokens_required_columns(self) -> None:
+        stmt = self._user_tables_dict()["app_tokens table"]
+        for column in (
+            "id",
+            "user_id",
+            "name",
+            "scope",
+            "token_hash",
+            "created_at",
+            "last_used_at",
+            "revoked_at",
+        ):
+            assert column in stmt, f"Missing column '{column}' in app_tokens schema"
+
+    def test_app_tokens_token_hash_is_sha256_sized(self) -> None:
+        """SHA-256 hex digests are exactly 64 chars; VARCHAR(64) prevents accidental other-algorithm storage."""
+        stmt = self._user_tables_dict()["app_tokens table"]
+        assert "token_hash   VARCHAR(64)" in stmt or "token_hash VARCHAR(64)" in stmt
+
+    def test_app_tokens_cascade_on_user_delete(self) -> None:
+        stmt = self._user_tables_dict()["app_tokens table"]
+        assert "REFERENCES users(id) ON DELETE CASCADE" in stmt
+
+    def test_app_tokens_scope_is_text_array(self) -> None:
+        stmt = self._user_tables_dict()["app_tokens table"]
+        assert "scope        TEXT[] NOT NULL" in stmt or "scope TEXT[] NOT NULL" in stmt
+
+    def test_app_tokens_partial_indexes_defined(self) -> None:
+        names = {name for name, _ in _USER_TABLES}
+        assert "idx_app_tokens_user_active" in names
+        assert "idx_app_tokens_token_lookup" in names
+
+    def test_app_tokens_indexes_are_partial_on_active_rows(self) -> None:
+        """Both indexes must skip revoked rows to keep lookups fast as tombstones accumulate."""
+        idx_stmts = {name: stmt for name, stmt in _USER_TABLES if name.startswith("idx_app_tokens_")}
+        for name, stmt in idx_stmts.items():
+            assert "WHERE revoked_at IS NULL" in stmt, f"{name} is not a partial index on active rows"
+
+    def test_app_tokens_token_lookup_index_keyed_by_hash(self) -> None:
+        """The lookup index must be on token_hash — this is the hot path for require_app_token."""
+        stmt = dict(_USER_TABLES)["idx_app_tokens_token_lookup"]
+        assert "ON app_tokens (token_hash)" in stmt
+
+    def test_app_tokens_user_active_index_keyed_by_user_id(self) -> None:
+        """The user-active index serves the settings page list view."""
+        stmt = dict(_USER_TABLES)["idx_app_tokens_user_active"]
+        assert "ON app_tokens (user_id)" in stmt
+
+    def test_app_tokens_no_drop_in_schema(self) -> None:
+        """Tombstone semantics: revoked rows are NEVER deleted; the schema must never drop the table."""
+        stmt = self._user_tables_dict()["app_tokens table"]
+        assert "DROP" not in stmt.upper()
+
+
 class TestCreatePostgresSchema:
     """Test create_postgres_schema with a mock pool."""
 


### PR DESCRIPTION
## Summary

P2 of the **App Tokens + Collection API for GRUVAX v2.0** milestone — see `.planning/v2-gruvax/SPEC.md` and `PLAN.md` (added in this PR).

Adds the \`app_tokens\` table for revocable Bearer tokens that authorize third-party apps (e.g. GRUVAX kiosk) to read a user's collection without sharing first-party credentials. Plaintext is shown ONCE at mint time; only the SHA-256 hex (VARCHAR(64)) is persisted. Revoked rows are **tombstones** — never deleted — so the audit trail is preserved.

Two partial indexes (\`WHERE revoked_at IS NULL\`) keep the lookup hot path fast as tombstones accumulate:
- \`idx_app_tokens_token_lookup\` — drives \`require_app_token()\` (P3)
- \`idx_app_tokens_user_active\` — drives the \`/settings/apps\` list view (P4)

## Milestone context

This is a self-contained milestone enabling GRUVAX v2.0 cross-repo integration. After this milestone ships, GRUVAX v2.0 work begins. The P1 verification spike (documented in SPEC.md §4) found that \`catalog_number\` is not stored anywhere on our side today — fixed in P6 with **no PG schema migrations** (uses existing JSONB columns and Neo4j's schemaless node properties). This PR's \`app_tokens\` table is the **only** schema migration in the milestone.

Subsequent phases (P3–P7) each land as their own worktree-based PR.

## Changes

- \`schema-init/postgres_schema.py\` — new \`app_tokens\` table + 2 partial indexes in \`_USER_TABLES\`, placed adjacent to \`oauth_tokens\` for logical grouping.
- \`tests/schema-init/test_postgres_schema.py\` — \`TestAppTokensTable\` class with 10 schema-shape tests (column presence, SHA-256 sizing, CASCADE behavior, partial-index predicates, tombstone semantics).
- \`.planning/v2-gruvax/SPEC.md\` and \`PLAN.md\` — milestone scope and phase breakdown.

## Test plan

- [x] \`uv run pytest tests/schema-init/test_postgres_schema.py\` — all 27 tests pass (10 new + 17 existing)
- [x] \`uv run ruff check\` clean on changed files
- [x] \`uv run mypy\` clean (pre-commit hook)
- [ ] E2E schema-init container boots clean against fresh PG (manual verification on review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)