### PR TITLE
feat(api+graphinator): catalog_number everywhere via metadata bag (v2-gruvax P6)

### DIFF
--- a/api/queries/user_queries.py
+++ b/api/queries/user_queries.py
@@ -40,6 +40,7 @@ async def get_user_collection(
          collect(DISTINCT g.name) AS genres,
          collect(DISTINCT s.name) AS styles
     RETURN r.id AS id, r.title AS title, r.year AS year,
+           r.catalog_number AS catalog_number,
            artist_name AS artist, label_name AS label,
            genres, styles,
            c.rating AS rating, c.date_added AS date_added,
@@ -80,6 +81,7 @@ async def get_user_wantlist(
          collect(DISTINCT g.name) AS genres,
          collect(DISTINCT s.name) AS styles
     RETURN r.id AS id, r.title AS title, r.year AS year,
+           r.catalog_number AS catalog_number,
            artist_name AS artist, label_name AS label,
            genres, styles,
            w.rating AS rating, w.date_added AS date_added

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -146,6 +146,16 @@ async def sync_collection(
                 artist_name = artists[0]["name"] if artists else None
                 labels = basic.get("labels", [])
                 label_name = labels[0]["name"] if labels else None
+                # Per-release metadata bag — only keys with non-null values are
+                # included so a missing field never wipes an existing value
+                # (in Neo4j, SET k = null deletes the property). Same shape is
+                # reused for both `user_collections.metadata` JSONB and the
+                # cypher `SET r += rel.metadata` write. Future fields just add
+                # a key here.
+                release_metadata: dict[str, Any] = {}
+                if labels and labels[0].get("catno"):
+                    release_metadata["catalog_number"] = labels[0]["catno"]
+                metadata_json = json.dumps(release_metadata) if release_metadata else None
                 formats_raw = basic.get("formats", [])
                 formats_json = json.dumps(formats_raw) if formats_raw else None
 
@@ -162,7 +172,7 @@ async def sync_collection(
                         label_name,
                         item.get("rating", 0),
                         item.get("date_added"),
-                        None,  # metadata reserved for future use
+                        metadata_json,
                     )
                 )
 
@@ -196,7 +206,10 @@ async def sync_collection(
                     )
                 total_synced += len(batch_params)
 
-            # Upsert to Neo4j — ensure User node and COLLECTED relationships
+            # Upsert to Neo4j — ensure User node and COLLECTED relationships.
+            # `SET r += rel.metadata` merges only the keys present in the bag —
+            # absent keys are untouched, so a sync without catalog_number never
+            # wipes a value that the bulk graphinator pipeline may have written.
             cypher = """
             MERGE (u:User {id: $user_id})
             ON CREATE SET u.discogs_username = $discogs_username
@@ -208,8 +221,19 @@ async def sync_collection(
             SET c.rating = rel.rating,
                 c.folder_id = rel.folder_id,
                 c.date_added = rel.date_added,
-                c.synced_at = $synced_at
+                c.synced_at = $synced_at,
+                r += rel.metadata
             """
+
+            def _release_metadata(item: dict[str, Any]) -> dict[str, Any]:
+                labels_for_item = item.get("basic_information", {}).get("labels") or []
+                first = labels_for_item[0] if labels_for_item else {}
+                catno_value = first.get("catno") if isinstance(first, dict) else None
+                bag: dict[str, Any] = {}
+                if catno_value:
+                    bag["catalog_number"] = catno_value
+                return bag
+
             neo4j_releases = [
                 {
                     "release_id": item.get("basic_information", {}).get("id"),
@@ -217,6 +241,7 @@ async def sync_collection(
                     "rating": item.get("rating", 0),
                     "folder_id": item.get("folder_id"),
                     "date_added": item.get("date_added"),
+                    "metadata": _release_metadata(item),
                 }
                 for item in releases
                 if item.get("basic_information", {}).get("id")
@@ -402,7 +427,9 @@ async def sync_wantlist(
                 except Exception as exc:  # seeding is a non-critical side-effect; never fail the sync over it
                     logger.warning("⚠️ Failed to seed digger priorities", error=str(exc))
 
-            # Upsert to Neo4j — ensure User node and WANTS relationships
+            # Upsert to Neo4j — ensure User node and WANTS relationships.
+            # Same metadata-bag pattern as the collection sync: `SET r += w.metadata`
+            # merges only the keys present, so missing fields don't wipe values.
             cypher = """
             MERGE (u:User {id: $user_id})
             ON CREATE SET u.discogs_username = $discogs_username
@@ -413,13 +440,25 @@ async def sync_wantlist(
             MERGE (u)-[wnt:WANTS]->(r)
             SET wnt.rating = w.rating,
                 wnt.date_added = w.date_added,
-                wnt.synced_at = $synced_at
+                wnt.synced_at = $synced_at,
+                r += w.metadata
             """
+
+            def _want_metadata(item: dict[str, Any]) -> dict[str, Any]:
+                labels_for_item = item.get("basic_information", {}).get("labels") or []
+                first = labels_for_item[0] if labels_for_item else {}
+                catno_value = first.get("catno") if isinstance(first, dict) else None
+                bag: dict[str, Any] = {}
+                if catno_value:
+                    bag["catalog_number"] = catno_value
+                return bag
+
             neo4j_wants = [
                 {
                     "release_id": item.get("id"),
                     "rating": item.get("rating", 0),
                     "date_added": item.get("date_added"),
+                    "metadata": _want_metadata(item),
                 }
                 for item in wants
                 if item.get("id")

--- a/graphinator/batch_processor.py
+++ b/graphinator/batch_processor.py
@@ -835,6 +835,26 @@ class Neo4jBatchProcessor:
                         for f in msg.data.get("formats", [])
                         if isinstance(f, dict) and "name" in f
                     ]
+                    # Per-release metadata bag — populated only with non-null
+                    # keys. The cypher uses `SET r += release.metadata`, which
+                    # merges only the keys present, so absent fields don't wipe
+                    # an existing value (in Neo4j, SET k = null deletes the
+                    # property). Future per-release fields just add a key here.
+                    raw_labels = msg.data.get("labels") or []
+                    first_label = (
+                        raw_labels[0]
+                        if isinstance(raw_labels, list) and raw_labels
+                        else {}
+                    )
+                    catno = (
+                        first_label.get("catno")
+                        if isinstance(first_label, dict)
+                        else None
+                    )
+                    release_metadata: dict[str, Any] = {}
+                    if catno:
+                        release_metadata["catalog_number"] = catno
+                    release_data["metadata"] = release_metadata
                     releases_to_process.append(release_data)
 
             if not releases_to_process:
@@ -842,7 +862,11 @@ class Neo4jBatchProcessor:
                 return nack_indices
 
             async def batch_write(tx: Any) -> None:
-                # Create/update all release nodes
+                # Create/update all release nodes. `r += release.metadata`
+                # merges the per-release metadata bag (catalog_number today,
+                # potentially more fields tomorrow). Only keys present in the
+                # bag are written — absent keys don't wipe existing values
+                # that the per-user sync pipeline may have set.
                 await tx.run(
                     """
                     UNWIND $releases AS release
@@ -850,7 +874,8 @@ class Neo4jBatchProcessor:
                     SET r.title = release.title,
                         r.year = release.year,
                         r.formats = release.format_names,
-                        r.sha256 = release.sha256
+                        r.sha256 = release.sha256,
+                        r += release.metadata
                     """,
                     releases=releases_to_process,
                 )

--- a/tests/api/test_syncer.py
+++ b/tests/api/test_syncer.py
@@ -864,3 +864,219 @@ class TestRunFullSync:
         )
 
         assert set(result.keys()) == {"sync_id", "status", "collection_count", "wantlist_count", "error"}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# catalog_number extraction (P6 — GRUVAX integration)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestCatalogNumberCapture:
+    """Verify catno from labels[0].catno is propagated to both PG metadata and Neo4j cypher params."""
+
+    @pytest.mark.asyncio
+    async def test_collection_persists_catalog_number_to_pg_metadata(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """labels[0].catno → user_collections.metadata as {"catalog_number": "..."}."""
+        release = _make_release_item(123)
+        release["basic_information"]["labels"] = [{"name": "Some Label", "catno": "ABC-123"}]
+        resp = _make_collection_response([release])
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = resp
+
+        with patch("api.syncer.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await sync_collection(
+                TEST_USER_UUID,
+                TEST_DISCOGS_USERNAME,
+                TEST_CONSUMER_KEY,
+                TEST_CONSUMER_SECRET,
+                TEST_ACCESS_TOKEN,
+                TEST_TOKEN_SECRET,
+                TEST_USER_AGENT,
+                mock_pg_pool,
+                mock_neo4j,
+            )
+
+        # executemany batch_params: tuple position 11 (0-indexed) is metadata_json
+        call_args = mock_pg_pool._mock_cur.executemany.await_args
+        batch_params = call_args[0][1]
+        assert len(batch_params) == 1
+        metadata_json = batch_params[0][11]
+        assert metadata_json is not None
+        assert '"catalog_number": "ABC-123"' in metadata_json
+
+    @pytest.mark.asyncio
+    async def test_collection_persists_metadata_to_neo4j_params(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """labels[0].catno → cypher UNWIND payload entry's `metadata` bag."""
+        release = _make_release_item(123)
+        release["basic_information"]["labels"] = [{"name": "Lbl", "catno": "ZYX-987"}]
+        resp = _make_collection_response([release])
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = resp
+
+        with patch("api.syncer.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await sync_collection(
+                TEST_USER_UUID,
+                TEST_DISCOGS_USERNAME,
+                TEST_CONSUMER_KEY,
+                TEST_CONSUMER_SECRET,
+                TEST_ACCESS_TOKEN,
+                TEST_TOKEN_SECRET,
+                TEST_USER_AGENT,
+                mock_pg_pool,
+                mock_neo4j,
+            )
+
+        # Cypher params live in the second positional arg of session.run(cypher, params)
+        run_call = mock_neo4j._mock_session.run.await_args
+        cypher_text = run_call[0][0]
+        cypher_params = run_call[0][1]
+        assert "r += rel.metadata" in cypher_text
+        assert cypher_params["releases"][0]["metadata"] == {"catalog_number": "ZYX-987"}
+
+    @pytest.mark.asyncio
+    async def test_collection_empty_metadata_when_labels_empty(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """labels=[] → metadata_json is None, cypher metadata is {} (SET r += {} is a no-op)."""
+        release = _make_release_item(123)
+        release["basic_information"]["labels"] = []
+        resp = _make_collection_response([release])
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = resp
+
+        with patch("api.syncer.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await sync_collection(
+                TEST_USER_UUID,
+                TEST_DISCOGS_USERNAME,
+                TEST_CONSUMER_KEY,
+                TEST_CONSUMER_SECRET,
+                TEST_ACCESS_TOKEN,
+                TEST_TOKEN_SECRET,
+                TEST_USER_AGENT,
+                mock_pg_pool,
+                mock_neo4j,
+            )
+
+        batch_params = mock_pg_pool._mock_cur.executemany.await_args[0][1]
+        assert batch_params[0][11] is None
+        cypher_params = mock_neo4j._mock_session.run.await_args[0][1]
+        assert cypher_params["releases"][0]["metadata"] == {}
+
+    @pytest.mark.asyncio
+    async def test_collection_empty_metadata_when_label_lacks_catno(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """labels[0] missing 'catno' key → metadata_json is None, cypher metadata is {}."""
+        release = _make_release_item(123)
+        release["basic_information"]["labels"] = [{"name": "No-Catno Label"}]
+        resp = _make_collection_response([release])
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = resp
+
+        with patch("api.syncer.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await sync_collection(
+                TEST_USER_UUID,
+                TEST_DISCOGS_USERNAME,
+                TEST_CONSUMER_KEY,
+                TEST_CONSUMER_SECRET,
+                TEST_ACCESS_TOKEN,
+                TEST_TOKEN_SECRET,
+                TEST_USER_AGENT,
+                mock_pg_pool,
+                mock_neo4j,
+            )
+
+        batch_params = mock_pg_pool._mock_cur.executemany.await_args[0][1]
+        assert batch_params[0][11] is None
+
+    @pytest.mark.asyncio
+    async def test_wantlist_persists_metadata_to_neo4j_params(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """labels[0].catno from basic_information is propagated to the WANTS cypher payload's metadata bag."""
+        want = _make_want_item(456)
+        want["basic_information"]["labels"] = [{"name": "Lbl", "catno": "WNT-001"}]
+        resp = _make_wantlist_response([want])
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = resp
+
+        with patch("api.syncer.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await sync_wantlist(
+                TEST_USER_UUID,
+                TEST_DISCOGS_USERNAME,
+                TEST_CONSUMER_KEY,
+                TEST_CONSUMER_SECRET,
+                TEST_ACCESS_TOKEN,
+                TEST_TOKEN_SECRET,
+                TEST_USER_AGENT,
+                mock_pg_pool,
+                mock_neo4j,
+            )
+
+        run_call = mock_neo4j._mock_session.run.await_args
+        cypher_text = run_call[0][0]
+        cypher_params = run_call[0][1]
+        assert "r += w.metadata" in cypher_text
+        assert cypher_params["wants"][0]["metadata"] == {"catalog_number": "WNT-001"}
+
+    @pytest.mark.asyncio
+    async def test_wantlist_empty_metadata_when_labels_missing(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """basic_information missing 'labels' entirely → metadata is {} on the cypher payload."""
+        want = _make_want_item(456)
+        # basic_information.labels intentionally absent
+        want["basic_information"].pop("labels", None)
+        resp = _make_wantlist_response([want])
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = resp
+
+        with patch("api.syncer.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await sync_wantlist(
+                TEST_USER_UUID,
+                TEST_DISCOGS_USERNAME,
+                TEST_CONSUMER_KEY,
+                TEST_CONSUMER_SECRET,
+                TEST_ACCESS_TOKEN,
+                TEST_TOKEN_SECRET,
+                TEST_USER_AGENT,
+                mock_pg_pool,
+                mock_neo4j,
+            )
+
+        cypher_params = mock_neo4j._mock_session.run.await_args[0][1]
+        assert cypher_params["wants"][0]["metadata"] == {}

--- a/tests/api/test_user_queries.py
+++ b/tests/api/test_user_queries.py
@@ -189,6 +189,53 @@ class TestGetUserCollection:
         assert len(results) == 1
         assert total == 10
 
+    @pytest.mark.asyncio
+    async def test_query_returns_catalog_number_field(self) -> None:
+        """The collection RETURN clause must surface r.catalog_number — required by the GRUVAX contract."""
+        from api.queries.user_queries import get_user_collection
+
+        releases = [
+            {
+                "id": "r1",
+                "title": "OK Computer",
+                "year": 1997,
+                "artist": "Radiohead",
+                "label": "Parlophone",
+                "catalog_number": "NODATA 02",
+                "rating": 5,
+                "date_added": "2023-01-01",
+                "folder_id": 1,
+            }
+        ]
+        driver = _make_driver_with_results([_MockResult(records=releases), _MockResult(single={"total": 1})])
+        results, _ = await get_user_collection(driver, "user-1")
+        assert results[0]["catalog_number"] == "NODATA 02"
+
+    @pytest.mark.asyncio
+    async def test_query_cypher_includes_catalog_number(self) -> None:
+        """Inspect the cypher passed to session.run — must include r.catalog_number AS catalog_number."""
+        from api.queries.user_queries import get_user_collection
+
+        seen_cypher: list[str] = []
+
+        async def _capture_run(*args: Any, **_kw: Any) -> _MockResult:
+            seen_cypher.append(args[0] if args else "")
+            if "count(r)" in seen_cypher[-1]:
+                return _MockResult(single={"total": 0})
+            return _MockResult(records=[])
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.run = AsyncMock(side_effect=_capture_run)
+        driver = MagicMock()
+        driver.session = MagicMock(return_value=mock_session)
+
+        await get_user_collection(driver, "user-1")
+
+        main_cypher = next((c for c in seen_cypher if "RETURN" in c and "r.catalog_number" in c), None)
+        assert main_cypher is not None, f"Expected r.catalog_number in cypher; saw: {seen_cypher!r}"
+
 
 # ---------------------------------------------------------------------------
 # get_user_wantlist

--- a/tests/graphinator/test_batch_processor.py
+++ b/tests/graphinator/test_batch_processor.py
@@ -1786,3 +1786,130 @@ class TestFlushQueuePublicMethod:
 
         # _flush_queue should never be called since queue is empty
         processor._flush_queue.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# catalog_number on Release node (P6 — GRUVAX integration)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestReleaseCatalogNumber:
+    """Verify the bulk graphinator pipeline propagates labels[0].catno → Release.catalog_number."""
+
+    def _capture_tx_runs(self, mock_session: AsyncMock) -> list[tuple[str, dict[str, Any]]]:
+        """Wire mock_session.execute_write so we can inspect every tx.run call inside batch_write."""
+        captured: list[tuple[str, dict[str, Any]]] = []
+
+        mock_tx = AsyncMock()
+
+        async def capture(cypher: str, **kwargs: Any) -> AsyncMock:
+            captured.append((cypher, kwargs))
+            return AsyncMock()
+
+        mock_tx.run = capture
+
+        async def call_tx_func(tx_func: Any) -> None:
+            await tx_func(mock_tx)
+
+        mock_session.execute_write.side_effect = call_tx_func
+        return captured
+
+    def _make_release_msg(self, release_id: str, labels: list[dict[str, Any]] | None) -> PendingMessage:
+        data: dict[str, Any] = {
+            "id": release_id,
+            "title": f"Release {release_id}",
+            "year": 2020,
+            "sha256": f"hash-{release_id}",
+        }
+        if labels is not None:
+            data["labels"] = labels
+        return PendingMessage("releases", data, AsyncMock(), AsyncMock())
+
+    @pytest.mark.asyncio
+    async def test_release_cypher_uses_metadata_bag(self) -> None:
+        """The MERGE cypher must merge `r += release.metadata`; the bag carries catalog_number."""
+        mock_driver, mock_session = create_async_session_mock()
+        # Hash check returns no existing release → needs processing
+        mock_result = create_async_result_mock([{"id": "R1", "hash": None}])
+        mock_session.run = AsyncMock(return_value=mock_result)
+
+        captured = self._capture_tx_runs(mock_session)
+        processor = Neo4jBatchProcessor(mock_driver)
+        msg = self._make_release_msg("R1", [{"id": "L1", "name": "Some Label", "catno": "ABC-123"}])
+
+        await processor._process_releases_batch([msg])
+
+        # First tx.run is the MERGE on Release nodes
+        first_cypher, first_kwargs = captured[0]
+        assert "r += release.metadata" in first_cypher
+        assert first_kwargs["releases"][0]["metadata"] == {"catalog_number": "ABC-123"}
+
+    @pytest.mark.asyncio
+    async def test_release_metadata_empty_when_labels_empty(self) -> None:
+        """labels=[] → metadata is {} on the payload (SET r += {} is a no-op)."""
+        mock_driver, mock_session = create_async_session_mock()
+        mock_result = create_async_result_mock([{"id": "R2", "hash": None}])
+        mock_session.run = AsyncMock(return_value=mock_result)
+
+        captured = self._capture_tx_runs(mock_session)
+        processor = Neo4jBatchProcessor(mock_driver)
+        msg = self._make_release_msg("R2", [])
+
+        await processor._process_releases_batch([msg])
+
+        _, first_kwargs = captured[0]
+        assert first_kwargs["releases"][0]["metadata"] == {}
+
+    @pytest.mark.asyncio
+    async def test_release_metadata_empty_when_labels_missing(self) -> None:
+        """`labels` key entirely absent → metadata is {} on the payload."""
+        mock_driver, mock_session = create_async_session_mock()
+        mock_result = create_async_result_mock([{"id": "R3", "hash": None}])
+        mock_session.run = AsyncMock(return_value=mock_result)
+
+        captured = self._capture_tx_runs(mock_session)
+        processor = Neo4jBatchProcessor(mock_driver)
+        msg = self._make_release_msg("R3", None)
+
+        await processor._process_releases_batch([msg])
+
+        _, first_kwargs = captured[0]
+        assert first_kwargs["releases"][0]["metadata"] == {}
+
+    @pytest.mark.asyncio
+    async def test_release_metadata_empty_when_first_label_lacks_catno(self) -> None:
+        """labels[0] without `catno` key → metadata is {} (no KeyError, catalog_number key absent)."""
+        mock_driver, mock_session = create_async_session_mock()
+        mock_result = create_async_result_mock([{"id": "R4", "hash": None}])
+        mock_session.run = AsyncMock(return_value=mock_result)
+
+        captured = self._capture_tx_runs(mock_session)
+        processor = Neo4jBatchProcessor(mock_driver)
+        msg = self._make_release_msg("R4", [{"id": "L1", "name": "Catno-less Label"}])
+
+        await processor._process_releases_batch([msg])
+
+        _, first_kwargs = captured[0]
+        assert first_kwargs["releases"][0]["metadata"] == {}
+
+    @pytest.mark.asyncio
+    async def test_release_uses_first_label_catno(self) -> None:
+        """Multiple labels — only labels[0].catno is taken (canonical pressing)."""
+        mock_driver, mock_session = create_async_session_mock()
+        mock_result = create_async_result_mock([{"id": "R5", "hash": None}])
+        mock_session.run = AsyncMock(return_value=mock_result)
+
+        captured = self._capture_tx_runs(mock_session)
+        processor = Neo4jBatchProcessor(mock_driver)
+        msg = self._make_release_msg(
+            "R5",
+            [
+                {"id": "L1", "name": "Primary", "catno": "PRI-001"},
+                {"id": "L2", "name": "Reissue", "catno": "REI-999"},
+            ],
+        )
+
+        await processor._process_releases_batch([msg])
+
+        _, first_kwargs = captured[0]
+        assert first_kwargs["releases"][0]["metadata"] == {"catalog_number": "PRI-001"}


### PR DESCRIPTION
## Summary

P6 of the **App Tokens + Collection API for GRUVAX v2.0** milestone. The P1 spike found \`catalog_number\` isn't stored anywhere on our side today though it IS present in upstream data (Discogs API responses carry it as \`labels[].catno\` per collection item; the Rust extractor preserves it through the bulk pipeline). GRUVAX needs catalog# on \`/api/user/collection\` responses to position records on the kiosk grid.

This PR adds catalog# end-to-end with **zero PG schema migrations** and uses a single generic mechanism — a per-release \`metadata\` dict that's only populated with non-null keys, written to Neo4j via \`SET r += release.metadata\`. Future fields just add a key to the dict instead of a new SET branch.

## Changes

### \`api/syncer.py\` — per-user Discogs API sync (collection + wantlist)

Build a \`metadata\` dict per release/want. Same dict is used for:
- \`user_collections.metadata\` JSONB on the upsert (the column already exists from the original schema)
- The \`metadata\` field on the Neo4j cypher UNWIND payload

Cypher uses \`SET r += rel.metadata\` (collection) / \`r += w.metadata\` (wantlist). Map-merge writes only the keys present, so a sync without catno never wipes a value the bulk pipeline may have set.

### \`graphinator/batch_processor.py\` — bulk Discogs XML → Neo4j

Same pattern. \`release_data["metadata"] = {"catalog_number": labels[0].catno}\` when present, \`{}\` otherwise. The Release MERGE cypher gets \`r += release.metadata\` appended to the existing SET clause. \`SET r += {}\` is a no-op.

### \`api/queries/user_queries.py\`

\`get_user_collection\` and \`get_user_wantlist\` RETURN clauses include \`r.catalog_number AS catalog_number\`.

### \`tableinator/batch_processor.py\` — **UNTOUCHED**

Full message payload including \`labels[].catno\` is already persisted via \`Jsonb(msg.data)\` (verified at batch_processor.py:418 during the P1 spike).

## Why the metadata-bag pattern

Two independent writers (bulk graphinator and per-user syncer) both need to set \`r.catalog_number\`. Neo4j semantics: \`SET k = null\` deletes the property. Without a guard, a bulk re-ingest where catno is missing would wipe the value the sync may have set, and vice versa. \`SET r += metadata\` only touches keys present in the dict — Python-side, we omit null keys — so neither writer can wipe the other.

Bonus: adding a new release-level field is a one-line change (add a key to the dict) instead of a new cypher SET branch.

## Test plan

- [x] **6 new tests** in \`tests/api/test_syncer.py\` covering collection + wantlist with catno, empty labels, missing labels, labels lacking catno
- [x] **5 new tests** in \`tests/graphinator/test_batch_processor.py\` using a \`tx.run\` capture helper to inspect cypher + payload across all empty/missing/multi-label cases
- [x] **2 new tests** in \`tests/api/test_user_queries.py\` verifying the RETURN includes \`catalog_number\`
- [x] **1954/1954** broad tests pass across \`tests/api/\` + \`tests/graphinator/\` (excluding the two digger-agent suites that need \`ANTHROPIC_API_KEY\`)
- [x] ruff + mypy clean
- [ ] Manual after deploy: trigger a user sync, then \`curl -H 'Authorization: Bearer dscg_…' \$API/api/user/collection\` returns items with non-null \`catalog_number\` where the source release has one

🤖 Generated with [Claude Code](https://claude.com/claude-code)