### PR TITLE
fix(digger): install workspace deps via --extra digger in Dockerfile

### DIFF
--- a/digger/Dockerfile
+++ b/digger/Dockerfile
@@ -20,23 +20,25 @@ ENV UV_SYSTEM_PYTHON=1 \
 
 WORKDIR /app
 
-# Copy workspace lockfile and source for the editable workspace install.
-# uv sync --package does an editable install of the digger workspace member,
-# so its source must be present before the sync step.
-COPY pyproject.toml uv.lock ./
-COPY common/ ./common/
-COPY digger/ ./digger/
+# Copy dependency files first for better caching
+COPY pyproject.toml uv.lock README.md ./
+COPY common/pyproject.toml ./common/
+COPY digger/pyproject.toml ./digger/
 
 # Install dependencies and clean up
 # hadolint ignore=SC2015
 RUN --mount=type=cache,target=/tmp/.cache/uv \
-    uv sync --frozen --no-dev --package discogsography-digger && \
+    uv sync --frozen --no-dev --extra digger && \
     find /app/.venv -type f -name "*.pyc" -delete && \
     find /app/.venv -type f -name "*.pyo" -delete && \
     find /app/.venv -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true && \
     find /app/.venv -type d -name ".pytest_cache" -exec rm -rf {} + 2>/dev/null || true && \
     find /app/.venv -type d -name "tests" -exec rm -rf {} + 2>/dev/null || true && \
     find /app/.venv -name "*.so" -exec strip --strip-unneeded {} \; 2>/dev/null || true
+
+# Copy source files
+COPY common/ ./common/
+COPY digger/ ./digger/
 
 # Final stage
 FROM python:${PYTHON_VERSION}-slim

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,8 +118,17 @@ mcp-server = [
     "mcp[cli]>=1.27.1",
     "structlog>=25.5.0",
 ]
+digger = [
+    "bleach>=6.3.0",
+    "httpx>=0.28.1",
+    "prometheus-client>=0.25.0",
+    "psycopg[binary]>=3.3.4",
+    "redis[hiredis]>=7.4.0",
+    "selectolax>=0.4.10",
+    "structlog>=25.5.0",
+]
 all = [
-    "discogsography[api,brainzgraphinator,brainztableinator,dashboard,explore,graphinator,insights,mcp-server,schema-init,tableinator,dev,utilities]",
+    "discogsography[api,brainzgraphinator,brainztableinator,dashboard,digger,explore,graphinator,insights,mcp-server,schema-init,tableinator,dev,utilities]",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -437,6 +437,7 @@ dependencies = [
 all = [
     { name = "anthropic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "bandit", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "bleach", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "brevo-python", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "cryptography", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "defusedxml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -463,6 +464,7 @@ all = [
     { name = "redis", extra = ["hiredis"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "ruff", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "selectolax", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "slowapi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "sse-starlette", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "structlog", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -524,6 +526,15 @@ dev = [
     { name = "types-psutil", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "types-pyyaml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "types-tqdm", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+digger = [
+    { name = "bleach", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "prometheus-client", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "psycopg", extra = ["binary"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "redis", extra = ["hiredis"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "selectolax", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "structlog", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 explore = [
     { name = "fastapi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -589,17 +600,19 @@ requires-dist = [
     { name = "aio-pika", specifier = ">=9.6.2" },
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.104.1" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.9.4" },
+    { name = "bleach", marker = "extra == 'digger'", specifier = ">=6.3.0" },
     { name = "brevo-python", marker = "extra == 'api'", specifier = ">=4.0.10" },
     { name = "cryptography", marker = "extra == 'api'", specifier = ">=48.0.0" },
     { name = "defusedxml", marker = "extra == 'api'", specifier = ">=0.7.1" },
     { name = "dict-hash", specifier = ">=1.3.7" },
-    { name = "discogsography", extras = ["api", "brainzgraphinator", "brainztableinator", "dashboard", "explore", "graphinator", "insights", "mcp-server", "schema-init", "tableinator", "dev", "utilities"], marker = "extra == 'all'" },
+    { name = "discogsography", extras = ["api", "brainzgraphinator", "brainztableinator", "dashboard", "digger", "explore", "graphinator", "insights", "mcp-server", "schema-init", "tableinator", "dev", "utilities"], marker = "extra == 'all'" },
     { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.136.3" },
     { name = "fastapi", marker = "extra == 'dashboard'", specifier = ">=0.136.3" },
     { name = "fastapi", marker = "extra == 'explore'", specifier = ">=0.136.3" },
     { name = "fastapi", marker = "extra == 'insights'", specifier = ">=0.136.3" },
     { name = "httpx", marker = "extra == 'api'", specifier = ">=0.28.1" },
     { name = "httpx", marker = "extra == 'dashboard'", specifier = ">=0.28.1" },
+    { name = "httpx", marker = "extra == 'digger'", specifier = ">=0.28.1" },
     { name = "httpx", marker = "extra == 'explore'", specifier = ">=0.28.1" },
     { name = "httpx", marker = "extra == 'insights'", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], marker = "extra == 'mcp-server'", specifier = ">=1.27.1" },
@@ -618,11 +631,13 @@ requires-dist = [
     { name = "playwright", marker = "extra == 'dev'", specifier = ">=1.60.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.6.0" },
     { name = "prometheus-client", marker = "extra == 'dashboard'", specifier = ">=0.25.0" },
+    { name = "prometheus-client", marker = "extra == 'digger'", specifier = ">=0.25.0" },
     { name = "psutil", marker = "extra == 'utilities'", specifier = ">=7.2.2" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.4" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'api'", specifier = ">=3.3.4" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'brainztableinator'", specifier = ">=3.3.4" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'dashboard'", specifier = ">=3.3.4" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'digger'", specifier = ">=3.3.4" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'schema-init'", specifier = ">=3.3.4" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'tableinator'", specifier = ">=3.3.4" },
     { name = "pulp", specifier = ">=3.3.2" },
@@ -640,12 +655,15 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'api'", specifier = ">=6.0.3" },
     { name = "redis", extras = ["hiredis"], specifier = ">=7.4.0" },
     { name = "redis", extras = ["hiredis"], marker = "extra == 'api'", specifier = ">=7.4.0" },
+    { name = "redis", extras = ["hiredis"], marker = "extra == 'digger'", specifier = ">=7.4.0" },
     { name = "requests", marker = "extra == 'utilities'", specifier = ">=2.34.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.14" },
+    { name = "selectolax", marker = "extra == 'digger'", specifier = ">=0.4.10" },
     { name = "slowapi", marker = "extra == 'api'", specifier = ">=0.1.9" },
     { name = "sse-starlette", marker = "extra == 'api'", specifier = ">=3.4.4" },
     { name = "structlog", specifier = ">=25.5.0" },
     { name = "structlog", marker = "extra == 'api'", specifier = ">=25.5.0" },
+    { name = "structlog", marker = "extra == 'digger'", specifier = ">=25.5.0" },
     { name = "structlog", marker = "extra == 'explore'", specifier = ">=25.5.0" },
     { name = "structlog", marker = "extra == 'mcp-server'", specifier = ">=25.5.0" },
     { name = "structlog", marker = "extra == 'schema-init'", specifier = ">=25.5.0" },
@@ -660,7 +678,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'insights'", specifier = ">=0.48.0" },
     { name = "websockets", marker = "extra == 'dashboard'", specifier = ">=16.0" },
 ]
-provides-extras = ["api", "dashboard", "brainzgraphinator", "graphinator", "insights", "tableinator", "brainztableinator", "dev", "utilities", "explore", "schema-init", "mcp-server", "all"]
+provides-extras = ["api", "dashboard", "brainzgraphinator", "graphinator", "insights", "tableinator", "brainztableinator", "dev", "utilities", "explore", "schema-init", "mcp-server", "digger", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Container build was producing a digger image whose venv was missing `structlog` (and other deps), causing `ModuleNotFoundError: No module named 'structlog'` at `python -m digger.main` time.
- Root cause: `digger/Dockerfile` used `uv sync --frozen --no-dev --package discogsography-digger`, which doesn't install the workspace member's dep closure the same way the rest of the services do with `--extra <service>`. There was also no `digger` entry in the root `[project.optional-dependencies]`.
- Aligned digger with the established repo pattern (matches graphinator/tableinator/explore/etc.):
  - Added `digger` to root `[project.optional-dependencies]` and to the `all` group.
  - Regenerated `uv.lock` to register the new extra.
  - Updated `digger/Dockerfile` to copy dep manifests first, run `uv sync --frozen --no-dev --extra digger`, then copy source.

## Test plan
- [x] `uv lock` resolves cleanly (159 packages).
- [x] `uv sync --frozen --no-dev --extra digger` against a clean workspace copy installs `structlog==25.5.0`, `bleach`, `httpx`, `selectolax`, `prometheus-client`, `redis`, `psycopg[binary]`.
- [ ] CI image build matrix produces a working digger image.
- [ ] `docker run …/digger` reaches health endpoint without import errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)