### PR TITLE
feat(taste): bold taste-card redesign + compact pill download button

### DIFF
--- a/api/routers/taste.py
+++ b/api/routers/taste.py
@@ -172,12 +172,12 @@ async def taste_card(
     for c in cells:
         g = c["genre"]
         genre_counts[g] = genre_counts.get(g, 0) + c.get("count", 1)
-    top_genres = sorted(genre_counts, key=genre_counts.get, reverse=True)[:5]  # type: ignore[arg-type]
+    top_genres = sorted(genre_counts.items(), key=lambda kv: kv[1], reverse=True)[:5]
     svg = render_taste_card(
         peak_decade=_peak_decade(cells),
         obscurity_score=obscurity_result["score"],
         top_genres=top_genres,
-        top_labels=[lb["label"] for lb in labels_result],
+        top_labels=[(lb["label"], lb["count"]) for lb in labels_result],
         drift=[TasteDriftYear(**d) for d in drift_result],
     )
     return Response(content=svg, media_type="image/svg+xml", headers={"Cache-Control": "no-store"})

--- a/api/taste_card.py
+++ b/api/taste_card.py
@@ -1,64 +1,155 @@
 """SVG taste card generator.
 
-Produces a 600x400 SVG summarising a user's taste fingerprint.
+Produces a 1200x630 (social-share aspect) SVG summarising a user's taste
+fingerprint: an obscurity ring, ranked genre/label bars, and a drift sparkline.
 All user-supplied strings are escaped via ``html.escape`` to prevent XSS.
 """
 
 import html
+import math
 
 from api.models import TasteDriftYear
+
+
+# Card geometry
+_W = 1200
+_H = 630
+
+# Palette (purple/violet on deep navy)
+_BG_TOP = "#1c1c2e"
+_BG_BOTTOM = "#101019"
+_HDR_FROM = "#7c3aed"
+_HDR_TO = "#a855f7"
+_ACCENT_FROM = "#6c5ce7"
+_ACCENT_TO = "#a855f7"
+_TEXT = "#f5f5fa"
+_MUTED = "#8b8ba7"
+_FAINT = "#6b6b85"
+
+
+def _esc(value: str) -> str:
+    return html.escape(value)
+
+
+def _obscurity_ring(cx: int, cy: int, r: int, score: float) -> str:
+    """A circular gauge showing the obscurity percentage."""
+    circ = 2 * math.pi * r
+    on = max(0.0, min(1.0, score)) * circ
+    pct = f"{score:.0%}"
+    return (
+        f'<circle cx="{cx}" cy="{cy}" r="{r}" fill="none" stroke="#ffffff26" stroke-width="10"/>'
+        f'<circle cx="{cx}" cy="{cy}" r="{r}" fill="none" stroke="url(#ringGrad)" stroke-width="10"'
+        f' stroke-linecap="round" stroke-dasharray="{on:.1f} {circ:.1f}" transform="rotate(-90 {cx} {cy})"/>'
+        f'<text x="{cx}" y="{cy}" font-size="28" font-weight="bold" fill="#fff" text-anchor="middle"'
+        f' dominant-baseline="central">{pct}</text>'
+    )
+
+
+def _ranked_bars(items: list[tuple[str, int]], x0: int, y_start: int, col_w: int, row_h: int) -> str:
+    """A vertical list of ranked horizontal bars (length proportional to count)."""
+    if not items:
+        return f'<text x="{x0}" y="{y_start + 4}" font-size="17" fill="{_FAINT}">No data yet</text>'
+    max_count = max((c for _, c in items), default=0) or 1
+    parts: list[str] = []
+    for i, (name, count) in enumerate(items[:5]):
+        y = y_start + i * row_h
+        bar_w = max(6, round(col_w * (count / max_count)))
+        parts.append(f'<text x="{x0}" y="{y}" font-size="21" fill="{_TEXT}">{_esc(name)}</text>')
+        parts.append(f'<text x="{x0 + col_w}" y="{y}" font-size="15" fill="{_MUTED}" text-anchor="end">{count:,}</text>')
+        parts.append(f'<rect x="{x0}" y="{y + 11}" width="{col_w}" height="9" rx="4.5" fill="#ffffff14"/>')
+        parts.append(f'<rect x="{x0}" y="{y + 11}" width="{bar_w}" height="9" rx="4.5" fill="url(#barGrad)"/>')
+    return "\n  ".join(parts)
+
+
+def _drift_sparkline(drift: list[TasteDriftYear], x: int, y: int, w: int, h: int) -> str:
+    """A small line chart of additions-per-year, with year labels and genre tooltips."""
+    pts = drift[-8:]
+    if not pts:
+        return f'<text x="{x}" y="{y + h // 2}" font-size="17" fill="{_FAINT}">No drift data yet</text>'
+    max_count = max((d.count for d in pts), default=0) or 1
+    n = len(pts)
+    step = w / (n - 1) if n > 1 else 0.0
+    coords: list[tuple[float, float, TasteDriftYear]] = []
+    for i, d in enumerate(pts):
+        px = x + i * step if n > 1 else x + w / 2
+        py = y + h - (d.count / max_count) * h
+        coords.append((px, py, d))
+
+    parts: list[str] = []
+    if n > 1:
+        line = " ".join(f"{px:.1f},{py:.1f}" for px, py, _ in coords)
+        parts.append(f'<polyline points="{line}" fill="none" stroke="url(#barGrad)" stroke-width="3" stroke-linejoin="round"/>')
+    for idx, (px, py, d) in enumerate(coords):
+        last = idx == n - 1
+        parts.append(
+            f'<circle cx="{px:.1f}" cy="{py:.1f}" r="{5 if last else 4}" fill="{_ACCENT_TO if last else _ACCENT_FROM}">'
+            f"<title>{_esc(d.year)}: {_esc(d.top_genre)} ({d.count:,})</title></circle>"
+        )
+        parts.append(f'<text x="{px:.1f}" y="{y + h + 20}" font-size="13" fill="{_MUTED}" text-anchor="middle">{_esc(d.year)}</text>')
+    # Caption: the most recent year's top genre.
+    parts.append(f'<text x="{x}" y="{y - 14}" font-size="15" fill="{_FAINT}">Now: {_esc(coords[-1][2].top_genre)}</text>')
+    return "\n  ".join(parts)
 
 
 def render_taste_card(
     *,
     peak_decade: int | None,
     obscurity_score: float,
-    top_genres: list[str],
-    top_labels: list[str],
+    top_genres: list[tuple[str, int]],
+    top_labels: list[tuple[str, int]],
     drift: list[TasteDriftYear],
 ) -> str:
-    """Return a 600x400 SVG string summarising the user's taste fingerprint."""
-    decade_text = f"{html.escape(str(peak_decade))}s" if peak_decade is not None else "N/A"
-    bar_width = max(4, min(200, int(obscurity_score * 200)))
+    """Return a 1200x630 SVG string summarising the user's taste fingerprint."""
+    decade_text = f"{_esc(str(peak_decade))}s" if peak_decade is not None else "N/A"
 
-    genre_lines = ""
-    for i, genre in enumerate(top_genres[:5]):
-        y = 155 + i * 20
-        genre_lines += f'    <text x="30" y="{y}" font-size="13" fill="#ccc">{html.escape(genre)}</text>\n'
+    genre_bars = _ranked_bars(top_genres, x0=50, y_start=250, col_w=480, row_h=56)
+    label_bars = _ranked_bars(top_labels, x0=640, y_start=250, col_w=480, row_h=56)
+    sparkline = _drift_sparkline(drift, x=360, y=560, w=560, h=34)
 
-    label_lines = ""
-    for i, label in enumerate(top_labels[:5]):
-        y = 155 + i * 20
-        label_lines += f'    <text x="320" y="{y}" font-size="13" fill="#ccc">{html.escape(label)}</text>\n'
+    return f"""\
+<svg xmlns="http://www.w3.org/2000/svg" width="{_W}" height="{_H}" viewBox="0 0 {_W} {_H}">
+  <defs>
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="{_BG_TOP}"/>
+      <stop offset="1" stop-color="{_BG_BOTTOM}"/>
+    </linearGradient>
+    <linearGradient id="hdrGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="{_HDR_FROM}"/>
+      <stop offset="1" stop-color="{_HDR_TO}"/>
+    </linearGradient>
+    <linearGradient id="barGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="{_ACCENT_FROM}"/>
+      <stop offset="1" stop-color="{_ACCENT_TO}"/>
+    </linearGradient>
+    <linearGradient id="ringGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#d8b4fe"/>
+    </linearGradient>
+    <clipPath id="card"><rect x="0" y="0" width="{_W}" height="{_H}" rx="28"/></clipPath>
+  </defs>
 
-    drift_lines = ""
-    for i, d in enumerate(drift[-5:]):
-        y = 320 + i * 18
-        drift_lines += f'    <text x="30" y="{y}" font-size="12" fill="#aaa">{html.escape(d.year)}: {html.escape(d.top_genre)}</text>\n'
+  <g clip-path="url(#card)">
+    <rect x="0" y="0" width="{_W}" height="{_H}" fill="url(#bgGrad)"/>
+    <rect x="0" y="0" width="{_W}" height="150" fill="url(#hdrGrad)"/>
+  </g>
 
-    svg = f"""\
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400">
-  <rect width="600" height="400" rx="12" fill="#1a1a2e"/>
-  <text x="300" y="35" font-size="18" font-weight="bold" fill="#e0e0e0" text-anchor="middle">Taste Fingerprint</text>
+  <!-- Header -->
+  <text x="50" y="70" font-size="40" font-weight="bold" fill="#ffffff" letter-spacing="1">TASTE FINGERPRINT</text>
+  <text x="50" y="108" font-size="20" fill="#ffffffcc">Peak decade <tspan font-weight="bold" fill="#ffffff">{decade_text}</tspan></text>
+  <text x="1095" y="38" font-size="14" fill="#ffffffcc" text-anchor="middle" letter-spacing="1">OBSCURITY</text>
+  {_obscurity_ring(1095, 90, 44, obscurity_score)}
 
-  <!-- Peak Decade -->
-  <text x="30" y="70" font-size="14" fill="#888">Peak Decade</text>
-  <text x="30" y="92" font-size="22" font-weight="bold" fill="#fff">{decade_text}</text>
+  <!-- Section headers -->
+  <text x="50" y="210" font-size="18" font-weight="bold" fill="{_MUTED}" letter-spacing="2">TOP GENRES</text>
+  <text x="640" y="210" font-size="18" font-weight="bold" fill="{_MUTED}" letter-spacing="2">TOP LABELS</text>
 
-  <!-- Obscurity -->
-  <text x="320" y="70" font-size="14" fill="#888">Obscurity</text>
-  <rect x="320" y="78" width="200" height="16" rx="4" fill="#333"/>
-  <rect x="320" y="78" width="{bar_width}" height="16" rx="4" fill="#6c5ce7"/>
-  <text x="530" y="91" font-size="12" fill="#ccc">{obscurity_score:.0%}</text>
+  <!-- Ranked bars -->
+  {genre_bars}
+  {label_bars}
 
-  <!-- Top Genres -->
-  <text x="30" y="130" font-size="14" fill="#888">Top Genres</text>
-{genre_lines}
-  <!-- Top Labels -->
-  <text x="320" y="130" font-size="14" fill="#888">Top Labels</text>
-{label_lines}
-  <!-- Drift -->
-  <text x="30" y="300" font-size="14" fill="#888">Taste Drift</text>
-{drift_lines}</svg>"""
-
-    return svg
+  <!-- Footer band: drift sparkline + branding -->
+  <line x1="50" y1="520" x2="1150" y2="520" stroke="#ffffff14" stroke-width="1"/>
+  <text x="50" y="560" font-size="14" font-weight="bold" fill="{_MUTED}" letter-spacing="2">TASTE DRIFT</text>
+  {sparkline}
+  <text x="50" y="600" font-size="20" font-weight="bold" fill="url(#barGrad)">discogsography</text>
+</svg>"""

--- a/api/taste_card.py
+++ b/api/taste_card.py
@@ -1,12 +1,11 @@
 """SVG taste card generator.
 
 Produces a 1200x630 (social-share aspect) SVG summarising a user's taste
-fingerprint: an obscurity ring, ranked genre/label bars, and a drift sparkline.
+fingerprint: an obscurity scale, ranked genre/label bars, and a drift sparkline.
 All user-supplied strings are escaped via ``html.escape`` to prevent XSS.
 """
 
 import html
-import math
 
 from api.models import TasteDriftYear
 
@@ -26,22 +25,48 @@ _TEXT = "#f5f5fa"
 _MUTED = "#8b8ba7"
 _FAINT = "#6b6b85"
 
+# Obscurity tiers (mainstream -> obscure). Boundary is inclusive on the upper
+# tier (``score >= threshold``), matching the project's tier convention.
+# Keep in sync with the Explore strip (explore/static/js/user-panes.js).
+_OBSCURITY_TIERS = [
+    (0.75, "Deep Cuts", "#f43f5e"),
+    (0.50, "Obscure", "#a855f7"),
+    (0.25, "Eclectic", "#818cf8"),
+    (0.0, "Mainstream", "#38bdf8"),
+]
+
 
 def _esc(value: str) -> str:
     return html.escape(value)
 
 
-def _obscurity_ring(cx: int, cy: int, r: int, score: float) -> str:
-    """A circular gauge showing the obscurity percentage."""
-    circ = 2 * math.pi * r
-    on = max(0.0, min(1.0, score)) * circ
+def _obscurity_tier(score: float) -> tuple[str, str]:
+    """Return the (name, color) tier for an obscurity score in [0, 1]."""
+    for threshold, name, color in _OBSCURITY_TIERS:
+        if score >= threshold:
+            return name, color
+    return _OBSCURITY_TIERS[-1][1], _OBSCURITY_TIERS[-1][2]
+
+
+def _obscurity_scale(score: float, x: int, y: int, w: int) -> str:
+    """A mainstream->obscure gradient track with a glowing marker at ``score``."""
+    s = max(0.0, min(1.0, score))
+    name, color = _obscurity_tier(s)
     pct = f"{score:.0%}"
-    return (
-        f'<circle cx="{cx}" cy="{cy}" r="{r}" fill="none" stroke="#ffffff26" stroke-width="10"/>'
-        f'<circle cx="{cx}" cy="{cy}" r="{r}" fill="none" stroke="url(#ringGrad)" stroke-width="10"'
-        f' stroke-linecap="round" stroke-dasharray="{on:.1f} {circ:.1f}" transform="rotate(-90 {cx} {cy})"/>'
-        f'<text x="{cx}" y="{cy}" font-size="28" font-weight="bold" fill="#fff" text-anchor="middle"'
-        f' dominant-baseline="central">{pct}</text>'
+    mx = x + s * w
+    track_y = y + 15
+    h = 12
+    dot_cy = track_y + h / 2
+    return "\n  ".join(
+        [
+            f'<text x="{x}" y="{y}" font-size="16" font-weight="bold" fill="{_MUTED}" letter-spacing="2">OBSCURITY</text>',
+            f'<text x="{x + w}" y="{y}" font-size="18" font-weight="bold" fill="{color}" text-anchor="end">{_esc(name)} · {pct}</text>',
+            f'<rect x="{x}" y="{track_y}" width="{w}" height="{h}" rx="6" fill="url(#obscGrad)"/>',
+            f'<circle cx="{mx:.1f}" cy="{dot_cy:.1f}" r="16" fill="{color}" opacity="0.35"/>',
+            f'<circle cx="{mx:.1f}" cy="{dot_cy:.1f}" r="9" fill="#fff" stroke="{color}" stroke-width="3"/>',
+            f'<text x="{x}" y="{track_y + h + 22}" font-size="13" fill="{_FAINT}">Mainstream</text>',
+            f'<text x="{x + w}" y="{track_y + h + 22}" font-size="13" fill="{_FAINT}" text-anchor="end">Obscure</text>',
+        ]
     )
 
 
@@ -102,9 +127,10 @@ def render_taste_card(
     """Return a 1200x630 SVG string summarising the user's taste fingerprint."""
     decade_text = f"{_esc(str(peak_decade))}s" if peak_decade is not None else "N/A"
 
-    genre_bars = _ranked_bars(top_genres, x0=50, y_start=250, col_w=480, row_h=56)
-    label_bars = _ranked_bars(top_labels, x0=640, y_start=250, col_w=480, row_h=56)
-    sparkline = _drift_sparkline(drift, x=360, y=560, w=560, h=34)
+    obscurity = _obscurity_scale(obscurity_score, x=50, y=190, w=1100)
+    genre_bars = _ranked_bars(top_genres, x0=50, y_start=330, col_w=480, row_h=48)
+    label_bars = _ranked_bars(top_labels, x0=640, y_start=330, col_w=480, row_h=48)
+    sparkline = _drift_sparkline(drift, x=360, y=584, w=560, h=26)
 
     return f"""\
 <svg xmlns="http://www.w3.org/2000/svg" width="{_W}" height="{_H}" viewBox="0 0 {_W} {_H}">
@@ -121,9 +147,11 @@ def render_taste_card(
       <stop offset="0" stop-color="{_ACCENT_FROM}"/>
       <stop offset="1" stop-color="{_ACCENT_TO}"/>
     </linearGradient>
-    <linearGradient id="ringGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#ffffff"/>
-      <stop offset="1" stop-color="#d8b4fe"/>
+    <linearGradient id="obscGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#38bdf8"/>
+      <stop offset="0.33" stop-color="#818cf8"/>
+      <stop offset="0.66" stop-color="#a855f7"/>
+      <stop offset="1" stop-color="#f43f5e"/>
     </linearGradient>
     <clipPath id="card"><rect x="0" y="0" width="{_W}" height="{_H}" rx="28"/></clipPath>
   </defs>
@@ -136,20 +164,21 @@ def render_taste_card(
   <!-- Header -->
   <text x="50" y="70" font-size="40" font-weight="bold" fill="#ffffff" letter-spacing="1">TASTE FINGERPRINT</text>
   <text x="50" y="108" font-size="20" fill="#ffffffcc">Peak decade <tspan font-weight="bold" fill="#ffffff">{decade_text}</tspan></text>
-  <text x="1095" y="38" font-size="14" fill="#ffffffcc" text-anchor="middle" letter-spacing="1">OBSCURITY</text>
-  {_obscurity_ring(1095, 90, 44, obscurity_score)}
+
+  <!-- Obscurity scale -->
+  {obscurity}
 
   <!-- Section headers -->
-  <text x="50" y="210" font-size="18" font-weight="bold" fill="{_MUTED}" letter-spacing="2">TOP GENRES</text>
-  <text x="640" y="210" font-size="18" font-weight="bold" fill="{_MUTED}" letter-spacing="2">TOP LABELS</text>
+  <text x="50" y="300" font-size="18" font-weight="bold" fill="{_MUTED}" letter-spacing="2">TOP GENRES</text>
+  <text x="640" y="300" font-size="18" font-weight="bold" fill="{_MUTED}" letter-spacing="2">TOP LABELS</text>
 
   <!-- Ranked bars -->
   {genre_bars}
   {label_bars}
 
   <!-- Footer band: drift sparkline + branding -->
-  <line x1="50" y1="520" x2="1150" y2="520" stroke="#ffffff14" stroke-width="1"/>
-  <text x="50" y="560" font-size="14" font-weight="bold" fill="{_MUTED}" letter-spacing="2">TASTE DRIFT</text>
+  <line x1="50" y1="556" x2="1150" y2="556" stroke="#ffffff14" stroke-width="1"/>
+  <text x="50" y="586" font-size="14" font-weight="bold" fill="{_MUTED}" letter-spacing="2">TASTE DRIFT</text>
   {sparkline}
-  <text x="50" y="600" font-size="20" font-weight="bold" fill="url(#barGrad)">discogsography</text>
+  <text x="1150" y="604" font-size="20" font-weight="bold" fill="url(#barGrad)" text-anchor="end">discogsography</text>
 </svg>"""

--- a/explore/__tests__/user-panes.test.js
+++ b/explore/__tests__/user-panes.test.js
@@ -1371,7 +1371,7 @@ describe('UserPanes', () => {
             expect(cols).toHaveLength(3);
         });
 
-        it('should render obscurity score', () => {
+        it('should render obscurity score as a tier + percentage scale', () => {
             const strip = document.getElementById('tasteStrip');
             userPanes._renderTasteStrip({
                 obscurity: { score: 0.42 },
@@ -1381,7 +1381,13 @@ describe('UserPanes', () => {
                 blind_spots: [],
             });
 
-            expect(strip.textContent).toContain('0.42');
+            // 0.42 → "Eclectic" tier (0.25–0.5), shown with the percentage.
+            expect(strip.textContent).toContain('Eclectic');
+            expect(strip.textContent).toContain('42%');
+            expect(strip.querySelector('.taste-obscurity-track')).not.toBeNull();
+            const marker = strip.querySelector('.taste-obscurity-marker');
+            expect(marker).not.toBeNull();
+            expect(marker.style.left).toBe('42%');
         });
 
         it('should render dash for null obscurity', () => {

--- a/explore/static/css/styles.css
+++ b/explore/static/css/styles.css
@@ -1843,6 +1843,55 @@ select option {
 .taste-stat-value.blue { color: var(--blue-accent); }
 .taste-stat-value.green { color: var(--accent-green); }
 
+/* Obscurity scale: mainstream → obscure gradient with a marker. */
+.taste-obscurity {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    margin-bottom: 10px;
+}
+
+.taste-obscurity-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+}
+
+.taste-obscurity-label {
+    font-size: 12px;
+    color: var(--text-mid);
+}
+
+.taste-obscurity-value {
+    font-size: 12px;
+    font-weight: 700;
+}
+
+.taste-obscurity-track {
+    position: relative;
+    height: 8px;
+    border-radius: 4px;
+    background: linear-gradient(90deg, #38bdf8 0%, #818cf8 33%, #a855f7 66%, #f43f5e 100%);
+}
+
+.taste-obscurity-marker {
+    position: absolute;
+    top: 50%;
+    width: 12px;
+    height: 12px;
+    border: 2px solid #fff;
+    border-radius: 50%;
+    background: #fff;
+    transform: translate(-50%, -50%);
+}
+
+.taste-obscurity-ends {
+    display: flex;
+    justify-content: space-between;
+    font-size: 9px;
+    color: var(--text-dim);
+}
+
 .taste-heatmap-grid {
     display: grid;
     gap: 2px;

--- a/explore/static/css/styles.css
+++ b/explore/static/css/styles.css
@@ -1892,24 +1892,41 @@ select option {
 
 .taste-download-btn {
     margin-top: auto;
-    padding: 6px 12px;
-    background: var(--purple-accent);
+    align-self: center;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 9px 20px;
+    background: linear-gradient(135deg, #6c5ce7, #a855f7);
     color: #fff;
     border: none;
-    border-radius: 4px;
-    font-size: 11px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    white-space: nowrap;
     cursor: pointer;
-    text-align: center;
-    transition: opacity 0.15s;
+    box-shadow: 0 2px 8px rgba(108, 92, 231, 0.35);
+    transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
 }
 
 .taste-download-btn:hover {
-    opacity: 0.85;
+    transform: translateY(-1px);
+    filter: brightness(1.08);
+    box-shadow: 0 6px 18px rgba(108, 92, 231, 0.55);
+}
+
+.taste-download-btn:active {
+    transform: translateY(0);
+    box-shadow: 0 2px 8px rgba(108, 92, 231, 0.4);
 }
 
 .taste-download-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+    transform: none;
+    filter: none;
+    box-shadow: none;
 }
 
 .taste-empty {

--- a/explore/static/js/user-panes.js
+++ b/explore/static/js/user-panes.js
@@ -507,12 +507,8 @@ class UserPanes {
         h1.textContent = 'Fingerprint';
         col1.appendChild(h1);
 
-        // Obscurity
-        col1.appendChild(this._tasteStat(
-            'Obscurity',
-            data.obscurity?.score != null ? data.obscurity.score.toFixed(2) : '—',
-            'purple',
-        ));
+        // Obscurity (mainstream → obscure scale with a marker)
+        col1.appendChild(this._obscurityScale(data.obscurity?.score ?? null));
 
         // Peak decade
         const peakText = data.peak_decade != null ? `${data.peak_decade}s` : '—';
@@ -596,6 +592,61 @@ class UserPanes {
         valueEl.textContent = value;
         row.append(labelEl, valueEl);
         return row;
+    }
+
+    // Obscurity tiers (mainstream → obscure). Boundary inclusive on the upper
+    // tier. Keep in sync with api/taste_card.py (_OBSCURITY_TIERS).
+    _obscurityTier(score) {
+        if (score >= 0.75) return { name: 'Deep Cuts', color: '#f43f5e' };
+        if (score >= 0.5) return { name: 'Obscure', color: '#a855f7' };
+        if (score >= 0.25) return { name: 'Eclectic', color: '#818cf8' };
+        return { name: 'Mainstream', color: '#38bdf8' };
+    }
+
+    _obscurityScale(score) {
+        const wrap = document.createElement('div');
+        wrap.className = 'taste-obscurity';
+
+        const head = document.createElement('div');
+        head.className = 'taste-obscurity-head';
+        const label = document.createElement('span');
+        label.className = 'taste-obscurity-label';
+        label.textContent = 'Obscurity';
+        const value = document.createElement('span');
+        value.className = 'taste-obscurity-value';
+        head.append(label, value);
+        wrap.appendChild(head);
+
+        if (score == null) {
+            value.textContent = '—';
+            return wrap;
+        }
+
+        const s = Math.max(0, Math.min(1, score));
+        const tier = this._obscurityTier(s);
+        value.textContent = `${tier.name} · ${Math.round(score * 100)}%`;
+        value.style.color = tier.color;
+
+        const track = document.createElement('div');
+        track.className = 'taste-obscurity-track';
+        const marker = document.createElement('div');
+        marker.className = 'taste-obscurity-marker';
+        marker.style.left = `${s * 100}%`;
+        marker.style.borderColor = tier.color;
+        marker.style.boxShadow = `0 0 8px ${tier.color}`;
+        track.appendChild(marker);
+        wrap.appendChild(track);
+
+        const ends = document.createElement('div');
+        ends.className = 'taste-obscurity-ends';
+        const lo = document.createElement('span');
+        lo.textContent = 'Mainstream';
+        const hi = document.createElement('span');
+        hi.textContent = 'Obscure';
+        ends.append(lo, hi);
+        wrap.appendChild(ends);
+
+        return wrap;
     }
 
     _formatDrift(drift) {

--- a/tests/api/test_taste_card.py
+++ b/tests/api/test_taste_card.py
@@ -9,8 +9,8 @@ def _default_card(**overrides: object) -> str:
     kwargs: dict[str, object] = {
         "peak_decade": 1990,
         "obscurity_score": 0.65,
-        "top_genres": ["Rock", "Electronic", "Jazz"],
-        "top_labels": ["Warp Records", "4AD"],
+        "top_genres": [("Rock", 120), ("Electronic", 90), ("Jazz", 40)],
+        "top_labels": [("Warp Records", 30), ("4AD", 18)],
         "drift": [
             TasteDriftYear(year="2020", top_genre="Rock", count=10),
             TasteDriftYear(year="2021", top_genre="Electronic", count=8),
@@ -25,13 +25,13 @@ class TestRenderTasteCard:
         svg = _default_card()
         assert svg.startswith("<svg")
         assert svg.endswith("</svg>")
-        assert 'width="600"' in svg
-        assert 'height="400"' in svg
+        assert 'width="1200"' in svg
+        assert 'height="630"' in svg
 
     def test_size_limit(self) -> None:
         svg = _default_card()
-        # SVG should be reasonably small (< 10KB for a simple card)
-        assert len(svg) < 10_000
+        # SVG should stay reasonably small for an inline asset.
+        assert len(svg) < 20_000
 
     def test_none_decade(self) -> None:
         svg = _default_card(peak_decade=None)
@@ -45,38 +45,61 @@ class TestRenderTasteCard:
         svg = _default_card(top_genres=[], top_labels=[], drift=[])
         assert svg.startswith("<svg")
         assert svg.endswith("</svg>")
+        # Graceful empty-state placeholders, no crash.
+        assert "No data yet" in svg
+        assert "No drift data yet" in svg
 
     def test_special_chars_escaped(self) -> None:
-        svg = _default_card(top_genres=["Rock & Roll", "R&B"])
+        svg = _default_card(top_genres=[("Rock & Roll", 10), ("R&B", 5)])
         assert "Rock &amp; Roll" in svg
         assert "R&amp;B" in svg
 
     def test_xss_injection(self) -> None:
         malicious = '<script>alert("xss")</script>'
-        svg = _default_card(top_genres=[malicious])
+        svg = _default_card(top_genres=[(malicious, 1)])
         assert "<script>" not in svg
         assert "&lt;script&gt;" in svg
 
-    def test_bar_width_clamped_low(self) -> None:
-        svg = _default_card(obscurity_score=0.0)
-        # 0.0 * 200 = 0 -> clamped to 4
-        assert 'width="4"' in svg
-
-    def test_bar_width_clamped_high(self) -> None:
-        svg = _default_card(obscurity_score=1.0)
-        # 1.0 * 200 = 200
-        assert 'width="200"' in svg
+    def test_xss_injection_in_drift(self) -> None:
+        svg = _default_card(drift=[TasteDriftYear(year="2020", top_genre="<b>x</b>", count=1)])
+        assert "<b>x</b>" not in svg
+        assert "&lt;b&gt;x&lt;/b&gt;" in svg
 
     def test_obscurity_percentage(self) -> None:
         svg = _default_card(obscurity_score=0.65)
         assert "65%" in svg
 
-    def test_drift_entries(self) -> None:
+    def test_obscurity_ring_bounds(self) -> None:
+        # Extremes render without error and show the right percentage.
+        assert "0%" in _default_card(obscurity_score=0.0)
+        assert "100%" in _default_card(obscurity_score=1.0)
+
+    def test_drift_year_labels(self) -> None:
         svg = _default_card()
+        # Years are rendered as axis labels under the sparkline.
+        assert ">2020<" in svg
+        assert ">2021<" in svg
+
+    def test_drift_genre_in_tooltip(self) -> None:
+        svg = _default_card()
+        # Genre is preserved in the point tooltip.
         assert "2020: Rock" in svg
-        assert "2021: Electronic" in svg
+
+    def test_single_drift_point(self) -> None:
+        svg = _default_card(drift=[TasteDriftYear(year="2024", top_genre="Pop", count=3)])
+        assert svg.startswith("<svg")
+        assert ">2024<" in svg
 
     def test_label_entries(self) -> None:
         svg = _default_card()
         assert "Warp Records" in svg
         assert "4AD" in svg
+
+    def test_genre_counts_rendered(self) -> None:
+        svg = _default_card()
+        assert "Rock" in svg
+        # Counts are shown alongside the bars (formatted with thousands separators).
+        assert "120" in svg
+
+    def test_branding_present(self) -> None:
+        assert "discogsography" in _default_card()


### PR DESCRIPTION
## Summary

Redesigns the **taste fingerprint card**, the **Download Taste Card button**, and the **obscurity display** (now a mainstream→obscure scale, shown identically on the card and the Explore taste strip).

## Card — `api/taste_card.py`

- **Larger, social-share aspect** (1200×630).
- **Gradient header band** with the title + peak decade.
- **Obscurity scale** — a full-width gradient track (sky→indigo→purple→rose) with a glowing marker at the score, a tier+% caption, and Mainstream/Obscure endpoints (replaces the old ring/flat bar).
- **Ranked accent bars** for top genres and top labels (length ∝ count, count shown). `render_taste_card` takes `(name, count)` tuples; the router threads counts through.
- **Taste drift sparkline** with year labels, per-point genre tooltips, and a "Now: <genre>" caption.
- **discogsography wordmark.**
- Graceful empty states; all user strings `html.escape`-d (XSS-safe).

## Obscurity scale — consistent in both places

- Tiers (inclusive upper bound): **Mainstream / Eclectic / Obscure / Deep Cuts** at 0 / 0.25 / 0.5 / 0.75, with the percentage shown.
- `explore/static/js/user-panes.js` (`_obscurityScale` / `_obscurityTier`) + `explore/static/css/styles.css` render the same gradient-track-with-marker in the Explore strip, replacing the bare `0.42` stat.
- Thresholds are duplicated in Python and JS and annotated to stay in sync.

## Button — `.taste-download-btn`

Compact, centered **gradient pill** with hover lift + glow and active/disabled states, replacing the flat full-width bar.

## Verification

- `uv run pytest tests/api/test_taste_card.py tests/api/test_taste.py` — pass; `ruff` / `mypy` clean
- `npx vitest run __tests__/user-panes.test.js` — 134 pass
- All pre-commit hooks pass
- Card + strip rendered and reviewed visually (Mainstream/Eclectic/Deep Cuts states)

## Notes

The card SVG is generated server-side (downloaded file). Built on `main`; independent of the implausible-years fix in #382.

> Obscurity remains a *relative* metric (median co-collectors ÷ your most-collected release). This PR only changes its presentation; reworking the metric toward an absolute popularity baseline is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)