### PR TITLE
feat(api+explore): Connected Apps settings UI for app tokens (v2-gruvax P4)

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -38,6 +38,7 @@ from api.metrics_collector import MetricsBuffer, normalize_path, run_collector
 from api.notifications import BrevoNotificationChannel, LogNotificationChannel
 from api.queries.search_queries import ALL_TYPES, execute_search
 import api.routers.admin as _admin_router
+import api.routers.app_tokens as _app_tokens_router
 import api.routers.auth as _auth_router
 import api.routers.collection as _collection_router
 import api.routers.credits as _credits_router
@@ -430,6 +431,7 @@ app.include_router(_nlq_router.router)
 app.include_router(_rarity_router.router)
 app.include_router(_network_router.router)
 app.include_router(_musicbrainz_router.router)
+app.include_router(_app_tokens_router.router)
 
 
 @app.get("/health")

--- a/api/models.py
+++ b/api/models.py
@@ -413,6 +413,51 @@ class ChallengeResponse(BaseModel):
     challenge_token: str
 
 
+# ── App tokens (third-party app authorization) ────────────────────────────────
+
+
+class MintAppTokenRequest(BaseModel):
+    """Request body for POST /api/user/app-tokens."""
+
+    name: str = Field(min_length=1, max_length=255, description='Human label, e.g. "GRUVAX kiosk"')
+    scopes: list[str] = Field(min_length=1, description='Permission scopes, e.g. ["collection:read"]')
+
+
+class MintAppTokenResponse(BaseModel):
+    """Response from POST /api/user/app-tokens — plaintext returned ONCE."""
+
+    id: UUID
+    name: str
+    scopes: list[str]
+    token: str = Field(description="Plaintext token (dscg_…) — never recoverable")
+    created_at: datetime
+
+
+class AppTokenActive(BaseModel):
+    """One active row from GET /api/user/app-tokens.active."""
+
+    id: UUID
+    name: str
+    scopes: list[str]
+    created_at: datetime
+    last_used_at: datetime | None
+
+
+class AppTokenRevoked(BaseModel):
+    """Tombstone row from GET /api/user/app-tokens.revoked."""
+
+    id: UUID
+    name: str
+    revoked_at: datetime
+
+
+class ListAppTokensResponse(BaseModel):
+    """Response from GET /api/user/app-tokens."""
+
+    active: list[AppTokenActive]
+    revoked: list[AppTokenRevoked]
+
+
 class ExtractionHistoryResponse(BaseModel):
     id: UUID
     triggered_by: UUID

--- a/api/routers/app_tokens.py
+++ b/api/routers/app_tokens.py
@@ -1,0 +1,138 @@
+"""User-facing endpoints for managing app tokens (third-party app authorization).
+
+All endpoints here are gated by `require_user` (first-party JWT). The actual
+token-authenticated endpoints are wired in P5 — this router only deals with
+the *management* surface: mint, list, revoke.
+
+The plaintext token is returned EXACTLY ONCE from POST /api/user/app-tokens
+and is never recoverable thereafter — only its SHA-256 hex hash is persisted.
+"""
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi.responses import JSONResponse
+import structlog
+
+from api.app_tokens import (
+    list_user_tokens as _list_user_tokens,
+    mint_token as _mint_token,
+    revoke_token as _revoke_token,
+)
+from api.dependencies import require_user
+from api.models import MintAppTokenRequest
+
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+
+# Public scope vocabulary. Centralized here so future scopes are added in one place
+# and the settings UI can enumerate options without hardcoding.
+ALLOWED_SCOPES = frozenset({"collection:read"})
+
+
+@router.post("/api/user/app-tokens", status_code=status.HTTP_201_CREATED)
+async def mint_app_token(
+    body: MintAppTokenRequest,
+    current_user: Annotated[dict[str, Any], Depends(require_user)],
+) -> JSONResponse:
+    """Mint a new app token. Plaintext is returned ONCE — never recoverable."""
+    unknown = [s for s in body.scopes if s not in ALLOWED_SCOPES]
+    if unknown:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown scope(s): {', '.join(unknown)}",
+        )
+
+    user_id: str = current_user.get("sub", "")
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    name = body.name.strip()
+    if not name:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="name must be non-empty")
+
+    token_id, plaintext = await _mint_token(user_id=user_id, name=name, scopes=list(body.scopes))
+
+    # Re-read the row to surface server-generated created_at — saves us a SELECT race.
+    active, _revoked = await _list_user_tokens(user_id)
+    created_at = next((str(t["created_at"]) for t in active if str(t["id"]) == str(token_id)), None)
+
+    logger.info("🔐 app token minted", user_id=user_id, token_id=str(token_id), scopes=list(body.scopes))
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content={
+            "id": str(token_id),
+            "name": name,
+            "scopes": list(body.scopes),
+            "token": plaintext,
+            "created_at": created_at,
+        },
+    )
+
+
+@router.get("/api/user/app-tokens")
+async def list_app_tokens(
+    current_user: Annotated[dict[str, Any], Depends(require_user)],
+) -> JSONResponse:
+    """Return the current user's active + revoked (tombstone) tokens. token_hash is never returned."""
+    user_id: str = current_user.get("sub", "")
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    active, revoked = await _list_user_tokens(user_id)
+
+    def _shape_active(row: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "id": str(row["id"]),
+            "name": row["name"],
+            "scopes": list(row.get("scope") or []),
+            "created_at": _isoformat(row.get("created_at")),
+            "last_used_at": _isoformat(row.get("last_used_at")),
+        }
+
+    def _shape_revoked(row: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "id": str(row["id"]),
+            "name": row["name"],
+            "revoked_at": _isoformat(row.get("revoked_at")),
+        }
+
+    return JSONResponse(
+        content={
+            "active": [_shape_active(r) for r in active],
+            "revoked": [_shape_revoked(r) for r in revoked],
+        }
+    )
+
+
+@router.delete("/api/user/app-tokens/{token_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_app_token(
+    token_id: str,
+    current_user: Annotated[dict[str, Any], Depends(require_user)],
+) -> Response:
+    """Revoke (tombstone) the named token. 404 if not owned by the caller."""
+    user_id: str = current_user.get("sub", "")
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    success = await _revoke_token(token_id=token_id, user_id=user_id)
+    if not success:
+        # Owner-scoped check happens inside revoke_token's WHERE clause; failure here
+        # could mean: wrong owner, unknown id, or already-revoked. We don't disclose
+        # which to avoid leaking token-existence info to other users.
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Token not found")
+
+    logger.info("🔐 app token revoked", user_id=user_id, token_id=token_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+def _isoformat(value: Any) -> str | None:
+    """Best-effort ISO-8601 stringification for timestamps, preserving null."""
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return str(value.isoformat())
+    return str(value)

--- a/explore/__tests__/api-client.test.js
+++ b/explore/__tests__/api-client.test.js
@@ -2110,4 +2110,111 @@ describe('ApiClient', () => {
             expect(onError.mock.calls[0][0].message).toBe('stream aborted');
         });
     });
+
+    describe('listAppTokens', () => {
+        it('returns parsed body on 200', async () => {
+            const expected = { active: [{ id: 'a' }], revoked: [] };
+            vi.stubGlobal('fetch', createMockFetch({ '/api/user/app-tokens': { data: expected } }));
+            const result = await window.apiClient.listAppTokens('jwt-tok');
+            expect(result).toEqual(expected);
+        });
+
+        it('returns null when token is falsy', async () => {
+            const result = await window.apiClient.listAppTokens(null);
+            expect(result).toBeNull();
+        });
+
+        it('returns null on non-2xx', async () => {
+            vi.stubGlobal('fetch', createMockFetch({ '/api/user/app-tokens': { status: 401 } }));
+            const result = await window.apiClient.listAppTokens('jwt-tok');
+            expect(result).toBeNull();
+        });
+
+        it('sends Authorization header', async () => {
+            const fetchSpy = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ active: [], revoked: [] }) }));
+            vi.stubGlobal('fetch', fetchSpy);
+            await window.apiClient.listAppTokens('jwt-tok');
+            expect(fetchSpy.mock.calls[0][0]).toContain('/api/user/app-tokens');
+            expect(fetchSpy.mock.calls[0][1].headers.Authorization).toBe('Bearer jwt-tok');
+        });
+    });
+
+    describe('mintAppToken', () => {
+        it('returns wrapped {ok, status, body} on 201', async () => {
+            const body = { id: 'tok-1', name: 'kiosk', scopes: ['collection:read'], token: 'dscg_secret', created_at: '2026-05-26T00:00:00Z' };
+            vi.stubGlobal('fetch', createMockFetch({ '/api/user/app-tokens': { status: 201, data: body } }));
+            const result = await window.apiClient.mintAppToken('jwt-tok', 'kiosk', ['collection:read']);
+            expect(result.ok).toBe(true);
+            expect(result.status).toBe(201);
+            expect(result.body).toEqual(body);
+        });
+
+        it('returns {ok:false, status:0, body:null} when token is falsy', async () => {
+            const result = await window.apiClient.mintAppToken('', 'kiosk', ['collection:read']);
+            expect(result).toEqual({ ok: false, status: 0, body: null });
+        });
+
+        it('returns wrapped error body on 4xx', async () => {
+            const body = { detail: 'Unknown scope(s): foo' };
+            vi.stubGlobal('fetch', createMockFetch({ '/api/user/app-tokens': { status: 400, data: body } }));
+            const result = await window.apiClient.mintAppToken('jwt-tok', 'kiosk', ['foo']);
+            expect(result.ok).toBe(false);
+            expect(result.status).toBe(400);
+            expect(result.body).toEqual(body);
+        });
+
+        it('sets body to null and still returns wrapper when JSON parsing throws', async () => {
+            vi.stubGlobal('fetch', async () => ({
+                ok: false, status: 500,
+                json: async () => { throw new Error('bad json'); },
+            }));
+            const result = await window.apiClient.mintAppToken('jwt-tok', 'kiosk', ['collection:read']);
+            expect(result.ok).toBe(false);
+            expect(result.status).toBe(500);
+            expect(result.body).toBeNull();
+        });
+
+        it('sends JSON body and Authorization header', async () => {
+            const fetchSpy = vi.fn(async () => ({ ok: true, status: 201, json: async () => ({}) }));
+            vi.stubGlobal('fetch', fetchSpy);
+            await window.apiClient.mintAppToken('jwt-tok', 'GRUVAX kiosk', ['collection:read']);
+            const [, opts] = fetchSpy.mock.calls[0];
+            expect(opts.method).toBe('POST');
+            expect(opts.headers.Authorization).toBe('Bearer jwt-tok');
+            expect(opts.headers['Content-Type']).toBe('application/json');
+            expect(JSON.parse(opts.body)).toEqual({ name: 'GRUVAX kiosk', scopes: ['collection:read'] });
+        });
+    });
+
+    describe('revokeAppToken', () => {
+        it('returns true on 204', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: true, status: 204, json: async () => ({}) }));
+            const result = await window.apiClient.revokeAppToken('jwt-tok', 'tok-1');
+            expect(result).toBe(true);
+        });
+
+        it('returns false on 404', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: false, status: 404, json: async () => ({}) }));
+            const result = await window.apiClient.revokeAppToken('jwt-tok', 'tok-1');
+            expect(result).toBe(false);
+        });
+
+        it('returns false when token is falsy', async () => {
+            const result = await window.apiClient.revokeAppToken(null, 'tok-1');
+            expect(result).toBe(false);
+        });
+
+        it('returns false when tokenId is falsy', async () => {
+            const result = await window.apiClient.revokeAppToken('jwt-tok', '');
+            expect(result).toBe(false);
+        });
+
+        it('uri-encodes the tokenId path segment', async () => {
+            const fetchSpy = vi.fn(async () => ({ ok: true, status: 204 }));
+            vi.stubGlobal('fetch', fetchSpy);
+            await window.apiClient.revokeAppToken('jwt-tok', 'has space & slash/?');
+            expect(fetchSpy.mock.calls[0][0]).toContain('has%20space%20%26%20slash%2F%3F');
+            expect(fetchSpy.mock.calls[0][1].method).toBe('DELETE');
+        });
+    });
 });

--- a/explore/__tests__/settings-app-tokens.test.js
+++ b/explore/__tests__/settings-app-tokens.test.js
@@ -1,0 +1,288 @@
+/**
+ * Tests for the App Tokens (Connected Apps) settings card in settings.js.
+ *
+ * Uses fake timers per project memory (leaked-timer flake) for the
+ * setTimeout in _handleCopyToken.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { loadScript } from './helpers.js';
+
+globalThis.QRCode = vi.fn();
+QRCode.CorrectLevel = { M: 1 };
+
+function setupDOM() {
+    document.body.textContent = '';
+    // Bare minimum elements settings.js touches during init()
+    for (const id of [
+        'settingsEmail', 'settingsCreatedAt', 'settingsDiscogsStatus',
+        'settingsCurrentPassword', 'settingsNewPassword', 'settingsConfirmPassword',
+        'passwordChangeError', 'passwordChangeSuccess', 'changePasswordBtn',
+        'twoFactorContent', 'diggerEnabled', 'diggerCountry', 'diggerCurrency',
+        'diggerCadence', 'diggerModel', 'diggerCapInteractive', 'diggerCapScheduled',
+        'diggerSettingsError', 'diggerSettingsSuccess', 'diggerSettingsSaveBtn',
+        'settingsDiggerCard', 'settingsAppTokensCard',
+    ]) {
+        const el = document.createElement('div');
+        el.id = id;
+        document.body.appendChild(el);
+    }
+    // The container the app-tokens card renders into
+    const container = document.createElement('div');
+    container.id = 'appTokensContent';
+    document.body.appendChild(container);
+    return container;
+}
+
+function setupMocks(opts = {}) {
+    window.authManager = {
+        getUser: vi.fn().mockReturnValue({ id: 1, email: 'u@test.com', totp_enabled: false }),
+        getDiscogsStatus: vi.fn().mockReturnValue(null),
+        getToken: vi.fn().mockReturnValue(opts.signedOut ? null : 'test-token'),
+        updateTotpEnabled: vi.fn(),
+    };
+    window.apiClient = {
+        // Stubs for parts of settings.js init() that we don't care about
+        changePassword: vi.fn().mockResolvedValue({ ok: true }),
+        twoFactorSetup: vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }),
+        twoFactorConfirm: vi.fn(),
+        twoFactorVerify: vi.fn(),
+        twoFactorRecovery: vi.fn(),
+        twoFactorDisable: vi.fn(),
+        getDiggerSettings: vi.fn().mockResolvedValue({ ok: false, status: 404 }),
+        putDiggerSettings: vi.fn(),
+        // The actual app token surface
+        listAppTokens: vi.fn().mockResolvedValue(opts.listResponse ?? { active: [], revoked: [] }),
+        mintAppToken: vi.fn().mockResolvedValue({
+            ok: true,
+            status: 201,
+            body: { id: 'tok-1', name: 'kiosk', scopes: ['collection:read'], token: 'dscg_secret_plaintext_value', created_at: '2026-05-26T00:00:00Z' },
+        }),
+        revokeAppToken: vi.fn().mockResolvedValue(true),
+    };
+}
+
+async function flush() {
+    // Allow microtask queue to drain so awaits in init() complete before assertions.
+    await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+describe('SettingsPane — App Tokens card', () => {
+    let container;
+
+    beforeEach(() => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        container = setupDOM();
+        setupMocks();
+        loadScript('settings.js');
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe('list view', () => {
+        it('renders empty state when no active tokens', async () => {
+            window.settingsPane.init();
+            await flush();
+
+            expect(window.apiClient.listAppTokens).toHaveBeenCalledWith('test-token');
+            expect(container.textContent).toContain('No connected apps yet');
+            const mintBtn = container.querySelector('#appTokenMintBtn');
+            expect(mintBtn).toBeTruthy();
+        });
+
+        it('renders active tokens with name, scope, and revoke button', async () => {
+            window.apiClient.listAppTokens.mockResolvedValue({
+                active: [{
+                    id: 'tok-a', name: 'GRUVAX kiosk', scopes: ['collection:read'],
+                    created_at: '2026-05-26T00:00:00Z', last_used_at: null,
+                }],
+                revoked: [],
+            });
+            window.settingsPane.init();
+            await flush();
+
+            expect(container.textContent).toContain('GRUVAX kiosk');
+            expect(container.textContent).toContain('collection:read');
+            expect(container.querySelector('[data-token-id="tok-a"]')).toBeTruthy();
+            expect(container.querySelector('.app-token-revoke')).toBeTruthy();
+        });
+
+        it('renders revoked tokens in a separate audit trail section', async () => {
+            window.apiClient.listAppTokens.mockResolvedValue({
+                active: [],
+                revoked: [{ id: 'tok-b', name: 'old-kiosk', revoked_at: '2026-05-25T00:00:00Z' }],
+            });
+            window.settingsPane.init();
+            await flush();
+
+            expect(container.textContent).toContain('Revoked (audit trail)');
+            expect(container.textContent).toContain('old-kiosk');
+        });
+
+        it('renders sign-in prompt when not authenticated', async () => {
+            setupMocks({ signedOut: true });
+            window.settingsPane.init();
+            await flush();
+
+            expect(container.textContent).toContain('Sign in to manage');
+            expect(window.apiClient.listAppTokens).not.toHaveBeenCalled();
+        });
+
+        it('escapes token names safely — XSS-impossible via textContent', async () => {
+            window.apiClient.listAppTokens.mockResolvedValue({
+                active: [{ id: 'tok-x', name: '<script>alert(1)</script>', scopes: ['collection:read'], created_at: null, last_used_at: null }],
+                revoked: [],
+            });
+            window.settingsPane.init();
+            await flush();
+
+            // The literal text appears, but as text — never as DOM
+            const nameEl = container.querySelector('.app-token-name');
+            expect(nameEl.textContent).toBe('<script>alert(1)</script>');
+            expect(container.querySelector('script')).toBeNull();
+        });
+    });
+
+    describe('mint flow', () => {
+        it('switches to mint form when Connect button is clicked', async () => {
+            window.settingsPane.init();
+            await flush();
+
+            container.querySelector('#appTokenMintBtn').click();
+
+            expect(container.querySelector('#appTokenName')).toBeTruthy();
+            expect(container.querySelector('#appTokenScope_collectionRead')).toBeTruthy();
+            expect(container.querySelector('#appTokenSubmitMint')).toBeTruthy();
+        });
+
+        it('rejects empty name with inline error', async () => {
+            window.settingsPane.init();
+            await flush();
+            container.querySelector('#appTokenMintBtn').click();
+
+            container.querySelector('#appTokenName').value = '';
+            container.querySelector('#appTokenSubmitMint').click();
+            await flush();
+
+            expect(container.querySelector('#appTokenMintError').textContent).toContain('App name is required');
+            expect(window.apiClient.mintAppToken).not.toHaveBeenCalled();
+        });
+
+        it('calls mintAppToken and switches to reveal view on success', async () => {
+            window.settingsPane.init();
+            await flush();
+            container.querySelector('#appTokenMintBtn').click();
+
+            container.querySelector('#appTokenName').value = 'GRUVAX kiosk';
+            container.querySelector('#appTokenSubmitMint').click();
+            await flush();
+
+            expect(window.apiClient.mintAppToken).toHaveBeenCalledWith('test-token', 'GRUVAX kiosk', ['collection:read']);
+            const plaintextEl = container.querySelector('#appTokenPlaintext');
+            expect(plaintextEl).toBeTruthy();
+            expect(plaintextEl.textContent).toBe('dscg_secret_plaintext_value');
+            expect(container.textContent).toContain('only time you will see this token');
+        });
+
+        it('shows API error detail inline when mint fails', async () => {
+            window.apiClient.mintAppToken.mockResolvedValue({
+                ok: false, status: 400, body: { detail: 'Unknown scope(s): foo' },
+            });
+            window.settingsPane.init();
+            await flush();
+            container.querySelector('#appTokenMintBtn').click();
+            container.querySelector('#appTokenName').value = 'kiosk';
+            container.querySelector('#appTokenSubmitMint').click();
+            await flush();
+
+            expect(container.querySelector('#appTokenMintError').textContent).toContain('Unknown scope');
+            // Stayed on the mint form, not the reveal screen
+            expect(container.querySelector('#appTokenPlaintext')).toBeNull();
+        });
+
+        it('Cancel returns to list without minting', async () => {
+            window.settingsPane.init();
+            await flush();
+            container.querySelector('#appTokenMintBtn').click();
+            container.querySelector('#appTokenCancelMint').click();
+            await flush();
+
+            expect(container.querySelector('#appTokenName')).toBeNull();
+            expect(container.querySelector('#appTokenMintBtn')).toBeTruthy();
+            expect(window.apiClient.mintAppToken).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('reveal screen', () => {
+        async function reachRevealScreen() {
+            window.settingsPane.init();
+            await flush();
+            container.querySelector('#appTokenMintBtn').click();
+            container.querySelector('#appTokenName').value = 'kiosk';
+            container.querySelector('#appTokenSubmitMint').click();
+            await flush();
+        }
+
+        it('Done clears the plaintext from DOM and reloads list', async () => {
+            await reachRevealScreen();
+            expect(container.querySelector('#appTokenPlaintext').textContent).toBe('dscg_secret_plaintext_value');
+
+            window.apiClient.listAppTokens.mockResolvedValue({
+                active: [{ id: 'tok-1', name: 'kiosk', scopes: ['collection:read'], created_at: null, last_used_at: null }],
+                revoked: [],
+            });
+            container.querySelector('#appTokenDoneReveal').click();
+            await flush();
+
+            // Plaintext element gone (back on list view); name appears as a row instead.
+            expect(container.querySelector('#appTokenPlaintext')).toBeNull();
+            expect(container.textContent).toContain('kiosk');
+            expect(container.querySelector('[data-token-id="tok-1"]')).toBeTruthy();
+        });
+
+        it('Copy button writes plaintext to clipboard', async () => {
+            const writeText = vi.fn().mockResolvedValue(undefined);
+            Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+
+            await reachRevealScreen();
+            container.querySelector('#appTokenCopy').click();
+            await flush();
+
+            expect(writeText).toHaveBeenCalledWith('dscg_secret_plaintext_value');
+        });
+    });
+
+    describe('revoke flow', () => {
+        it('confirms then calls revokeAppToken', async () => {
+            window.apiClient.listAppTokens.mockResolvedValue({
+                active: [{ id: 'tok-a', name: 'kiosk', scopes: ['collection:read'], created_at: null, last_used_at: null }],
+                revoked: [],
+            });
+            window.confirm = vi.fn().mockReturnValue(true);
+            window.settingsPane.init();
+            await flush();
+
+            container.querySelector('.app-token-revoke').click();
+            await flush();
+
+            expect(window.confirm).toHaveBeenCalled();
+            expect(window.apiClient.revokeAppToken).toHaveBeenCalledWith('test-token', 'tok-a');
+        });
+
+        it('does NOT call API when user cancels the confirm dialog', async () => {
+            window.apiClient.listAppTokens.mockResolvedValue({
+                active: [{ id: 'tok-a', name: 'kiosk', scopes: ['collection:read'], created_at: null, last_used_at: null }],
+                revoked: [],
+            });
+            window.confirm = vi.fn().mockReturnValue(false);
+            window.settingsPane.init();
+            await flush();
+
+            container.querySelector('.app-token-revoke').click();
+            await flush();
+
+            expect(window.apiClient.revokeAppToken).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/explore/__tests__/settings-app-tokens.test.js
+++ b/explore/__tests__/settings-app-tokens.test.js
@@ -201,6 +201,34 @@ describe('SettingsPane — App Tokens card', () => {
             expect(container.querySelector('#appTokenPlaintext')).toBeNull();
         });
 
+        it('rejects when no permission scope is checked', async () => {
+            window.settingsPane.init();
+            await flush();
+            container.querySelector('#appTokenMintBtn').click();
+            container.querySelector('#appTokenName').value = 'kiosk';
+            container.querySelector('#appTokenScope_collectionRead').checked = false;
+            container.querySelector('#appTokenSubmitMint').click();
+            await flush();
+
+            expect(container.querySelector('#appTokenMintError').textContent).toContain('Select at least one permission');
+            expect(window.apiClient.mintAppToken).not.toHaveBeenCalled();
+        });
+
+        it('shows "not signed in" error if token disappears between form open and submit', async () => {
+            window.settingsPane.init();
+            await flush();
+            container.querySelector('#appTokenMintBtn').click();
+            container.querySelector('#appTokenName').value = 'kiosk';
+
+            // Simulate sign-out after the form is open
+            window.authManager.getToken = vi.fn().mockReturnValue(null);
+            container.querySelector('#appTokenSubmitMint').click();
+            await flush();
+
+            expect(container.querySelector('#appTokenMintError').textContent).toContain('not signed in');
+            expect(window.apiClient.mintAppToken).not.toHaveBeenCalled();
+        });
+
         it('Cancel returns to list without minting', async () => {
             window.settingsPane.init();
             await flush();
@@ -251,6 +279,38 @@ describe('SettingsPane — App Tokens card', () => {
 
             expect(writeText).toHaveBeenCalledWith('dscg_secret_plaintext_value');
         });
+
+        it('Copy shows then hides the "Copied" note after 2s', async () => {
+            const writeText = vi.fn().mockResolvedValue(undefined);
+            Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+
+            await reachRevealScreen();
+            container.querySelector('#appTokenCopy').click();
+            // Resolve the writeText promise + scheduling
+            await flush();
+
+            const note = container.querySelector('#appTokenCopiedNote');
+            expect(note).toBeTruthy();
+            expect(note.classList.contains('hidden')).toBe(false);
+
+            // Advance fake timers by 2s → the setTimeout callback re-adds 'hidden'
+            vi.advanceTimersByTime(2000);
+            expect(note.classList.contains('hidden')).toBe(true);
+        });
+
+        it('Copy silently swallows a clipboard write rejection', async () => {
+            const writeText = vi.fn().mockRejectedValue(new Error('clipboard unavailable'));
+            Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+
+            await reachRevealScreen();
+            // Must not throw, must not exit reveal view
+            container.querySelector('#appTokenCopy').click();
+            await flush();
+
+            expect(writeText).toHaveBeenCalled();
+            // Still on the reveal screen
+            expect(container.querySelector('#appTokenPlaintext')).toBeTruthy();
+        });
     });
 
     describe('revoke flow', () => {
@@ -283,6 +343,72 @@ describe('SettingsPane — App Tokens card', () => {
             await flush();
 
             expect(window.apiClient.revokeAppToken).not.toHaveBeenCalled();
+        });
+
+        it('alerts the user when the revoke API call fails', async () => {
+            window.apiClient.listAppTokens.mockResolvedValue({
+                active: [{ id: 'tok-a', name: 'kiosk', scopes: ['collection:read'], created_at: null, last_used_at: null }],
+                revoked: [],
+            });
+            window.apiClient.revokeAppToken.mockResolvedValue(false);
+            window.confirm = vi.fn().mockReturnValue(true);
+            const alertSpy = vi.fn();
+            window.alert = alertSpy;
+
+            window.settingsPane.init();
+            await flush();
+            container.querySelector('.app-token-revoke').click();
+            await flush();
+
+            expect(alertSpy).toHaveBeenCalled();
+            // Subsequent _loadAppTokens still runs
+            expect(window.apiClient.listAppTokens).toHaveBeenCalledTimes(2);
+        });
+
+        it('is a no-op when the token row has no id', async () => {
+            window.confirm = vi.fn();
+            // Reach the revoke handler with an empty id directly
+            window.settingsPane._handleRevoke('', 'kiosk');
+            await flush();
+            expect(window.confirm).not.toHaveBeenCalled();
+            expect(window.apiClient.revokeAppToken).not.toHaveBeenCalled();
+        });
+
+        it('is a no-op when user is signed out at revoke time', async () => {
+            // Sign user out between list-load and revoke-click
+            window.apiClient.listAppTokens.mockResolvedValue({
+                active: [{ id: 'tok-a', name: 'kiosk', scopes: ['collection:read'], created_at: null, last_used_at: null }],
+                revoked: [],
+            });
+            window.confirm = vi.fn().mockReturnValue(true);
+            window.settingsPane.init();
+            await flush();
+
+            // After list loads, simulate sign-out
+            window.authManager.getToken = vi.fn().mockReturnValue(null);
+            container.querySelector('.app-token-revoke').click();
+            await flush();
+
+            expect(window.apiClient.revokeAppToken).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('listAppTokens error handling', () => {
+        it('falls back to empty arrays when listAppTokens throws', async () => {
+            window.apiClient.listAppTokens.mockRejectedValue(new Error('network down'));
+            window.settingsPane.init();
+            await flush();
+
+            // List view still rendered, no thrown error reaches the user
+            expect(container.textContent).toContain('No connected apps yet');
+        });
+
+        it('falls back to empty arrays when listAppTokens returns malformed shape', async () => {
+            window.apiClient.listAppTokens.mockResolvedValue({ not_active: 'oops' });
+            window.settingsPane.init();
+            await flush();
+
+            expect(container.textContent).toContain('No connected apps yet');
         });
     });
 });

--- a/explore/static/css/styles.css
+++ b/explore/static/css/styles.css
@@ -3187,3 +3187,162 @@ select option {
     height: 100%;
     background: var(--blue-accent);
 }
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * App tokens (Connected Apps card)
+ * ────────────────────────────────────────────────────────────────────────── */
+
+.app-tokens-intro {
+    font-size: 0.8125rem;
+    color: var(--text-mid);
+    margin-bottom: 0.75rem;
+}
+
+.app-tokens-empty {
+    font-size: 0.875rem;
+    color: var(--text-dim);
+    padding: 0.75rem 0;
+    font-style: italic;
+}
+
+.app-tokens-active {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.app-token-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.625rem 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: 0.375rem;
+    background: var(--inner-bg);
+}
+
+.app-token-row-main {
+    flex: 1;
+    min-width: 0;
+}
+
+.app-token-name {
+    font-size: 0.9375rem;
+    font-weight: 500;
+    color: var(--text-high);
+    margin-bottom: 0.125rem;
+}
+
+.app-token-name-revoked {
+    color: var(--text-dim);
+    text-decoration: line-through;
+}
+
+.app-token-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    font-size: 0.75rem;
+    color: var(--text-dim);
+}
+
+.app-token-revoke {
+    flex-shrink: 0;
+}
+
+.app-tokens-revoked-header {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-dim);
+    margin-top: 1rem;
+    margin-bottom: 0.375rem;
+}
+
+.app-tokens-revoked-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-bottom: 0.75rem;
+}
+
+.app-token-revoked-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.25rem 0;
+    font-size: 0.8125rem;
+}
+
+.app-token-mint-form .settings-label-inline {
+    display: inline-flex;
+    flex-direction: column;
+    margin-left: 0.5rem;
+    cursor: pointer;
+}
+
+.app-token-scope-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    border: 1px solid var(--border-color);
+    border-radius: 0.25rem;
+}
+
+.app-token-scope-desc {
+    font-size: 0.75rem;
+    color: var(--text-dim);
+}
+
+.app-token-mint-actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-top: 0.5rem;
+}
+
+/* Reveal screen */
+
+.app-token-reveal-warning {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.75rem;
+    background: rgba(234, 179, 8, 0.12);
+    border: 1px solid rgba(234, 179, 8, 0.35);
+    border-radius: 0.375rem;
+    margin-bottom: 0.75rem;
+    color: #f5a623;
+    font-size: 0.875rem;
+    line-height: 1.4;
+}
+
+.app-token-reveal-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-bottom: 0.75rem;
+    font-size: 0.875rem;
+}
+
+.app-token-plaintext {
+    background: var(--inner-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 0.375rem;
+    padding: 0.75rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.8125rem;
+    color: var(--text-high);
+    word-break: break-all;
+    white-space: pre-wrap;
+    margin: 0.375rem 0 0.75rem;
+}
+
+.app-token-reveal-actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+}

--- a/explore/static/index.html
+++ b/explore/static/index.html
@@ -1227,6 +1227,17 @@ body {
                         </button>
                     </div>
                 </div>
+
+                <!-- App Tokens Card -->
+                <div class="settings-card" id="settingsAppTokensCard">
+                    <div class="settings-card-header">
+                        <span class="material-symbols-outlined">key</span>
+                        <h3>Connected Apps</h3>
+                    </div>
+                    <div class="settings-card-body" id="appTokensContent">
+                        <!-- Populated dynamically by settings.js -->
+                    </div>
+                </div>
                 </div><!-- /.settings-grid -->
             </div>
         </div>

--- a/explore/static/js/api-client.js
+++ b/explore/static/js/api-client.js
@@ -323,6 +323,50 @@ class ApiClient {
         return response.json();
     }
 
+    // --- App tokens (third-party app authorization) ---
+
+    /**
+     * List the current user's active and revoked app tokens.
+     * @returns {Promise<{active: object[], revoked: object[]} | null>}
+     */
+    async listAppTokens(token) {
+        if (!token) return null;
+        const response = await fetch('/api/user/app-tokens', {
+            headers: { 'Authorization': `Bearer ${token}` },
+        });
+        if (!response.ok) return null;
+        return response.json();
+    }
+
+    /**
+     * Mint a new app token. Plaintext is returned ONCE and never recoverable.
+     * @returns {Promise<{ok: boolean, status: number, body: object | null}>}
+     */
+    async mintAppToken(token, name, scopes) {
+        if (!token) return { ok: false, status: 0, body: null };
+        const response = await fetch('/api/user/app-tokens', {
+            method: 'POST',
+            headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, scopes }),
+        });
+        let body = null;
+        try { body = await response.json(); } catch { /* no-op */ }
+        return { ok: response.ok, status: response.status, body };
+    }
+
+    /**
+     * Revoke (tombstone) an existing app token. Returns true on 204.
+     * @returns {Promise<boolean>}
+     */
+    async revokeAppToken(token, tokenId) {
+        if (!token || !tokenId) return false;
+        const response = await fetch(`/api/user/app-tokens/${encodeURIComponent(tokenId)}`, {
+            method: 'DELETE',
+            headers: { 'Authorization': `Bearer ${token}` },
+        });
+        return response.status === 204;
+    }
+
     // --- User data ---
 
     async getUserCollection(token, limit = 50, offset = 0) {

--- a/explore/static/js/settings.js
+++ b/explore/static/js/settings.js
@@ -10,6 +10,12 @@ class SettingsPane {
         this._twoFaState = 'disabled'; // disabled | setup | recovery | enabled | disableConfirm
         this._setupData = null;        // { secret, otpauth_uri } from /api/auth/2fa/setup
         this._recoveryCodes = null;    // string[] from /api/auth/2fa/confirm
+        // App tokens (third-party app authorization)
+        this._appTokensView = 'list';   // list | minting | revealing
+        this._activeTokens = [];
+        this._revokedTokens = [];
+        this._mintedPlaintext = null;   // held only while view === 'revealing'
+        this._mintedTokenMeta = null;   // { name, scopes } shown alongside plaintext
     }
 
     /** Called when pane activates. Loads profile, renders 2FA, binds events once. */
@@ -17,6 +23,7 @@ class SettingsPane {
         this._loadProfile();
         this._loadDiggerSettings();
         this._renderTwoFaState();
+        this._loadAppTokens();
 
         if (!this._initialized) {
             this._bindEvents();
@@ -729,6 +736,424 @@ class SettingsPane {
     /** Convert camelCase data attribute name to kebab-case for querySelector. */
     _camelToKebab(str) {
         return str.replace(/([A-Z])/g, '-$1').toLowerCase();
+    }
+
+    // ------------------------------------------------------------------ //
+    // App tokens (third-party app authorization) — Connected Apps card
+    //
+    // All DOM is built with createElement + textContent — no innerHTML —
+    // so token names and metadata cannot be interpreted as HTML even if
+    // a future endpoint forgets to sanitize.
+    // ------------------------------------------------------------------ //
+
+    _appTokensClear(container) {
+        while (container.firstChild) container.removeChild(container.firstChild);
+    }
+
+    async _loadAppTokens() {
+        const container = document.getElementById('appTokensContent');
+        if (!container) return;
+        const token = window.authManager && window.authManager.getToken && window.authManager.getToken();
+        if (!token) {
+            this._appTokensClear(container);
+            const msg = document.createElement('div');
+            msg.className = 'settings-empty';
+            msg.textContent = 'Sign in to manage connected apps.';
+            container.appendChild(msg);
+            return;
+        }
+        let res = null;
+        try {
+            res = await window.apiClient.listAppTokens(token);
+        } catch {
+            res = null;
+        }
+        this._activeTokens = (res && Array.isArray(res.active)) ? res.active : [];
+        this._revokedTokens = (res && Array.isArray(res.revoked)) ? res.revoked : [];
+        if (this._appTokensView !== 'revealing') {
+            this._appTokensView = 'list';
+        }
+        this._renderAppTokensView();
+    }
+
+    _renderAppTokensView() {
+        const container = document.getElementById('appTokensContent');
+        if (!container) return;
+        switch (this._appTokensView) {
+            case 'minting':   this._renderMintForm(container); break;
+            case 'revealing': this._renderRevealScreen(container); break;
+            case 'list':
+            default:          this._renderAppTokensList(container); break;
+        }
+    }
+
+    _fmtDate(iso) {
+        if (!iso) return '—';
+        try {
+            const d = new Date(iso);
+            return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+        } catch {
+            return String(iso);
+        }
+    }
+
+    _renderAppTokensList(container) {
+        this._appTokensClear(container);
+
+        const intro = document.createElement('p');
+        intro.className = 'app-tokens-intro';
+        intro.textContent = 'Authorize third-party apps (e.g. GRUVAX kiosk) to read your data. Each app gets a unique token you can revoke at any time.';
+        container.appendChild(intro);
+
+        const activeWrap = document.createElement('div');
+        activeWrap.className = 'app-tokens-active';
+        if (!this._activeTokens.length) {
+            const empty = document.createElement('div');
+            empty.className = 'app-tokens-empty';
+            empty.textContent = 'No connected apps yet.';
+            activeWrap.appendChild(empty);
+        } else {
+            for (const t of this._activeTokens) {
+                activeWrap.appendChild(this._buildActiveTokenRow(t));
+            }
+        }
+        container.appendChild(activeWrap);
+
+        if (this._revokedTokens.length) {
+            const header = document.createElement('div');
+            header.className = 'app-tokens-revoked-header';
+            header.textContent = 'Revoked (audit trail)';
+            container.appendChild(header);
+
+            const revokedList = document.createElement('div');
+            revokedList.className = 'app-tokens-revoked-list';
+            for (const t of this._revokedTokens) {
+                const row = document.createElement('div');
+                row.className = 'app-token-revoked-row';
+
+                const name = document.createElement('span');
+                name.className = 'app-token-name app-token-name-revoked';
+                name.textContent = t.name || '';
+                row.appendChild(name);
+
+                const meta = document.createElement('span');
+                meta.className = 'app-token-meta';
+                meta.textContent = `Revoked: ${this._fmtDate(t.revoked_at)}`;
+                row.appendChild(meta);
+
+                revokedList.appendChild(row);
+            }
+            container.appendChild(revokedList);
+        }
+
+        const mintBtn = document.createElement('button');
+        mintBtn.id = 'appTokenMintBtn';
+        mintBtn.type = 'button';
+        mintBtn.className = 'btn-primary mt-3';
+        const mintIcon = document.createElement('span');
+        mintIcon.className = 'material-symbols-outlined mr-1';
+        mintIcon.style.fontSize = '18px';
+        mintIcon.textContent = 'add';
+        mintBtn.appendChild(mintIcon);
+        mintBtn.appendChild(document.createTextNode('Connect an app'));
+        mintBtn.addEventListener('click', () => this._handleStartMint());
+        container.appendChild(mintBtn);
+    }
+
+    _buildActiveTokenRow(t) {
+        const row = document.createElement('div');
+        row.className = 'app-token-row';
+        row.setAttribute('data-token-id', t.id || '');
+
+        const mainCol = document.createElement('div');
+        mainCol.className = 'app-token-row-main';
+
+        const name = document.createElement('div');
+        name.className = 'app-token-name';
+        name.textContent = t.name || '';
+        mainCol.appendChild(name);
+
+        const meta = document.createElement('div');
+        meta.className = 'app-token-meta';
+        const scopeSpan = document.createElement('span');
+        scopeSpan.textContent = `Scope: ${(t.scopes || []).join(', ')}`;
+        const createdSpan = document.createElement('span');
+        createdSpan.textContent = `Created: ${this._fmtDate(t.created_at)}`;
+        const usedSpan = document.createElement('span');
+        usedSpan.textContent = `Last used: ${this._fmtDate(t.last_used_at)}`;
+        meta.appendChild(scopeSpan);
+        meta.appendChild(createdSpan);
+        meta.appendChild(usedSpan);
+        mainCol.appendChild(meta);
+
+        row.appendChild(mainCol);
+
+        const revokeBtn = document.createElement('button');
+        revokeBtn.type = 'button';
+        revokeBtn.className = 'btn-secondary app-token-revoke';
+        revokeBtn.textContent = 'Revoke';
+        revokeBtn.addEventListener('click', () => this._handleRevoke(t.id, t.name));
+        row.appendChild(revokeBtn);
+
+        return row;
+    }
+
+    _renderMintForm(container) {
+        this._appTokensClear(container);
+
+        const form = document.createElement('div');
+        form.className = 'app-token-mint-form';
+
+        // Name field
+        const nameWrap = document.createElement('div');
+        nameWrap.className = 'mb-3';
+        const nameLabel = document.createElement('label');
+        nameLabel.className = 'settings-label';
+        nameLabel.htmlFor = 'appTokenName';
+        nameLabel.textContent = 'App name';
+        const nameInput = document.createElement('input');
+        nameInput.type = 'text';
+        nameInput.id = 'appTokenName';
+        nameInput.className = 'form-input-dark';
+        nameInput.maxLength = 255;
+        nameInput.placeholder = 'e.g. GRUVAX kiosk';
+        nameInput.autocomplete = 'off';
+        nameWrap.appendChild(nameLabel);
+        nameWrap.appendChild(nameInput);
+        form.appendChild(nameWrap);
+
+        // Scopes
+        const scopesWrap = document.createElement('div');
+        scopesWrap.className = 'mb-3';
+        const scopesLabel = document.createElement('label');
+        scopesLabel.className = 'settings-label';
+        scopesLabel.textContent = 'Permissions';
+        scopesWrap.appendChild(scopesLabel);
+
+        const scopeRow = document.createElement('div');
+        scopeRow.className = 'app-token-scope-row';
+        const scopeChk = document.createElement('input');
+        scopeChk.type = 'checkbox';
+        scopeChk.id = 'appTokenScope_collectionRead';
+        scopeChk.checked = true;
+        const scopeChkLabel = document.createElement('label');
+        scopeChkLabel.className = 'settings-label-inline';
+        scopeChkLabel.htmlFor = 'appTokenScope_collectionRead';
+        const scopeBold = document.createElement('strong');
+        scopeBold.textContent = 'collection:read';
+        const scopeDesc = document.createElement('span');
+        scopeDesc.className = 'app-token-scope-desc';
+        scopeDesc.textContent = 'Read your collection, stats, and timeline';
+        scopeChkLabel.appendChild(scopeBold);
+        scopeChkLabel.appendChild(document.createTextNode(' '));
+        scopeChkLabel.appendChild(scopeDesc);
+        scopeRow.appendChild(scopeChk);
+        scopeRow.appendChild(scopeChkLabel);
+        scopesWrap.appendChild(scopeRow);
+        form.appendChild(scopesWrap);
+
+        // Error region
+        const err = document.createElement('div');
+        err.id = 'appTokenMintError';
+        err.className = 'mb-2 min-h-[1.2rem] text-sm text-accent-red';
+        form.appendChild(err);
+
+        // Buttons
+        const actions = document.createElement('div');
+        actions.className = 'app-token-mint-actions';
+        const cancelBtn = document.createElement('button');
+        cancelBtn.id = 'appTokenCancelMint';
+        cancelBtn.type = 'button';
+        cancelBtn.className = 'btn-secondary';
+        cancelBtn.textContent = 'Cancel';
+        cancelBtn.addEventListener('click', () => this._handleCancelMint());
+        const submitBtn = document.createElement('button');
+        submitBtn.id = 'appTokenSubmitMint';
+        submitBtn.type = 'button';
+        submitBtn.className = 'btn-primary';
+        const submitIcon = document.createElement('span');
+        submitIcon.className = 'material-symbols-outlined mr-1';
+        submitIcon.style.fontSize = '18px';
+        submitIcon.textContent = 'vpn_key';
+        submitBtn.appendChild(submitIcon);
+        submitBtn.appendChild(document.createTextNode('Mint token'));
+        submitBtn.addEventListener('click', () => this._handleSubmitMint());
+        actions.appendChild(cancelBtn);
+        actions.appendChild(submitBtn);
+        form.appendChild(actions);
+
+        container.appendChild(form);
+        nameInput.focus();
+    }
+
+    _renderRevealScreen(container) {
+        this._appTokensClear(container);
+
+        const wrap = document.createElement('div');
+        wrap.className = 'app-token-reveal';
+
+        const warn = document.createElement('div');
+        warn.className = 'app-token-reveal-warning';
+        const warnIcon = document.createElement('span');
+        warnIcon.className = 'material-symbols-outlined';
+        warnIcon.style.fontSize = '20px';
+        warnIcon.textContent = 'warning';
+        const warnStrong = document.createElement('strong');
+        warnStrong.textContent = 'This is the only time you will see this token.';
+        warn.appendChild(warnIcon);
+        warn.appendChild(warnStrong);
+        warn.appendChild(document.createTextNode(' Copy it now and store it somewhere safe — it cannot be recovered.'));
+        wrap.appendChild(warn);
+
+        const meta = this._mintedTokenMeta || { name: '', scopes: [] };
+
+        const metaBlock = document.createElement('div');
+        metaBlock.className = 'app-token-reveal-meta';
+        const appDiv = document.createElement('div');
+        const appLbl = document.createElement('span');
+        appLbl.className = 'settings-label';
+        appLbl.textContent = 'App:';
+        appDiv.appendChild(appLbl);
+        appDiv.appendChild(document.createTextNode(' ' + (meta.name || '')));
+        const permDiv = document.createElement('div');
+        const permLbl = document.createElement('span');
+        permLbl.className = 'settings-label';
+        permLbl.textContent = 'Permissions:';
+        permDiv.appendChild(permLbl);
+        permDiv.appendChild(document.createTextNode(' ' + (meta.scopes || []).join(', ')));
+        metaBlock.appendChild(appDiv);
+        metaBlock.appendChild(permDiv);
+        wrap.appendChild(metaBlock);
+
+        const tokenLabel = document.createElement('label');
+        tokenLabel.className = 'settings-label';
+        tokenLabel.textContent = 'Token';
+        wrap.appendChild(tokenLabel);
+
+        const pre = document.createElement('pre');
+        pre.id = 'appTokenPlaintext';
+        pre.className = 'app-token-plaintext';
+        // textContent is the only safe sink — the plaintext is opaque random data,
+        // but even so, never interpolate it as HTML.
+        pre.textContent = this._mintedPlaintext || '';
+        wrap.appendChild(pre);
+
+        const actions = document.createElement('div');
+        actions.className = 'app-token-reveal-actions';
+        const copyBtn = document.createElement('button');
+        copyBtn.id = 'appTokenCopy';
+        copyBtn.type = 'button';
+        copyBtn.className = 'btn-secondary';
+        const copyIcon = document.createElement('span');
+        copyIcon.className = 'material-symbols-outlined mr-1';
+        copyIcon.style.fontSize = '18px';
+        copyIcon.textContent = 'content_copy';
+        copyBtn.appendChild(copyIcon);
+        copyBtn.appendChild(document.createTextNode('Copy'));
+        copyBtn.addEventListener('click', () => this._handleCopyToken());
+        const doneBtn = document.createElement('button');
+        doneBtn.id = 'appTokenDoneReveal';
+        doneBtn.type = 'button';
+        doneBtn.className = 'btn-primary';
+        doneBtn.textContent = 'Done';
+        doneBtn.addEventListener('click', () => this._handleDoneReveal());
+        actions.appendChild(copyBtn);
+        actions.appendChild(doneBtn);
+        wrap.appendChild(actions);
+
+        const note = document.createElement('div');
+        note.id = 'appTokenCopiedNote';
+        note.className = 'mb-2 min-h-[1.2rem] text-sm text-accent-green hidden';
+        note.textContent = 'Copied to clipboard';
+        wrap.appendChild(note);
+
+        container.appendChild(wrap);
+    }
+
+    _handleStartMint() {
+        this._appTokensView = 'minting';
+        this._renderAppTokensView();
+    }
+
+    _handleCancelMint() {
+        this._appTokensView = 'list';
+        this._renderAppTokensView();
+    }
+
+    async _handleSubmitMint() {
+        const errorEl = document.getElementById('appTokenMintError');
+        if (errorEl) errorEl.textContent = '';
+
+        const nameEl = document.getElementById('appTokenName');
+        const collectionReadEl = document.getElementById('appTokenScope_collectionRead');
+        const name = nameEl ? nameEl.value.trim() : '';
+        if (!name) {
+            if (errorEl) errorEl.textContent = 'App name is required';
+            return;
+        }
+
+        const scopes = [];
+        if (collectionReadEl && collectionReadEl.checked) scopes.push('collection:read');
+        if (scopes.length === 0) {
+            if (errorEl) errorEl.textContent = 'Select at least one permission';
+            return;
+        }
+
+        const token = window.authManager && window.authManager.getToken && window.authManager.getToken();
+        if (!token) {
+            if (errorEl) errorEl.textContent = 'You are not signed in';
+            return;
+        }
+
+        const res = await window.apiClient.mintAppToken(token, name, scopes);
+        if (!res || !res.ok || !res.body || !res.body.token) {
+            const detail = (res && res.body && res.body.detail) ? res.body.detail : 'Failed to mint token';
+            if (errorEl) errorEl.textContent = detail;
+            return;
+        }
+
+        this._mintedPlaintext = res.body.token;
+        this._mintedTokenMeta = { name: res.body.name, scopes: res.body.scopes };
+        this._appTokensView = 'revealing';
+        this._renderAppTokensView();
+    }
+
+    async _handleCopyToken() {
+        if (!this._mintedPlaintext) return;
+        try {
+            await navigator.clipboard.writeText(this._mintedPlaintext);
+            const note = document.getElementById('appTokenCopiedNote');
+            if (note) {
+                note.classList.remove('hidden');
+                setTimeout(() => note.classList.add('hidden'), 2000);
+            }
+        } catch {
+            // Clipboard write may be unavailable in some browsers/contexts.
+        }
+    }
+
+    _handleDoneReveal() {
+        this._mintedPlaintext = null;
+        this._mintedTokenMeta = null;
+        const plaintextEl = document.getElementById('appTokenPlaintext');
+        if (plaintextEl) plaintextEl.textContent = '';
+        this._appTokensView = 'list';
+        this._loadAppTokens();
+    }
+
+    async _handleRevoke(tokenId, tokenName) {
+        if (!tokenId) return;
+        const confirmed = window.confirm(`Revoke the token "${tokenName}"?\n\nThis cannot be undone. Any app using it will lose access immediately.`);
+        if (!confirmed) return;
+
+        const token = window.authManager && window.authManager.getToken && window.authManager.getToken();
+        if (!token) return;
+
+        const ok = await window.apiClient.revokeAppToken(token, tokenId);
+        if (!ok) {
+            window.alert('Failed to revoke token. It may have already been revoked.');
+        }
+        this._loadAppTokens();
     }
 }
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -236,6 +236,10 @@ def test_client(
 
     _deps.configure(TEST_JWT_SECRET, mock_redis, pool=_admin_verify_pool, digger_api_service_token=test_api_config.digger_api_service_token)
 
+    import api.app_tokens as _app_tokens_module
+
+    _app_tokens_module.configure(mock_pool)
+
     from api.nlq.config import NLQConfig
     import api.routers.nlq as _nlq_router
 

--- a/tests/api/test_app_tokens_router.py
+++ b/tests/api/test_app_tokens_router.py
@@ -1,0 +1,227 @@
+"""Tests for api/routers/app_tokens.py — settings UI backend."""
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from fastapi.testclient import TestClient
+import pytest
+
+import api.app_tokens as app_tokens_module
+from tests.api.conftest import TEST_USER_ID, make_test_jwt
+
+
+_AUTH_HEADER = {"Authorization": f"Bearer {make_test_jwt()}"}
+_NEW_TOKEN_ID = UUID("11111111-1111-1111-1111-111111111111")
+
+
+def _fake_mint_token() -> tuple[UUID, str]:
+    """Static stand-in for app_tokens.mint_token in tests."""
+    return _NEW_TOKEN_ID, "dscg_test_plaintext_token_value_here"
+
+
+def _patch_module_pool(mock_pool: Any) -> None:
+    """Wire the module-level pool used by app_tokens.mint_token / list / revoke."""
+    app_tokens_module._pool = mock_pool
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# POST /api/user/app-tokens
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestMintAppToken:
+    def test_requires_authentication(self, test_client: TestClient) -> None:
+        resp = test_client.post("/api/user/app-tokens", json={"name": "kiosk", "scopes": ["collection:read"]})
+        assert resp.status_code == 401
+
+    def test_returns_plaintext_token_and_201(self, test_client: TestClient, mock_pool: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_module_pool(mock_pool)
+
+        async def _mint(user_id: str, name: str, scopes: list[str]) -> tuple[UUID, str]:  # noqa: ARG001
+            return _NEW_TOKEN_ID, "dscg_PLAINTEXT_SECRET"
+
+        async def _list(user_id: str) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:  # noqa: ARG001
+            return (
+                [
+                    {
+                        "id": _NEW_TOKEN_ID,
+                        "name": "kiosk",
+                        "scope": ["collection:read"],
+                        "created_at": datetime(2026, 5, 26, tzinfo=UTC),
+                        "last_used_at": None,
+                        "revoked_at": None,
+                    }
+                ],
+                [],
+            )
+
+        monkeypatch.setattr("api.routers.app_tokens._mint_token", _mint)
+        monkeypatch.setattr("api.routers.app_tokens._list_user_tokens", _list)
+
+        resp = test_client.post(
+            "/api/user/app-tokens",
+            json={"name": "kiosk", "scopes": ["collection:read"]},
+            headers=_AUTH_HEADER,
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["id"] == str(_NEW_TOKEN_ID)
+        assert body["name"] == "kiosk"
+        assert body["scopes"] == ["collection:read"]
+        assert body["token"] == "dscg_PLAINTEXT_SECRET"
+        assert body["created_at"] is not None
+
+    def test_rejects_unknown_scope(self, test_client: TestClient) -> None:
+        resp = test_client.post(
+            "/api/user/app-tokens",
+            json={"name": "kiosk", "scopes": ["collection:read", "admin:everything"]},
+            headers=_AUTH_HEADER,
+        )
+        assert resp.status_code == 400
+        assert "admin:everything" in resp.json()["detail"]
+
+    def test_rejects_whitespace_only_name(self, test_client: TestClient, mock_pool: Any) -> None:
+        _patch_module_pool(mock_pool)
+        resp = test_client.post(
+            "/api/user/app-tokens",
+            json={"name": "   ", "scopes": ["collection:read"]},
+            headers=_AUTH_HEADER,
+        )
+        assert resp.status_code == 400
+
+    def test_rejects_empty_scopes_via_validation(self, test_client: TestClient) -> None:
+        resp = test_client.post(
+            "/api/user/app-tokens",
+            json={"name": "kiosk", "scopes": []},
+            headers=_AUTH_HEADER,
+        )
+        # Pydantic v2 returns 422 for failed Field(min_length=1) validation
+        assert resp.status_code == 422
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# GET /api/user/app-tokens
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestListAppTokens:
+    def test_requires_authentication(self, test_client: TestClient) -> None:
+        resp = test_client.get("/api/user/app-tokens")
+        assert resp.status_code == 401
+
+    def test_partitions_active_and_revoked(self, test_client: TestClient, mock_pool: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_module_pool(mock_pool)
+
+        async def _list(user_id: str) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:  # noqa: ARG001
+            active = [
+                {
+                    "id": UUID("22222222-2222-2222-2222-222222222222"),
+                    "name": "kiosk-A",
+                    "scope": ["collection:read"],
+                    "created_at": datetime(2026, 5, 26, tzinfo=UTC),
+                    "last_used_at": None,
+                    "revoked_at": None,
+                }
+            ]
+            revoked = [
+                {
+                    "id": UUID("33333333-3333-3333-3333-333333333333"),
+                    "name": "old-kiosk",
+                    "scope": ["collection:read"],
+                    "created_at": datetime(2026, 5, 1, tzinfo=UTC),
+                    "last_used_at": None,
+                    "revoked_at": datetime(2026, 5, 10, tzinfo=UTC),
+                }
+            ]
+            return active, revoked
+
+        monkeypatch.setattr("api.routers.app_tokens._list_user_tokens", _list)
+
+        resp = test_client.get("/api/user/app-tokens", headers=_AUTH_HEADER)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["active"]) == 1
+        assert len(body["revoked"]) == 1
+        assert body["active"][0]["name"] == "kiosk-A"
+        assert body["active"][0]["scopes"] == ["collection:read"]
+        assert body["revoked"][0]["name"] == "old-kiosk"
+
+    def test_active_row_never_contains_token_hash(self, test_client: TestClient, mock_pool: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The router maps rows explicitly; even if list_user_tokens added token_hash it must not leak."""
+        _patch_module_pool(mock_pool)
+
+        async def _list(user_id: str) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:  # noqa: ARG001
+            return (
+                [
+                    {
+                        "id": UUID("44444444-4444-4444-4444-444444444444"),
+                        "name": "kiosk",
+                        "scope": ["collection:read"],
+                        "created_at": datetime(2026, 5, 26, tzinfo=UTC),
+                        "last_used_at": None,
+                        "revoked_at": None,
+                        # Simulated leak from the inner CRUD — must be stripped by the router.
+                        "token_hash": "should-never-leak",
+                    }
+                ],
+                [],
+            )
+
+        monkeypatch.setattr("api.routers.app_tokens._list_user_tokens", _list)
+
+        resp = test_client.get("/api/user/app-tokens", headers=_AUTH_HEADER)
+        assert resp.status_code == 200
+        body_text = resp.text
+        assert "should-never-leak" not in body_text
+        assert "token_hash" not in body_text
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# DELETE /api/user/app-tokens/{token_id}
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestRevokeAppToken:
+    def test_requires_authentication(self, test_client: TestClient) -> None:
+        resp = test_client.delete("/api/user/app-tokens/00000000-0000-0000-0000-000000000099")
+        assert resp.status_code == 401
+
+    def test_returns_204_on_success(self, test_client: TestClient, mock_pool: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_module_pool(mock_pool)
+
+        captured: dict[str, Any] = {}
+
+        async def _revoke(token_id: str, user_id: str) -> bool:
+            captured["token_id"] = token_id
+            captured["user_id"] = user_id
+            return True
+
+        monkeypatch.setattr("api.routers.app_tokens._revoke_token", _revoke)
+
+        resp = test_client.delete(
+            "/api/user/app-tokens/00000000-0000-0000-0000-000000000099",
+            headers=_AUTH_HEADER,
+        )
+        assert resp.status_code == 204
+        # 204 must have empty body
+        assert resp.content == b""
+        # Owner scoping: revoke_token must have been called with the JWT's user_id
+        assert captured["user_id"] == TEST_USER_ID
+        assert captured["token_id"] == "00000000-0000-0000-0000-000000000099"
+
+    def test_returns_404_when_no_active_row(self, test_client: TestClient, mock_pool: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A token belonging to a different user, an unknown id, or an already-revoked
+        token all surface as 404 — we do not disclose token existence to non-owners."""
+        _patch_module_pool(mock_pool)
+
+        async def _revoke(token_id: str, user_id: str) -> bool:  # noqa: ARG001
+            return False
+
+        monkeypatch.setattr("api.routers.app_tokens._revoke_token", _revoke)
+
+        resp = test_client.delete(
+            "/api/user/app-tokens/00000000-0000-0000-0000-000000000099",
+            headers=_AUTH_HEADER,
+        )
+        assert resp.status_code == 404

--- a/tests/api/test_app_tokens_router.py
+++ b/tests/api/test_app_tokens_router.py
@@ -1,6 +1,10 @@
 """Tests for api/routers/app_tokens.py — settings UI backend."""
 
+import base64
 from datetime import UTC, datetime
+import hashlib
+import hmac
+import json
 from typing import Any
 from uuid import UUID
 
@@ -8,11 +12,32 @@ from fastapi.testclient import TestClient
 import pytest
 
 import api.app_tokens as app_tokens_module
-from tests.api.conftest import TEST_USER_ID, make_test_jwt
+from api.routers.app_tokens import _isoformat
+from tests.api.conftest import TEST_JWT_SECRET, TEST_USER_ID, make_test_jwt
 
 
 _AUTH_HEADER = {"Authorization": f"Bearer {make_test_jwt()}"}
 _NEW_TOKEN_ID = UUID("11111111-1111-1111-1111-111111111111")
+
+
+def _make_jwt_with_empty_sub() -> str:
+    """Craft a valid HS256 JWT whose `sub` claim is literally the empty string.
+
+    `require_user` only blocks `sub is None`; an explicit `sub=""` slips through
+    so the router's own defensive 401 check is the next line of defence.
+    """
+
+    def b64url(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+    header = b64url(json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode())
+    body = b64url(json.dumps({"sub": "", "email": "x@example.com", "exp": 9_999_999_999}, separators=(",", ":")).encode())
+    signing_input = f"{header}.{body}".encode("ascii")
+    sig = b64url(hmac.new(TEST_JWT_SECRET.encode("utf-8"), signing_input, hashlib.sha256).digest())
+    return f"{header}.{body}.{sig}"
+
+
+_AUTH_HEADER_EMPTY_SUB = {"Authorization": f"Bearer {_make_jwt_with_empty_sub()}"}
 
 
 def _fake_mint_token() -> tuple[UUID, str]:
@@ -225,3 +250,57 @@ class TestRevokeAppToken:
             headers=_AUTH_HEADER,
         )
         assert resp.status_code == 404
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Defensive 401 — JWT with empty sub claim slips past require_user
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestEmptySubDefense:
+    """A JWT with `sub=""` is technically valid (require_user only blocks sub=None),
+    so each router handler has its own check. Exercise all three."""
+
+    def test_mint_rejects_empty_sub(self, test_client: TestClient) -> None:
+        resp = test_client.post(
+            "/api/user/app-tokens",
+            json={"name": "kiosk", "scopes": ["collection:read"]},
+            headers=_AUTH_HEADER_EMPTY_SUB,
+        )
+        assert resp.status_code == 401
+        assert "Invalid token" in resp.json()["detail"]
+
+    def test_list_rejects_empty_sub(self, test_client: TestClient) -> None:
+        resp = test_client.get("/api/user/app-tokens", headers=_AUTH_HEADER_EMPTY_SUB)
+        assert resp.status_code == 401
+
+    def test_revoke_rejects_empty_sub(self, test_client: TestClient) -> None:
+        resp = test_client.delete(
+            "/api/user/app-tokens/00000000-0000-0000-0000-000000000099",
+            headers=_AUTH_HEADER_EMPTY_SUB,
+        )
+        assert resp.status_code == 401
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _isoformat helper
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestIsoFormatHelper:
+    def test_none_passes_through(self) -> None:
+        assert _isoformat(None) is None
+
+    def test_datetime_uses_isoformat(self) -> None:
+        d = datetime(2026, 5, 26, 12, 0, tzinfo=UTC)
+        out = _isoformat(d)
+        assert out is not None
+        assert "2026-05-26" in out
+
+    def test_string_falls_back_to_str(self) -> None:
+        """If a DB driver hands us a pre-serialized timestamp string, we surface it as-is."""
+        assert _isoformat("2026-05-26T12:00:00Z") == "2026-05-26T12:00:00Z"
+
+    def test_arbitrary_object_falls_back_to_str(self) -> None:
+        """Any non-None value without `.isoformat()` falls through to str() — never errors."""
+        assert _isoformat(12345) == "12345"


### PR DESCRIPTION
## Summary

P4 of the **App Tokens + Collection API for GRUVAX v2.0** milestone — builds on the table from #362 and the dependency from #363. Adds the user-facing management surface (mint / list / revoke) plus the Connected Apps card in Account Settings.

## Backend

\`api/routers/app_tokens.py\` (wired in \`api/api.py\`), all gated by \`require_user\` (first-party JWT only):

| Method | Path                              | Behavior |
|--------|-----------------------------------|----------|
| POST   | \`/api/user/app-tokens\`          | Mint a new token. Plaintext returned **once** as \`{id, name, scopes, token, created_at}\` with 201. Validates scopes against \`ALLOWED_SCOPES = {"collection:read"}\`. |
| GET    | \`/api/user/app-tokens\`          | List \`{active: [...], revoked: [...]}\`. \`token_hash\` is **never** in the response. |
| DELETE | \`/api/user/app-tokens/{id}\`     | Owner-scoped revoke (sets \`revoked_at = NOW()\`). 204 on success, 404 otherwise. |

The DELETE endpoint deliberately returns 404 for "no active row" without disclosing whether the token (a) doesn't exist, (b) belongs to another user, or (c) is already revoked — that prevents leaking token-existence info to non-owners.

## Frontend

New "Connected Apps" card in the existing Account Settings pane:

- 3 view states managed by \`SettingsPane\`: \`list\` → \`minting\` → \`revealing\` → \`list\`
- All DOM built with \`createElement\` + \`textContent\` — **no \`innerHTML\`** — so a token name containing HTML is rendered as text, never interpreted as DOM
- Reveal screen shows the plaintext exactly once with a prominent warning, Copy-to-clipboard, and a Done button that clears both the in-memory plaintext reference and the DOM node
- New \`listAppTokens\` / \`mintAppToken\` / \`revokeAppToken\` methods in \`api-client.js\`
- New \`.app-token-*\` CSS rules in \`styles.css\`

## Tests

**Backend** — \`tests/api/test_app_tokens_router.py\` (11 tests):
- Mint: requires auth · returns plaintext + 201 · rejects unknown scope · rejects whitespace-only name · rejects empty scopes (422)
- List: requires auth · partitions active/revoked · never leaks \`token_hash\` even if inner CRUD returns it
- Revoke: requires auth · returns 204 + asserts owner-scoping · returns 404 (single shape) when no active row

**Frontend** — \`explore/__tests__/settings-app-tokens.test.js\` (14 Vitest tests):
- List view: empty state · populated rows · revoked audit trail · sign-in prompt · **XSS-impossible rendering** of \`<script>\` in token name
- Mint flow: button switches to form · rejects empty name · happy path → reveal · API error shown inline · Cancel returns to list
- Reveal: Done clears plaintext + reloads list · Copy writes to clipboard
- Revoke: confirms then DELETE · cancel skips API

Uses fake timers per project memory (leaked-timer flake).

## Test plan

- [x] \`uv run pytest tests/api/test_app_tokens_router.py tests/api/test_dependencies.py tests/api/test_app_token_auth.py\` — 71/71 green
- [x] \`npm test -- __tests__/settings.test.js __tests__/settings-app-tokens.test.js __tests__/api-client.test.js\` — 252/252 green
- [x] \`ruff check\` + \`mypy\` + \`bandit\` clean
- [ ] Manual: mint a token via UI, copy, see in list, revoke, see in audit trail (deferred to deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)