### PR TITLE
fix(digger): use python -m digger.main in container start script

### DIFF
--- a/digger/Dockerfile
+++ b/digger/Dockerfile
@@ -94,7 +94,7 @@ COPY --from=builder --chown=digger:digger /app/digger /app/digger
 
 # Create startup script
 # hadolint ignore=SC2016
-RUN printf '#!/bin/sh\nset -e\nsleep "${STARTUP_DELAY:-0}"\nexec /app/.venv/bin/digger "$@"\n' > /app/start.sh && \
+RUN printf '#!/bin/sh\nset -e\nsleep "${STARTUP_DELAY:-0}"\nexec /app/.venv/bin/python -m digger.main "$@"\n' > /app/start.sh && \
     chmod +x /app/start.sh
 
 EXPOSE 8012


### PR DESCRIPTION
## Summary

- The digger container failed at startup with `exec: /app/.venv/bin/digger: not found` (line 4 of `/app/start.sh`)
- Switch the start script to `python -m digger.main`, matching the pattern used by every other Python service in this repo
- Removes the runtime dependency on the `digger` console script being installed into `/app/.venv/bin/`

## Why this slipped past CI

PR #369 introduced a multi-stage Dockerfile that invokes the `digger` console script from `[project.scripts] digger = "digger:main"` in `digger/pyproject.toml`. The only CI validation for the digger image (`docker-validate.yml`) runs `docker build --target builder` — it stops at the builder stage and never executes the runtime command. So the broken invocation never surfaced until the image was actually started.

`digger/main.py` already has `if __name__ == "__main__": main()`, so `python -m digger.main` calls the exact same entrypoint without depending on console-script installation succeeding.

## Test plan

- [ ] `just rebuild` (or `docker compose build digger && docker compose up -d digger`)
- [ ] `docker logs -f discogsography-digger` shows the Digger ASCII art and the health server starting on port 8012
- [ ] `curl -fs http://localhost:8012/health` returns OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)