### PR TITLE
chore(tests): silence pytest warnings (markers, AsyncMock leaks, deprecations)

### DIFF
--- a/api/routers/admin.py
+++ b/api/routers/admin.py
@@ -308,7 +308,7 @@ async def admin_queue_history(
     try:
         data = await get_queue_history(_pool, range)
     except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
     return JSONResponse(content=data)
 
 
@@ -323,7 +323,7 @@ async def admin_health_history(
     try:
         data = await get_health_history(_pool, range)
     except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
     return JSONResponse(content=data)
 
 

--- a/common/digger_optimizer/ilp.py
+++ b/common/digger_optimizer/ilp.py
@@ -63,14 +63,14 @@ def solve_ilp_bundle(inp: OptimizerInput, *, name: BundleName, timeout_seconds: 
 
     prob = pulp.LpProblem(f"digger_{name}", pulp.LpMinimize)
 
-    x = {lid: pulp.LpVariable(f"x_{lid}", cat="Binary") for lid in listing_id_set}
-    y = {sid: pulp.LpVariable(f"y_{sid}", cat="Binary") for sid in seller_listings}
+    x = {lid: prob.add_variable(f"x_{lid}", cat="Binary") for lid in listing_id_set}
+    y = {sid: prob.add_variable(f"y_{sid}", cat="Binary") for sid in seller_listings}
 
     max_k_per_seller: dict[int, int] = {sid: len(lids) for sid, lids in seller_listings.items()}
     z: dict[tuple[int, int], pulp.LpVariable] = {}
     for sid, k_max in max_k_per_seller.items():
         for k in range(1, k_max + 1):
-            z[(sid, k)] = pulp.LpVariable(f"z_{sid}_{k}", cat="Binary")
+            z[(sid, k)] = prob.add_variable(f"z_{sid}_{k}", cat="Binary")
 
     # Must-have: each Must release covered exactly once if any usable listing exists.
     for must in inp.must_have_releases:
@@ -114,7 +114,7 @@ def solve_ilp_bundle(inp: OptimizerInput, *, name: BundleName, timeout_seconds: 
     obj_ev = -weights.lambda_eventually * pulp.lpSum(x[lid] for lid in listing_id_set if listings_by_id[lid].release_id in eventually_set)
     prob += obj_item + obj_ship + obj_seller_penalty + obj_quality + obj_nice + obj_ev
 
-    solver = pulp.PULP_CBC_CMD(msg=False, timeLimit=timeout_seconds, options=["randomSeed 42"])
+    solver = pulp.COIN_CMD(path=pulp.PULP_CBC_CMD.pulp_cbc_path, msg=False, timeLimit=timeout_seconds, options=["randomSeed 42"])
     status = prob.solve(solver)
     status_label = pulp.LpStatus[status]
     if status not in (pulp.LpStatusOptimal, pulp.LpStatusNotSolved):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,10 +219,6 @@ module = [
 ]
 ignore_missing_imports = true
 
-[[tool.mypy.overrides]]
-module = "tests.*"
-disallow_untyped_decorators = false
-
 
 [tool.coverage.run]
 source = ["api", "brainzgraphinator", "brainztableinator", "common", "dashboard", "digger", "explore", "graphinator", "insights", "mcp-server", "schema-init", "tableinator"]
@@ -253,6 +249,7 @@ timeout_method = "thread"
 markers = [
     "e2e: End-to-end tests requiring external services (deselect with '-m \"not e2e\"')",
     "eval: Digger agent evals requiring ANTHROPIC_API_KEY + a live stack (skipped in CI; run nightly)",
+    "benchmark: Performance regression benchmarks (informational; run separately)",
 ]
 
 # Package discovery for multi-service setup

--- a/tests/api/test_admin_endpoints.py
+++ b/tests/api/test_admin_endpoints.py
@@ -792,6 +792,17 @@ class TestTrackExtraction:
         import api.routers.admin as admin_mod
 
         mock_pool = MagicMock()
+        mock_cur = AsyncMock()
+        mock_conn = AsyncMock()
+        cur_ctx = AsyncMock()
+        cur_ctx.__aenter__ = AsyncMock(return_value=mock_cur)
+        cur_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_conn.cursor = MagicMock(return_value=cur_ctx)
+        conn_ctx = AsyncMock()
+        conn_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+        conn_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_pool.connection = MagicMock(return_value=conn_ctx)
+
         mock_config = MagicMock()
         mock_config.extractor_host = "localhost"
         mock_config.extractor_health_port = 8000

--- a/tests/api/test_sync.py
+++ b/tests/api/test_sync.py
@@ -2,12 +2,25 @@
 
 import asyncio
 from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 import pytest
 
 from tests.api.conftest import TEST_JWT_SECRET, TEST_USER_EMAIL, TEST_USER_ID, make_test_jwt
+
+
+def _close_coro_and_return(task_mock: Any) -> Any:
+    """Return a side_effect for patched asyncio.create_task that closes the
+    coroutine argument (preventing 'never awaited' warnings) and returns the
+    provided task mock."""
+
+    def _side_effect(coro: Any) -> Any:
+        coro.close()
+        return task_mock
+
+    return _side_effect
 
 
 class TestTriggerSyncEndpoint:
@@ -29,9 +42,9 @@ class TestTriggerSyncEndpoint:
     ) -> None:
         mock_cur.fetchone.return_value = {"id": "new-sync-id"}
 
-        with patch("api.routers.sync.asyncio.create_task") as mock_task:
-            mock_task.return_value = MagicMock(spec=asyncio.Task)
-            mock_task.return_value.done.return_value = False
+        fake_task = MagicMock(spec=asyncio.Task)
+        fake_task.done.return_value = False
+        with patch("api.routers.sync.asyncio.create_task", side_effect=_close_coro_and_return(fake_task)):
             response = test_client.post("/api/sync", headers=auth_headers)
 
         assert response.status_code == 202
@@ -344,9 +357,9 @@ class TestSyncRedisCooldown:
 
         mock_redis.get.return_value = None  # not in cooldown
         mock_cur.fetchone.return_value = {"id": "new-sync-id"}
-        with patch("api.routers.sync.asyncio.create_task") as mock_task:
-            mock_task.return_value = MagicMock(spec=asyncio.Task)
-            mock_task.return_value.done.return_value = False
+        fake_task = MagicMock(spec=asyncio.Task)
+        fake_task.done.return_value = False
+        with patch("api.routers.sync.asyncio.create_task", side_effect=_close_coro_and_return(fake_task)):
             test_client.post("/api/sync", headers=auth_headers)
         mock_redis.setex.assert_awaited_once()
         setex_args = mock_redis.setex.call_args[0]
@@ -363,9 +376,9 @@ class TestSyncRedisCooldown:
         sync_module._redis = None
         mock_cur.fetchone.return_value = {"id": "sync-id"}
         try:
-            with patch("api.routers.sync.asyncio.create_task") as mock_task:
-                mock_task.return_value = MagicMock(spec=asyncio.Task)
-                mock_task.return_value.done.return_value = False
+            fake_task = MagicMock(spec=asyncio.Task)
+            fake_task.done.return_value = False
+            with patch("api.routers.sync.asyncio.create_task", side_effect=_close_coro_and_return(fake_task)):
                 response = test_client.post("/api/sync", headers=auth_headers)
             assert response.status_code == 202
         finally:
@@ -378,16 +391,20 @@ class TestSyncRedisCooldown:
         import api.routers.sync as sync_module
 
         mock_cur.fetchone.return_value = {"id": "sync-id"}
-        with patch("api.routers.sync.asyncio.create_task") as mock_task:
-            mock_task.return_value = MagicMock(spec=asyncio.Task)
-            mock_task.return_value.done.return_value = False
+        fake_task = MagicMock(spec=asyncio.Task)
+        fake_task.done.return_value = False
+        captured: dict[str, Any] = {}
+
+        def _capture_and_close(coro: Any) -> Any:
+            captured["coro"] = coro
+            coro.close()
+            return fake_task
+
+        with patch("api.routers.sync.asyncio.create_task", side_effect=_capture_and_close):
             test_client.post("/api/sync", headers=auth_headers)
 
-        create_task_call = mock_task.call_args
-        # The coroutine is run_full_sync(...) — check kwargs contain oauth_encryption_key
-        coroutine = create_task_call[0][0]
-        assert coroutine is not None
-        coroutine.close()  # clean up unawaited coroutine
+        # The coroutine passed to create_task was run_full_sync(...)
+        assert captured["coro"] is not None
 
         # Verify getattr used on config with oauth_encryption_key
         assert hasattr(sync_module._config, "jwt_secret_key")

--- a/tests/brainzgraphinator/test_brainzgraphinator.py
+++ b/tests/brainzgraphinator/test_brainzgraphinator.py
@@ -757,7 +757,7 @@ class TestScheduleConsumerCancellation:
     async def test_cancels_existing_scheduled_task(self) -> None:
         """Test cancels existing scheduled task before creating new one."""
         mock_queue = AsyncMock()
-        mock_existing_task = AsyncMock()
+        mock_existing_task = MagicMock()
 
         bgmod.consumer_tags = {"artists": "consumer-tag-123"}
         bgmod.consumer_cancel_tasks = {"artists": mock_existing_task}

--- a/tests/brainztableinator/test_brainztableinator.py
+++ b/tests/brainztableinator/test_brainztableinator.py
@@ -628,6 +628,8 @@ class TestOnDataMessage:
 
         mock_pool = MagicMock()
         mock_conn = AsyncMock()
+        # conn.transaction() is called synchronously; mock the returned async context manager
+        mock_conn.transaction = MagicMock(return_value=AsyncMock())
         mock_conn_cm = AsyncMock()
         mock_conn_cm.__aenter__ = AsyncMock(return_value=mock_conn)
         mock_conn_cm.__aexit__ = AsyncMock(return_value=None)
@@ -884,7 +886,7 @@ class TestScheduleConsumerCancellation:
         """Test that existing scheduled task is cancelled."""
         import brainztableinator.brainztableinator as bt
 
-        existing_task = AsyncMock()
+        existing_task = MagicMock()
         bt.consumer_cancel_tasks = {"artists": existing_task}
         bt.consumer_tags = {"artists": "consumer-tag-1"}
         bt.shutdown_requested = False
@@ -1801,9 +1803,10 @@ class TestMain:
 
             with patch("asyncio.create_task", side_effect=mock_create_task):
 
-                async def mock_wait_for(_coro: Any, timeout: float) -> None:  # noqa: ARG001
+                async def mock_wait_for(coro: Any, timeout: float) -> None:  # noqa: ARG001
                     import brainztableinator.brainztableinator
 
+                    coro.close()
                     brainztableinator.brainztableinator.shutdown_requested = True
                     raise TimeoutError()
 
@@ -2746,10 +2749,16 @@ class TestMainEdgeCases:
         import brainztableinator.brainztableinator as bt
 
         bt.shutdown_requested = False
-        bt.consumer_cancel_tasks = {"artists": AsyncMock()}
-        bt.connection_check_task = AsyncMock()
+        # Tasks: .cancel() is sync, but the task itself is awaitable
+        _cancel_task = AsyncMock()
+        _cancel_task.cancel = MagicMock()
+        _check_task = AsyncMock()
+        _check_task.cancel = MagicMock()
+        bt.consumer_cancel_tasks = {"artists": _cancel_task}
+        bt.connection_check_task = _check_task
 
-        async def raise_keyboard_interrupt(_coro: Any, timeout: float) -> None:  # noqa: ARG001
+        async def raise_keyboard_interrupt(coro: Any, timeout: float) -> None:  # noqa: ARG001
+            coro.close()
             raise KeyboardInterrupt()
 
         original_sleep = asyncio.sleep
@@ -2807,9 +2816,10 @@ class TestMainEdgeCases:
         mock_queue = AsyncMock()
         mock_channel.declare_queue.return_value = mock_queue
 
-        async def mock_wait_for(_coro: Any, timeout: float) -> None:  # noqa: ARG001
+        async def mock_wait_for(coro: Any, timeout: float) -> None:  # noqa: ARG001
             import brainztableinator.brainztableinator
 
+            coro.close()
             brainztableinator.brainztableinator.shutdown_requested = True
             raise TimeoutError()
 

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -12,6 +12,13 @@ import pytest
 from dashboard.dashboard import PIPELINE_CONFIGS, DashboardApp, DatabaseInfo, QueueInfo, ServiceStatus, SystemMetrics
 
 
+def _close_and_mock_task(coro: Any) -> MagicMock:
+    """Stand-in for asyncio.create_task that closes the coroutine to prevent
+    "coroutine was never awaited" warnings, then returns a sentinel mock task."""
+    coro.close()
+    return MagicMock()
+
+
 class TestDashboardAppInit:
     """Test DashboardApp initialization."""
 
@@ -55,7 +62,7 @@ class TestDashboardAppStartup:
             patch("dashboard.dashboard.AsyncResilientRabbitMQ", return_value=mock_rabbitmq),
             patch("dashboard.dashboard.AsyncResilientNeo4jDriver", return_value=mock_neo4j),
             patch("dashboard.dashboard.AsyncResilientPostgreSQL", return_value=mock_postgres),
-            patch("asyncio.create_task") as mock_create_task,
+            patch("asyncio.create_task", side_effect=_close_and_mock_task) as mock_create_task,
             patch.object(DashboardApp, "collect_metrics_loop", new_callable=AsyncMock),
         ):
             app = DashboardApp()
@@ -88,7 +95,7 @@ class TestDashboardAppStartup:
             patch("dashboard.dashboard.AsyncResilientRabbitMQ", return_value=AsyncMock()),
             patch("dashboard.dashboard.AsyncResilientNeo4jDriver", return_value=AsyncMock()),
             patch("dashboard.dashboard.AsyncResilientPostgreSQL") as mock_postgres_class,
-            patch("asyncio.create_task"),
+            patch("asyncio.create_task", side_effect=_close_and_mock_task),
             patch.object(DashboardApp, "collect_metrics_loop", new_callable=AsyncMock),
         ):
             app = DashboardApp()
@@ -1303,7 +1310,7 @@ class TestPostgresAddressParsing:
                 patch("dashboard.dashboard.AsyncResilientRabbitMQ", return_value=mock_rabbitmq),
                 patch("dashboard.dashboard.AsyncResilientNeo4jDriver", return_value=mock_neo4j),
                 patch("dashboard.dashboard.AsyncResilientPostgreSQL", return_value=mock_postgres),
-                patch("asyncio.create_task") as _mock_create_task,
+                patch("asyncio.create_task", side_effect=_close_and_mock_task) as _mock_create_task,
             ):
                 await app.startup()
 
@@ -1414,7 +1421,7 @@ class TestLifespanFunction:
             patch("dashboard.dashboard.AsyncResilientRabbitMQ", return_value=mock_rabbitmq),
             patch("dashboard.dashboard.AsyncResilientNeo4jDriver", return_value=mock_neo4j),
             patch("dashboard.dashboard.AsyncResilientPostgreSQL", return_value=mock_postgres),
-            patch("asyncio.create_task"),
+            patch("asyncio.create_task", side_effect=_close_and_mock_task),
             patch.object(DashboardApp, "collect_metrics_loop", new_callable=AsyncMock),
         ):
             from dashboard.dashboard import app

--- a/tests/digger/test_main.py
+++ b/tests/digger/test_main.py
@@ -195,9 +195,13 @@ class TestMain:
         async def _fake_amain() -> None:
             pass
 
+        def _capture_and_close(coro: Any) -> None:
+            run_calls.append(coro)
+            coro.close()
+
         with (
             patch("digger.main.amain", _fake_amain),
-            patch("digger.main.asyncio.run", side_effect=run_calls.append),
+            patch("digger.main.asyncio.run", side_effect=_capture_and_close),
         ):
             from digger.main import main
 
@@ -210,8 +214,12 @@ class TestMain:
         for k, v in _DIGGER_REQUIRED.items():
             monkeypatch.setenv(k, v)
 
+        def _close_and_raise(coro: Any) -> None:
+            coro.close()
+            raise KeyboardInterrupt
+
         with (
-            patch("digger.main.asyncio.run", side_effect=KeyboardInterrupt),
+            patch("digger.main.asyncio.run", side_effect=_close_and_raise),
             patch("digger.main.sys.exit") as mock_exit,
         ):
             from digger.main import main

--- a/tests/graphinator/test_graphinator.py
+++ b/tests/graphinator/test_graphinator.py
@@ -406,10 +406,11 @@ class TestMain:
 
             with patch("asyncio.create_task", side_effect=mock_create_task):
                 # Make the main loop exit after setup
-                async def mock_wait_for(_coro: Any, **_kwargs: Any) -> None:
+                async def mock_wait_for(coro: Any, **_kwargs: Any) -> None:
                     # First call times out, second call sets shutdown_requested
                     import graphinator.graphinator
 
+                    coro.close()
                     graphinator.graphinator.shutdown_requested = True
                     raise TimeoutError()
 
@@ -1183,7 +1184,7 @@ class TestScheduleConsumerCancellation:
     async def test_cancels_existing_scheduled_task(self) -> None:
         """Test cancels existing scheduled task before creating new one."""
         mock_queue = AsyncMock()
-        mock_existing_task = AsyncMock()
+        mock_existing_task = MagicMock()
 
         import graphinator.graphinator
 
@@ -3086,9 +3087,10 @@ class TestMainBatchProcessorFlushError:
                 patch("asyncio.create_task", side_effect=mock_create_task),
             ):
 
-                async def mock_wait_for(_coro: Any, **_kwargs: Any) -> None:
+                async def mock_wait_for(coro: Any, **_kwargs: Any) -> None:
                     import graphinator.graphinator as _gm
 
+                    coro.close()
                     _gm.shutdown_requested = True
                     raise TimeoutError()
 
@@ -3206,9 +3208,10 @@ class TestMainNeo4jCloseError:
                 patch("asyncio.create_task", side_effect=mock_create_task),
             ):
 
-                async def mock_wait_for(_coro: Any, **_kwargs: Any) -> None:
+                async def mock_wait_for(coro: Any, **_kwargs: Any) -> None:
                     import graphinator.graphinator as _gm
 
+                    coro.close()
                     _gm.shutdown_requested = True
                     raise TimeoutError()
 

--- a/tests/schema-init/test_schema_init.py
+++ b/tests/schema-init/test_schema_init.py
@@ -410,7 +410,10 @@ class TestInitNeo4jPartialFailure:
         mock_result = AsyncMock()
         mock_result.single = AsyncMock(return_value={"health": 1})
         mock_session.run = AsyncMock(return_value=mock_result)
-        mock_driver.session = AsyncMock(return_value=mock_session)
+        # driver.session(...) is called synchronously and the returned object
+        # must support `async with` — so use MagicMock (sync) wrapping the
+        # AsyncMock context manager, not AsyncMock which returns a coroutine.
+        mock_driver.session = MagicMock(return_value=mock_session)
         mock_driver.close = AsyncMock()
 
         with (

--- a/tests/tableinator/test_tableinator.py
+++ b/tests/tableinator/test_tableinator.py
@@ -405,8 +405,8 @@ class TestScheduleConsumerCancellation:
         """Test that existing scheduled task is cancelled."""
         import tableinator.tableinator
 
-        # Create a mock existing task
-        existing_task = AsyncMock()
+        # Create a mock existing task (Task.cancel() is synchronous)
+        existing_task = MagicMock()
         tableinator.tableinator.consumer_cancel_tasks = {"artists": existing_task}
         tableinator.tableinator.consumer_tags = {"artists": "consumer-tag-1"}
         tableinator.tableinator.shutdown_requested = False


### PR DESCRIPTION
## Summary

Resolves every warning emitted by the test suite. After this PR, `uv run pytest` runs warning-free against this codebase (the 45 remaining warnings are third-party `slowapi.extension` `asyncio.iscoroutinefunction` deprecations and are out of scope).

### Source changes
- **`pyproject.toml`** — register `benchmark` pytest marker (was triggering `PytestUnknownMarkWarning` under `--strict-markers`); also remove a dead `[[tool.mypy.overrides]] module = "tests.*"` block (its `disallow_untyped_decorators = false` had no effect because `exclude = "^tests/"` already skips tests entirely).
- **`api/routers/admin.py`** — replace deprecated `HTTP_422_UNPROCESSABLE_ENTITY` with `HTTP_422_UNPROCESSABLE_CONTENT`.
- **`common/digger_optimizer/ilp.py`** — migrate to PuLP 4.0-style API: `prob.add_variable(...)` instead of `LpVariable(...)` and `pulp.COIN_CMD(path=pulp.PULP_CBC_CMD.pulp_cbc_path, ...)` instead of `pulp.PULP_CBC_CMD(...)`. Drops 4500+ `DeprecationWarning`s per run.

### Test mock fixes (root cause: `AsyncMock` returning unawaited coroutines)
- **Scheduler-cancellation tests** (`brainzgraphinator`, `brainztableinator`, `graphinator`, `tableinator`) — `task.cancel()` is **sync** on a real `asyncio.Task`, so the mock should be `MagicMock`, not `AsyncMock`.
- **Main-loop tests** (`brainztableinator`, `graphinator`) — `mock_wait_for` now `coro.close()`s the unawaited `shutdown_event.wait()` coroutine before raising `TimeoutError`/`KeyboardInterrupt`.
- **`asyncio.create_task` patches** (`dashboard`, `api.sync`, `digger.main`) — `side_effect` now closes the coroutine it receives (otherwise the mocked `create_task` swallows it without awaiting).
- **`schema_init`** — `driver.session` is a sync `MagicMock` returning the async context manager (was `AsyncMock` returning a coroutine, which `async with` cannot enter).
- **`brainztableinator` `OperationalError` test** — mock `conn.transaction()` as a sync `MagicMock` returning an `AsyncMock` async context manager.
- **`admin._track_extraction` cancelled test** — configure full pool / cursor async context manager mocks instead of bare `MagicMock()` (which fell back to `__aenter__` auto-created on a regular MagicMock).

## Test plan
- [x] `uv run pytest tests/` — 609 passed; only third-party slowapi warnings remain
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy .` — `Success: no issues found in 174 source files` (previously also emitted `unused section(s): module = ['tests.*']`)
- [x] Pre-commit hooks pass (ruff, mypy, bandit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)