### PR TITLE
chore(just): clean reclaims cargo + worktree target dirs

### DIFF
--- a/justfile
+++ b/justfile
@@ -646,6 +646,10 @@ clean:
     @find . -type f -name '*.swp' ! -path './.claude/*' -delete 2>/dev/null || true
     @find . -type f -name '*.swo' ! -path './.claude/*' -delete 2>/dev/null || true
     @find . -type f -name '*~' ! -path './.claude/*' -delete 2>/dev/null || true
+    @echo '🦀 Running cargo clean for the Rust workspace...'
+    @if command -v cargo >/dev/null 2>&1 && [ -f 'Cargo.toml' ]; then \
+        cargo clean 2>/dev/null || true; \
+    fi
     @if [ -d 'extractor/target' ]; then \
         rm -rf extractor/target; \
     fi
@@ -666,6 +670,10 @@ clean:
     fi
     @if [ -d 'rust-version/target' ]; then \
         rm -rf rust-version/target; \
+    fi
+    @if [ -d '.worktrees' ]; then \
+        echo '🌳 Removing target/ directories in git worktrees under .worktrees/...'; \
+        find .worktrees -type d -name target -prune -exec rm -rf {} + 2>/dev/null || true; \
     fi
     @if [ -d 'data' ]; then \
         rm -rf data; \


### PR DESCRIPTION
## Summary

The `just clean` recipe removed `target/` with `rm -rf` but never invoked `cargo clean`, and it left `target/` directories inside git worktrees under `.worktrees/` untouched. `cargo clean` at the workspace root does **not** reach worktree targets, so they accumulated several GB (3.2 G in one worktree at the time of this change).

This extends the existing `clean` recipe with two guarded steps — no other behavior changes.

## Changes

- **`cargo clean` for the Rust workspace** — guarded on `cargo` being installed and a root `Cargo.toml` existing. It's a single workspace (`members = ["extractor"]` sharing one `./target`), so one invocation covers all manifests.
- **Remove `target/` under `.worktrees/`** — depth-agnostic `find .worktrees -type d -name target -prune -exec rm -rf {} +`, guarded on `.worktrees` existing (handles both `.worktrees/<branch>/target` and `.worktrees/<group>/<branch>/target` layouts).

Preserved as-is: the recipe's existing `.venv`/`data` removal, temp-file cleanup, and the `! -path './.claude/*'` exclusions (so `.claude/worktrees/*` is untouched).

## Verification

- `just --show clean` parses cleanly; pre-commit hooks pass.
- `just clean` removed all worktree `target/` dirs while keeping all 5 git worktrees registered; `.worktrees/` shrank 4.5 G → 1.2 G (source preserved).
- From the cleaned state: `cargo build` compiled the workspace from an empty `target/` (exit 0); `uv run pytest tests/common` → **481 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NbZdgPf5yKT8ziXNxkmVH