### PR TITLE
fix(insights): stop implausible release years (e.g. year 400) at the source

### DIFF
--- a/common/data_normalizer.py
+++ b/common/data_normalizer.py
@@ -6,6 +6,7 @@ only consumer-side concerns: year parsing and the normalize_record() entry
 point that consumers call.
 """
 
+from datetime import UTC, datetime
 from typing import Any
 
 import structlog
@@ -13,31 +14,49 @@ import structlog
 
 logger = structlog.get_logger(__name__)
 
+#: Earliest plausible release year.  Sound recording predates this only
+#: marginally (Scott de Martinville's phonautograms, 1857), so anything
+#: earlier is a data error — typos, sentinels, or mis-parsed dates.
+#: Must stay in sync with the year bounds in ``extractor/extraction-rules.yaml``.
+MIN_RELEASE_YEAR = 1860
+
+
+def _max_release_year() -> int:
+    """Latest plausible release year: next calendar year (allows pre-orders/announcements)."""
+    return datetime.now(UTC).year + 1
+
 
 def _parse_year_int(value: Any) -> int | None:
-    """Parse a Discogs year value into an integer.
+    """Parse a Discogs year value into a *plausible* integer year.
 
     Handles both plain year strings ("1969", as used in Master.<year>) and
     full/partial date strings ("1969-09-26", "1969-00-00", as used in
-    Release.<released>).  Returns None when no valid year is found.
+    Release.<released>).  Returns None when no valid year is found **or** when
+    the year falls outside ``[MIN_RELEASE_YEAR, current_year + 1]``.
 
-    Note: The extractor's ``nullify_when`` filter now converts sentinel years
-    (year < 1860, including 0) to null before messages reach consumers.  The
-    ``year == 0`` check below is a defensive fallback for extractions run
-    without the updated rules config.
+    This is the authoritative year gate for releases.  The extractor's
+    ``nullify_when`` / ``year-out-of-range`` rules key on a record's ``year``
+    field, but a Discogs *release* carries its date in ``released`` (a date
+    string) and has no ``year`` field at extraction time — so those rules are
+    no-ops for releases.  Release (and master) years are derived here, so the
+    plausibility bound must be enforced here too; otherwise dates like
+    ``"0400-01-01"`` leak into the graph as year 400.
     """
     if value is None:
         return None
     if isinstance(value, int):
-        return value if value != 0 else None
-    s = str(value).strip()
-    if not s:
-        return None
-    try:
-        year = int(s[:4])
-        return year if year != 0 else None
-    except ValueError:
-        return None
+        year = value
+    else:
+        s = str(value).strip()
+        if not s:
+            return None
+        try:
+            year = int(s[:4])
+        except ValueError:
+            return None
+    if MIN_RELEASE_YEAR <= year <= _max_release_year():
+        return year
+    return None
 
 
 def normalize_record(data_type: str, data: dict[str, Any]) -> dict[str, Any]:

--- a/extractor/extraction-rules.yaml
+++ b/extractor/extraction-rules.yaml
@@ -27,15 +27,24 @@ filters:
     - field: genres.genre
       remove_matching: "^\\d+$"
       reason: "Strip legacy numeric genre IDs from upstream data"
-    # NOTE: A Discogs *release* has no `year` field at extraction — its date
-    # lives in `released` (a date string like "1969-09-26"). This `year` filter
-    # is therefore a no-op for releases; the release year is derived and bounded
-    # consumer-side in common/data_normalizer.py (_parse_year_int). Kept for
-    # parity/robustness in case upstream ever emits a release `year`.
+    # A Discogs *release* has no `year` field at extraction — its date lives in
+    # `released` (a date string like "1969-09-26"). The nullify_when range filter
+    # parses the leading year out of such date strings, so an implausible date
+    # like "0400-01-01" is nullified here, at the extractor, before it reaches
+    # any consumer. (data_normalizer._parse_year_int re-checks the bound as a
+    # defensive backstop.)
+    - field: released
+      nullify_when:
+        type: range
+        below: 1860
+        above: 2027
+      reason: "Treat sentinel and implausible release dates as unknown"
+    # Kept for robustness in case upstream ever emits a release `year` field.
     - field: year
       nullify_when:
         type: range
         below: 1860
+        above: 2027
       reason: "Treat sentinel and implausible years as unknown"
   masters:
     - field: genres.genre
@@ -45,6 +54,7 @@ filters:
       nullify_when:
         type: range
         below: 1860
+        above: 2027
       reason: "Treat sentinel and implausible years as unknown"
 
 rules:

--- a/extractor/extraction-rules.yaml
+++ b/extractor/extraction-rules.yaml
@@ -27,6 +27,11 @@ filters:
     - field: genres.genre
       remove_matching: "^\\d+$"
       reason: "Strip legacy numeric genre IDs from upstream data"
+    # NOTE: A Discogs *release* has no `year` field at extraction — its date
+    # lives in `released` (a date string like "1969-09-26"). This `year` filter
+    # is therefore a no-op for releases; the release year is derived and bounded
+    # consumer-side in common/data_normalizer.py (_parse_year_int). Kept for
+    # parity/robustness in case upstream ever emits a release `year`.
     - field: year
       nullify_when:
         type: range

--- a/extractor/src/rules.rs
+++ b/extractor/src/rules.rs
@@ -385,6 +385,22 @@ pub struct FilterAction {
     pub reason: String,
 }
 
+/// Extract a numeric year from a date-like string for range comparison.
+///
+/// `nullify_when` range filters compare numerically, but a Discogs *release*
+/// stores its date in `released` as a string like `"1969-09-26"` (or the
+/// implausible `"0400-01-01"`). Such values don't parse as a single number, so
+/// callers fall back to this — the leading date component (the year) — so the
+/// year-range filter can catch bad release dates the same way it catches bad
+/// master years.
+fn parse_leading_year(value: &str) -> Option<f64> {
+    let token = value.split(['-', '/', '.', ' ', 'T']).next()?.trim();
+    if token.is_empty() {
+        return None;
+    }
+    token.parse::<f64>().ok()
+}
+
 pub fn apply_filters(config: &CompiledRulesConfig, data_type: &str, record: &mut Value) -> Vec<FilterAction> {
     let conditions = config.filters_for(data_type);
     let mut actions = Vec::new();
@@ -450,14 +466,18 @@ pub fn apply_filters(config: &CompiledRulesConfig, data_type: &str, record: &mut
                     Value::Null => continue, // already null — no action
                     _ => continue,
                 };
-                if let Ok(num) = str_val.parse::<f64>() {
+                // Compare numerically. A plain number ("1969") parses directly;
+                // a date string ("1969-09-26", "0400-01-01") falls back to its
+                // leading year component so date fields like `released` can be
+                // range-checked too.
+                if let Some(num) = str_val.parse::<f64>().ok().or_else(|| parse_leading_year(&str_val)) {
                     let should_nullify = below.is_some_and(|b| num < b) || above.is_some_and(|a| num > a);
                     if should_nullify {
                         obj.insert(field.clone(), Value::Null);
                         actions.push(FilterAction { field: field.clone(), removed_count: 1, removed_values: vec![str_val], reason: reason.clone() });
                     }
                 }
-                // Non-numeric string: leave unchanged
+                // Non-numeric, non-date string: leave unchanged
             }
         }
     }

--- a/extractor/src/tests/rules_tests.rs
+++ b/extractor/src/tests/rules_tests.rs
@@ -1547,6 +1547,51 @@ rules: {}
 }
 
 #[test]
+fn test_nullify_when_released_date_string_year_out_of_range() {
+    // A Discogs release stores its date in `released` (a date string), not `year`.
+    // The range filter must parse the leading year out of the date so implausible
+    // release dates are nullified at the extractor.
+    let config = compile_yaml(
+        r#"
+filters:
+  releases:
+    - field: released
+      nullify_when:
+        type: range
+        below: 1860
+        above: 2027
+      reason: "Implausible release date"
+rules: {}
+"#,
+    );
+
+    // Antiquity date -> null (this is the bug: "0400-01-01" was stored as year 400)
+    let mut record = json!({"released": "0400-01-01", "title": "Test"});
+    let actions = apply_filters(&config, "releases", &mut record);
+    assert_eq!(record["released"], json!(null));
+    assert_eq!(actions.len(), 1);
+    assert_eq!(actions[0].removed_values, vec!["0400-01-01"]);
+
+    // Far-future date -> null
+    let mut record2 = json!({"released": "9999-12-31", "title": "Test"});
+    let actions2 = apply_filters(&config, "releases", &mut record2);
+    assert_eq!(record2["released"], json!(null));
+    assert_eq!(actions2.len(), 1);
+
+    // Plausible full date -> preserved
+    let mut record3 = json!({"released": "1969-09-26", "title": "Test"});
+    let actions3 = apply_filters(&config, "releases", &mut record3);
+    assert_eq!(record3["released"], json!("1969-09-26"));
+    assert!(actions3.is_empty());
+
+    // Partial date (year only, zeroed month/day) -> preserved
+    let mut record4 = json!({"released": "1987-00-00", "title": "Test"});
+    let actions4 = apply_filters(&config, "releases", &mut record4);
+    assert_eq!(record4["released"], json!("1987-00-00"));
+    assert!(actions4.is_empty());
+}
+
+#[test]
 fn test_nullify_when_non_numeric_unchanged() {
     let config = compile_yaml(
         r#"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -182,6 +182,33 @@ NEO4J_CONTAINER=my-neo4j NEO4J_PASSWORD=secret ./scripts/migrate-master-year-to-
 - `NEO4J_USER`: Neo4j username (default: `neo4j`)
 - `NEO4J_PASSWORD`: Neo4j password (default: `discogsography`)
 
+## 📅 cleanup-implausible-years.sh
+
+One-time cleanup that nulls out implausible release/master years (outside `[1860, current_year + 1]`) from existing data in **both** Neo4j and PostgreSQL.
+
+Discogs *releases* carry their date in `<released>` (a date string), not `<year>`, so the extractor's year-range rules — which key on the `year` field — never fired for releases. Before the `common/data_normalizer.py` fix, a release dated `"0400-01-01"` was stored as year `400`, polluting the Insights "Genre Trends" chart. The code fix stops new bad years at ingest; this script aligns historical data without a full re-ingest. MusicBrainz entities use a different ingest path and are out of scope.
+
+The script defaults to a **dry run** (counts only). Pass `--apply` to make changes.
+
+### Usage
+
+```bash
+# Dry run — report how many records would be affected, no changes
+./scripts/cleanup-implausible-years.sh
+
+# Perform the cleanup
+./scripts/cleanup-implausible-years.sh --apply
+```
+
+### Environment Variables
+
+- `NEO4J_CONTAINER`: Neo4j container name (default: `discogsography-neo4j`)
+- `NEO4J_USER`: Neo4j username (default: `neo4j`)
+- `NEO4J_PASSWORD`: Neo4j password (default: `discogsography`)
+- `POSTGRES_CONTAINER`: PostgreSQL container name (default: `discogsography-postgres`)
+- `POSTGRES_USER`: PostgreSQL username (default: `discogsography`)
+- `POSTGRES_DB`: PostgreSQL database (default: `discogsography`)
+
 ## 🐳 neo4j-entrypoint.sh
 
 Thin wrapper for the Neo4j Docker container entrypoint. Reads the password from `/run/secrets/neo4j_password` and sets `NEO4J_AUTH` before delegating to the official Neo4j entrypoint. This is needed because Neo4j does not natively support the Docker `_FILE` secret convention.

--- a/scripts/cleanup-implausible-years.sh
+++ b/scripts/cleanup-implausible-years.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# cleanup-implausible-years.sh
+#
+# One-time cleanup: nulls out implausible release/master years from existing
+# data in Neo4j and PostgreSQL.
+#
+# Background: a Discogs *release* carries its date in <released> (a date string),
+# not <year>, so the extractor's year-range rules — which key on the `year`
+# field — never fired for releases. The release year is derived consumer-side
+# in common/data_normalizer.py, which (prior to this fix) only rejected year 0.
+# As a result, releases with antiquity/sentinel dates (e.g. "0400-01-01") were
+# stored as year 400, polluting the Insights "Genre Trends" chart.
+#
+# The code fix (common/data_normalizer.py) stops new bad years at ingest. This
+# script brings *existing* data in line without a full re-ingest. New ingests
+# need no cleanup.
+#
+# Scope: Discogs Release/Master nodes (Neo4j) and the public `releases`/`masters`
+# tables (PostgreSQL). MusicBrainz entities take a different ingest path and are
+# out of scope.
+#
+# Plausible range: [1860, current_year + 1] — must stay in sync with
+# MIN_RELEASE_YEAR in common/data_normalizer.py and extractor/extraction-rules.yaml.
+#
+# Usage:
+#   ./scripts/cleanup-implausible-years.sh            # dry run — counts only, no changes
+#   ./scripts/cleanup-implausible-years.sh --apply    # perform the cleanup
+#
+# Environment variables (all optional, defaults shown):
+#   NEO4J_CONTAINER     docker container name  (default: discogsography-neo4j)
+#   NEO4J_USER          Neo4j username         (default: neo4j)
+#   NEO4J_PASSWORD      Neo4j password         (default: discogsography)
+#   POSTGRES_CONTAINER  docker container name  (default: discogsography-postgres)
+#   POSTGRES_USER       PostgreSQL username    (default: discogsography)
+#   POSTGRES_DB         PostgreSQL database    (default: discogsography)
+
+set -euo pipefail
+
+NEO4J_CONTAINER="${NEO4J_CONTAINER:-discogsography-neo4j}"
+NEO4J_USER="${NEO4J_USER:-neo4j}"
+NEO4J_PASSWORD="${NEO4J_PASSWORD:-discogsography}"
+POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-discogsography-postgres}"
+POSTGRES_USER="${POSTGRES_USER:-discogsography}"
+POSTGRES_DB="${POSTGRES_DB:-discogsography}"
+
+MIN_YEAR=1860
+MAX_YEAR=$(($(date +%Y) + 1))
+
+APPLY=0
+if [[ "${1:-}" == "--apply" ]]; then
+  APPLY=1
+elif [[ -n "${1:-}" ]]; then
+  echo "❌ Unknown argument '${1}'. Use --apply to perform the cleanup (omit for a dry run)."
+  exit 1
+fi
+
+if [[ "${APPLY}" -eq 1 ]]; then
+  echo "⚠️  APPLY mode: implausible years will be set to null."
+else
+  echo "🧪 DRY RUN: counting affected records only. Re-run with --apply to make changes."
+fi
+echo "📅 Plausible year range: [${MIN_YEAR}, ${MAX_YEAR}]"
+echo ""
+
+run_neo4j() {
+  docker exec "${NEO4J_CONTAINER}" cypher-shell -u "${NEO4J_USER}" -p "${NEO4J_PASSWORD}" "$@"
+}
+
+run_pg() {
+  docker exec "${POSTGRES_CONTAINER}" psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -t -A "$@"
+}
+
+# ── Neo4j ──────────────────────────────────────────────────────────────────
+echo "🔍 Checking Neo4j container '${NEO4J_CONTAINER}' is running..."
+if ! docker inspect --format '{{.State.Running}}' "${NEO4J_CONTAINER}" 2>/dev/null | grep -q true; then
+  echo "❌ Container '${NEO4J_CONTAINER}' is not running. Start it first with: docker compose up -d neo4j"
+  exit 1
+fi
+
+for label in Release Master; do
+  COUNT=$(run_neo4j --format plain \
+    "MATCH (n:${label}) WHERE n.year IS NOT NULL AND (n.year < ${MIN_YEAR} OR n.year > ${MAX_YEAR}) RETURN count(n) AS n;" |
+    tail -1)
+  echo "   ${label}: ${COUNT} node(s) with an implausible year."
+  if [[ "${APPLY}" -eq 1 && "${COUNT}" -gt 0 ]]; then
+    echo "   🔄 Nulling ${label}.year for out-of-range values..."
+    run_neo4j \
+      "MATCH (n:${label})
+         WHERE n.year IS NOT NULL AND (n.year < ${MIN_YEAR} OR n.year > ${MAX_YEAR})
+         CALL { WITH n SET n.year = null } IN TRANSACTIONS OF 50000 ROWS;"
+  fi
+done
+echo ""
+
+# ── PostgreSQL ───────────────────────────────────────────────────────────────
+echo "🔍 Checking PostgreSQL container '${POSTGRES_CONTAINER}' is running..."
+if ! docker inspect --format '{{.State.Running}}' "${POSTGRES_CONTAINER}" 2>/dev/null | grep -q true; then
+  echo "❌ Container '${POSTGRES_CONTAINER}' is not running. Start it first with: docker compose up -d postgres"
+  exit 1
+fi
+
+for table in releases masters; do
+  COUNT=$(run_pg -c \
+    "SELECT count(*) FROM ${table}
+       WHERE data->>'year' ~ '^[0-9]+\$'
+         AND ((data->>'year')::int < ${MIN_YEAR} OR (data->>'year')::int > ${MAX_YEAR});")
+  echo "   ${table}: ${COUNT} row(s) with an implausible year."
+  if [[ "${APPLY}" -eq 1 && "${COUNT}" -gt 0 ]]; then
+    echo "   🔄 Setting ${table}.data->'year' to null for out-of-range values..."
+    run_pg -c \
+      "UPDATE ${table}
+         SET data = jsonb_set(data, '{year}', 'null'::jsonb)
+       WHERE data->>'year' ~ '^[0-9]+\$'
+         AND ((data->>'year')::int < ${MIN_YEAR} OR (data->>'year')::int > ${MAX_YEAR});"
+  fi
+done
+echo ""
+
+if [[ "${APPLY}" -eq 1 ]]; then
+  echo "✅ Cleanup complete."
+else
+  echo "✅ Dry run complete. Re-run with --apply to null the years counted above."
+fi

--- a/tests/common/test_data_normalizer.py
+++ b/tests/common/test_data_normalizer.py
@@ -1,4 +1,7 @@
+from datetime import UTC, datetime
+
 from common.data_normalizer import (
+    MIN_RELEASE_YEAR,
     _parse_year_int,
     normalize_record,
 )
@@ -36,6 +39,32 @@ class TestParseYearInt:
 
     def test_whitespace_string(self) -> None:
         assert _parse_year_int("   ") is None
+
+    def test_implausibly_early_year_int_returns_none(self) -> None:
+        """Years before the minimum plausible release year are rejected."""
+        assert _parse_year_int(400) is None
+        assert _parse_year_int(MIN_RELEASE_YEAR - 1) is None
+
+    def test_implausibly_early_date_string_returns_none(self) -> None:
+        """A release dated in antiquity (e.g. '0400-01-01') is rejected, not kept as 400."""
+        assert _parse_year_int("0400-01-01") is None
+        assert _parse_year_int("0997") is None
+
+    def test_min_boundary_inclusive(self) -> None:
+        """The minimum plausible year itself is accepted."""
+        assert _parse_year_int(MIN_RELEASE_YEAR) == MIN_RELEASE_YEAR
+        assert _parse_year_int(str(MIN_RELEASE_YEAR)) == MIN_RELEASE_YEAR
+
+    def test_far_future_year_returns_none(self) -> None:
+        """Implausible future years are rejected."""
+        assert _parse_year_int(9999) is None
+        assert _parse_year_int("3000-01-01") is None
+
+    def test_next_year_inclusive_but_beyond_rejected(self) -> None:
+        """Next calendar year is allowed (pre-orders); two years out is not."""
+        current_year = datetime.now(UTC).year
+        assert _parse_year_int(current_year + 1) == current_year + 1
+        assert _parse_year_int(current_year + 2) is None
 
 
 class TestNormalizeRecord:
@@ -76,6 +105,18 @@ class TestNormalizeRecord:
         """Releases with no released field get year=None."""
         data = {"id": "1", "title": "Test", "sha256": "abc"}
         result = normalize_record("releases", data)
+        assert result["year"] is None
+
+    def test_releases_implausibly_early_released_is_nulled(self) -> None:
+        """A release with an antiquity 'released' date must not leak year=400 into the graph."""
+        data = {"id": "1", "title": "Test", "released": "0400-01-01", "sha256": "abc"}
+        result = normalize_record("releases", data)
+        assert result["year"] is None
+
+    def test_masters_implausibly_early_year_is_nulled(self) -> None:
+        """Masters with an out-of-range year are nulled too."""
+        data = {"id": "1", "title": "Test", "year": "997", "sha256": "abc"}
+        result = normalize_record("masters", data)
         assert result["year"] is None
 
     def test_unknown_type_passthrough(self) -> None:


### PR DESCRIPTION
## Problem

The Insights **Genre Trends** chart plotted releases at decades like **400 / 600 / 800 AD**, stretching the x-axis back to antiquity.

This was *not* stale pre-filter data — the host was provisioned after the year filter shipped, so every ingest ran with the filter active. The filter simply never applied to releases.

## Root cause (two gaps, both in the extractor)

A Discogs **release** stores its date in `<released>` (a date string like `"1969-09-26"`), **not** `<year>`:

1. The extractor's `nullify_when` / `year-out-of-range` rules key on the `year` field, which doesn't exist on a release — so they were **silent no-ops for releases** (masters, which have `<year>`, were fine).
2. Even pointed at `released`, `nullify_when`'s range check did `parse::<f64>()` on the whole value, so `"0400-01-01"` failed to parse and was left untouched.

The release year was then derived consumer-side in `common/data_normalizer.py` → `_parse_year_int(data.get("released"))`, which only rejected `year == 0`. So `"0400-01-01"` → `400` → written straight to Neo4j.

## Fix — at the rules engine (where bad data is meant to be caught), plus a defensive backstop and cleanup

**Extractor (primary):**
- `extractor/src/rules.rs` — `nullify_when`'s range check now falls back to the **leading year component** (`parse_leading_year`) when the value isn't a plain number, so date fields like `released` are range-checked.
- `extractor/extraction-rules.yaml` — add a `released` `nullify_when` filter for releases (`below: 1860`, `above: 2027`), and add the `above` upper bound to the existing `year` filters (releases + masters) for parity. Bad release dates are now nullified **at the extractor, before reaching any consumer**.

**Consumer (defensive backstop):**
- `common/data_normalizer.py` — `_parse_year_int` bounds the parsed year to `[MIN_RELEASE_YEAR (1860), current_year + 1]` (added `MIN_RELEASE_YEAR`; corrected the misleading docstring). Catches anything that slips past, for both releases and masters.

**Existing data:**
- `scripts/cleanup-implausible-years.sh` — one-time cleanup for rows already ingested via the buggy path. **Dry-run by default**; `--apply` nulls out-of-range years in existing **Neo4j** (`Release`/`Master`) and **PostgreSQL** (`releases`/`masters` JSONB) records. Documented in `scripts/README.md`.

## Verification

- `cargo test` (extractor) — all pass incl. new `test_nullify_when_released_date_string_year_out_of_range`; `cargo clippy -D warnings` + `cargo fmt --check` clean
- `uv run pytest tests/common tests/graphinator tests/tableinator` — all pass; `ruff` + `mypy` clean
- `shellcheck` + `bash -n` on the cleanup script — clean
- All pre-commit hooks pass

## Operator note

After merge, run on the host once to clean existing data:

```bash
./scripts/cleanup-implausible-years.sh            # dry run — see counts
./scripts/cleanup-implausible-years.sh --apply    # perform cleanup
```

## Scope

MusicBrainz entities take a different ingest path (no `normalize_record`, no `year` write) and are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)