### PR TITLE
fix(postgres): right-size pools & bound brainztableinator concurrency to fit shared PgBouncer cap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,14 @@ All variables support `_FILE` variants for Docker Compose runtime secrets in pro
 - **Single-statement writes** (upserts, inserts): use autocommit directly, no `conn.transaction()` needed
 - **Never call `await conn.commit()`** on autocommit connections — it's a no-op
 
+### Connection-pool sizing (shared PgBouncer budget)
+
+- Production runs behind a PgBouncer pooler in **session** mode — every pooled connection pins a dedicated Postgres backend for its whole lifetime (no multiplexing), against a hard per-database cap (currently 45)
+- **The sum of every service's `postgres_pool_max_size` is the deployment's real footprint and must stay under that cap.** Never let a single service's pool max exceed the cap
+- Pool sizes come from `resolve_postgres_pool_sizes()` in `common/config.py` (per-service defaults + `POSTGRES_POOL_MIN_SIZE` / `POSTGRES_POOL_MAX_SIZE` overrides) — do not hardcode `max_connections=` at the call site
+- **Couple RabbitMQ prefetch to pool capacity** for one-transaction-per-message consumers (`brainztableinator` uses channel-global QoS = pool max). Prefetch ≫ pool max drives the "pool exhausted" retry churn
+- Batch child-row writes (`executemany`) to keep transactions short — long *idle in transaction* windows pin backends. See [docs/postgres-pool-exhaustion-analysis.md](docs/postgres-pool-exhaustion-analysis.md)
+
 ### asyncio primitives
 
 - **Never create `asyncio.Lock`, `asyncio.Queue`, `asyncio.Event`, or `asyncio.Semaphore` in `__init__` or at module level** — they bind to the current event loop at creation time

--- a/api/api.py
+++ b/api/api.py
@@ -223,8 +223,8 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:  # pragma: no cover
             "user": _config.postgres_username,
             "password": _config.postgres_password,
         },
-        max_connections=10,
-        min_connections=2,
+        max_connections=_config.postgres_pool_max_size,
+        min_connections=_config.postgres_pool_min_size,
     )
     await _pool.initialize()
     logger.info("💾 Database pool initialized")

--- a/brainztableinator/brainztableinator.py
+++ b/brainztableinator/brainztableinator.py
@@ -32,6 +32,22 @@ logger = structlog.get_logger(__name__)
 # Config will be initialized in main
 config: BrainztableinatorConfig | None = None
 
+# Fallback prefetch when config is not yet loaded (matches BrainztableinatorConfig default).
+_DEFAULT_POOL_MAX = 12
+
+
+def _channel_prefetch() -> int:
+    """RabbitMQ prefetch coupled to the PostgreSQL pool capacity.
+
+    Unlike tableinator, brainztableinator opens one transaction per message, so every
+    in-flight handler holds a pooled connection for the duration of its write. Bounding
+    the channel's total unacked deliveries (channel-global QoS) to the pool's ``max``
+    means the broker — not the pool's exhausted-wait retry loop — applies backpressure,
+    so the pool is never oversubscribed and the shared PgBouncer budget is respected.
+    """
+    return config.postgres_pool_max_size if config is not None else _DEFAULT_POOL_MAX
+
+
 # Progress tracking
 message_counts = {"artists": 0, "labels": 0, "release-groups": 0, "releases": 0}
 progress_interval = 100  # Log progress every 100 messages
@@ -351,7 +367,10 @@ async def _recover_consumers() -> None:
             active_connection = temp_connection
             active_channel = temp_channel
 
-            await active_channel.set_qos(prefetch_count=200)
+            # Channel-global QoS bounds total in-flight handlers to the pool capacity.
+            await active_channel.set_qos(
+                prefetch_count=_channel_prefetch(), global_=True
+            )
 
             # Declare per-data-type fanout exchanges and consumer-owned queues
             queues = {}
@@ -433,56 +452,76 @@ async def _recover_consumers() -> None:
         queues = {}
 
 
-async def _insert_relationship(
-    conn: Any, source_mbid: str, source_type: str, rel: dict[str, Any]
+async def _insert_relationships(
+    conn: Any, source_mbid: str, source_type: str, rels: list[dict[str, Any]]
 ) -> None:
-    """Insert a relationship record into musicbrainz.relationships."""
-    if not rel.get("target_mbid"):
-        return  # Skip relations without a target MBID (would fail UUID cast)
-    if not rel.get("target_type"):
-        return  # Skip relations without a target entity type
-    if not rel.get("type"):
-        return  # Skip relations without a relationship type
+    """Batch-insert relationship records for one entity into musicbrainz.relationships.
+
+    All of an entity's relationships are written with a single ``executemany`` so the
+    set is pipelined in one round-trip instead of one statement (and one network
+    round-trip) per relationship. This keeps the per-message transaction short, which
+    minimizes how long the connection sits ``idle in transaction`` holding a backend —
+    the dominant pressure on the shared PgBouncer budget during a bulk import.
+    """
+    params = [
+        (
+            source_mbid,
+            source_type,
+            rel.get("target_mbid", ""),
+            rel.get("target_type", ""),
+            rel.get("type", ""),
+            Jsonb(rel.get("attributes", [])),
+            rel.get("begin_date"),
+            rel.get("end_date"),
+            rel.get("ended", False),
+        )
+        for rel in rels
+        # Skip relations missing a target MBID (would fail UUID cast), target entity
+        # type, or relationship type — these would violate NOT NULL / cast constraints.
+        if rel.get("target_mbid") and rel.get("target_type") and rel.get("type")
+    ]
+    if not params:
+        return
     async with conn.cursor() as cursor:
-        await cursor.execute(
+        await cursor.executemany(
             "INSERT INTO musicbrainz.relationships "
             "(source_mbid, source_entity_type, target_mbid, target_entity_type, relationship_type, attributes, begin_date, end_date, ended) "
             "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) "
             "ON CONFLICT (source_mbid, target_mbid, source_entity_type, target_entity_type, relationship_type) "
             "DO UPDATE SET attributes = EXCLUDED.attributes, begin_date = EXCLUDED.begin_date, "
             "end_date = EXCLUDED.end_date, ended = EXCLUDED.ended",
-            (
-                source_mbid,
-                source_type,
-                rel.get("target_mbid", ""),
-                rel.get("target_type", ""),
-                rel.get("type", ""),
-                Jsonb(rel.get("attributes", [])),
-                rel.get("begin_date"),
-                rel.get("end_date"),
-                rel.get("ended", False),
-            ),
+            params,
         )
 
 
-async def _insert_external_link(
-    conn: Any, mbid: str, entity_type: str, link: dict[str, Any]
+async def _insert_external_links(
+    conn: Any, mbid: str, entity_type: str, links: list[dict[str, Any]]
 ) -> None:
-    """Insert an external link record into musicbrainz.external_links."""
-    if not link.get("url") or not link.get("service"):
-        return  # Skip links with missing URL or service name
+    """Batch-insert external link records for one entity into musicbrainz.external_links.
+
+    Uses a single ``executemany`` for the same round-trip / transaction-window reasons
+    described in :func:`_insert_relationships`.
+    """
+    params = [
+        (
+            mbid,
+            entity_type,
+            link.get("url", ""),
+            link.get("service", ""),
+        )
+        for link in links
+        if link.get("url")
+        and link.get("service")  # Skip links missing URL or service name
+    ]
+    if not params:
+        return
     async with conn.cursor() as cursor:
-        await cursor.execute(
+        await cursor.executemany(
             "INSERT INTO musicbrainz.external_links "
             "(mbid, entity_type, url, service_name) "
             "VALUES (%s, %s, %s, %s) "
             "ON CONFLICT (mbid, entity_type, service_name, url) DO UPDATE SET url = EXCLUDED.url",
-            (
-                mbid,
-                entity_type,
-                link.get("url", ""),
-                link.get("service", ""),
-            ),
+            params,
         )
 
 
@@ -528,13 +567,9 @@ async def process_artist(conn: Any, record: dict[str, Any]) -> None:
             ),
         )
 
-    # Insert relationships
-    for rel in record.get("relations", []):
-        await _insert_relationship(conn, mbid, "artist", rel)
-
-    # Insert external links
-    for link in record.get("external_links", []):
-        await _insert_external_link(conn, mbid, "artist", link)
+    # Insert relationships and external links (batched into one round-trip each)
+    await _insert_relationships(conn, mbid, "artist", record.get("relations", []))
+    await _insert_external_links(conn, mbid, "artist", record.get("external_links", []))
 
 
 async def process_label(conn: Any, record: dict[str, Any]) -> None:
@@ -571,13 +606,9 @@ async def process_label(conn: Any, record: dict[str, Any]) -> None:
             ),
         )
 
-    # Insert relationships
-    for rel in record.get("relations", []):
-        await _insert_relationship(conn, mbid, "label", rel)
-
-    # Insert external links
-    for link in record.get("external_links", []):
-        await _insert_external_link(conn, mbid, "label", link)
+    # Insert relationships and external links (batched into one round-trip each)
+    await _insert_relationships(conn, mbid, "label", record.get("relations", []))
+    await _insert_external_links(conn, mbid, "label", record.get("external_links", []))
 
 
 async def process_release(conn: Any, record: dict[str, Any]) -> None:
@@ -605,13 +636,11 @@ async def process_release(conn: Any, record: dict[str, Any]) -> None:
             ),
         )
 
-    # Insert relationships
-    for rel in record.get("relations", []):
-        await _insert_relationship(conn, mbid, "release", rel)
-
-    # Insert external links
-    for link in record.get("external_links", []):
-        await _insert_external_link(conn, mbid, "release", link)
+    # Insert relationships and external links (batched into one round-trip each)
+    await _insert_relationships(conn, mbid, "release", record.get("relations", []))
+    await _insert_external_links(
+        conn, mbid, "release", record.get("external_links", [])
+    )
 
 
 async def process_release_group(conn: Any, record: dict[str, Any]) -> None:
@@ -642,13 +671,13 @@ async def process_release_group(conn: Any, record: dict[str, Any]) -> None:
             ),
         )
 
-    # Insert relationships
-    for rel in record.get("relations", []):
-        await _insert_relationship(conn, mbid, "release-group", rel)
-
-    # Insert external links
-    for link in record.get("external_links", []):
-        await _insert_external_link(conn, mbid, "release-group", link)
+    # Insert relationships and external links (batched into one round-trip each)
+    await _insert_relationships(
+        conn, mbid, "release-group", record.get("relations", [])
+    )
+    await _insert_external_links(
+        conn, mbid, "release-group", record.get("external_links", [])
+    )
 
 
 # Map data types to their processing functions
@@ -963,15 +992,17 @@ async def main() -> None:
     try:
         connection_pool = AsyncPostgreSQLPool(
             connection_params=connection_params,
-            max_connections=50,
-            min_connections=5,
+            max_connections=config.postgres_pool_max_size,
+            min_connections=config.postgres_pool_min_size,
             max_retries=5,
             health_check_interval=30,
         )
         await connection_pool.initialize()
         logger.info("🐘 Connected to PostgreSQL with async resilient connection pool")
         logger.info(
-            "✅ Async connection pool initialized (min: 5, max: 50 connections)"
+            "✅ Async connection pool initialized (min: %d, max: %d connections)",
+            config.postgres_pool_min_size,
+            config.postgres_pool_max_size,
         )
     except Exception as e:
         logger.error("❌ Failed to initialize connection pool", error=str(e))
@@ -1044,10 +1075,13 @@ async def main() -> None:
         channel = await amqp_connection.channel()
         active_channel = channel
 
-        await channel.set_qos(prefetch_count=200)
+        # Channel-global QoS bounds total in-flight handlers across all consumers to the
+        # pool capacity, so the connection pool is never oversubscribed (see _channel_prefetch).
+        prefetch = _channel_prefetch()
+        await channel.set_qos(prefetch_count=prefetch, global_=True)
         logger.info(
-            "🔧 QoS prefetch configured",
-            prefetch_count=200,
+            "🔧 QoS prefetch configured (channel-global, coupled to pool max)",
+            prefetch_count=prefetch,
         )
 
         # Declare per-data-type fanout exchanges and consumer-owned queues
@@ -1099,7 +1133,7 @@ async def main() -> None:
 
         logger.info(
             f"🚀 Brainztableinator started! Connected to AMQP broker ({len(MUSICBRAINZ_DATA_TYPES)} fanout exchanges). "
-            f"Consuming from {len(MUSICBRAINZ_DATA_TYPES)} queues with connection pool (max 50 connections). "
+            f"Consuming from {len(MUSICBRAINZ_DATA_TYPES)} queues with connection pool (max {config.postgres_pool_max_size} connections). "
             "Ready to process MusicBrainz messages into PostgreSQL. Press CTRL+C to exit"
         )
 

--- a/common/config.py
+++ b/common/config.py
@@ -117,6 +117,35 @@ def parse_postgres_host_port(value: str | None, default_port: int = 5432) -> tup
     return raw, default_port
 
 
+def _coerce_pool_size(value: str | None, default: int) -> int:
+    """Parse a pool-size string to a positive int, falling back to default on anything invalid."""
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 1 else default
+
+
+def resolve_postgres_pool_sizes(default_min: int, default_max: int) -> tuple[int, int]:
+    """Resolve ``(min, max)`` PostgreSQL pool sizes from env with budget-aware defaults.
+
+    Every long-lived service shares a single PostgreSQL backend budget (in production
+    a PgBouncer pooler in *session* mode pins one backend per client connection for its
+    whole lifetime, with a hard per-database cap). The sum of every service's pool
+    ``max`` is therefore the deployment's real connection footprint and must stay under
+    that cap. Each service ships a conservative per-service default; an operator can
+    additionally clamp the whole fleet with the shared ``POSTGRES_POOL_MIN_SIZE`` /
+    ``POSTGRES_POOL_MAX_SIZE`` overrides without a code change.
+
+    Values are clamped so ``1 <= min <= max``.
+    """
+    min_size = _coerce_pool_size(getenv("POSTGRES_POOL_MIN_SIZE"), default_min)
+    max_size = _coerce_pool_size(getenv("POSTGRES_POOL_MAX_SIZE"), default_max)
+    max_size = max(max_size, 1)
+    min_size = min(min_size, max_size)
+    return min_size, max_size
+
+
 def _build_postgres_connstr() -> str:
     """Build a canonical ``host:port`` connection string for PostgreSQL.
 
@@ -289,6 +318,11 @@ class TableinatorConfig:
     postgres_username: str
     postgres_password: str
     postgres_database: str
+    # Connection-pool sizing. Tableinator batches writes through a BatchProcessor
+    # whose semaphore caps concurrent flushes, so it never needs many connections.
+    # Kept small to fit the shared PgBouncer backend budget (see resolve_postgres_pool_sizes).
+    postgres_pool_min_size: int = 2
+    postgres_pool_max_size: int = 12
 
     @classmethod
     def from_env(cls) -> "TableinatorConfig":
@@ -311,12 +345,16 @@ class TableinatorConfig:
         if missing_vars:
             raise ValueError(f"Missing required environment variables: {', '.join(missing_vars)}")
 
+        pool_min, pool_max = resolve_postgres_pool_sizes(default_min=2, default_max=12)
+
         return cls(
             amqp_connection=amqp_connection,
             postgres_host=_build_postgres_connstr(),
             postgres_username=cast("str", postgres_username),
             postgres_password=cast("str", postgres_password),
             postgres_database=cast("str", postgres_database),
+            postgres_pool_min_size=pool_min,
+            postgres_pool_max_size=pool_max,
         )
 
 
@@ -329,6 +367,11 @@ class BrainztableinatorConfig:
     postgres_username: str
     postgres_password: str
     postgres_database: str
+    # Connection-pool sizing. Brainztableinator's RabbitMQ prefetch is coupled to this
+    # max (see brainztableinator.py) so in-flight message handlers can never exceed the
+    # connection capacity. Kept small to fit the shared PgBouncer backend budget.
+    postgres_pool_min_size: int = 2
+    postgres_pool_max_size: int = 12
 
     @classmethod
     def from_env(cls) -> "BrainztableinatorConfig":
@@ -351,12 +394,16 @@ class BrainztableinatorConfig:
         if missing_vars:
             raise ValueError(f"Missing required environment variables: {', '.join(missing_vars)}")
 
+        pool_min, pool_max = resolve_postgres_pool_sizes(default_min=2, default_max=12)
+
         return cls(
             amqp_connection=amqp_connection,
             postgres_host=_build_postgres_connstr(),
             postgres_username=cast("str", postgres_username),
             postgres_password=cast("str", postgres_password),
             postgres_database=cast("str", postgres_database),
+            postgres_pool_min_size=pool_min,
+            postgres_pool_max_size=pool_max,
         )
 
 
@@ -596,6 +643,10 @@ class ApiConfig:
     neo4j_host: str
     neo4j_username: str
     neo4j_password: str
+    # Connection-pool sizing. The API is user-facing; modest concurrency is enough and
+    # it must share the PgBouncer backend budget with the importers (see resolve_postgres_pool_sizes).
+    postgres_pool_min_size: int = 2
+    postgres_pool_max_size: int = 8
     redis_host: str = "redis://redis:6379/0"
     jwt_algorithm: str = "HS256"
     jwt_expire_minutes: int = 30
@@ -690,6 +741,8 @@ class ApiConfig:
         except ValueError:
             snapshot_max_nodes = 100
 
+        pool_min, pool_max = resolve_postgres_pool_sizes(default_min=2, default_max=8)
+
         encryption_master_key = get_secret("ENCRYPTION_MASTER_KEY") or None
         brevo_api_key = get_secret("BREVO_API_KEY") or None
         brevo_sender_email = getenv("BREVO_SENDER_EMAIL", "noreply@discogsography.com")
@@ -721,6 +774,8 @@ class ApiConfig:
             neo4j_host=_build_neo4j_uri(),
             neo4j_username=cast("str", neo4j_username),
             neo4j_password=cast("str", neo4j_password),
+            postgres_pool_min_size=pool_min,
+            postgres_pool_max_size=pool_max,
             cors_origins=cors_origins,
             snapshot_ttl_days=snapshot_ttl_days,
             snapshot_max_nodes=snapshot_max_nodes,
@@ -770,6 +825,10 @@ class InsightsConfig:
     postgres_username: str
     postgres_password: str
     postgres_database: str
+    # Connection-pool sizing. Insights runs periodic batch analytics jobs and only needs
+    # a handful of connections; kept small to fit the shared PgBouncer backend budget.
+    postgres_pool_min_size: int = 1
+    postgres_pool_max_size: int = 4
     redis_host: str = "redis://localhost:6379/0"
     schedule_hours: int = 24
     milestone_years: tuple[int, ...] = (25, 30, 40, 50, 75, 100)
@@ -813,12 +872,16 @@ class InsightsConfig:
 
         redis_host = _build_redis_url()
 
+        pool_min, pool_max = resolve_postgres_pool_sizes(default_min=1, default_max=4)
+
         return cls(
             api_base_url=api_base_url,
             postgres_host=_build_postgres_connstr(),
             postgres_username=cast("str", postgres_username),
             postgres_password=cast("str", postgres_password),
             postgres_database=cast("str", postgres_database),
+            postgres_pool_min_size=pool_min,
+            postgres_pool_max_size=pool_max,
             redis_host=redis_host,
             schedule_hours=schedule_hours,
             milestone_years=milestone_years,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -232,6 +232,8 @@ Bolt traffic crosses an untrusted network (separate host/VM, overlay network, cl
 | `POSTGRES_USERNAME` | PostgreSQL username                          | (none)           | Yes      |
 | `POSTGRES_PASSWORD` | PostgreSQL password                          | (none)           | Yes      |
 | `POSTGRES_DATABASE` | Database name                                | `discogsography` | Yes      |
+| `POSTGRES_POOL_MIN_SIZE` | Override the connection-pool minimum for **all** pooled services | per-service default | No |
+| `POSTGRES_POOL_MAX_SIZE` | Override the connection-pool maximum for **all** pooled services | per-service default | No |
 
 **Used By**: Tableinator, Dashboard, API, Insights, Brainztableinator, Schema-Init
 
@@ -240,11 +242,21 @@ Bolt traffic crosses an untrusted network (separate host/VM, overlay network, cl
 > over `POSTGRES_PORT`; if no port is present, `POSTGRES_PORT` (default `5432`) is used.
 > IPv6 hosts may be bracketed, e.g. `[::1]:6432`.
 
+> **Connection-pool sizing**: Under a shared pooler in *session* mode (e.g. PgBouncer),
+> each client connection pins a dedicated Postgres backend for its lifetime, so the sum
+> of every service's pool maximum is the deployment's real backend footprint and must
+> stay under the pooler's per-database cap. Each service ships a conservative, workload-
+> appropriate default (api 2/8, tableinator 2/12, brainztableinator 2/12, insights 1/4;
+> dashboard uses a single connection). The two `POSTGRES_POOL_*` overrides clamp the whole
+> fleet uniformly without a code change. See
+> [postgres-pool-exhaustion-analysis.md](postgres-pool-exhaustion-analysis.md) for the
+> rationale.
+
 **Connection Details**:
 
 - Protocol: PostgreSQL wire protocol
 - Default port: 5432 (mapped to 5433 in Docker)
-- Connection pool: 20 connections (max)
+- Connection pool: budget-aware per-service sizing (see note above)
 - Retry logic: Exponential backoff (max 5 attempts)
 - Query timeout: 30 seconds
 

--- a/docs/postgres-pool-exhaustion-analysis.md
+++ b/docs/postgres-pool-exhaustion-analysis.md
@@ -1,0 +1,205 @@
+# PostgreSQL Connection-Pool Exhaustion — Root-Cause Analysis
+
+## Context
+
+In production all long-lived services connect to a shared PostgreSQL through a
+**PgBouncer pooler in session-pooling mode** (`POSTGRES_HOST=pgbouncer:6432`). In
+session mode every client connection is pinned to a dedicated Postgres backend for its
+entire lifetime — there is no multiplexing, even while the connection is idle. PgBouncer
+enforces a **per-database backend cap of 45**. The total number of Postgres connections
+the discogsography app holds open is therefore its real footprint and must stay modest.
+
+### Observed symptoms (during a MusicBrainz bulk import)
+
+- `brainztableinator` logs repeatedly: `⚠️ Connection pool exhausted (attempt 1/5),
+  waiting for available connection...` (`common/postgres_resilient.py:512`).
+- PgBouncer: 45/45 server connections in use, 0 idle, ~18 client connections queued, max
+  wait ~78–107 s (hard `query_wait_timeout` is 120 s).
+- Postgres: ~46 backends — 3 active, 14 idle, 29 *idle in transaction*. The
+  *idle in transaction* backends cycle sub-millisecond running
+  `INSERT INTO musicbrainz.relationships (...)` — genuine work, not a hung leak.
+- No crashes (the 5-retry resilient pool absorbs it), but the import is throttled and
+  constantly churning on "pool exhausted".
+
+The app collectively wants ~63 connections against a 45 cap.
+
+---
+
+## 1. Per-service connection-pool sizing
+
+The pool class is `AsyncPostgreSQLPool` in `common/postgres_resilient.py:303` with
+constructor defaults `max_connections=20, min_connections=2`. Each service overrides
+these at construction.
+
+### Before this change
+
+| Service | Pool site (before) | min | max | Write model |
+| --- | --- | --- | --- | --- |
+| api | `api/api.py:218` | 2 | 10 | connection-per-request |
+| tableinator | `tableinator/tableinator.py:893` | 5 | 50 | **batched** — `BatchProcessor`, semaphore caps concurrent flushes at 2 |
+| brainztableinator | `brainztableinator/brainztableinator.py:964` | 5 | 50 | **one transaction per message**, prefetch 200 × 4 consumers |
+| insights | `insights/insights.py:116` | 1 | 5 | periodic batch analytics |
+| dashboard | `dashboard/dashboard.py:173` | — | — | single `AsyncResilientPostgreSQL` (~1 backend), no pool |
+| graphinator / brainzgraphinator | — | — | — | Neo4j only, no PostgreSQL |
+
+**Sum of pool maxima = 10 + 50 + 50 + 5 = 115** (plus ~1 for dashboard) — **2.5× the
+45-backend cap.** The sizes were not coordinated against the shared budget; the two
+`*tableinator` values are a copy-pasted `max=50` "to match prefetch_count" (see the
+comment that was at `tableinator/tableinator.py:891`). Under session pooling, every one
+of these is a real, exclusively-held backend.
+
+Two facts make this the primary root cause:
+
+- **`brainztableinator` alone (max 50) exceeds the entire 45 cap.** A single importer can
+  starve the whole database of backends.
+- Even the **idle** footprint was wasteful: the `min` connections (5 + 5 + 2 + 1 = 13,
+  plus dashboard) are pinned backends held even when a service is doing nothing — e.g.
+  `tableinator` sits idle during a MusicBrainz import but still holds its 5 minimum.
+
+### After this change
+
+Pool sizes are now **budget-aware, env-overridable defaults** resolved by
+`resolve_postgres_pool_sizes()` (`common/config.py`) and stored on each service config
+(`postgres_pool_min_size` / `postgres_pool_max_size`):
+
+| Service | min | max |
+| --- | --- | --- |
+| api | 2 | 8 |
+| tableinator | 2 | 12 |
+| brainztableinator | 2 | 12 |
+| insights | 1 | 4 |
+| dashboard | ~1 (single connection, unchanged) |
+
+**Sum of maxima = 8 + 12 + 12 + 4 ≈ 36 (+1 dashboard) ≤ 45**, with headroom for
+health-check transients. Idle footprint (sum of minima) drops to **8**. Worst realistic
+concurrent demand during a MusicBrainz import — `brainztableinator` saturated at 12 +
+`tableinator` idle min 2 + api ~8 + insights ~4 + dashboard 1 ≈ **27**, comfortably under
+45. Operators can clamp the whole fleet at once with `POSTGRES_POOL_MIN_SIZE` /
+`POSTGRES_POOL_MAX_SIZE` without a code change.
+
+---
+
+## 2. Transaction scope
+
+`brainztableinator`'s write path holds one transaction per message:
+
+```python
+# brainztableinator/brainztableinator.py (on_data_message)
+async with connection_pool.connection() as conn:
+    await conn.set_autocommit(False)
+    async with conn.transaction():
+        await processor(conn, data)   # entity upsert + N relationships + M external links
+```
+
+The transaction window itself is correctly scoped to a single message (`BEGIN → work →
+COMMIT`) and is **not** held across message-fetch waits or batch boundaries. However the
+*work inside it* was the problem: each processor issued **one `INSERT` per child row** in
+a Python `for` loop (`_insert_relationship` / `_insert_external_link`, called once per
+relationship and once per external link). Between each statement the connection sits
+*idle in transaction* — pinning a backend — while Python builds and dispatches the next
+`INSERT` and waits a network round-trip through PgBouncer → Postgres. An artist with many
+relations produced many sequential round-trips, all inside one open transaction. This is
+exactly the observed "29 backends *idle in transaction*, cycling sub-millisecond on
+`INSERT INTO musicbrainz.relationships`".
+
+By contrast `tableinator` writes a whole batch of messages in **one** transaction
+through its `BatchProcessor` (`tableinator/batch_processor.py:386`), so it holds far fewer
+transactions open for far less wall-clock — which is why it never exhausted the pool
+despite the identical `max=50`.
+
+**Fix:** the per-row loops are replaced with batched `_insert_relationships` /
+`_insert_external_links` that issue a single `executemany(...)` for the whole set
+(psycopg3 pipelines `executemany`), collapsing N + M round-trips into 2 and shrinking the
+*idle in transaction* window proportionally.
+
+---
+
+## 3. Connection acquisition / release
+
+Acquisition/release is correct in every service — connections are taken per-operation via
+the `async with pool.connection()` context manager and returned promptly in the `finally`
+block (`common/postgres_resilient.py:469-585`), which also restores `autocommit=True`
+before returning the connection to the pool. No service holds a pooled connection idle for
+the lifetime of a worker.
+
+The pressure was therefore **not** a leak or a held-open connection; it was **too many
+connections acquired concurrently at once**: `brainztableinator` sets channel QoS
+`prefetch_count=200` (`brainztableinator.py:1047` and the reconnect path at `:354`), and
+declares **4 consumers** (one per MusicBrainz data type). With per-consumer prefetch that
+is up to **800 messages in flight simultaneously**, each running `on_data_message`, each
+trying to check out a pooled connection. Demand (≤ 800) vastly exceeds the pool max (50),
+which itself exceeds the PgBouncer cap (45) — so the pool is permanently driven to its
+ceiling and the "exhausted, waiting" retry path runs continuously.
+
+**Fix:** prefetch is now coupled to pool capacity. Both `set_qos` calls use
+**channel-global QoS** (`global_=True`) with `prefetch_count = postgres_pool_max_size`
+(`_channel_prefetch()`), so the broker never delivers more unacked messages than the pool
+can service. Backpressure moves to RabbitMQ — where it belongs — instead of the pool's
+retry loop. `tableinator` keeps its high prefetch because its `BatchProcessor` semaphore
+already decouples prefetch from connection demand (its prefetch fills an in-memory batch,
+not a connection each).
+
+---
+
+## 4. Write efficiency
+
+The bulk path can do the same work with far fewer connection-seconds:
+
+- **Batched child inserts (implemented):** `executemany` for relationships and external
+  links cuts per-message round-trips from `1 + N + M` to `1 + 2`, shortening each
+  transaction and freeing the backend sooner — fewer connection-seconds per message means
+  lower concurrency is needed for the same throughput.
+- **Bounded concurrency (implemented):** capping in-flight handlers to the pool size
+  removes the retry churn that was itself throttling the import. 12 clean concurrent
+  writers with no churn sustain more useful throughput than "50 wanted, constantly
+  retrying".
+- **Future option (not implemented):** adopt `tableinator`'s `BatchProcessor` pattern in
+  `brainztableinator` (accumulate many messages, write each entity type in one batched
+  transaction). This would push connection demand even lower, at the cost of a larger,
+  MusicBrainz-schema-specific refactor. Recommended only if 12 concurrent writers prove
+  insufficient.
+
+---
+
+## 5. Resilient-pool retry behavior
+
+The "exhausted" path (`common/postgres_resilient.py:502-515`): when the pool is at
+`max_connections` and empty, the caller waits on `asyncio.wait_for(self.connections.get(),
+timeout=backoff.get_delay(retry_count))`; on `TimeoutError` it increments `retry_count`,
+logs the warning, and retries. After `max_retries` (5) it raises
+`Failed to get PostgreSQL connection after 5 attempts` (`:543`). With
+`ExponentialBackoff(initial_delay=0.5, max_delay=30)` the cumulative wait across 5
+attempts is bounded at roughly 0.5 + 1 + 2 + 4 + 8 ≈ 15 s, well under PgBouncer's 120 s
+`query_wait_timeout`, and it **does** surface a clear hard failure rather than silently
+degrading.
+
+The retry logic is sound as a safety net and is **left unchanged**. The concern is not its
+correctness but that it was being used as a substitute for correct sizing: the system was
+relying on retries to paper over structural oversubscription. With sizing and prefetch
+fixed, this path should rarely trigger.
+
+---
+
+## Recommendation & tradeoffs
+
+This is fundamentally an **app-side over-pooling** problem, so the fix is app-side and
+preferred over asking the platform to raise the cap:
+
+1. **Right-size pools to fit the shared budget** (sum of maxima 115 → ~36) and make them
+   env-overridable. *Tradeoff:* lower per-service ceiling; mitigated by coupling prefetch
+   so the ceiling is never the bottleneck, and by the fact that `tableinator`'s real usage
+   was only ~2-3 connections anyway.
+2. **Couple `brainztableinator` prefetch to pool capacity** (channel-global QoS). *Tradeoff:*
+   fewer messages buffered in the consumer; the broker holds them instead — which is the
+   correct place for backpressure. One hot queue can use the whole budget (desired).
+3. **Batch child-row inserts** to shrink the *idle in transaction* window. *Tradeoff:* a
+   single `executemany` is now all-or-nothing within the message's transaction (already
+   the semantics, since it was one transaction per message).
+
+**When to raise the PgBouncer cap instead:** only if, after these fixes, measured import
+throughput at 12 concurrent writers is genuinely insufficient for the business need. In
+that case the principled move is to raise the cap **and** the relevant
+`POSTGRES_POOL_MAX_SIZE` *together* (keeping the sum of service maxima under the new cap) —
+never to let a single service's pool max exceed the cap, which is what caused this
+incident. The 45 cap is not currently the limiting factor; the uncoordinated 115 of demand
+was.

--- a/insights/insights.py
+++ b/insights/insights.py
@@ -121,8 +121,8 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
             "user": _config.postgres_username,
             "password": _config.postgres_password,
         },
-        max_connections=5,
-        min_connections=1,
+        max_connections=_config.postgres_pool_max_size,
+        min_connections=_config.postgres_pool_min_size,
     )
     await _pool.initialize()
     logger.info("🐘 PostgreSQL pool initialized")

--- a/tableinator/tableinator.py
+++ b/tableinator/tableinator.py
@@ -887,20 +887,24 @@ async def main() -> None:
         "password": str(config.postgres_password),
     }
 
-    # Initialize async resilient connection pool for concurrent access
-    # Increased from max=20 to max=50 to match prefetch_count for better throughput
+    # Initialize async resilient connection pool for concurrent access.
+    # Writes go through the BatchProcessor, whose semaphore (max_concurrent_flushes)
+    # caps simultaneous PostgreSQL flushes — so a small pool is sufficient and keeps
+    # the service within the shared PgBouncer backend budget (see resolve_postgres_pool_sizes).
     try:
         connection_pool = AsyncPostgreSQLPool(
             connection_params=connection_params,
-            max_connections=50,
-            min_connections=5,
+            max_connections=config.postgres_pool_max_size,
+            min_connections=config.postgres_pool_min_size,
             max_retries=5,
             health_check_interval=30,
         )
         await connection_pool.initialize()
         logger.info("🐘 Connected to PostgreSQL with async resilient connection pool")
         logger.info(
-            "✅ Async connection pool initialized (min: 5, max: 50 connections)"
+            "✅ Async connection pool initialized (min: %d, max: %d connections)",
+            config.postgres_pool_min_size,
+            config.postgres_pool_max_size,
         )
     except Exception as e:
         logger.error("❌ Failed to initialize connection pool", error=str(e))

--- a/tests/brainztableinator/test_brainztableinator.py
+++ b/tests/brainztableinator/test_brainztableinator.py
@@ -12,8 +12,9 @@ import pytest
 
 from brainztableinator.brainztableinator import (
     PROCESSORS,
-    _insert_external_link,
-    _insert_relationship,
+    _channel_prefetch,
+    _insert_external_links,
+    _insert_relationships,
     _recover_consumers,
     check_all_consumers_idle,
     close_rabbitmq_connection,
@@ -152,15 +153,16 @@ class TestProcessArtist:
 
         await process_artist(mock_conn, record)
 
-        # Should have 3 execute calls: artist insert + relationship + external link
-        assert mock_cursor.execute.call_count == 3
+        # The entity upsert uses execute(); relationships and external links are each
+        # batched into a single executemany() to keep the transaction short.
+        assert mock_cursor.execute.call_count == 1
+        assert "INSERT INTO musicbrainz.artists" in mock_cursor.execute.call_args_list[0][0][0]
+        assert mock_cursor.executemany.call_count == 2
 
-        # Check relationship insert
-        rel_sql = mock_cursor.execute.call_args_list[1][0][0]
+        rel_sql = mock_cursor.executemany.call_args_list[0][0][0]
         assert "INSERT INTO musicbrainz.relationships" in rel_sql
 
-        # Check external link insert
-        link_sql = mock_cursor.execute.call_args_list[2][0][0]
+        link_sql = mock_cursor.executemany.call_args_list[1][0][0]
         assert "INSERT INTO musicbrainz.external_links" in link_sql
 
 
@@ -264,15 +266,16 @@ class TestProcessReleaseGroup:
 
         await process_release_group(mock_conn, record)
 
-        # Should have 3 execute calls: release_group insert + relationship + external link
-        assert mock_cursor.execute.call_count == 3
+        # The entity upsert uses execute(); relationships and external links are each
+        # batched into a single executemany() to keep the transaction short.
+        assert mock_cursor.execute.call_count == 1
+        assert "INSERT INTO musicbrainz.release_groups" in mock_cursor.execute.call_args_list[0][0][0]
+        assert mock_cursor.executemany.call_count == 2
 
-        # Check relationship insert
-        rel_sql = mock_cursor.execute.call_args_list[1][0][0]
+        rel_sql = mock_cursor.executemany.call_args_list[0][0][0]
         assert "INSERT INTO musicbrainz.relationships" in rel_sql
 
-        # Check external link insert
-        link_sql = mock_cursor.execute.call_args_list[2][0][0]
+        link_sql = mock_cursor.executemany.call_args_list[1][0][0]
         assert "INSERT INTO musicbrainz.external_links" in link_sql
 
 
@@ -281,119 +284,130 @@ class TestProcessReleaseGroup:
 # ===========================================================================
 
 
-class TestInsertRelationship:
-    """Tests for _insert_relationship."""
+class TestInsertRelationships:
+    """Tests for _insert_relationships (batched executemany)."""
 
     @pytest.mark.asyncio
-    async def test_insert_relationship(self):
-        """Verify INSERT INTO musicbrainz.relationships is called."""
+    async def test_insert_relationships(self):
+        """Verify all relationships are written with a single executemany."""
         mock_conn, mock_cursor = _make_mock_conn()
-        rel = {
-            "target_mbid": "target-mbid-1",
-            "target_type": "artist",
-            "type": "member of band",
-            "attributes": ["guitar"],
-            "begin_date": "2000-01-01",
-            "end_date": None,
-            "ended": False,
-        }
+        rels = [
+            {
+                "target_mbid": "target-mbid-1",
+                "target_type": "artist",
+                "type": "member of band",
+                "attributes": ["guitar"],
+                "begin_date": "2000-01-01",
+                "end_date": None,
+                "ended": False,
+            },
+            {
+                "target_mbid": "target-mbid-2",
+                "target_type": "artist",
+                "type": "collaboration",
+            },
+        ]
 
-        await _insert_relationship(mock_conn, "source-mbid-1", "artist", rel)
+        await _insert_relationships(mock_conn, "source-mbid-1", "artist", rels)
 
-        mock_cursor.execute.assert_called_once()
-        sql = mock_cursor.execute.call_args[0][0]
+        # One pipelined round-trip for the whole set, not one execute per relationship.
+        mock_cursor.execute.assert_not_called()
+        mock_cursor.executemany.assert_called_once()
+        sql = mock_cursor.executemany.call_args[0][0]
+        params = mock_cursor.executemany.call_args[0][1]
         assert "INSERT INTO musicbrainz.relationships" in sql
         assert "ON CONFLICT" in sql
         assert "DO UPDATE SET" in sql
+        assert len(params) == 2
 
     @pytest.mark.asyncio
-    async def test_insert_relationship_no_target_skips(self):
-        """Empty target_mbid is skipped to avoid PostgreSQL UUID cast failure."""
+    async def test_insert_relationships_filters_invalid_rows(self):
+        """Rows missing target_mbid/target_type/type are dropped from the batch."""
         mock_conn, mock_cursor = _make_mock_conn()
-        rel = {
-            "target_mbid": "",
-            "target_type": "artist",
-            "type": "member of band",
-        }
+        rels = [
+            {"target_mbid": "", "target_type": "artist", "type": "x"},  # empty mbid (UUID cast)
+            {"target_type": "artist", "type": "x"},  # missing target_mbid
+            {"target_mbid": "ok", "type": "x"},  # missing target_type
+            {"target_mbid": "ok", "target_type": "artist"},  # missing type
+            {"target_mbid": "ok", "target_type": "artist", "type": "valid"},  # the only good row
+        ]
 
-        await _insert_relationship(mock_conn, "source-mbid-1", "artist", rel)
+        await _insert_relationships(mock_conn, "source-mbid-1", "artist", rels)
 
-        # Empty target_mbid should be skipped (would fail UUID cast)
-        mock_cursor.execute.assert_not_called()
+        mock_cursor.executemany.assert_called_once()
+        params = mock_cursor.executemany.call_args[0][1]
+        assert len(params) == 1
 
     @pytest.mark.asyncio
-    async def test_insert_relationship_missing_target_skips(self):
-        """Missing target_mbid key is skipped."""
+    async def test_insert_relationships_empty_skips_db(self):
+        """An empty/all-invalid batch issues no database call."""
         mock_conn, mock_cursor = _make_mock_conn()
-        rel = {
-            "target_type": "artist",
-            "type": "member of band",
-        }
 
-        await _insert_relationship(mock_conn, "source-mbid-1", "artist", rel)
-
-        # Missing target_mbid should be skipped
-        mock_cursor.execute.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_insert_relationship_no_target_type_skips(self):
-        """Missing target_type is skipped."""
-        mock_conn, mock_cursor = _make_mock_conn()
-        rel = {
-            "target_mbid": "target-mbid-1",
-            "type": "member of band",
-        }
-
-        await _insert_relationship(mock_conn, "source-mbid-1", "artist", rel)
+        await _insert_relationships(mock_conn, "source-mbid-1", "artist", [])
 
         mock_cursor.execute.assert_not_called()
+        mock_cursor.executemany.assert_not_called()
+
+
+class TestInsertExternalLinks:
+    """Tests for _insert_external_links (batched executemany)."""
 
     @pytest.mark.asyncio
-    async def test_insert_relationship_no_type_skips(self):
-        """Missing relationship type is skipped."""
+    async def test_insert_external_links(self):
+        """Verify external links are written with a single executemany upsert."""
         mock_conn, mock_cursor = _make_mock_conn()
-        rel = {
-            "target_mbid": "target-mbid-1",
-            "target_type": "artist",
-        }
+        links = [
+            {"url": "https://example.com", "service": "official homepage"},
+            {"url": "https://discogs.com/x", "service": "discogs"},
+        ]
 
-        await _insert_relationship(mock_conn, "source-mbid-1", "artist", rel)
+        await _insert_external_links(mock_conn, "mbid-1", "artist", links)
 
         mock_cursor.execute.assert_not_called()
-
-
-class TestInsertExternalLink:
-    """Tests for _insert_external_link."""
-
-    @pytest.mark.asyncio
-    async def test_insert_external_link(self):
-        """Verify INSERT INTO musicbrainz.external_links is called with upsert."""
-        mock_conn, mock_cursor = _make_mock_conn()
-        link = {
-            "url": "https://example.com",
-            "service": "official homepage",
-        }
-
-        await _insert_external_link(mock_conn, "mbid-1", "artist", link)
-
-        mock_cursor.execute.assert_called_once()
-        sql = mock_cursor.execute.call_args[0][0]
+        mock_cursor.executemany.assert_called_once()
+        sql = mock_cursor.executemany.call_args[0][0]
+        params = mock_cursor.executemany.call_args[0][1]
         assert "INSERT INTO musicbrainz.external_links" in sql
         assert "ON CONFLICT (mbid, entity_type, service_name, url) DO UPDATE SET url = EXCLUDED.url" in sql
+        assert len(params) == 2
 
     @pytest.mark.asyncio
-    async def test_insert_external_link_no_service_skips(self):
-        """Empty service/url skips the insert entirely."""
+    async def test_insert_external_links_filters_invalid_rows(self):
+        """Links with empty url or service are dropped; an empty batch issues no DB call."""
         mock_conn, mock_cursor = _make_mock_conn()
-        link = {
-            "url": "",
-            "service": "",
-        }
+        links = [
+            {"url": "", "service": ""},
+            {"url": "https://example.com", "service": ""},
+            {"url": "", "service": "discogs"},
+        ]
 
-        await _insert_external_link(mock_conn, "mbid-1", "artist", link)
+        await _insert_external_links(mock_conn, "mbid-1", "artist", links)
 
-        # Links with empty url or service are skipped
         mock_cursor.execute.assert_not_called()
+        mock_cursor.executemany.assert_not_called()
+
+
+# ===========================================================================
+# Prefetch / pool-coupling tests
+# ===========================================================================
+
+
+class TestChannelPrefetch:
+    """Tests for _channel_prefetch (RabbitMQ prefetch coupled to pool capacity)."""
+
+    def test_prefetch_matches_pool_max_when_config_loaded(self):
+        """Prefetch equals the configured pool max so in-flight handlers can't exceed it."""
+        mock_config = MagicMock()
+        mock_config.postgres_pool_max_size = 7
+        with patch("brainztableinator.brainztableinator.config", mock_config):
+            assert _channel_prefetch() == 7
+
+    def test_prefetch_falls_back_when_config_unset(self):
+        """Before config loads, prefetch falls back to the default pool max."""
+        from brainztableinator.brainztableinator import _DEFAULT_POOL_MAX
+
+        with patch("brainztableinator.brainztableinator.config", None):
+            assert _channel_prefetch() == _DEFAULT_POOL_MAX
 
 
 # ===========================================================================
@@ -1821,8 +1835,9 @@ class TestMain:
 
         assert mock_pool_class.call_count == 1
         call_args = mock_pool_class.call_args
-        assert call_args[1]["max_connections"] == 50
-        assert call_args[1]["min_connections"] == 5
+        # Budget-aware defaults from BrainztableinatorConfig (resolve_postgres_pool_sizes).
+        assert call_args[1]["max_connections"] == 12
+        assert call_args[1]["min_connections"] == 2
         mock_rabbitmq_class.assert_called_once()
 
     @pytest.mark.asyncio
@@ -2026,10 +2041,10 @@ class TestProcessLabelRelationshipsAndLinks:
 
         await process_label(mock_conn, record)
 
-        # Should have calls for the main insert + relationship insert
-        assert mock_cursor.execute.call_count >= 2
-        rel_call = mock_cursor.execute.call_args_list[1]
-        assert "musicbrainz.relationships" in rel_call[0][0]
+        # Entity upsert via execute(); relationships batched via a single executemany().
+        assert mock_cursor.execute.call_count == 1
+        mock_cursor.executemany.assert_called_once()
+        assert "musicbrainz.relationships" in mock_cursor.executemany.call_args[0][0]
 
     @pytest.mark.asyncio
     async def test_process_label_with_external_links(self) -> None:
@@ -2046,9 +2061,10 @@ class TestProcessLabelRelationshipsAndLinks:
 
         await process_label(mock_conn, record)
 
-        assert mock_cursor.execute.call_count >= 2
-        link_call = mock_cursor.execute.call_args_list[1]
-        assert "musicbrainz.external_links" in link_call[0][0]
+        # Entity upsert via execute(); external links batched via a single executemany().
+        assert mock_cursor.execute.call_count == 1
+        mock_cursor.executemany.assert_called_once()
+        assert "musicbrainz.external_links" in mock_cursor.executemany.call_args[0][0]
 
     @pytest.mark.asyncio
     async def test_process_release_with_relationships(self) -> None:
@@ -2065,9 +2081,10 @@ class TestProcessLabelRelationshipsAndLinks:
 
         await process_release(mock_conn, record)
 
-        assert mock_cursor.execute.call_count >= 2
-        rel_call = mock_cursor.execute.call_args_list[1]
-        assert "musicbrainz.relationships" in rel_call[0][0]
+        # Entity upsert via execute(); relationships batched via a single executemany().
+        assert mock_cursor.execute.call_count == 1
+        mock_cursor.executemany.assert_called_once()
+        assert "musicbrainz.relationships" in mock_cursor.executemany.call_args[0][0]
 
     @pytest.mark.asyncio
     async def test_process_release_with_external_links(self) -> None:
@@ -2084,9 +2101,10 @@ class TestProcessLabelRelationshipsAndLinks:
 
         await process_release(mock_conn, record)
 
-        assert mock_cursor.execute.call_count >= 2
-        link_call = mock_cursor.execute.call_args_list[1]
-        assert "musicbrainz.external_links" in link_call[0][0]
+        # Entity upsert via execute(); external links batched via a single executemany().
+        assert mock_cursor.execute.call_count == 1
+        mock_cursor.executemany.assert_called_once()
+        assert "musicbrainz.external_links" in mock_cursor.executemany.call_args[0][0]
 
 
 # ===========================================================================

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -14,7 +14,7 @@ from common import (
     neo4j_security_kwargs,
     setup_logging,
 )
-from common.config import _build_postgres_connstr, get_secret, parse_postgres_host_port
+from common.config import _build_postgres_connstr, get_secret, parse_postgres_host_port, resolve_postgres_pool_sizes
 
 
 class TestExtractorConfig:
@@ -115,6 +115,23 @@ class TestTableinatorConfig:
         assert config.postgres_username == "pguser"
         assert config.postgres_password == "pgpass"
         assert config.postgres_database == "mydb"
+        # Budget-aware pool defaults (no POSTGRES_POOL_* override set).
+        assert config.postgres_pool_min_size == 2
+        assert config.postgres_pool_max_size == 12
+
+    def test_pool_size_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """POSTGRES_POOL_* overrides let an operator clamp the fleet without code changes."""
+        monkeypatch.setenv("POSTGRES_HOST", "pghost")
+        monkeypatch.setenv("POSTGRES_USERNAME", "pguser")
+        monkeypatch.setenv("POSTGRES_PASSWORD", "pgpass")
+        monkeypatch.setenv("POSTGRES_DATABASE", "mydb")
+        monkeypatch.setenv("POSTGRES_POOL_MIN_SIZE", "3")
+        monkeypatch.setenv("POSTGRES_POOL_MAX_SIZE", "6")
+
+        config = TableinatorConfig.from_env()
+
+        assert config.postgres_pool_min_size == 3
+        assert config.postgres_pool_max_size == 6
 
     def test_from_env_missing_required(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test configuration loading with missing required variables."""
@@ -1329,3 +1346,31 @@ class TestBuildPostgresConnstr:
         monkeypatch.delenv("POSTGRES_HOST", raising=False)
         monkeypatch.delenv("POSTGRES_PORT", raising=False)
         assert _build_postgres_connstr() == "localhost:5432"
+
+
+class TestResolvePostgresPoolSizes:
+    """Test resolve_postgres_pool_sizes — the shared PgBouncer-budget pool sizer."""
+
+    def test_defaults_used_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With no env overrides, the per-service defaults are returned verbatim."""
+        monkeypatch.delenv("POSTGRES_POOL_MIN_SIZE", raising=False)
+        monkeypatch.delenv("POSTGRES_POOL_MAX_SIZE", raising=False)
+        assert resolve_postgres_pool_sizes(default_min=2, default_max=12) == (2, 12)
+
+    def test_env_overrides_win(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Both overrides are honored when set."""
+        monkeypatch.setenv("POSTGRES_POOL_MIN_SIZE", "1")
+        monkeypatch.setenv("POSTGRES_POOL_MAX_SIZE", "5")
+        assert resolve_postgres_pool_sizes(default_min=2, default_max=12) == (1, 5)
+
+    def test_invalid_values_fall_back_to_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Non-integer / non-positive overrides are ignored in favor of the defaults."""
+        monkeypatch.setenv("POSTGRES_POOL_MIN_SIZE", "not-a-number")
+        monkeypatch.setenv("POSTGRES_POOL_MAX_SIZE", "0")
+        assert resolve_postgres_pool_sizes(default_min=2, default_max=8) == (2, 8)
+
+    def test_min_clamped_to_max(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """min is clamped so it never exceeds max (1 <= min <= max)."""
+        monkeypatch.setenv("POSTGRES_POOL_MIN_SIZE", "20")
+        monkeypatch.setenv("POSTGRES_POOL_MAX_SIZE", "4")
+        assert resolve_postgres_pool_sizes(default_min=2, default_max=12) == (4, 4)

--- a/tests/tableinator/test_tableinator.py
+++ b/tests/tableinator/test_tableinator.py
@@ -277,10 +277,11 @@ class TestMain:
 
         # Verify setup was performed
         assert mock_pool_class.call_count == 1
-        # Check that it was called with correct parameters (updated for performance optimization)
+        # Budget-aware defaults from TableinatorConfig (resolve_postgres_pool_sizes). The
+        # BatchProcessor semaphore caps concurrent flushes, so a small pool is sufficient.
         call_args = mock_pool_class.call_args
-        assert call_args[1]["max_connections"] == 50
-        assert call_args[1]["min_connections"] == 5
+        assert call_args[1]["max_connections"] == 12
+        assert call_args[1]["min_connections"] == 2
         mock_rabbitmq_class.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/test_batch_performance.py
+++ b/tests/test_batch_performance.py
@@ -371,15 +371,19 @@ class TestQoSOptimization:
 
     @pytest.mark.asyncio
     async def test_tableinator_connection_pool_size(self):
-        """Test that Tableinator uses appropriate connection pool size."""
+        """Document Tableinator's connection-pool sizing intent.
 
-        # Connection pool should match or exceed prefetch_count
-        # This is tested implicitly in the code, but documented here
-        # Expected: min_connections=5, max_connections=50
+        Tableinator no longer sizes its pool to match prefetch_count. Writes flow
+        through the BatchProcessor, whose ``max_concurrent_flushes`` semaphore caps
+        simultaneous PostgreSQL flushes, so only a small pool is ever needed. Pool
+        sizing is now budget-aware (see common.config.resolve_postgres_pool_sizes) and
+        coordinated across services to fit the shared PgBouncer per-database cap rather
+        than scaled per-service to prefetch.
+        """
+        from common.config import resolve_postgres_pool_sizes
 
-        # In actual deployment, verify pool size matches QoS
-        # This test serves as documentation of the requirement
-        assert True  # Placeholder - actual validation is in integration tests
+        # Default tableinator sizing stays small and within the shared backend budget.
+        assert resolve_postgres_pool_sizes(default_min=2, default_max=12) == (2, 12)
 
 
 @pytest.mark.benchmark


### PR DESCRIPTION
## Problem

In production, all long-lived services connect to a shared PostgreSQL through a **PgBouncer pooler in session-pooling mode** (`POSTGRES_HOST=pgbouncer:6432`). In session mode every client connection pins a dedicated Postgres backend for its whole lifetime against a hard **per-database cap of 45**. During a MusicBrainz bulk import, `brainztableinator` churns constantly on `⚠️ Connection pool exhausted (attempt 1/5)…` while PgBouncer sits at 45/45 with ~18 clients queued and Postgres shows ~29 backends *idle in transaction*. The app collectively wants ~63 connections against the 45 cap.

Full write-up: [`docs/postgres-pool-exhaustion-analysis.md`](../blob/worktree-fix+pg-pool-exhaustion/docs/postgres-pool-exhaustion-analysis.md).

## Root causes (with evidence)

1. **Uncoordinated, oversized pool maxima.** Sum of service pool `max` was **115** (api 10 + tableinator 50 + brainztableinator 50 + insights 5) — 2.5× the cap. `brainztableinator`'s `max=50` *alone* exceeds the 45 cap. Sizes were copy-pasted "to match prefetch", not budgeted against the shared backend pool.
2. **No concurrency bound in `brainztableinator`.** One transaction per message, with `prefetch_count=200` × 4 consumers = up to **800 in-flight handlers**, each grabbing a pooled connection — permanently driving the pool to its ceiling. (`tableinator` never exhausts despite the same `max=50` because its `BatchProcessor` semaphore caps concurrent flushes at 2.)
3. **Per-row child inserts widen the *idle-in-transaction* window.** Each relationship/external-link was a separate `INSERT` in a Python loop inside one open transaction — N+M sequential round-trips pinning the backend between statements.

## Fixes (app-side — the app was over-pooling)

- **Budget-aware pool sizing** via `resolve_postgres_pool_sizes()` in `common/config.py`, with per-service defaults (api 2/8, tableinator 2/12, brainztableinator 2/12, insights 1/4) and shared `POSTGRES_POOL_MIN_SIZE` / `POSTGRES_POOL_MAX_SIZE` overrides. New sum of maxima ≈ **36 ≤ 45**; idle footprint drops from 13 → 8.
- **Couple `brainztableinator` prefetch to pool capacity** — channel-global QoS (`global_=True`) with `prefetch_count = pool max` (`_channel_prefetch`), so RabbitMQ applies backpressure instead of the pool's retry loop.
- **Batch child-row inserts** — `_insert_relationships` / `_insert_external_links` use a single `executemany`, collapsing N+M round-trips to 2 and shrinking the transaction window.

The resilient pool's 5-retry "exhausted" path already surfaces a clear hard failure (`common/postgres_resilient.py:543`) and is left unchanged — it should now rarely trigger.

## When to raise the cap instead

Only if 12 concurrent writers prove insufficient after these fixes — then raise the PgBouncer cap **and** `POSTGRES_POOL_MAX_SIZE` together, keeping the sum of service maxima under the new cap. The 45 cap was not the limiting factor; the uncoordinated 115 of demand was.

## Tests & verification

- New: `resolve_postgres_pool_sizes` unit tests (defaults, env override, invalid values, clamping); `_channel_prefetch` coupling tests; batched-insert tests (single `executemany`, invalid-row filtering, empty-batch no-op).
- Updated: pool-size assertions in `tableinator`/`brainztableinator` main tests, process-with-relationships/links tests, stale `test_batch_performance` placeholder.
- `2494 passed` across common/brainztableinator/tableinator/api/insights; `ruff`, `ruff format`, `mypy`, `bandit` all green.

Does **not** change `POSTGRES_HOST` handling (host:port via PgBouncer remains the intended deployment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)