### PR TITLE
feat(api): Discogs OAuth callback flow (no more PIN copy/paste)

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -501,6 +501,7 @@ async def authorize_discogs(
             consumer_key=consumer_key,
             consumer_secret=consumer_secret,
             user_agent=_config.discogs_user_agent,
+            callback_url=_config.discogs_oauth_callback_url,
         )
     except DiscogsOAuthError as exc:
         logger.error("❌ Failed to get Discogs request token", error=str(exc))
@@ -518,13 +519,15 @@ async def authorize_discogs(
     await _redis.setex(redis_key, REDIS_OAUTH_STATE_TTL, state_data)
 
     authorize_url = f"{DISCOGS_AUTHORIZE_URL}?oauth_token={state}"
-    logger.info("🔐 Discogs OAuth flow started", user_id=current_user.get("sub"))
+    callback_mode = "callback" if _config.discogs_oauth_callback_url else "oob"
+    logger.info("🔐 Discogs OAuth flow started", user_id=current_user.get("sub"), callback_mode=callback_mode)
 
     return JSONResponse(
         content={
             "authorize_url": authorize_url,
             "state": state,
             "expires_in": REDIS_OAUTH_STATE_TTL,
+            "callback_mode": callback_mode,
         }
     )
 

--- a/api/services/discogs.py
+++ b/api/services/discogs.py
@@ -39,8 +39,17 @@ async def request_oauth_token(
     consumer_key: str,
     consumer_secret: str,
     user_agent: str,
+    callback_url: str | None = None,
 ) -> dict[str, str]:
     """Request an OAuth request token from Discogs.
+
+    Args:
+        consumer_key: Discogs app consumer key
+        consumer_secret: Discogs app consumer secret
+        user_agent: User-Agent string for Discogs API
+        callback_url: Public URL Discogs should redirect to after authorization.
+            When None, falls back to OAuth 1.0a "out-of-band" mode and Discogs
+            displays a verifier code for the user to copy back into the app.
 
     Returns:
         dict with 'oauth_token' and 'oauth_token_secret'
@@ -53,7 +62,7 @@ async def request_oauth_token(
     url = DISCOGS_REQUEST_TOKEN_URL
 
     oauth_params = {
-        "oauth_callback": "oob",
+        "oauth_callback": callback_url if callback_url else "oob",
         "oauth_consumer_key": consumer_key,
         "oauth_nonce": nonce,
         "oauth_signature_method": "HMAC-SHA1",

--- a/common/config.py
+++ b/common/config.py
@@ -540,6 +540,10 @@ class ApiConfig:
     jwt_algorithm: str = "HS256"
     jwt_expire_minutes: int = 30
     discogs_user_agent: str = "discogsography/1.0 +https://github.com/SimplicityGuy/discogsography"
+    # Public URL Discogs should redirect to after the user authorizes the app.
+    # When unset, the OAuth 1.0a "out-of-band" flow is used and the user has to
+    # paste a verifier code shown by Discogs back into the app.
+    discogs_oauth_callback_url: str | None = None
     cors_origins: list[str] | None = None
     snapshot_ttl_days: int = 28
     snapshot_max_nodes: int = 100
@@ -615,6 +619,7 @@ class ApiConfig:
             "DISCOGS_USER_AGENT",
             "discogsography/1.0 +https://github.com/SimplicityGuy/discogsography",
         )
+        discogs_oauth_callback_url = getenv("DISCOGS_OAUTH_CALLBACK_URL") or None
 
         cors_origins_env = getenv("CORS_ORIGINS")
         cors_origins = [o.strip() for o in cors_origins_env.split(",") if o.strip()] if cors_origins_env else None
@@ -660,6 +665,7 @@ class ApiConfig:
             jwt_algorithm=jwt_algorithm,
             jwt_expire_minutes=jwt_expire_minutes,
             discogs_user_agent=discogs_user_agent,
+            discogs_oauth_callback_url=discogs_oauth_callback_url,
             neo4j_host=_build_neo4j_uri(),
             neo4j_username=cast("str", neo4j_username),
             neo4j_password=cast("str", neo4j_password),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -317,11 +317,12 @@ REDIS_PASSWORD_FILE="/run/secrets/redis_password"
 
 ## JWT Configuration
 
-| Variable             | Description                         | Default | Required  |
-| -------------------- | ----------------------------------- | ------- | --------- |
-| `JWT_SECRET_KEY`     | HMAC-SHA256 signing secret          | (none)  | Yes (API) |
-| `JWT_EXPIRE_MINUTES` | Token lifetime in minutes           | `30`    | No        |
-| `DISCOGS_USER_AGENT` | User-Agent for Discogs API requests | (none)  | Yes (API) |
+| Variable                       | Description                                                       | Default | Required  |
+| ------------------------------ | ----------------------------------------------------------------- | ------- | --------- |
+| `JWT_SECRET_KEY`               | HMAC-SHA256 signing secret                                        | (none)  | Yes (API) |
+| `JWT_EXPIRE_MINUTES`           | Token lifetime in minutes                                         | `30`    | No        |
+| `DISCOGS_USER_AGENT`           | User-Agent for Discogs API requests                               | (none)  | Yes (API) |
+| `DISCOGS_OAUTH_CALLBACK_URL`   | Public callback URL Discogs redirects to after the user authorizes the app. When unset, the OAuth flow falls back to the out-of-band (OOB) mode where the user copy/pastes a verifier code into the app. When set, the value must exactly match the **Callback URL** field on your Discogs developer app settings page and point at `oauth-discogs-callback.html` on the Explore frontend (e.g. `https://your-host/oauth-discogs-callback.html`). | (none)  | No        |
 
 **Used By**: API
 
@@ -351,6 +352,12 @@ JWT_EXPIRE_MINUTES=1440   # 24 hours
 
 # Discogs User-Agent (required for Discogs API)
 DISCOGS_USER_AGENT="Discogsography/1.0 +https://github.com/SimplicityGuy/discogsography"
+
+# Optional — public Discogs OAuth callback URL. When set, end users no longer
+# have to copy/paste a verifier code; Discogs redirects directly back to the
+# app. The URL must also be registered as the "Callback URL" on the Discogs
+# developer app settings page.
+DISCOGS_OAUTH_CALLBACK_URL="https://your-host/oauth-discogs-callback.html"
 ```
 
 ## Logging Configuration

--- a/explore/__tests__/user-panes.test.js
+++ b/explore/__tests__/user-panes.test.js
@@ -807,8 +807,10 @@ describe('UserPanes', () => {
     });
 
     describe('startDiscogsOAuth', () => {
+        let modalsStore;
         beforeEach(() => {
-            globalThis.Alpine = { store: vi.fn().mockReturnValue({ discogsOpen: false }) };
+            modalsStore = { discogsOpen: false };
+            globalThis.Alpine = { store: vi.fn().mockReturnValue(modalsStore) };
         });
 
         it('should return early when no token', async () => {
@@ -819,7 +821,7 @@ describe('UserPanes', () => {
 
         it('should call authorizeDiscogs with token', async () => {
             window.apiClient.authorizeDiscogs.mockResolvedValue({
-                authorize_url: 'https://discogs.com/oauth', state: 'abc',
+                authorize_url: 'https://discogs.com/oauth', state: 'abc', callback_mode: 'oob',
             });
             const origOpen = window.open;
             window.open = vi.fn();
@@ -830,7 +832,7 @@ describe('UserPanes', () => {
 
         it('should store OAuth state', async () => {
             window.apiClient.authorizeDiscogs.mockResolvedValue({
-                authorize_url: 'https://discogs.com/oauth', state: 'test-state',
+                authorize_url: 'https://discogs.com/oauth', state: 'test-state', callback_mode: 'oob',
             });
             window.open = vi.fn();
             await userPanes.startDiscogsOAuth();
@@ -843,6 +845,86 @@ describe('UserPanes', () => {
             await userPanes.startDiscogsOAuth();
             expect(window.alert).toHaveBeenCalled();
             expect(userPanes._discogsOAuthState).toBeNull();
+        });
+
+        it('should open the OOB modal when callback_mode is "oob"', async () => {
+            window.apiClient.authorizeDiscogs.mockResolvedValue({
+                authorize_url: 'https://discogs.com/oauth', state: 'abc', callback_mode: 'oob',
+            });
+            window.open = vi.fn();
+            await userPanes.startDiscogsOAuth();
+            expect(modalsStore.discogsOpen).toBe(true);
+        });
+
+        it('should NOT open the OOB modal when callback_mode is "callback"', async () => {
+            window.apiClient.authorizeDiscogs.mockResolvedValue({
+                authorize_url: 'https://discogs.com/oauth', state: 'abc', callback_mode: 'callback',
+            });
+            window.open = vi.fn();
+            await userPanes.startDiscogsOAuth();
+            expect(modalsStore.discogsOpen).toBe(false);
+        });
+
+        it('should auto-verify when the callback popup posts a discogs-oauth message', async () => {
+            window.apiClient.authorizeDiscogs.mockResolvedValue({
+                authorize_url: 'https://discogs.com/oauth', state: 'cb-state', callback_mode: 'callback',
+            });
+            const popup = { closed: false, close: vi.fn() };
+            window.open = vi.fn().mockReturnValue(popup);
+            window.apiClient.verifyDiscogs.mockResolvedValue({ connected: true });
+            window.apiClient.getDiscogsStatus.mockResolvedValue({ connected: true });
+
+            await userPanes.startDiscogsOAuth();
+
+            window.dispatchEvent(new MessageEvent('message', {
+                data: { type: 'discogs-oauth', oauth_token: 'cb-state', oauth_verifier: 'cb-verifier' },
+                origin: window.location.origin,
+                source: popup,
+            }));
+
+            // Allow microtask queue to flush the awaited verify call
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(window.apiClient.verifyDiscogs).toHaveBeenCalledWith('test-token', 'cb-state', 'cb-verifier');
+            expect(window.authManager.setDiscogsStatus).toHaveBeenCalledWith({ connected: true });
+        });
+
+        it('should ignore messages from a foreign origin', async () => {
+            window.apiClient.authorizeDiscogs.mockResolvedValue({
+                authorize_url: 'https://discogs.com/oauth', state: 's', callback_mode: 'callback',
+            });
+            const popup = { closed: false, close: vi.fn() };
+            window.open = vi.fn().mockReturnValue(popup);
+
+            await userPanes.startDiscogsOAuth();
+
+            window.dispatchEvent(new MessageEvent('message', {
+                data: { type: 'discogs-oauth', oauth_token: 'x', oauth_verifier: 'y' },
+                origin: 'https://evil.example',
+                source: popup,
+            }));
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(window.apiClient.verifyDiscogs).not.toHaveBeenCalled();
+        });
+
+        it('should ignore messages of the wrong shape', async () => {
+            window.apiClient.authorizeDiscogs.mockResolvedValue({
+                authorize_url: 'https://discogs.com/oauth', state: 's', callback_mode: 'callback',
+            });
+            const popup = { closed: false, close: vi.fn() };
+            window.open = vi.fn().mockReturnValue(popup);
+
+            await userPanes.startDiscogsOAuth();
+
+            window.dispatchEvent(new MessageEvent('message', {
+                data: { type: 'other-thing', payload: 'noise' },
+                origin: window.location.origin,
+                source: popup,
+            }));
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(window.apiClient.verifyDiscogs).not.toHaveBeenCalled();
         });
     });
 

--- a/explore/__tests__/user-panes.test.js
+++ b/explore/__tests__/user-panes.test.js
@@ -926,6 +926,209 @@ describe('UserPanes', () => {
 
             expect(window.apiClient.verifyDiscogs).not.toHaveBeenCalled();
         });
+
+        it('should ignore null data on a message event', async () => {
+            window.apiClient.authorizeDiscogs.mockResolvedValue({
+                authorize_url: 'https://discogs.com/oauth', state: 's', callback_mode: 'callback',
+            });
+            const popup = { closed: false, close: vi.fn() };
+            window.open = vi.fn().mockReturnValue(popup);
+
+            await userPanes.startDiscogsOAuth();
+
+            window.dispatchEvent(new MessageEvent('message', {
+                data: null,
+                origin: window.location.origin,
+                source: popup,
+            }));
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(window.apiClient.verifyDiscogs).not.toHaveBeenCalled();
+        });
+
+        it('should ignore messages from a foreign window source', async () => {
+            window.apiClient.authorizeDiscogs.mockResolvedValue({
+                authorize_url: 'https://discogs.com/oauth', state: 's', callback_mode: 'callback',
+            });
+            const popup = { closed: false, close: vi.fn() };
+            const otherWindow = { closed: false, close: vi.fn() };
+            window.open = vi.fn().mockReturnValue(popup);
+
+            await userPanes.startDiscogsOAuth();
+
+            window.dispatchEvent(new MessageEvent('message', {
+                data: { type: 'discogs-oauth', oauth_token: 's', oauth_verifier: 'v' },
+                origin: window.location.origin,
+                source: otherWindow,
+            }));
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(window.apiClient.verifyDiscogs).not.toHaveBeenCalled();
+        });
+
+        it('should alert and clear state when the popup reports "denied"', async () => {
+            window.apiClient.authorizeDiscogs.mockResolvedValue({
+                authorize_url: 'https://discogs.com/oauth', state: 's', callback_mode: 'callback',
+            });
+            const popup = { closed: false, close: vi.fn() };
+            window.open = vi.fn().mockReturnValue(popup);
+            window.alert = vi.fn();
+
+            await userPanes.startDiscogsOAuth();
+
+            window.dispatchEvent(new MessageEvent('message', {
+                data: { type: 'discogs-oauth', error: 'denied' },
+                origin: window.location.origin,
+                source: popup,
+            }));
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(window.alert).toHaveBeenCalledWith(expect.stringMatching(/cancelled/i));
+            expect(userPanes._discogsOAuthState).toBeNull();
+            expect(window.apiClient.verifyDiscogs).not.toHaveBeenCalled();
+        });
+
+        it('should alert and clear state on a non-denied error from the popup', async () => {
+            window.apiClient.authorizeDiscogs.mockResolvedValue({
+                authorize_url: 'https://discogs.com/oauth', state: 's', callback_mode: 'callback',
+            });
+            const popup = { closed: false, close: vi.fn() };
+            window.open = vi.fn().mockReturnValue(popup);
+            window.alert = vi.fn();
+
+            await userPanes.startDiscogsOAuth();
+
+            window.dispatchEvent(new MessageEvent('message', {
+                data: { type: 'discogs-oauth', error: 'missing-params' },
+                origin: window.location.origin,
+                source: popup,
+            }));
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(window.alert).toHaveBeenCalledWith(expect.stringMatching(/failed/i));
+            expect(userPanes._discogsOAuthState).toBeNull();
+        });
+
+        it('should bail without verifying when the message oauth_token does not match stored state', async () => {
+            window.apiClient.authorizeDiscogs.mockResolvedValue({
+                authorize_url: 'https://discogs.com/oauth', state: 'expected-state', callback_mode: 'callback',
+            });
+            const popup = { closed: false, close: vi.fn() };
+            window.open = vi.fn().mockReturnValue(popup);
+
+            await userPanes.startDiscogsOAuth();
+
+            window.dispatchEvent(new MessageEvent('message', {
+                data: { type: 'discogs-oauth', oauth_token: 'mismatched-state', oauth_verifier: 'v' },
+                origin: window.location.origin,
+                source: popup,
+            }));
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(window.apiClient.verifyDiscogs).not.toHaveBeenCalled();
+            expect(userPanes._discogsOAuthState).toBeNull();
+        });
+
+        it('should bail without verifying when the user is no longer authenticated', async () => {
+            window.apiClient.authorizeDiscogs.mockResolvedValue({
+                authorize_url: 'https://discogs.com/oauth', state: 's', callback_mode: 'callback',
+            });
+            const popup = { closed: false, close: vi.fn() };
+            window.open = vi.fn().mockReturnValue(popup);
+
+            await userPanes.startDiscogsOAuth();
+
+            // Token disappears between popup open and message arrival
+            window.authManager.getToken.mockReturnValue(null);
+
+            window.dispatchEvent(new MessageEvent('message', {
+                data: { type: 'discogs-oauth', oauth_token: 's', oauth_verifier: 'v' },
+                origin: window.location.origin,
+                source: popup,
+            }));
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(window.apiClient.verifyDiscogs).not.toHaveBeenCalled();
+            expect(userPanes._discogsOAuthState).toBeNull();
+        });
+
+        it('should alert when the verify call returns not-connected', async () => {
+            window.apiClient.authorizeDiscogs.mockResolvedValue({
+                authorize_url: 'https://discogs.com/oauth', state: 's', callback_mode: 'callback',
+            });
+            const popup = { closed: false, close: vi.fn() };
+            window.open = vi.fn().mockReturnValue(popup);
+            window.alert = vi.fn();
+            window.apiClient.verifyDiscogs.mockResolvedValue({ connected: false });
+
+            await userPanes.startDiscogsOAuth();
+
+            window.dispatchEvent(new MessageEvent('message', {
+                data: { type: 'discogs-oauth', oauth_token: 's', oauth_verifier: 'v' },
+                origin: window.location.origin,
+                source: popup,
+            }));
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(window.apiClient.verifyDiscogs).toHaveBeenCalled();
+            expect(window.alert).toHaveBeenCalledWith(expect.stringMatching(/failed/i));
+            expect(userPanes._discogsOAuthState).toBeNull();
+            expect(window.authManager.setDiscogsStatus).not.toHaveBeenCalled();
+        });
+
+        it('should alert when the verify call returns null', async () => {
+            window.apiClient.authorizeDiscogs.mockResolvedValue({
+                authorize_url: 'https://discogs.com/oauth', state: 's', callback_mode: 'callback',
+            });
+            const popup = { closed: false, close: vi.fn() };
+            window.open = vi.fn().mockReturnValue(popup);
+            window.alert = vi.fn();
+            window.apiClient.verifyDiscogs.mockResolvedValue(null);
+
+            await userPanes.startDiscogsOAuth();
+
+            window.dispatchEvent(new MessageEvent('message', {
+                data: { type: 'discogs-oauth', oauth_token: 's', oauth_verifier: 'v' },
+                origin: window.location.origin,
+                source: popup,
+            }));
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(window.alert).toHaveBeenCalledWith(expect.stringMatching(/failed/i));
+            expect(userPanes._discogsOAuthState).toBeNull();
+        });
+
+        it('should tear down the previous listener when called twice in a row', async () => {
+            window.apiClient.authorizeDiscogs.mockResolvedValue({
+                authorize_url: 'https://discogs.com/oauth', state: 'state-a', callback_mode: 'callback',
+            });
+            const popupA = { closed: false, close: vi.fn() };
+            window.open = vi.fn().mockReturnValue(popupA);
+
+            await userPanes.startDiscogsOAuth();
+
+            // Second click — new state, new popup. The first listener must be removed so
+            // a stray late-arriving message from popupA cannot verify against state-a anymore.
+            window.apiClient.authorizeDiscogs.mockResolvedValue({
+                authorize_url: 'https://discogs.com/oauth', state: 'state-b', callback_mode: 'callback',
+            });
+            const popupB = { closed: false, close: vi.fn() };
+            window.open = vi.fn().mockReturnValue(popupB);
+
+            await userPanes.startDiscogsOAuth();
+
+            // Stray message from the first popup should be ignored by the new (only) listener
+            // because event.source !== popupB.
+            window.dispatchEvent(new MessageEvent('message', {
+                data: { type: 'discogs-oauth', oauth_token: 'state-a', oauth_verifier: 'v' },
+                origin: window.location.origin,
+                source: popupA,
+            }));
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(window.apiClient.verifyDiscogs).not.toHaveBeenCalled();
+            expect(userPanes._discogsOAuthState).toBe('state-b');
+        });
     });
 
     describe('submitDiscogsVerifier', () => {

--- a/explore/static/js/user-panes.js
+++ b/explore/static/js/user-panes.js
@@ -292,11 +292,70 @@ class UserPanes {
 
         this._discogsOAuthState = data.state;
 
-        // Open Discogs auth page in a new tab
-        window.open(data.authorize_url, '_blank', 'noopener,noreferrer');
+        // When the server has a public callback registered, Discogs will redirect
+        // the user back to our /oauth-discogs-callback.html page, which posts the
+        // verifier code to us via window.postMessage. Otherwise we fall back to
+        // the OOB modal where the user pastes the code by hand.
+        const useCallback = data.callback_mode === 'callback';
 
-        // Show verifier modal
-        Alpine.store('modals').discogsOpen = true;
+        const popup = window.open(
+            data.authorize_url,
+            useCallback ? 'discogsOAuth' : '_blank',
+            useCallback ? 'popup=yes,width=720,height=820' : 'noopener,noreferrer',
+        );
+
+        if (useCallback) {
+            this._registerDiscogsOAuthMessageListener(popup);
+        } else {
+            Alpine.store('modals').discogsOpen = true;
+        }
+    }
+
+    _registerDiscogsOAuthMessageListener(popup) {
+        // Tear down any previous listener so repeated attempts don't stack up
+        if (this._discogsOAuthMessageHandler) {
+            window.removeEventListener('message', this._discogsOAuthMessageHandler);
+            this._discogsOAuthMessageHandler = null;
+        }
+
+        const handler = async (event) => {
+            if (event.origin !== window.location.origin) return;
+            if (popup && event.source && event.source !== popup) return;
+            const data = event.data;
+            if (!data || data.type !== 'discogs-oauth') return;
+
+            window.removeEventListener('message', handler);
+            this._discogsOAuthMessageHandler = null;
+
+            if (data.error) {
+                this._discogsOAuthState = null;
+                alert(data.error === 'denied'
+                    ? 'Discogs authorization was cancelled.'
+                    : 'Discogs authorization failed. Please try again.');
+                return;
+            }
+
+            const token = window.authManager.getToken();
+            if (!token || data.oauth_token !== this._discogsOAuthState) {
+                this._discogsOAuthState = null;
+                return;
+            }
+
+            const result = await window.apiClient.verifyDiscogs(token, data.oauth_token, data.oauth_verifier);
+            if (!result || !result.connected) {
+                this._discogsOAuthState = null;
+                alert('Discogs verification failed. Please try again.');
+                return;
+            }
+
+            const status = await window.apiClient.getDiscogsStatus(token);
+            window.authManager.setDiscogsStatus(status);
+            this._discogsOAuthState = null;
+            window.authManager.notify();
+        };
+
+        this._discogsOAuthMessageHandler = handler;
+        window.addEventListener('message', handler);
     }
 
     async submitDiscogsVerifier() {

--- a/explore/static/oauth-discogs-callback.html
+++ b/explore/static/oauth-discogs-callback.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="referrer" content="no-referrer">
+    <title>Connecting Discogs…</title>
+    <link href="tailwind.css" rel="stylesheet">
+</head>
+<body class="bg-bg-base text-text-high flex h-screen items-center justify-center">
+    <main class="text-center px-6">
+        <h1 class="text-xl font-semibold mb-2">Connecting your Discogs account…</h1>
+        <p id="status" class="text-text-mid">You can close this window if it doesn't close automatically.</p>
+    </main>
+    <script>
+        (function () {
+            'use strict';
+
+            const params = new URLSearchParams(window.location.search);
+            const oauthToken = params.get('oauth_token');
+            const oauthVerifier = params.get('oauth_verifier');
+            const denied = params.get('denied') === 'true';
+            const statusEl = document.getElementById('status');
+
+            function reportToOpener(payload) {
+                if (!window.opener || window.opener.closed) {
+                    statusEl.textContent = 'No parent window found. Please return to Discogsography and try again.';
+                    return false;
+                }
+                try {
+                    window.opener.postMessage(payload, window.location.origin);
+                    return true;
+                } catch (err) {
+                    statusEl.textContent = 'Could not communicate with the main window.';
+                    return false;
+                }
+            }
+
+            if (denied) {
+                reportToOpener({ type: 'discogs-oauth', error: 'denied' });
+                window.close();
+                return;
+            }
+
+            if (!oauthToken || !oauthVerifier) {
+                statusEl.textContent = 'Missing oauth_token or oauth_verifier in the callback URL.';
+                reportToOpener({ type: 'discogs-oauth', error: 'missing-params' });
+                return;
+            }
+
+            if (reportToOpener({ type: 'discogs-oauth', oauth_token: oauthToken, oauth_verifier: oauthVerifier })) {
+                window.close();
+            }
+        }());
+    </script>
+</body>
+</html>

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -472,6 +472,97 @@ class TestDiscogsOAuthEndpoints:
 
         assert response.status_code == 502
 
+    def test_authorize_discogs_passes_configured_callback_url(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,  # noqa: ARG002
+        auth_headers: dict[str, str],
+    ) -> None:
+        """When DISCOGS_OAUTH_CALLBACK_URL is set, the endpoint forwards it to request_oauth_token."""
+        import dataclasses
+
+        import api.api as api_module
+
+        mock_cur.fetchall.return_value = [
+            {"key": "discogs_consumer_key", "value": "consumer_key_value"},
+            {"key": "discogs_consumer_secret", "value": "consumer_secret_value"},
+        ]
+
+        callback = "https://example.com/oauth-discogs-callback.html"
+        original_config = api_module._config
+        api_module._config = dataclasses.replace(api_module._config, discogs_oauth_callback_url=callback)
+
+        mock_request = AsyncMock(return_value={"oauth_token": "reqtok", "oauth_token_secret": "reqsec"})
+        try:
+            with patch("api.api.request_oauth_token", new=mock_request):
+                response = test_client.get("/api/oauth/authorize/discogs", headers=auth_headers)
+        finally:
+            api_module._config = original_config
+
+        assert response.status_code == 200
+        assert mock_request.await_args.kwargs.get("callback_url") == callback
+
+    def test_authorize_discogs_omits_callback_when_unset(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,  # noqa: ARG002
+        auth_headers: dict[str, str],
+    ) -> None:
+        """When DISCOGS_OAUTH_CALLBACK_URL is None, the OOB fallback (callback_url=None) is used."""
+        mock_cur.fetchall.return_value = [
+            {"key": "discogs_consumer_key", "value": "consumer_key_value"},
+            {"key": "discogs_consumer_secret", "value": "consumer_secret_value"},
+        ]
+
+        mock_request = AsyncMock(return_value={"oauth_token": "reqtok", "oauth_token_secret": "reqsec"})
+        with patch("api.api.request_oauth_token", new=mock_request):
+            response = test_client.get("/api/oauth/authorize/discogs", headers=auth_headers)
+
+        assert response.status_code == 200
+        assert mock_request.await_args.kwargs.get("callback_url") is None
+
+    def test_authorize_discogs_response_signals_callback_mode(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,  # noqa: ARG002
+        auth_headers: dict[str, str],
+    ) -> None:
+        """The authorize response includes callback_mode so the frontend knows which flow to use."""
+        import dataclasses
+
+        import api.api as api_module
+
+        mock_cur.fetchall.return_value = [
+            {"key": "discogs_consumer_key", "value": "ckey"},
+            {"key": "discogs_consumer_secret", "value": "csecret"},
+        ]
+
+        # With callback URL configured → "callback" mode
+        original_config = api_module._config
+        api_module._config = dataclasses.replace(api_module._config, discogs_oauth_callback_url="https://example.com/cb.html")
+        try:
+            with patch(
+                "api.api.request_oauth_token",
+                new=AsyncMock(return_value={"oauth_token": "reqtok", "oauth_token_secret": "reqsec"}),
+            ):
+                response = test_client.get("/api/oauth/authorize/discogs", headers=auth_headers)
+            assert response.status_code == 200
+            assert response.json()["callback_mode"] == "callback"
+        finally:
+            api_module._config = original_config
+
+        # Without callback URL → "oob" mode
+        with patch(
+            "api.api.request_oauth_token",
+            new=AsyncMock(return_value={"oauth_token": "reqtok2", "oauth_token_secret": "reqsec2"}),
+        ):
+            response = test_client.get("/api/oauth/authorize/discogs", headers=auth_headers)
+        assert response.status_code == 200
+        assert response.json()["callback_mode"] == "oob"
+
     def test_verify_discogs_success(
         self,
         test_client: TestClient,

--- a/tests/api/test_discogs_service.py
+++ b/tests/api/test_discogs_service.py
@@ -190,6 +190,59 @@ class TestRequestOauthToken:
         ):
             await request_oauth_token("ckey", "csecret", "TestAgent/1.0")
 
+    @pytest.mark.asyncio
+    async def test_default_callback_is_oob(self) -> None:
+        """When no callback_url is supplied, oauth_callback must default to 'oob'."""
+        response_text = "oauth_token=reqtok&oauth_token_secret=reqsec&oauth_callback_confirmed=true"
+        mock_client, _ = _make_mock_httpx_client(200, response_text)
+
+        with patch("api.services.discogs.httpx.AsyncClient", return_value=mock_client):
+            await request_oauth_token("ckey", "csecret", "TestAgent/1.0")
+
+        auth_header = mock_client.get.call_args.kwargs["headers"]["Authorization"]
+        assert 'oauth_callback="oob"' in auth_header
+
+    @pytest.mark.asyncio
+    async def test_explicit_callback_url_used(self) -> None:
+        """When a callback_url is supplied, it must be percent-encoded into oauth_callback."""
+        response_text = "oauth_token=reqtok&oauth_token_secret=reqsec&oauth_callback_confirmed=true"
+        mock_client, _ = _make_mock_httpx_client(200, response_text)
+        callback_url = "https://example.com/oauth-discogs-callback.html"
+
+        with patch("api.services.discogs.httpx.AsyncClient", return_value=mock_client):
+            await request_oauth_token("ckey", "csecret", "TestAgent/1.0", callback_url=callback_url)
+
+        auth_header = mock_client.get.call_args.kwargs["headers"]["Authorization"]
+        # Percent-encoded value of the URL appears in the OAuth header
+        encoded = "https%3A%2F%2Fexample.com%2Foauth-discogs-callback.html"
+        assert f'oauth_callback="{encoded}"' in auth_header
+        # And the literal "oob" is NOT present as the callback value
+        assert 'oauth_callback="oob"' not in auth_header
+
+    @pytest.mark.asyncio
+    async def test_callback_url_changes_signature(self) -> None:
+        """oauth_callback is part of the signature base string, so the signature must differ."""
+        response_text = "oauth_token=reqtok&oauth_token_secret=reqsec&oauth_callback_confirmed=true"
+
+        sigs: list[str] = []
+        for callback in (None, "https://example.com/cb"):
+            mock_client, _ = _make_mock_httpx_client(200, response_text)
+            # Pin nonce + timestamp so that the only varying input is oauth_callback
+            with (
+                patch("api.services.discogs.os.urandom", return_value=b"\x00" * 16),
+                patch("api.services.discogs.time.time", return_value=1_700_000_000),
+                patch("api.services.discogs.httpx.AsyncClient", return_value=mock_client),
+            ):
+                await request_oauth_token("ckey", "csecret", "TestAgent/1.0", callback_url=callback)
+            header = mock_client.get.call_args.kwargs["headers"]["Authorization"]
+            # Extract oauth_signature="..." value
+            marker = 'oauth_signature="'
+            start = header.index(marker) + len(marker)
+            end = header.index('"', start)
+            sigs.append(header[start:end])
+
+        assert sigs[0] != sigs[1], "Signature must change when oauth_callback changes"
+
 
 class TestExchangeOauthVerifier:
     """Tests for exchange_oauth_verifier."""

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -533,6 +533,39 @@ class TestApiConfig:
         assert config.jwt_expire_minutes == 60
         assert config.discogs_user_agent == "CustomAgent/2.0"
 
+    def test_discogs_oauth_callback_url_defaults_to_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When DISCOGS_OAUTH_CALLBACK_URL is unset, the field is None (OOB fallback)."""
+        from common.config import ApiConfig
+
+        monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+        monkeypatch.delenv("DISCOGS_OAUTH_CALLBACK_URL", raising=False)
+
+        config = ApiConfig.from_env()
+
+        assert config.discogs_oauth_callback_url is None
+
+    def test_discogs_oauth_callback_url_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """DISCOGS_OAUTH_CALLBACK_URL is read into the config."""
+        from common.config import ApiConfig
+
+        monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+        monkeypatch.setenv("DISCOGS_OAUTH_CALLBACK_URL", "https://example.com/oauth-discogs-callback.html")
+
+        config = ApiConfig.from_env()
+
+        assert config.discogs_oauth_callback_url == "https://example.com/oauth-discogs-callback.html"
+
+    def test_discogs_oauth_callback_url_empty_string_treated_as_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An empty DISCOGS_OAUTH_CALLBACK_URL collapses to None, preserving OOB fallback."""
+        from common.config import ApiConfig
+
+        monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+        monkeypatch.setenv("DISCOGS_OAUTH_CALLBACK_URL", "")
+
+        config = ApiConfig.from_env()
+
+        assert config.discogs_oauth_callback_url is None
+
     def test_redis_password_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """REDIS_PASSWORD is embedded in the redis_host URL for authenticated Redis."""
         from common.config import ApiConfig


### PR DESCRIPTION
## Summary

Add an alternative Discogs OAuth flow that uses a real callback URL instead of the OAuth 1.0a out-of-band (OOB) mode, eliminating the \"copy this PIN from Discogs\" step that's currently shown to every user.

When the new \`DISCOGS_OAUTH_CALLBACK_URL\` env var is set and matches the **Callback URL** field on the Discogs developer app settings page, the flow becomes:

1. User clicks Connect Discogs → backend asks Discogs for a request token with that callback URL.
2. Popup opens to Discogs → user clicks Authorize.
3. Discogs redirects the popup back to \`/oauth-discogs-callback.html\` (new static page) with \`oauth_token\` + \`oauth_verifier\`.
4. The callback page \`postMessage\`s those values to the opener and closes itself.
5. The opener validates origin + source, calls \`/api/oauth/verify/discogs\`, and updates status.

When \`DISCOGS_OAUTH_CALLBACK_URL\` is **unset**, behavior is unchanged: the existing OOB modal still works as a fallback for self-hosters with no public HTTPS host. The authorize endpoint now returns a \`callback_mode\` field (\`\"callback\"\` or \`\"oob\"\`) so the frontend branches deterministically.

## Changes

- \`common/config.py\` — new \`discogs_oauth_callback_url: str \| None\` (env: \`DISCOGS_OAUTH_CALLBACK_URL\`), empty string treated as unset.
- \`api/services/discogs.py\` — \`request_oauth_token\` accepts \`callback_url\`, falls back to \`\"oob\"\` when \`None\`.
- \`api/api.py\` — \`/api/oauth/authorize/discogs\` forwards the configured URL and returns \`callback_mode\` in the response.
- \`explore/static/oauth-discogs-callback.html\` — new minimal page that posts \`{type:'discogs-oauth', oauth_token, oauth_verifier}\` to its opener with strict origin/source validation. Handles denied + missing-params edge cases.
- \`explore/static/js/user-panes.js\` — \`startDiscogsOAuth\` branches on \`callback_mode\`; in callback mode it registers a one-shot \`message\` listener that validates \`event.origin === location.origin\`, \`event.source === popup\`, and \`data.type === 'discogs-oauth'\` before completing the flow.
- \`docs/configuration.md\` — documents the new env var + Discogs app registration requirement.

## Test plan

- [x] \`just test\` — 3592 passed, 20 skipped (live-stack only)
- [x] \`just test-js\` — 1288 passed (31 files)
- [x] \`uv run ruff check\` / \`uv run ruff format --check\` — clean
- [x] \`uv run mypy api/services/discogs.py api/api.py common/config.py\` — clean
- New service tests cover: OOB default preserved, explicit callback URL appears percent-encoded in OAuth header, oauth_callback inclusion changes the signature.
- New endpoint tests cover: configured callback forwarded to \`request_oauth_token\`, omitted when unset, response \`callback_mode\` returns the right value in both modes.
- New JS tests cover: OOB mode opens the modal, callback mode does **not** open the modal, popup-message handler verifies on valid postMessage, ignores foreign-origin messages, ignores wrong-shape messages.
- [ ] Manual: register a callback URL on the Discogs developer app, set \`DISCOGS_OAUTH_CALLBACK_URL\` to the matching public URL, and confirm a real Discogs connection completes without the PIN prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)