### PR TITLE
fix: deep bug-hunt 2026-07-19 — land all 72 P0/P1/P2 fixes (epic discogsography-cu2)

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -136,8 +136,10 @@ async def _get_current_user(
         )
     try:
         payload = decode_token(credentials.credentials, _config.jwt_secret_key)
-        # Reject admin tokens — they must not be used as regular user tokens
-        if payload.get("type") == "admin":
+        # Allowlist: only pure access tokens (which carry NO `type` claim) may
+        # authenticate. Admin tokens and 2FA challenge tokens (type="2fa_challenge")
+        # must never be accepted here — a challenge token proves only the password.
+        if payload.get("type") is not None:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid token",

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -1,5 +1,6 @@
 """Shared FastAPI dependency functions for API routers."""
 
+import asyncio
 from dataclasses import dataclass
 from typing import Annotated, Any, Literal
 
@@ -10,7 +11,9 @@ from psycopg.rows import dict_row
 from api.app_tokens import (
     TOKEN_PREFIX as _APP_TOKEN_PREFIX,
     AppTokenAuth,  # noqa: F401  — re-exported for callers
+    _background_tasks,
     _lookup_active_token,
+    _touch_last_used_at,
     hash_token,
     require_app_token,  # noqa: F401  — re-exported for callers
 )
@@ -155,6 +158,14 @@ def require_user_or_app_token(scopes: list[str]) -> Any:
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail=f"App token missing required scope(s): {', '.join(missing)}",
                 )
+            # Fire-and-forget last_used_at bookkeeping — mirrors require_app_token
+            # so tokens authenticated through the unified path are also audited.
+            # A slow PG round trip never blocks the request; the reference is held
+            # in _background_tasks so the loop does not GC the coroutine mid-flight.
+            task = asyncio.create_task(_touch_last_used_at(str(row["id"])))
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
+
             return UnifiedAuth(
                 user_id=str(row["user_id"]),
                 via="app_token",

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -39,6 +39,10 @@ async def get_optional_user(
         payload = decode_token(credentials.credentials, _jwt_secret)
     except ValueError:
         return None
+    # Allowlist: only pure access tokens (no `type` claim) resolve to a user.
+    # Admin and 2FA challenge tokens must not be treated as an authenticated user.
+    if payload.get("type") is not None:
+        return None
     # Check JTI revocation
     jti: str | None = payload.get("jti")
     if jti and _redis:
@@ -72,6 +76,11 @@ async def require_user(
     # Reject admin tokens on user endpoints
     if payload.get("type") == "admin":
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin tokens cannot be used for user endpoints")
+    # Allowlist: only pure access tokens (which carry NO `type` claim) may
+    # authenticate user endpoints. A 2FA challenge token (type="2fa_challenge")
+    # proves only the password — it must NOT grant access before TOTP is verified.
+    if payload.get("type") is not None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token", headers={"WWW-Authenticate": "Bearer"})
     # Validate sub claim presence
     user_id: str | None = payload.get("sub")
     if user_id is None:

--- a/api/queries/credits_queries.py
+++ b/api/queries/credits_queries.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from api.queries.helpers import run_query, run_single
+from api.queries.neo4j_queries import _build_autocomplete_query
 
 
 if TYPE_CHECKING:
@@ -157,10 +158,11 @@ async def autocomplete_person(
     limit: int = 10,
 ) -> list[dict[str, Any]]:
     """Search credited people by name using fulltext index."""
-    # Build autocomplete query: add wildcard for partial matching
-    search_query = query.strip()
-    if search_query and not search_query.endswith("*"):
-        search_query = search_query + "*"
+    # Build the Lucene query with the shared escaper so metacharacters in names
+    # (AC/DC, C++, "Emerson, Lake (Palmer", bare ':' '/' '~' '(' ...) are escaped
+    # exactly as the artist/label/genre/style autocompletes do — otherwise a raw
+    # string with Lucene syntax triggers a ParseException and an unhandled 500.
+    search_query = _build_autocomplete_query(query)
 
     cypher = """
     CALL db.index.fulltext.queryNodes('person_name_fulltext', $query)

--- a/api/queries/helpers.py
+++ b/api/queries/helpers.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from neo4j import Query
+
 from common.query_debug import (
     is_db_profiling,
     log_cypher_query,
@@ -25,6 +27,19 @@ if TYPE_CHECKING:
     from common import AsyncResilientNeo4jDriver
 
 _logger = logging.getLogger(__name__)
+
+
+def _build_query(cypher: str, timeout: float | None) -> Query | str:
+    """Wrap ``cypher`` in a :class:`neo4j.Query` when a timeout is requested.
+
+    ``session.run()`` has no ``timeout`` keyword argument — passing one merges
+    it into the Cypher parameter map instead of applying a server-side
+    transaction timeout (see neo4j._async.work.session.AsyncSession.run). A
+    per-query timeout must be set via ``Query(cypher, timeout=...)``.
+    """
+    if timeout is not None:
+        return Query(cypher, timeout=timeout)
+    return cypher
 
 
 async def _try_explain_on_error(
@@ -76,10 +91,7 @@ async def run_query(
 
     profiling = is_db_profiling()
     actual_cypher = f"PROFILE {cypher}" if profiling else cypher
-
-    run_kwargs: dict[str, Any] = {}
-    if timeout is not None:
-        run_kwargs["timeout"] = timeout
+    query = _build_query(actual_cypher, timeout)
 
     session_kwargs: dict[str, Any] = {}
     if database:
@@ -87,7 +99,7 @@ async def run_query(
 
     try:
         async with driver.session(**session_kwargs) as session:
-            result = await session.run(actual_cypher, params, **run_kwargs)
+            result = await session.run(query, params)
             records = [dict(record) async for record in result]
             summary = await result.consume()
             if profiling:
@@ -123,10 +135,7 @@ async def run_single(
 
     profiling = is_db_profiling()
     actual_cypher = f"PROFILE {cypher}" if profiling else cypher
-
-    run_kwargs: dict[str, Any] = {}
-    if timeout is not None:
-        run_kwargs["timeout"] = timeout
+    query = _build_query(actual_cypher, timeout)
 
     session_kwargs: dict[str, Any] = {}
     if database:
@@ -134,7 +143,7 @@ async def run_single(
 
     try:
         async with driver.session(**session_kwargs) as session:
-            result = await session.run(actual_cypher, params, **run_kwargs)
+            result = await session.run(query, params)
             record = await result.single()
             summary = await result.consume()
             if profiling:
@@ -172,10 +181,7 @@ async def run_count(
 
     profiling = is_db_profiling()
     actual_cypher = f"PROFILE {cypher}" if profiling else cypher
-
-    run_kwargs: dict[str, Any] = {}
-    if timeout is not None:
-        run_kwargs["timeout"] = timeout
+    query = _build_query(actual_cypher, timeout)
 
     session_kwargs: dict[str, Any] = {}
     if database:
@@ -183,7 +189,7 @@ async def run_count(
 
     try:
         async with driver.session(**session_kwargs) as session:
-            result = await session.run(actual_cypher, params, **run_kwargs)
+            result = await session.run(query, params)
             record = await result.single()
             summary = await result.consume()
             if profiling:

--- a/api/queries/neo4j_queries.py
+++ b/api/queries/neo4j_queries.py
@@ -90,7 +90,7 @@ async def find_shortest_path(
     MATCH {a_match}, {b_match}
     MATCH p = shortestPath((a)-[:{_PATH_REL_TYPES}*..{depth}]-(b))
     RETURN [node IN nodes(p) | {{
-               id: node.id,
+               id: coalesce(node.id, node.name),
                name: coalesce(node.name, node.title, ''),
                labels: labels(node)
            }}] AS nodes,

--- a/api/queries/rarity_queries.py
+++ b/api/queries/rarity_queries.py
@@ -410,7 +410,7 @@ async def get_rarity_leaderboard(
                 SELECT release_id, title, artist_name, year, rarity_score, tier, hidden_gem_score
                 FROM insights.release_rarity
                 WHERE tier = %s
-                ORDER BY rarity_score DESC
+                ORDER BY rarity_score DESC, release_id
                 LIMIT %s OFFSET %s
                 """,
                 (tier, page_size, offset),
@@ -426,7 +426,7 @@ async def get_rarity_leaderboard(
                 """
                 SELECT release_id, title, artist_name, year, rarity_score, tier, hidden_gem_score
                 FROM insights.release_rarity
-                ORDER BY rarity_score DESC
+                ORDER BY rarity_score DESC, release_id
                 LIMIT %s OFFSET %s
                 """,
                 (page_size, offset),
@@ -458,7 +458,7 @@ async def get_rarity_hidden_gems(
             SELECT release_id, title, artist_name, year, rarity_score, tier, hidden_gem_score
             FROM insights.release_rarity
             WHERE rarity_score >= %s AND hidden_gem_score IS NOT NULL
-            ORDER BY hidden_gem_score DESC
+            ORDER BY hidden_gem_score DESC, release_id
             LIMIT %s OFFSET %s
             """,
             (min_rarity, page_size, offset),
@@ -516,7 +516,7 @@ async def get_rarity_by_artist(
             SELECT release_id, title, artist_name, year, rarity_score, tier, hidden_gem_score
             FROM insights.release_rarity
             WHERE release_id = ANY(%s)
-            ORDER BY rarity_score DESC
+            ORDER BY rarity_score DESC, release_id
             LIMIT %s OFFSET %s
             """,
             (release_ids, page_size, offset),
@@ -574,7 +574,7 @@ async def get_rarity_by_label(
             SELECT release_id, title, artist_name, year, rarity_score, tier, hidden_gem_score
             FROM insights.release_rarity
             WHERE release_id = ANY(%s)
-            ORDER BY rarity_score DESC
+            ORDER BY rarity_score DESC, release_id
             LIMIT %s OFFSET %s
             """,
             (release_ids, page_size, offset),

--- a/api/queries/recommend_queries.py
+++ b/api/queries/recommend_queries.py
@@ -430,7 +430,7 @@ async def get_explore_traversal(
          [r IN relationships(path) | type(r)] AS rel_types,
          length(path) AS dist
     ORDER BY dist
-    RETURN discovered.id AS id,
+    RETURN coalesce(discovered.id, discovered.name) AS id,
            coalesce(discovered.name, discovered.id) AS name,
            CASE
              WHEN discovered:Artist THEN 'artist'
@@ -483,7 +483,10 @@ def score_discoveries(
 
         scored.append(
             {
-                "id": d.get("id", d.get("name", "")),
+                # d.get("id", default) does NOT help when the "id" key is present
+                # with value None (e.g. name-keyed Genre/Style nodes) — dict.get's
+                # default only applies to a MISSING key. Use `or` to fall back.
+                "id": d.get("id") or d.get("name", ""),
                 "name": d["name"],
                 "type": node_type,
                 "score": round(base_score, 4),

--- a/api/queries/search_queries.py
+++ b/api/queries/search_queries.py
@@ -260,9 +260,7 @@ async def _run_total(
     union_sql, union_params = _build_union(types, per_table_limit=_TOTAL_COUNT_CAP, year_min=year_min, year_max=year_max, genres=genres)
 
     query = sql.SQL(
-        "WITH q AS (SELECT plainto_tsquery('english', %s) AS tsq),"
-        " results AS ({union_sql})"
-        " SELECT COUNT(*) AS total FROM results"
+        "WITH q AS (SELECT plainto_tsquery('english', %s) AS tsq), results AS ({union_sql}) SELECT COUNT(*) AS total FROM results"
     ).format(union_sql=union_sql)
     params = [q, *union_params]
     async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:

--- a/api/queries/search_queries.py
+++ b/api/queries/search_queries.py
@@ -62,25 +62,88 @@ def cache_key(q: str, types: list[str], genres: list[str], year_min: int | None,
     return f"search:{digest}"
 
 
-def _entity_select(entity_type: str, name_field: str, has_year: bool, has_genres: bool, *, per_table_limit: int | None = None) -> sql.Composable:
-    """Return a SELECT fragment for one entity type in the UNION ALL.
+def _year_filter_clause(year_min: int | None, year_max: int | None, column: sql.Composable | None = None) -> tuple[sql.Composable, list[Any]]:
+    """Return (SQL_clause, params) for optional year filtering.
+
+    Rows with NULL year (artists, labels) are always included regardless of
+    year filter — only rows with a parseable year are filtered.
+
+    ``column`` lets callers point the clause at a raw column expression (e.g.
+    ``(data->>'year')``) instead of the default ``year`` identifier — needed
+    to push the filter into a per-table subquery *before* its rank LIMIT.
+    """
+    col = column if column is not None else sql.SQL("year")
+    clauses: list[sql.Composable] = []
+    params: list[Any] = []
+    if year_min is not None:
+        clauses.append(sql.SQL("({c} IS NULL OR {c}::int >= %s)").format(c=col))
+        params.append(year_min)
+    if year_max is not None:
+        clauses.append(sql.SQL("({c} IS NULL OR {c}::int <= %s)").format(c=col))
+        params.append(year_max)
+    return (sql.SQL(" AND ").join(clauses), params) if clauses else (sql.SQL("TRUE"), [])
+
+
+def _genre_filter_clause(genres: list[str], column: sql.Composable | None = None) -> tuple[sql.Composable, list[Any]]:
+    """Return (SQL_clause, params) for optional genre filtering.
+
+    Rows with NULL genres (artists, labels, masters) are always included
+    regardless of genre filter — only rows with genre data are filtered.
+
+    ``column`` lets callers point the clause at a raw column expression (e.g.
+    ``(data->'genres')``) instead of the default ``genres`` identifier —
+    needed to push the filter into a per-table subquery *before* its rank
+    LIMIT.
+    """
+    if not genres:
+        return (sql.SQL("TRUE"), [])
+    col = column if column is not None else sql.SQL("genres")
+    # ?| checks if JSONB array contains any of the given strings
+    return (sql.SQL("({c} IS NULL OR {c} ?| %s::text[])").format(c=col), [genres])
+
+
+def _entity_select(
+    entity_type: str,
+    name_field: str,
+    has_year: bool,
+    has_genres: bool,
+    *,
+    per_table_limit: int | None = None,
+    year_min: int | None = None,
+    year_max: int | None = None,
+    genres: list[str] | None = None,
+) -> tuple[sql.Composable, list[Any]]:
+    """Return a (SELECT fragment, params) for one entity type in the UNION ALL.
 
     When per_table_limit is set, each entity type returns at most that many
     rows (ordered by ts_rank DESC).  This prevents high-cardinality terms
     like "Rock" from materializing 100K+ rows in the UNION ALL CTE.
+
+    year_min/year_max/genres — when given — are applied INSIDE this subquery's
+    WHERE, before its ORDER BY rank LIMIT, so the rank cap is applied to
+    already-filtered rows. Applying them only in an outer WHERE (after the
+    cap) would silently drop/empty filtered results for high-cardinality
+    terms, since rank is uncorrelated with year/genre.
     """
     year_col = sql.SQL("(data->>'year')") if has_year else sql.SQL("NULL::text")
     genres_col = sql.SQL("(data->'genres')") if has_genres else sql.SQL("NULL::jsonb")
     table = sql.Identifier(_ENTITY_CONFIG[entity_type][0])
     name_lit = sql.Literal(name_field)
     limit_clause = sql.SQL(" ORDER BY rank DESC LIMIT {n}").format(n=sql.Literal(per_table_limit)) if per_table_limit else sql.SQL("")
-    return sql.SQL(
+
+    year_clause, year_params = _year_filter_clause(year_min, year_max, column=year_col)
+    genre_clause, genre_params = _genre_filter_clause(genres or [], column=genres_col)
+    filter_params = [*year_params, *genre_params]
+    filter_clause = sql.SQL(" AND {y} AND {g}").format(y=year_clause, g=genre_clause) if filter_params else sql.SQL("")
+
+    select_sql = sql.SQL(
         "(SELECT {entity_type}::text AS type, data_id AS id, data->>{name} AS name,"
         " ts_rank(to_tsvector('english', COALESCE(data->>{name}, '')), q.tsq) AS rank,"
         " ts_headline('english', COALESCE(data->>{name}, ''), q.tsq) AS highlight,"
         " {year_col} AS year, {genres_col} AS genres"
         " FROM {table}, q"
         " WHERE to_tsvector('english', COALESCE(data->>{name}, '')) @@ q.tsq"
+        "{filter_clause}"
         "{limit_clause})"
     ).format(
         entity_type=sql.Literal(entity_type),
@@ -88,52 +151,48 @@ def _entity_select(entity_type: str, name_field: str, has_year: bool, has_genres
         year_col=year_col,
         genres_col=genres_col,
         table=table,
+        filter_clause=filter_clause,
         limit_clause=limit_clause,
     )
+    return select_sql, filter_params
 
 
-def _build_union(types: list[str], *, per_table_limit: int | None = None) -> sql.Composable:
+def _build_union(
+    types: list[str],
+    *,
+    per_table_limit: int | None = None,
+    year_min: int | None = None,
+    year_max: int | None = None,
+    genres: list[str] | None = None,
+) -> tuple[sql.Composable, list[Any]]:
     """Build UNION ALL of SELECT fragments for the requested entity types.
 
     When per_table_limit is set, each entity type returns at most that many
     rows (pre-sorted by rank), preventing high-cardinality term explosion.
+    year_min/year_max/genres are pushed into each per-table subquery so the
+    rank cap is applied to already-filtered rows (see _entity_select).
+
+    Returns (UNION_ALL SQL fragment, flattened params list in emission order).
     """
     if not types:  # would produce invalid SQL
         raise ValueError("types must not be empty")
-    parts = []
+    parts: list[sql.Composable] = []
+    params: list[Any] = []
     for t in types:
         _table, name_field, has_year, has_genres = _ENTITY_CONFIG[t]
-        parts.append(_entity_select(t, name_field, has_year, has_genres, per_table_limit=per_table_limit))
-    return sql.SQL(" UNION ALL ").join(parts)
-
-
-def _year_filter_clause(year_min: int | None, year_max: int | None) -> tuple[sql.Composable, list[Any]]:
-    """Return (SQL_clause, params) for optional year filtering.
-
-    Rows with NULL year (artists, labels) are always included regardless of
-    year filter — only rows with a parseable year are filtered.
-    """
-    clauses: list[sql.Composable] = []
-    params: list[Any] = []
-    if year_min is not None:
-        clauses.append(sql.SQL("(year IS NULL OR year::int >= %s)"))
-        params.append(year_min)
-    if year_max is not None:
-        clauses.append(sql.SQL("(year IS NULL OR year::int <= %s)"))
-        params.append(year_max)
-    return (sql.SQL(" AND ").join(clauses), params) if clauses else (sql.SQL("TRUE"), [])
-
-
-def _genre_filter_clause(genres: list[str]) -> tuple[sql.Composable, list[Any]]:
-    """Return (SQL_clause, params) for optional genre filtering.
-
-    Rows with NULL genres (artists, labels, masters) are always included
-    regardless of genre filter — only rows with genre data are filtered.
-    """
-    if not genres:
-        return (sql.SQL("TRUE"), [])
-    # ?| checks if JSONB array contains any of the given strings
-    return (sql.SQL("(genres IS NULL OR genres ?| %s::text[])"), [genres])
+        select_sql, select_params = _entity_select(
+            t,
+            name_field,
+            has_year,
+            has_genres,
+            per_table_limit=per_table_limit,
+            year_min=year_min,
+            year_max=year_max,
+            genres=genres,
+        )
+        parts.append(select_sql)
+        params.extend(select_params)
+    return sql.SQL(" UNION ALL ").join(parts), params
 
 
 async def _run_results(
@@ -151,29 +210,27 @@ async def _run_results(
     Uses per-table LIMIT in the UNION ALL to prevent high-cardinality terms
     like "Rock" from materializing 100K+ rows before outer LIMIT/OFFSET.
     Each table returns at most (limit + offset) rows pre-sorted by rank.
+
+    year/genre filters are pushed INTO each per-table subquery (before its
+    rank LIMIT) — applying them only in an outer WHERE after the per-table
+    cap would silently drop/empty filtered results for high-cardinality
+    terms, since rank is uncorrelated with year/genre.
     """
     # Each entity table returns up to per_table_limit rows pre-sorted by rank.
     # Use 2x multiplier to reduce result loss at higher page offsets while
     # keeping the materialisation bounded.
     per_table_limit = (limit + offset) * 2
-    union_sql = _build_union(types, per_table_limit=per_table_limit)
-    year_clause, year_params = _year_filter_clause(year_min, year_max)
-    genre_clause, genre_params = _genre_filter_clause(genres)
+    union_sql, union_params = _build_union(types, per_table_limit=per_table_limit, year_min=year_min, year_max=year_max, genres=genres)
 
     query = sql.SQL(
         "WITH q AS (SELECT plainto_tsquery('english', %s) AS tsq),"
         " results AS ({union_sql})"
         " SELECT type, id, name, rank, highlight, year, genres"
         " FROM results"
-        " WHERE {year_clause} AND {genre_clause}"
         " ORDER BY rank DESC"
         " LIMIT %s OFFSET %s"
-    ).format(
-        union_sql=union_sql,
-        year_clause=year_clause,
-        genre_clause=genre_clause,
-    )
-    params = [q, *year_params, *genre_params, limit, offset]
+    ).format(union_sql=union_sql)
+    params = [q, *union_params, limit, offset]
     async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
         await execute_sql(cur, query, params)  # nosemgrep
         rows = await cur.fetchall()
@@ -196,22 +253,18 @@ async def _run_total(
     Each table is capped at _TOTAL_COUNT_CAP rows to prevent full scans
     on high-cardinality terms like "Rock" (18.9M releases).  The reported
     total is an approximate lower bound when capped.
+
+    year/genre filters are pushed INTO each per-table subquery (before its
+    rank LIMIT) for the same reason as _run_results — see its docstring.
     """
-    union_sql = _build_union(types, per_table_limit=_TOTAL_COUNT_CAP)
-    year_clause, year_params = _year_filter_clause(year_min, year_max)
-    genre_clause, genre_params = _genre_filter_clause(genres)
+    union_sql, union_params = _build_union(types, per_table_limit=_TOTAL_COUNT_CAP, year_min=year_min, year_max=year_max, genres=genres)
 
     query = sql.SQL(
         "WITH q AS (SELECT plainto_tsquery('english', %s) AS tsq),"
         " results AS ({union_sql})"
         " SELECT COUNT(*) AS total FROM results"
-        " WHERE {year_clause} AND {genre_clause}"
-    ).format(
-        union_sql=union_sql,
-        year_clause=year_clause,
-        genre_clause=genre_clause,
-    )
-    params = [q, *year_params, *genre_params]
+    ).format(union_sql=union_sql)
+    params = [q, *union_params]
     async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
         await execute_sql(cur, query, params)  # nosemgrep
         row = await cur.fetchone()

--- a/api/queries/search_queries.py
+++ b/api/queries/search_queries.py
@@ -129,7 +129,9 @@ def _entity_select(
     genres_col = sql.SQL("(data->'genres')") if has_genres else sql.SQL("NULL::jsonb")
     table = sql.Identifier(_ENTITY_CONFIG[entity_type][0])
     name_lit = sql.Literal(name_field)
-    limit_clause = sql.SQL(" ORDER BY rank DESC LIMIT {n}").format(n=sql.Literal(per_table_limit)) if per_table_limit else sql.SQL("")
+    # data_id is a unique tiebreaker so the per-table rank cap selects a
+    # deterministic subset among tied ts_rank values across page executions.
+    limit_clause = sql.SQL(" ORDER BY rank DESC, data_id LIMIT {n}").format(n=sql.Literal(per_table_limit)) if per_table_limit else sql.SQL("")
 
     year_clause, year_params = _year_filter_clause(year_min, year_max, column=year_col)
     genre_clause, genre_params = _genre_filter_clause(genres or [], column=genres_col)
@@ -227,7 +229,7 @@ async def _run_results(
         " results AS ({union_sql})"
         " SELECT type, id, name, rank, highlight, year, genres"
         " FROM results"
-        " ORDER BY rank DESC"
+        " ORDER BY rank DESC, id"
         " LIMIT %s OFFSET %s"
     ).format(union_sql=union_sql)
     params = [q, *union_params, limit, offset]

--- a/api/queries/search_queries.py
+++ b/api/queries/search_queries.py
@@ -395,10 +395,15 @@ async def execute_search(
 
     key = cache_key(q, types, genres, year_min, year_max, limit, offset)
 
+    # Cache-aside read — Redis is a pure optimization. A Redis outage (or a
+    # corrupt cache entry) must degrade to a fresh PostgreSQL query, never 500.
     if redis is not None:
-        cached = await redis.get(key)
-        if cached:
-            return json.loads(cached)  # type: ignore[no-any-return]
+        try:
+            cached = await redis.get(key)
+            if cached:
+                return json.loads(cached)  # type: ignore[no-any-return]
+        except Exception:
+            logger.debug("⚠️ Search cache read failed, falling through to DB", key=key)
 
     logger.debug("🔍 Search cache miss, querying DB", q=q, types=types)
 
@@ -426,7 +431,12 @@ async def execute_search(
         },
     }
 
+    # Best-effort cache write — a Redis outage must not fail an otherwise
+    # successful, fully PostgreSQL-backed search response.
     if redis is not None:
-        await redis.setex(key, _SEARCH_CACHE_TTL, json.dumps(response))
+        try:
+            await redis.setex(key, _SEARCH_CACHE_TTL, json.dumps(response))
+        except Exception:
+            logger.debug("⚠️ Search cache write failed", key=key)
 
     return response

--- a/api/queries/user_queries.py
+++ b/api/queries/user_queries.py
@@ -227,9 +227,9 @@ async def get_user_collection_timeline(
     WITH bucket, r, collect(DISTINCT g.name) AS rg,
          collect(DISTINCT s.name) AS rs, collect(DISTINCT l.name) AS rl
     WITH bucket, count(DISTINCT r) AS count,
-         collect(DISTINCT rg) AS genre_lists,
+         collect(rg) AS genre_lists,
          collect(DISTINCT rs) AS style_lists,
-         collect(DISTINCT rl) AS label_lists
+         collect(rl) AS label_lists
     RETURN bucket AS year, count,
            reduce(acc = [], lst IN genre_lists | acc + lst) AS genres,
            reduce(acc = [], lst IN style_lists | acc + lst) AS styles,

--- a/api/routers/admin.py
+++ b/api/routers/admin.py
@@ -406,6 +406,18 @@ async def _track_extraction(extraction_id: str) -> None:
                 except (httpx.ConnectError, httpx.RequestError):
                     consecutive_failures += 1
                     logger.warning("⚠️ Extractor unreachable", extraction_id=extraction_id, attempt=consecutive_failures)
+                except Exception as exc:
+                    # Any other per-iteration fault — a non-JSON 200 body
+                    # (resp.json()) or a transient PG error on the progress
+                    # UPDATE — must not kill the tracker. Count it as a failure
+                    # and let the max_failures gate below write a terminal status.
+                    consecutive_failures += 1
+                    logger.warning(
+                        "⚠️ Extraction tracking iteration failed",
+                        extraction_id=extraction_id,
+                        attempt=consecutive_failures,
+                        error=str(exc),
+                    )
 
                 if consecutive_failures >= max_failures:
                     async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
@@ -434,6 +446,19 @@ async def _track_extraction(extraction_id: str) -> None:
                 )
         except Exception:
             logger.warning("⚠️ Could not mark cancelled extraction as failed", extraction_id=extraction_id)
+    except Exception as exc:
+        # Final safety net — an unexpected crash must never leave the record
+        # stuck in 'running' forever. Mirror the CancelledError handler and mark
+        # it failed so the admin dashboard shows a terminal state.
+        logger.error("❌ Extraction tracking crashed", extraction_id=extraction_id, error=str(exc), exc_info=True)
+        try:
+            async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+                await cur.execute(
+                    "UPDATE extraction_history SET status = 'failed', completed_at = NOW(), error_message = %s WHERE id = %s AND status = 'running'",
+                    ("Tracking task crashed", extraction_id),
+                )
+        except Exception:
+            logger.warning("⚠️ Could not mark crashed extraction as failed", extraction_id=extraction_id)
     finally:
         _tracking_tasks.pop(extraction_id, None)
 

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -634,47 +634,57 @@ async def twofa_recovery(request: Request, body: TwoFactorRecoveryModel) -> JSON
     if not jti:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid challenge token")
 
-    # Atomically consume challenge from Redis to prevent replay
-    challenge_data = await _redis.getdel(f"2fa_challenge:{jti}")
+    # Verify the challenge EXISTS (without consuming) before validating the code,
+    # so a mistyped recovery code does not burn the challenge token. The challenge
+    # is consumed only after the recovery code is successfully redeemed below.
+    challenge_key = f"2fa_challenge:{jti}"
+    challenge_data = await _redis.get(challenge_key)
     if not challenge_data:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Challenge expired or already used")
 
     user_id = payload["sub"]
     email = payload.get("email", "")
 
-    # Fetch recovery codes
-    async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
-        await execute_sql(
-            cur,
-            "SELECT totp_recovery_codes FROM users WHERE id = %s::uuid",
-            (user_id,),
-        )
-        user = await cur.fetchone()
-
-    if not user or not user.get("totp_recovery_codes"):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="No recovery codes available")
-
-    stored_hashes: list[str] = (
-        json.loads(user["totp_recovery_codes"]) if isinstance(user["totp_recovery_codes"], str) else user["totp_recovery_codes"]
-    )
     submitted_hash = hash_recovery_code(body.code)
 
-    if submitted_hash not in stored_hashes:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid recovery code")
-
-    # Remove used code (challenge already consumed above)
-    stored_hashes.remove(submitted_hash)
-
+    # Consume the recovery code ATOMICALLY in a single guarded statement. Recovery
+    # codes are one-time by contract; a Python read-modify-write across two
+    # autocommit round-trips loses updates under concurrency, letting a used code
+    # be resurrected (last-writer-wins) or the same code be redeemed twice.
+    #
+    # `totp_recovery_codes ? %s` guards that the hash is still present, and
+    # `totp_recovery_codes - %s` removes it in the same UPDATE. Under Postgres
+    # row locking, concurrent redemptions serialize and the WHERE qual is
+    # re-evaluated against the committed row, so only one redemption of a given
+    # code can ever match (rowcount 1); the rest match nothing (rowcount 0).
     async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
         await execute_sql(
             cur,
-            "UPDATE users SET totp_recovery_codes = %s, updated_at = NOW() WHERE id = %s::uuid",
-            (json.dumps(stored_hashes), user_id),
+            """
+            UPDATE users
+            SET totp_recovery_codes = totp_recovery_codes - %s, updated_at = NOW()
+            WHERE id = %s::uuid
+              AND totp_recovery_codes IS NOT NULL
+              AND totp_recovery_codes ? %s
+            RETURNING totp_recovery_codes
+            """,
+            (submitted_hash, user_id, submitted_hash),
         )
+        updated = await cur.fetchone()
+
+    if not updated:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid recovery code")
+
+    remaining: list[str] = (
+        json.loads(updated["totp_recovery_codes"]) if isinstance(updated["totp_recovery_codes"], str) else (updated["totp_recovery_codes"] or [])
+    )
+
+    # Recovery code redeemed — now consume the challenge so it cannot be replayed.
+    await _redis.getdel(challenge_key)
 
     # Issue access token
     access_token, expires_in = _create_access_token_fn(user_id, email)
-    logger.info("✅ 2FA recovery code used", user_id=user_id, remaining_codes=len(stored_hashes))
+    logger.info("✅ 2FA recovery code used", user_id=user_id, remaining_codes=len(remaining))
 
     content: dict[str, Any] = {
         "access_token": access_token,
@@ -682,7 +692,7 @@ async def twofa_recovery(request: Request, body: TwoFactorRecoveryModel) -> JSON
         "expires_in": expires_in,
     }
 
-    if len(stored_hashes) == 0:
+    if len(remaining) == 0:
         content["warning"] = "This was your last recovery code. Please set up new recovery codes."
 
     return JSONResponse(content=content)

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -540,34 +540,61 @@ async def twofa_verify(request: Request, body: TwoFactorVerifyModel) -> JSONResp
     if locked_until and locked_until > datetime.now(UTC):
         raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Account temporarily locked due to failed 2FA attempts")
 
-    # Atomically consume challenge from Redis to prevent replay
-    challenge_data = await _redis.getdel(challenge_key)
-    if not challenge_data:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Challenge expired or already used")
-
     totp_key = get_totp_encryption_key(_config.encryption_master_key)
     if not totp_key:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Encryption not configured")
 
     secret = decrypt_totp_secret(user["totp_secret"], totp_key)
 
+    # NOTE: the challenge is intentionally NOT consumed until AFTER a successful
+    # verification (see success branch below). Consuming it here would burn the
+    # challenge on a single mistyped digit, forcing a full re-login for every typo.
     if not verify_totp_code(secret, body.code):
-        # Increment failed attempts
-        failed = (user.get("totp_failed_attempts") or 0) + 1
-        lock_sql = "UPDATE users SET totp_failed_attempts = %s, updated_at = NOW()"
-        params: list[Any] = [failed]
-        if failed >= 5:
-            lock_sql += ", totp_locked_until = NOW() + INTERVAL '15 minutes'"
-        lock_sql += " WHERE id = %s::uuid"
-        params.append(user_id)
-
+        # Increment the failed-attempt counter ATOMICALLY in SQL and derive the
+        # lock from the freshly-computed value. Parallel wrong-code submissions
+        # must each advance the counter — a Python read-then-blind-write lets K
+        # concurrent requests all write value+1, defeating the 5-strike lock.
+        #
+        # When a previous lock window has already elapsed (totp_locked_until is
+        # set but in the past — the gate above let us through), the counter is
+        # reset so each post-expiry window starts fresh instead of instantly
+        # re-locking at 5+1.
+        lock_sql = """
+            UPDATE users
+            SET totp_failed_attempts = CASE
+                    WHEN totp_locked_until IS NOT NULL AND totp_locked_until <= NOW() THEN 1
+                    ELSE COALESCE(totp_failed_attempts, 0) + 1
+                END,
+                totp_locked_until = CASE
+                    WHEN (CASE
+                            WHEN totp_locked_until IS NOT NULL AND totp_locked_until <= NOW() THEN 1
+                            ELSE COALESCE(totp_failed_attempts, 0) + 1
+                          END) >= 5
+                        THEN NOW() + INTERVAL '15 minutes'
+                    WHEN totp_locked_until IS NOT NULL AND totp_locked_until <= NOW()
+                        THEN NULL
+                    ELSE totp_locked_until
+                END,
+                updated_at = NOW()
+            WHERE id = %s::uuid
+            RETURNING totp_failed_attempts
+        """
         async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
-            await execute_sql(cur, lock_sql, tuple(params))
+            await execute_sql(cur, lock_sql, (user_id,))
+            updated = await cur.fetchone()
 
+        failed = updated["totp_failed_attempts"] if updated else None
         logger.warning("⚠️ Failed 2FA attempt", user_id=user_id, attempts=failed)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid TOTP code")
 
-    # Success — reset attempts (challenge already consumed above)
+    # Success — consume the challenge NOW (only after a correct code) to prevent
+    # replay. getdel is atomic, so concurrent requests replaying the same valid
+    # challenge race here and exactly one wins; the loser gets None -> 401.
+    consumed = await _redis.getdel(challenge_key)
+    if not consumed:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Challenge expired or already used")
+
+    # Reset attempts
     async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
         await execute_sql(
             cur,

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -393,6 +393,25 @@ async def twofa_setup(
     user_id = current_user.get("sub")
     email = current_user.get("email", "")
 
+    # Refuse to overwrite a LIVE 2FA configuration. When totp_enabled is already
+    # TRUE, regenerating totp_secret / totp_recovery_codes would silently orphan
+    # the user's authenticator app and printed recovery codes while login still
+    # demands 2FA — a permanent lockout. Require an explicit disable first
+    # (mirrors the totp_enabled guard in twofa_disable).
+    async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+        await execute_sql(
+            cur,
+            "SELECT totp_enabled FROM users WHERE id = %s::uuid",
+            (user_id,),
+        )
+        existing = await cur.fetchone()
+
+    if existing and existing.get("totp_enabled"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="2FA is already enabled — disable it first before setting up again",
+        )
+
     # Generate TOTP secret and encrypt it
     secret = generate_totp_secret()
     encrypted_secret = encrypt_totp_secret(secret, totp_key)
@@ -400,17 +419,23 @@ async def twofa_setup(
     # Generate recovery codes
     plaintext_codes, hashed_codes = generate_recovery_codes()
 
-    # Store encrypted secret and hashed recovery codes (but do NOT enable TOTP yet)
+    # Store encrypted secret and hashed recovery codes (but do NOT enable TOTP yet).
+    # Guarded WHERE totp_enabled IS NOT TRUE so a concurrent enable cannot be raced.
     async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
         await execute_sql(
             cur,
             """
             UPDATE users
             SET totp_secret = %s, totp_recovery_codes = %s, updated_at = NOW()
-            WHERE id = %s::uuid
+            WHERE id = %s::uuid AND totp_enabled IS NOT TRUE
             """,
             (encrypted_secret, json.dumps(hashed_codes), user_id),
         )
+        if cur.rowcount == 0:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="2FA is already enabled — disable it first before setting up again",
+            )
 
     otpauth_uri = f"otpauth://totp/Discogsography:{email}?secret={secret}&issuer=Discogsography"
 

--- a/api/routers/insights_compute.py
+++ b/api/routers/insights_compute.py
@@ -6,9 +6,10 @@ service can fetch data over HTTP instead of importing query modules directly.
 
 import asyncio
 import json
-from typing import Any
+import secrets
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 import httpx
 from neo4j.exceptions import TransientError
@@ -30,12 +31,43 @@ from api.syncer import DISCOGS_API_BASE, MAX_RATE_LIMIT_RETRIES, _auth_header
 
 logger = structlog.get_logger(__name__)
 
-router = APIRouter(prefix="/api/internal/insights", tags=["insights-compute"])
-
 _neo4j: Any = None
 _pool: Any = None
 _redis: Any = None
 _config: Any = None
+
+
+async def require_internal_secret(
+    x_internal_secret: Annotated[str | None, Header()] = None,
+) -> None:
+    """Gate the internal insights router with a shared secret.
+
+    These endpoints are mounted on the public app and reachable through the
+    explore ``/api/{path:path}`` proxy, so the ``/api/internal`` prefix alone
+    provides no isolation. The insights service presents the configured secret
+    as the ``X-Internal-Secret`` header; any other caller is rejected.
+
+    Fails closed: if no secret is configured the router is unreachable rather
+    than anonymously open.
+    """
+    configured = getattr(_config, "insights_internal_secret", None) if _config is not None else None
+    if not configured:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Internal insights API is not configured",
+        )
+    if not x_internal_secret or not secrets.compare_digest(x_internal_secret, configured):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing internal API credentials",
+        )
+
+
+router = APIRouter(
+    prefix="/api/internal/insights",
+    tags=["insights-compute"],
+    dependencies=[Depends(require_internal_secret)],
+)
 
 _ENRICHMENT_DELAY_SECONDS = 1.0  # 1 req/sec to stay under 60 req/min
 _STALENESS_DAYS = 7

--- a/api/routers/insights_compute.py
+++ b/api/routers/insights_compute.py
@@ -272,9 +272,18 @@ async def _enrich_community_counts(
                 "Accept": "application/json",
             }
 
-            # Retry loop for rate limiting — ensures the same release is retried
+            # Retry loop for rate limiting — ensures the same release is retried.
+            # A transient transport error (timeout, reset, truncated body) must
+            # count as an error for THIS release and move on, not abort the whole
+            # run — mirroring the non-200 branch below.
+            fetch_failed = False
             while True:
-                response = await client.get(url, headers=headers)
+                try:
+                    response = await client.get(url, headers=headers)
+                except httpx.HTTPError as exc:
+                    logger.warning("⚠️ Discogs API request failed for release", release_id=release_id, error=str(exc))
+                    fetch_failed = True
+                    break
 
                 if response.status_code == 429:
                     rate_limit_retries += 1
@@ -292,13 +301,24 @@ async def _enrich_community_counts(
             if exhausted:
                 break
 
+            if fetch_failed:
+                errors += 1
+                await asyncio.sleep(_ENRICHMENT_DELAY_SECONDS)
+                continue
+
             if response.status_code != 200:
                 logger.warning("⚠️ Discogs API error for release", release_id=release_id, status=response.status_code)
                 errors += 1
                 await asyncio.sleep(_ENRICHMENT_DELAY_SECONDS)
                 continue
 
-            data = response.json()
+            try:
+                data = response.json()
+            except (json.JSONDecodeError, ValueError) as exc:
+                logger.warning("⚠️ Discogs API returned a non-JSON body for release", release_id=release_id, error=str(exc))
+                errors += 1
+                await asyncio.sleep(_ENRICHMENT_DELAY_SECONDS)
+                continue
             community = data.get("community", {})
             have = community.get("have", 0)
             want = community.get("want", 0)

--- a/api/routers/nlq.py
+++ b/api/routers/nlq.py
@@ -57,7 +57,9 @@ def _extract_user_id(request: Request) -> str | None:
         if _jwt_secret is None:
             return None
         payload = decode_token(token, _jwt_secret)
-        if payload.get("type") == "admin":
+        # Allowlist: only pure access tokens (no `type` claim) resolve to a user.
+        # Admin and 2FA challenge tokens must not be treated as an authenticated user.
+        if payload.get("type") is not None:
             return None
         return payload.get("sub")
     except (ValueError, Exception):

--- a/api/routers/nlq.py
+++ b/api/routers/nlq.py
@@ -234,40 +234,50 @@ def _stream_response(
         # Run engine in background so status events can be yielded as they arrive
         engine_task = asyncio.create_task(_engine.run(query, ctx, on_status=emit_status))
 
-        # Yield status events as they arrive
-        while not engine_task.done():
-            try:
-                step = await asyncio.wait_for(status_queue.get(), timeout=0.1)
-                yield {"event": "status", "data": json.dumps({"step": step})}
-            except TimeoutError:
-                continue
-
-        # Drain any remaining status events
-        while not status_queue.empty():
-            step = status_queue.get_nowait()
-            yield {"event": "status", "data": json.dumps({"step": step})}
-
         try:
-            result = await engine_task
-        except Exception as exc:
-            logger.error("❌ NLQ engine error", error=str(exc), exc_info=True)
-            yield {"event": "error", "data": json.dumps({"error": "An internal error occurred"})}
-            return
+            # Yield status events as they arrive
+            while not engine_task.done():
+                try:
+                    step = await asyncio.wait_for(status_queue.get(), timeout=0.1)
+                    yield {"event": "status", "data": json.dumps({"step": step})}
+                except TimeoutError:
+                    continue
 
-        # Emit actions event before result so the client can snapshot and apply
-        yield {
-            "event": "actions",
-            "data": json.dumps({"actions": [action.model_dump(by_alias=True, mode="json") for action in result.actions]}),
-        }
+            # Drain any remaining status events
+            while not status_queue.empty():
+                step = status_queue.get_nowait()
+                yield {"event": "status", "data": json.dumps({"step": step})}
 
-        # Emit final result
-        response_data = {
-            "query": query,
-            "summary": result.summary,
-            "entities": result.entities,
-            "tools_used": result.tools_used,
-            "cached": False,
-        }
-        yield {"event": "result", "data": json.dumps(response_data)}
+            try:
+                result = await engine_task
+            except Exception as exc:
+                logger.error("❌ NLQ engine error", error=str(exc), exc_info=True)
+                yield {"event": "error", "data": json.dumps({"error": "An internal error occurred"})}
+                return
+
+            # Emit actions event before result so the client can snapshot and apply
+            yield {
+                "event": "actions",
+                "data": json.dumps({"actions": [action.model_dump(by_alias=True, mode="json") for action in result.actions]}),
+            }
+
+            # Emit final result
+            response_data = {
+                "query": query,
+                "summary": result.summary,
+                "entities": result.entities,
+                "tools_used": result.tools_used,
+                "cached": False,
+            }
+            yield {"event": "result", "data": json.dumps(response_data)}
+        finally:
+            # Client disconnect raises GeneratorExit at the current yield; cancel
+            # the still-running engine task so the Anthropic/Neo4j work does not
+            # leak and the pending task cannot be GC'd mid-flight. gather with
+            # return_exceptions swallows the resulting CancelledError. See
+            # discogsography-cu2.28.
+            if not engine_task.done():
+                engine_task.cancel()
+                await asyncio.gather(engine_task, return_exceptions=True)
 
     return EventSourceResponse(event_generator())

--- a/api/routers/nlq.py
+++ b/api/routers/nlq.py
@@ -129,7 +129,14 @@ async def nlq_query(request: Request, body: NLQQueryRequest) -> Any:
     # Extract optional user_id from Bearer token
     user_id = _extract_user_id(request)
 
+    # Determine the response mode BEFORE consulting the cache. A streaming client
+    # must ALWAYS receive an event stream — never a plain JSON cache body, which
+    # its SSE parser cannot read, hanging the Ask UI. See discogsography-cu2.27.
+    accept = request.headers.get("accept", "")
+    wants_stream = "text/event-stream" in accept
+
     # Check Redis cache for public (unauthenticated) queries
+    cached_data: dict[str, Any] | None = None
     if user_id is None and _redis is not None:
         cache_k = _cache_key(body.query)
         try:
@@ -137,14 +144,16 @@ async def nlq_query(request: Request, body: NLQQueryRequest) -> Any:
             if cached is not None:
                 cached_data = json.loads(cached)
                 cached_data["cached"] = True
-                return JSONResponse(content=cached_data)
         except Exception:
             logger.debug("⚠️ NLQ cache read failed", key=cache_k)
 
-    # Check for SSE request
-    accept = request.headers.get("accept", "")
-    if "text/event-stream" in accept:
-        return _stream_response(body.query, user_id, body.context)
+    # Streaming clients get an event stream regardless of cache state — a cache
+    # hit is replayed as synthetic SSE events inside _stream_response.
+    if wants_stream:
+        return _stream_response(body.query, user_id, body.context, cached=cached_data)
+
+    if cached_data is not None:
+        return JSONResponse(content=cached_data)
 
     # Build context
     ctx = NLQContext(
@@ -176,10 +185,38 @@ async def nlq_query(request: Request, body: NLQQueryRequest) -> Any:
     return JSONResponse(content=response_data)
 
 
-def _stream_response(query: str, user_id: str | None, context: dict[str, Any] | None) -> EventSourceResponse:
-    """Return an SSE EventSourceResponse that streams NLQ status and result."""
+def _stream_response(
+    query: str,
+    user_id: str | None,
+    context: dict[str, Any] | None,
+    cached: dict[str, Any] | None = None,
+) -> EventSourceResponse:
+    """Return an SSE EventSourceResponse that streams NLQ status and result.
+
+    When ``cached`` is provided (a prior JSON cache hit), the cached result is
+    replayed as synthetic actions/result SSE events instead of re-running the
+    engine — so a streaming client always receives a well-formed event stream.
+    """
 
     async def event_generator() -> Any:
+        # Replay a cached result as synthetic SSE events so a streaming client
+        # never hangs on a plain JSON cache body. See discogsography-cu2.27.
+        if cached is not None:
+            yield {"event": "actions", "data": json.dumps({"actions": cached.get("actions", [])})}
+            yield {
+                "event": "result",
+                "data": json.dumps(
+                    {
+                        "query": cached.get("query", query),
+                        "summary": cached.get("summary"),
+                        "entities": cached.get("entities"),
+                        "tools_used": cached.get("tools_used"),
+                        "cached": True,
+                    }
+                ),
+            }
+            return
+
         ctx = NLQContext(
             user_id=user_id,
             current_entity_id=context.get("entity_id") if context else None,

--- a/api/routers/recommend.py
+++ b/api/routers/recommend.py
@@ -123,8 +123,10 @@ async def explore_from_here(
 
     user_id: str = current_user.get("sub", "")
 
-    # Check cache
-    cache_key = f"recommend:explore:{user_id}:{entity_type}:{entity_id}"
+    # Check cache — hops changes the traversal depth (not merely a truncation
+    # like limit), so it MUST be part of the key or callers get results computed
+    # for a different hop depth. See discogsography-cu2.29.
+    cache_key = f"recommend:explore:{user_id}:{entity_type}:{entity_id}:{hops}"
     if _cache:
         cached = await _cache.get(cache_key)
         if cached is not None:

--- a/api/routers/snapshot.py
+++ b/api/routers/snapshot.py
@@ -41,6 +41,11 @@ async def _get_current_user(
         # Reject admin tokens
         if payload.get("type") == "admin":
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin tokens cannot be used for user endpoints")
+        # Allowlist: only pure access tokens (which carry NO `type` claim) may
+        # authenticate. A 2FA challenge token (type="2fa_challenge") proves only the
+        # password and must be rejected before TOTP verification.
+        if payload.get("type") is not None:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token", headers={"WWW-Authenticate": "Bearer"})
         # Check jti blacklist (revoked tokens via logout)
         jti: str | None = payload.get("jti")
         if jti and _redis:

--- a/api/routers/sync.py
+++ b/api/routers/sync.py
@@ -76,7 +76,10 @@ async def _get_current_user(
                         detail="Token has been revoked",
                         headers={"WWW-Authenticate": "Bearer"},
                     )
-        if payload.get("type") == "admin":
+        # Allowlist: only pure access tokens (which carry NO `type` claim) may
+        # authenticate. Admin tokens and 2FA challenge tokens (type="2fa_challenge")
+        # are rejected — a challenge token proves only the password, not the second factor.
+        if payload.get("type") is not None:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
         return payload
     except ValueError as exc:

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -37,6 +37,16 @@ PAGE_SIZE = 100
 MAX_RATE_LIMIT_RETRIES = 5
 
 
+class DiscogsSyncError(Exception):
+    """Raised when a Discogs collection/wantlist sync fails part-way through.
+
+    Non-200 responses and exhausted rate-limit retries must raise (not just
+    break the pagination loop) so run_full_sync's except-block records the
+    sync as 'failed' with a populated error_message instead of silently
+    reporting a partial/zero-item sync as 'completed'.
+    """
+
+
 def _auth_header(
     method: str,
     url: str,
@@ -92,6 +102,11 @@ async def sync_collection(
     total_synced = 0
     page = 1
     rate_limit_retries = 0
+    # Captured once, before the loop — used both as the Neo4j synced_at stamp
+    # for every page of this run and as the reconciliation cutoff below, so
+    # rows/edges untouched by this run (removed on Discogs, or superseded by
+    # a duplicate instance_id) can be identified and deleted.
+    sync_started = datetime.now(UTC)
 
     logger.info("📋 Starting collection sync", user=discogs_username)
 
@@ -114,7 +129,7 @@ async def sync_collection(
                 rate_limit_retries += 1
                 if rate_limit_retries > MAX_RATE_LIMIT_RETRIES:
                     logger.error("❌ Rate limit retries exhausted for collection sync", user=discogs_username, retries=rate_limit_retries)
-                    break
+                    raise DiscogsSyncError(f"Discogs rate limit retries exhausted for collection sync (user={discogs_username})")
                 logger.warning("⚠️ Rate limited by Discogs, waiting 60s...", retry=rate_limit_retries, max_retries=MAX_RATE_LIMIT_RETRIES)
                 await asyncio.sleep(60)
                 continue
@@ -126,7 +141,7 @@ async def sync_collection(
                     status=response.status_code,
                     page=page,
                 )
-                break
+                raise DiscogsSyncError(f"Discogs collection API error: status={response.status_code} page={page} user={discogs_username}")
 
             data = response.json()
             releases = data.get("releases", [])
@@ -252,7 +267,7 @@ async def sync_collection(
                     "user_id": str(user_uuid),
                     "discogs_username": discogs_username,
                     "releases": neo4j_releases,
-                    "synced_at": datetime.now(UTC).isoformat(),
+                    "synced_at": sync_started.isoformat(),
                 }
                 log_cypher_query(
                     cypher,
@@ -275,8 +290,46 @@ async def sync_collection(
             page += 1
             await asyncio.sleep(SYNC_DELAY_SECONDS)
 
+    # Reached only when the loop completed normally (no DiscogsSyncError raised
+    # above) — reconcile away rows/edges this run never touched: items removed
+    # from Discogs since the last sync, and stale duplicate instance_id rows
+    # left behind when an item was removed and re-added.
+    await _reconcile_stale_collection(user_uuid, pg_pool, neo4j_driver, sync_started)
+
     logger.info("✅ Collection sync complete", user=discogs_username, total=total_synced)
     return total_synced
+
+
+async def _reconcile_stale_collection(
+    user_uuid: UUID,
+    pg_pool: AsyncPostgreSQLPool,
+    neo4j_driver: AsyncResilientNeo4jDriver,
+    sync_started: datetime,
+) -> None:
+    """Delete collection rows/edges for this user untouched by the current sync run.
+
+    Every row/edge touched by sync_collection gets updated_at=NOW() (PG) /
+    synced_at=sync_started (Neo4j). Anything still stamped from before
+    sync_started was NOT present in the freshly-fetched Discogs data — either
+    the item was removed from the collection, or it was removed-and-re-added
+    under a new instance_id (leaving the old instance_id row/edge orphaned).
+    Only called after a fully successful pagination run (see sync_collection).
+    """
+    async with pg_pool.connection() as conn, conn.cursor() as cur:
+        await execute_sql(
+            cur,
+            "DELETE FROM user_collections WHERE user_id = %s::uuid AND updated_at < %s",
+            (str(user_uuid), sync_started),
+        )
+
+    cypher = """
+    MATCH (u:User {id: $user_id})-[c:COLLECTED]->()
+    WHERE c.synced_at < $sync_started
+    DELETE c
+    """
+    async with neo4j_driver.session() as session:
+        result = await session.run(cypher, {"user_id": str(user_uuid), "sync_started": sync_started.isoformat()})
+        await result.consume()
 
 
 async def sync_wantlist(
@@ -302,6 +355,8 @@ async def sync_wantlist(
     total_synced = 0
     page = 1
     rate_limit_retries = 0
+    # Captured once, before the loop — see sync_collection for why.
+    sync_started = datetime.now(UTC)
 
     logger.info("📋 Starting wantlist sync", user=discogs_username)
 
@@ -324,7 +379,7 @@ async def sync_wantlist(
                 rate_limit_retries += 1
                 if rate_limit_retries > MAX_RATE_LIMIT_RETRIES:
                     logger.error("❌ Rate limit retries exhausted for wantlist sync", user=discogs_username, retries=rate_limit_retries)
-                    break
+                    raise DiscogsSyncError(f"Discogs rate limit retries exhausted for wantlist sync (user={discogs_username})")
                 logger.warning("⚠️ Rate limited by Discogs, waiting 60s...", retry=rate_limit_retries, max_retries=MAX_RATE_LIMIT_RETRIES)
                 await asyncio.sleep(60)
                 continue
@@ -336,7 +391,7 @@ async def sync_wantlist(
                     status=response.status_code,
                     page=page,
                 )
-                break
+                raise DiscogsSyncError(f"Discogs wantlist API error: status={response.status_code} page={page} user={discogs_username}")
 
             data = response.json()
             wants = data.get("wants", [])
@@ -442,7 +497,7 @@ async def sync_wantlist(
                     "user_id": str(user_uuid),
                     "discogs_username": discogs_username,
                     "wants": neo4j_wants,
-                    "synced_at": datetime.now(UTC).isoformat(),
+                    "synced_at": sync_started.isoformat(),
                 }
                 log_cypher_query(
                     cypher,
@@ -464,8 +519,44 @@ async def sync_wantlist(
             page += 1
             await asyncio.sleep(SYNC_DELAY_SECONDS)
 
+    # Reached only when the loop completed normally — reconcile away rows/edges
+    # this run never touched (items removed from the wantlist since the last
+    # sync). See sync_collection's _reconcile_stale_collection for the same
+    # pattern.
+    await _reconcile_stale_wantlist(user_uuid, pg_pool, neo4j_driver, sync_started)
+
     logger.info("✅ Wantlist sync complete", user=discogs_username, total=total_synced)
     return total_synced
+
+
+async def _reconcile_stale_wantlist(
+    user_uuid: UUID,
+    pg_pool: AsyncPostgreSQLPool,
+    neo4j_driver: AsyncResilientNeo4jDriver,
+    sync_started: datetime,
+) -> None:
+    """Delete wantlist rows/edges for this user untouched by the current sync run.
+
+    Same reconciliation pattern as _reconcile_stale_collection: anything still
+    stamped from before sync_started was not present in the freshly-fetched
+    Discogs wantlist (removed from the wantlist, typically after purchase).
+    Only called after a fully successful pagination run (see sync_wantlist).
+    """
+    async with pg_pool.connection() as conn, conn.cursor() as cur:
+        await execute_sql(
+            cur,
+            "DELETE FROM user_wantlists WHERE user_id = %s::uuid AND updated_at < %s",
+            (str(user_uuid), sync_started),
+        )
+
+    cypher = """
+    MATCH (u:User {id: $user_id})-[wnt:WANTS]->()
+    WHERE wnt.synced_at < $sync_started
+    DELETE wnt
+    """
+    async with neo4j_driver.session() as session:
+        result = await session.run(cypher, {"user_id": str(user_uuid), "sync_started": sync_started.isoformat()})
+        await result.consume()
 
 
 async def run_full_sync(

--- a/brainzgraphinator/brainzgraphinator.py
+++ b/brainzgraphinator/brainzgraphinator.py
@@ -868,6 +868,11 @@ async def _recover_consumers() -> None:
         active_connection = None
         active_channel = None
         queues = {}
+        # Clear stale consumer tags: any consumers registered before the error
+        # died with the now-closed connection. Leaving them behind would keep
+        # len(consumer_tags) > 0 forever, permanently gating off both recovery
+        # routes (stuck-check requires 0 tags) while health still reads healthy.
+        consumer_tags.clear()
 
 
 async def main() -> None:

--- a/brainzgraphinator/brainzgraphinator.py
+++ b/brainzgraphinator/brainzgraphinator.py
@@ -824,7 +824,14 @@ async def _recover_consumers() -> None:
                 await queue.bind(exchange)
                 queues[data_type] = queue
 
-            for data_type, msg_count in queues_with_messages:
+            # Start consumers for ALL data types lacking one — not just those
+            # with a current backlog. A type whose queue was empty at the
+            # passive-declare instant still needs a consumer; otherwise messages
+            # that arrive later are never consumed, because once active_connection
+            # is set and consumer_tags is non-empty both periodic recovery routes
+            # are permanently gated off, silently starving that data type.
+            pending_counts = dict(queues_with_messages)
+            for data_type in MUSICBRAINZ_DATA_TYPES:
                 if data_type in queues and data_type not in consumer_tags:
                     handler = HANDLERS.get(data_type)
                     if handler:
@@ -832,11 +839,14 @@ async def _recover_consumers() -> None:
                             handler, consumer_tag=f"brainzgraphinator-{data_type}"
                         )
                         consumer_tags[data_type] = consumer_tag
-                        completed_files.discard(data_type)
+                        # Only un-complete a type that actually has a backlog, so
+                        # genuinely-finished types stay marked complete.
+                        if data_type in pending_counts:
+                            completed_files.discard(data_type)
                         last_message_time[data_type] = time.time()
                         logger.info(
                             f"✅ Started consumer for {data_type} "
-                            f"(pending: {msg_count})"
+                            f"(pending: {pending_counts.get(data_type, 0)})"
                         )
 
             logger.info(

--- a/brainzgraphinator/brainzgraphinator.py
+++ b/brainzgraphinator/brainzgraphinator.py
@@ -300,6 +300,12 @@ async def enrich_artist(
         s["entities_skipped_no_discogs_match"] += 1
         return True  # Deliberately skipped, not an error
 
+    # Discogs nodes store `id` as a String property (graphinator writes it
+    # from DataMessage.id, always a str); MusicBrainz emits discogs_*_id as a
+    # JSON integer. Coerce to the graph's string convention before matching,
+    # or the MATCH silently never finds the node.
+    discogs_id = str(discogs_id)
+
     result = await tx.run(
         "MATCH (a:Artist {id: $discogs_id}) "
         "SET a.mbid = $mbid, "
@@ -354,6 +360,9 @@ async def enrich_label(
         s["entities_skipped_no_discogs_match"] += 1
         return True
 
+    # See enrich_artist: coerce to the graph's string `id` convention.
+    discogs_id = str(discogs_id)
+
     result = await tx.run(
         "MATCH (l:Label {id: $discogs_id}) "
         "SET l.mbid = $mbid, "
@@ -397,6 +406,9 @@ async def enrich_release(
         s["entities_skipped_no_discogs_match"] += 1
         return True
 
+    # See enrich_artist: coerce to the graph's string `id` convention.
+    discogs_id = str(discogs_id)
+
     result = await tx.run(
         "MATCH (r:Release {id: $discogs_id}) "
         "SET r.mbid = $mbid, "
@@ -423,7 +435,7 @@ async def enrich_release(
 
 async def create_relationship_edges(
     tx: Any,
-    source_discogs_id: int,
+    source_discogs_id: str,
     relations: list[dict[str, Any]],
     stats: dict[str, int] | None = None,
 ) -> None:
@@ -451,14 +463,19 @@ async def create_relationship_edges(
             s["relationships_skipped_missing_side"] += 1
             continue
 
+        # Discogs nodes key on a String `id`; MB targets resolve to an int
+        # discogs id (see enrich_artist). Coerce both sides consistently.
+        edge_source_id = str(source_discogs_id)
+        edge_target_id = str(target_discogs_id)
+
         # Safe: edge_type comes from MB_RELATIONSHIP_MAP, not user input
         result = await tx.run(
             f"MATCH (a:Artist {{id: $source_id}}) "  # noqa: S608
             f"MATCH (b:Artist {{id: $target_id}}) "
             f"MERGE (a)-[r:{edge_type}]->(b) "
             f"SET r.source = 'musicbrainz'",
-            source_id=source_discogs_id,
-            target_id=target_discogs_id,
+            source_id=edge_source_id,
+            target_id=edge_target_id,
         )
         summary = await result.consume()
         if summary.counters.relationships_created > 0:
@@ -483,6 +500,9 @@ async def enrich_release_group(
     if discogs_id is None:
         s["entities_skipped_no_discogs_match"] += 1
         return True
+
+    # See enrich_artist: coerce to the graph's string `id` convention.
+    discogs_id = str(discogs_id)
 
     result = await tx.run(
         "MATCH (m:Master {id: $discogs_id}) "

--- a/brainzgraphinator/brainzgraphinator.py
+++ b/brainzgraphinator/brainzgraphinator.py
@@ -445,6 +445,10 @@ async def create_relationship_edges(
     - Look up the Neo4j edge type in MB_RELATIONSHIP_MAP
     - Skip unknown relationship types
     - If target_discogs_artist_id is None, skip
+    - Swap source/target when the relation's direction is "backward" — the
+      current entity is the relationship's target in that case, not its
+      source (see MB_RELATIONSHIP_MAP types, all of which are canonically
+      oriented, e.g. member->band for "member of band")
     - MERGE the edge with source: 'musicbrainz' property
 
     Cypher can't parameterize relationship types, so we format the edge type
@@ -467,6 +471,13 @@ async def create_relationship_edges(
         # discogs id (see enrich_artist). Coerce both sides consistently.
         edge_source_id = str(source_discogs_id)
         edge_target_id = str(target_discogs_id)
+
+        # MusicBrainz relations are directional and materialized on both
+        # endpoints. direction == "backward" means the record being
+        # processed is the relation's TARGET, not its source — swap so the
+        # edge is created in the canonical orientation (e.g. member->band).
+        if relation.get("direction") == "backward":
+            edge_source_id, edge_target_id = edge_target_id, edge_source_id
 
         # Safe: edge_type comes from MB_RELATIONSHIP_MAP, not user input
         result = await tx.run(

--- a/brainztableinator/brainztableinator.py
+++ b/brainztableinator/brainztableinator.py
@@ -416,18 +416,27 @@ async def _recover_consumers() -> None:
                 await queue.bind(exchange)
                 queues[data_type] = queue
 
-            # Start consumers for queues with messages
-            for data_type, msg_count in queues_with_messages:
+            # Start consumers for ALL data types lacking one — not just those
+            # with a current backlog. A type whose queue was empty at the
+            # passive-declare instant still needs a consumer; otherwise messages
+            # that arrive later are never consumed, because once active_connection
+            # is set and consumer_tags is non-empty both periodic recovery routes
+            # are permanently gated off, silently starving that data type.
+            pending_counts = dict(queues_with_messages)
+            for data_type in MUSICBRAINZ_DATA_TYPES:
                 if data_type in queues and data_type not in consumer_tags:
                     handler = make_data_handler(data_type)
                     consumer_tag = await queues[data_type].consume(handler)
                     consumer_tags[data_type] = consumer_tag
-                    completed_files.discard(data_type)
+                    # Only un-complete a type that actually has a backlog, so
+                    # genuinely-finished types stay marked complete.
+                    if data_type in pending_counts:
+                        completed_files.discard(data_type)
                     last_message_time[data_type] = time.time()
                     logger.info(
                         f"✅ Started consumer for {data_type}",
                         data_type=data_type,
-                        pending_messages=msg_count,
+                        pending_messages=pending_counts.get(data_type, 0),
                     )
 
             logger.info(

--- a/brainztableinator/brainztableinator.py
+++ b/brainztableinator/brainztableinator.py
@@ -462,24 +462,42 @@ async def _insert_relationships(
     round-trip) per relationship. This keeps the per-message transaction short, which
     minimizes how long the connection sits ``idle in transaction`` holding a backend —
     the dominant pressure on the shared PgBouncer budget during a bulk import.
+
+    MusicBrainz relations are directional and materialized on both endpoints;
+    ``direction`` == "backward" means the entity being processed is the
+    relation's TARGET, not its source (mirrors the fix in
+    brainzgraphinator.create_relationship_edges). Swap source/target in that
+    case so the stored row always reflects the relationship's canonical
+    orientation (e.g. member->band for "member of band"), regardless of
+    which endpoint's record we happened to be processing.
     """
-    params = [
-        (
-            source_mbid,
-            source_type,
-            rel.get("target_mbid", ""),
-            rel.get("target_type", ""),
-            rel.get("type", ""),
-            Jsonb(rel.get("attributes", [])),
-            rel.get("begin_date"),
-            rel.get("end_date"),
-            rel.get("ended", False),
-        )
-        for rel in rels
+    params = []
+    for rel in rels:
         # Skip relations missing a target MBID (would fail UUID cast), target entity
         # type, or relationship type — these would violate NOT NULL / cast constraints.
-        if rel.get("target_mbid") and rel.get("target_type") and rel.get("type")
-    ]
+        if not (rel.get("target_mbid") and rel.get("target_type") and rel.get("type")):
+            continue
+
+        if rel.get("direction") == "backward":
+            row_source_mbid, row_source_type = rel["target_mbid"], rel["target_type"]
+            row_target_mbid, row_target_type = source_mbid, source_type
+        else:
+            row_source_mbid, row_source_type = source_mbid, source_type
+            row_target_mbid, row_target_type = rel["target_mbid"], rel["target_type"]
+
+        params.append(
+            (
+                row_source_mbid,
+                row_source_type,
+                row_target_mbid,
+                row_target_type,
+                rel.get("type", ""),
+                Jsonb(rel.get("attributes", [])),
+                rel.get("begin_date"),
+                rel.get("end_date"),
+                rel.get("ended", False),
+            )
+        )
     if not params:
         return
     async with conn.cursor() as cursor:

--- a/brainztableinator/brainztableinator.py
+++ b/brainztableinator/brainztableinator.py
@@ -459,6 +459,11 @@ async def _recover_consumers() -> None:
         active_connection = None
         active_channel = None
         queues = {}
+        # Clear stale consumer tags: any consumers registered before the error
+        # died with the now-closed connection. Leaving them behind would keep
+        # len(consumer_tags) > 0 forever, permanently gating off both recovery
+        # routes (stuck-check requires 0 tags) while health still reads healthy.
+        consumer_tags.clear()
 
 
 async def _insert_relationships(

--- a/common/config.py
+++ b/common/config.py
@@ -659,6 +659,11 @@ class ApiConfig:
     snapshot_ttl_days: int = 28
     snapshot_max_nodes: int = 100
     encryption_master_key: str | None = None
+    # Shared secret gating the internal /api/internal/insights/* router. The
+    # insights service presents this as the X-Internal-Secret header; when unset
+    # the router fails closed (rejects all callers) so it is never anonymously
+    # reachable via the public explore proxy.
+    insights_internal_secret: str | None = None
 
     # Brevo email notifications
     brevo_api_key: str | None = None
@@ -744,6 +749,7 @@ class ApiConfig:
         pool_min, pool_max = resolve_postgres_pool_sizes(default_min=2, default_max=8)
 
         encryption_master_key = get_secret("ENCRYPTION_MASTER_KEY") or None
+        insights_internal_secret = get_secret("INSIGHTS_INTERNAL_SECRET") or None
         brevo_api_key = get_secret("BREVO_API_KEY") or None
         brevo_sender_email = getenv("BREVO_SENDER_EMAIL", "noreply@discogsography.com")
         brevo_sender_name = getenv("BREVO_SENDER_NAME", "Discogsography")
@@ -780,6 +786,7 @@ class ApiConfig:
             snapshot_ttl_days=snapshot_ttl_days,
             snapshot_max_nodes=snapshot_max_nodes,
             encryption_master_key=encryption_master_key,
+            insights_internal_secret=insights_internal_secret,
             brevo_api_key=brevo_api_key,
             brevo_sender_email=brevo_sender_email,
             brevo_sender_name=brevo_sender_name,
@@ -832,6 +839,9 @@ class InsightsConfig:
     redis_host: str = "redis://localhost:6379/0"
     schedule_hours: int = 24
     milestone_years: tuple[int, ...] = (25, 30, 40, 50, 75, 100)
+    # Shared secret sent as the X-Internal-Secret header when calling the API's
+    # /api/internal/insights/* endpoints. Must match the API's value.
+    internal_secret: str | None = None
 
     @classmethod
     def from_env(cls) -> "InsightsConfig":
@@ -874,6 +884,8 @@ class InsightsConfig:
 
         pool_min, pool_max = resolve_postgres_pool_sizes(default_min=1, default_max=4)
 
+        internal_secret = get_secret("INSIGHTS_INTERNAL_SECRET") or None
+
         return cls(
             api_base_url=api_base_url,
             postgres_host=_build_postgres_connstr(),
@@ -885,6 +897,7 @@ class InsightsConfig:
             redis_host=redis_host,
             schedule_hours=schedule_hours,
             milestone_years=milestone_years,
+            internal_secret=internal_secret,
         )
 
 

--- a/common/config.py
+++ b/common/config.py
@@ -670,8 +670,13 @@ class ApiConfig:
     brevo_sender_email: str = "noreply@discogsography.com"
     brevo_sender_name: str = "Discogsography"
 
-    # Admin dashboard — extractor connection
-    extractor_host: str = "extractor"
+    # Admin dashboard — extractor connection.
+    # No service named bare "extractor" exists (extractor runs as the two split
+    # services extractor-discogs and extractor-musicbrainz per docker-compose.yml);
+    # default to extractor-discogs so the admin panel resolves out of the box.
+    # NOTE: this single field can still only ever address ONE of the two
+    # extractor services — see discogsography-cu2.32.
+    extractor_host: str = "extractor-discogs"
     extractor_health_port: int = 8000
 
     # Admin dashboard — RabbitMQ management API
@@ -790,7 +795,7 @@ class ApiConfig:
             brevo_api_key=brevo_api_key,
             brevo_sender_email=brevo_sender_email,
             brevo_sender_name=brevo_sender_name,
-            extractor_host=getenv("EXTRACTOR_HOST", "extractor"),
+            extractor_host=getenv("EXTRACTOR_HOST", "extractor-discogs"),
             extractor_health_port=int(getenv("EXTRACTOR_HEALTH_PORT", "8000")),
             rabbitmq_management_host=getenv("RABBITMQ_MANAGEMENT_HOST", getenv("RABBITMQ_HOST", "rabbitmq")),
             rabbitmq_management_port=int(getenv("RABBITMQ_MANAGEMENT_PORT", "15672")),

--- a/common/db_resilience.py
+++ b/common/db_resilience.py
@@ -224,11 +224,28 @@ class ResilientConnection[T]:
         self._connection: T | None = None
         self._lock = Lock()
 
+    def _close_connection(self, connection: Any) -> None:
+        """Best-effort close of a connection, matching close()'s dispatch."""
+        if connection is None:
+            return
+        try:
+            if hasattr(connection, "close"):
+                connection.close()
+        except Exception as e:
+            logger.warning(f"⚠️ {self.name}: Error closing connection: {e}")
+
     def get_connection(self) -> T:
         """Get a healthy connection, creating or reconnecting if needed."""
         with self._lock:
             if self._connection and self._test_connection(self._connection):
                 return self._connection
+
+            # The existing connection is unhealthy. Close and discard it BEFORE reconnecting —
+            # otherwise the retry loop overwrites self._connection and orphans the old object
+            # (leaked driver pool / socket that GC cannot reliably clean up).
+            if self._connection is not None:
+                self._close_connection(self._connection)
+                self._connection = None
 
             # Connection is not healthy, try to create new one
             retry_count = 0
@@ -241,6 +258,8 @@ class ResilientConnection[T]:
                     def create_connection() -> T:
                         conn = self.connection_factory()
                         if not self.connection_test(conn):
+                            # Close the just-built connection before discarding it.
+                            self._close_connection(conn)
                             raise Exception("Connection test failed")
                         return conn
 
@@ -272,15 +291,9 @@ class ResilientConnection[T]:
     def close(self) -> None:
         """Close the connection."""
         with self._lock:
-            if self._connection:
-                try:
-                    # Attempt to close gracefully (implementation specific)
-                    if hasattr(self._connection, "close"):
-                        self._connection.close()
-                except Exception as e:
-                    logger.warning(f"⚠️ {self.name}: Error closing connection: {e}")
-                finally:
-                    self._connection = None
+            if self._connection is not None:
+                self._close_connection(self._connection)
+                self._connection = None
 
 
 class AsyncResilientConnection[T]:
@@ -304,6 +317,21 @@ class AsyncResilientConnection[T]:
         self._connection: T | None = None
         self._lock: asyncio.Lock | None = None
 
+    async def _aclose_connection(self, connection: Any) -> None:
+        """Best-effort close of a connection, dispatching aclose()/close() like close()."""
+        if connection is None:
+            return
+        try:
+            if hasattr(connection, "aclose"):
+                await connection.aclose()
+            elif hasattr(connection, "close"):
+                if asyncio.iscoroutinefunction(connection.close):
+                    await connection.close()
+                else:
+                    connection.close()
+        except Exception as e:
+            logger.warning(f"⚠️ {self.name}: Error closing connection: {e}")
+
     async def get_connection(self) -> T:
         """Get a healthy connection, creating or reconnecting if needed."""
         if self._lock is None:
@@ -311,6 +339,13 @@ class AsyncResilientConnection[T]:
         async with self._lock:
             if self._connection and await self._test_connection(self._connection):
                 return self._connection
+
+            # The existing connection is unhealthy. Close and discard it BEFORE reconnecting —
+            # otherwise the retry loop overwrites self._connection and orphans the old object
+            # (e.g. a whole Neo4j driver pool of 50 sockets that GC cannot close via __del__).
+            if self._connection is not None:
+                await self._aclose_connection(self._connection)
+                self._connection = None
 
             # Connection is not healthy, try to create new one
             retry_count = 0
@@ -326,11 +361,14 @@ class AsyncResilientConnection[T]:
                         else:
                             conn = self.connection_factory()
                         if asyncio.iscoroutinefunction(self.connection_test):
-                            if not await self.connection_test(conn):
-                                raise Exception("Connection test failed")
+                            test_ok = await self.connection_test(conn)
                         else:
-                            if not self.connection_test(conn):
-                                raise Exception("Connection test failed")
+                            test_ok = self.connection_test(conn)
+                        if not test_ok:
+                            # Close the just-built connection before discarding it, so a failed
+                            # health test does not leak a fresh pool/socket per attempt.
+                            await self._aclose_connection(conn)
+                            raise Exception("Connection test failed")
                         return cast("T", conn)
 
                     conn = await self.circuit_breaker.call_async(create_connection)
@@ -368,20 +406,9 @@ class AsyncResilientConnection[T]:
         if self._lock is None:
             self._lock = asyncio.Lock()
         async with self._lock:
-            if self._connection:
-                try:
-                    # Attempt to close gracefully
-                    if hasattr(self._connection, "aclose"):
-                        await self._connection.aclose()
-                    elif hasattr(self._connection, "close"):
-                        if asyncio.iscoroutinefunction(self._connection.close):
-                            await self._connection.close()
-                        else:
-                            self._connection.close()
-                except Exception as e:
-                    logger.warning(f"⚠️ {self.name}: Error closing connection: {e}")
-                finally:
-                    self._connection = None
+            if self._connection is not None:
+                await self._aclose_connection(self._connection)
+                self._connection = None
 
 
 # Context managers for resilient connections

--- a/common/health_server.py
+++ b/common/health_server.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from datetime import UTC, datetime
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import logging
 from threading import Thread
@@ -14,6 +14,13 @@ logger = logging.getLogger(__name__)
 
 class HealthHandler(BaseHTTPRequestHandler):
     """HTTP request handler for health checks and optional Prometheus metrics."""
+
+    # Bound how long a connected-but-silent peer (e.g. a TCP-connect port scan or a
+    # half-open connection after a network partition) can hold this handler's
+    # rfile.readline() before it is dropped. Without this, a single such peer blocks
+    # indefinitely; combined with a threading server this only ties up one worker
+    # thread instead of wedging the entire accept loop.
+    timeout = 5
 
     def do_GET(self) -> None:
         """Handle GET requests."""
@@ -42,8 +49,15 @@ class HealthHandler(BaseHTTPRequestHandler):
         pass
 
 
-class HealthServer(HTTPServer):
-    """HTTP server with health check endpoint and optional Prometheus metrics endpoint."""
+class HealthServer(ThreadingHTTPServer):
+    """HTTP server with health check endpoint and optional Prometheus metrics endpoint.
+
+    Uses ThreadingHTTPServer (rather than the single-threaded HTTPServer) so one
+    connection stuck in a blocking read (see HealthHandler.timeout) cannot wedge the
+    accept loop for every other client — each connection gets its own daemon thread.
+    """
+
+    daemon_threads = True
 
     def __init__(
         self,

--- a/common/postgres_resilient.py
+++ b/common/postgres_resilient.py
@@ -633,26 +633,32 @@ class AsyncPostgreSQLPool:
         finally:
             # Return connection to pool if it's still good
             if conn and not conn.closed and not self._closed:
+                autocommit_ok = True
                 try:
                     # Restore autocommit=True before returning to pool
                     # Callers using conn.transaction() must set autocommit=False,
                     # and we reset it here to prevent poisoning the pool
                     await conn.set_autocommit(True)
                 except Exception:
-                    # set_autocommit failed — connection is dead, discard it
+                    # set_autocommit failed — connection is dead, discard it.
+                    # Fall through WITHOUT `return`: a bare `return` in a `finally`
+                    # block silently swallows any exception propagating from the
+                    # `yield conn` body, so use a guard flag to skip the put-back
+                    # instead of short-circuiting the whole finally clause.
+                    autocommit_ok = False
                     with contextlib.suppress(Exception):
                         await conn.close()
                     async with self._lock:
                         self.active_connections = max(0, self.active_connections - 1)
-                    return
-                try:
-                    self.connections.put_nowait(conn)
-                except asyncio.QueueFull:
-                    # Pool is full, close connection
-                    with contextlib.suppress(Exception):
-                        await conn.close()
-                    async with self._lock:
-                        self.active_connections = max(0, self.active_connections - 1)
+                if autocommit_ok:
+                    try:
+                        self.connections.put_nowait(conn)
+                    except asyncio.QueueFull:
+                        # Pool is full, close connection
+                        with contextlib.suppress(Exception):
+                            await conn.close()
+                        async with self._lock:
+                            self.active_connections = max(0, self.active_connections - 1)
             elif conn:
                 # Close bad connections
                 with contextlib.suppress(Exception):

--- a/common/postgres_resilient.py
+++ b/common/postgres_resilient.py
@@ -137,19 +137,34 @@ class ResilientPostgreSQLPool:
                     with self._lock:
                         self.active_connections = max(0, self.active_connections - 1)
 
-            # Ensure minimum connections
+            # Ensure minimum connections — but never mint past max_connections. qsize() counts
+            # only IDLE connections; checked-out connections are not in the queue, so gating on
+            # queue size alone would mint fresh backends past the cap under saturation. Reserve the
+            # slot under the lock first (active_connections < max_connections), mirroring checkout.
             current_size = self.connections.qsize()
             if current_size < self.min_connections:
                 logger.info(f"🔄 Replenishing connection pool ({current_size}/{self.min_connections} connections)")
                 for _ in range(self.min_connections - current_size):
+                    reserved = False
+                    with self._lock:
+                        if self.active_connections < self.max_connections:
+                            self.active_connections += 1
+                            reserved = True
+                    if not reserved:
+                        break
                     try:
                         conn = self._create_connection()
-                        if conn:
-                            self.connections.put_nowait(conn)
-                            with self._lock:
-                                self.active_connections += 1
                     except Exception as e:
+                        with self._lock:
+                            self.active_connections = max(0, self.active_connections - 1)
                         logger.warning(f"⚠️ Failed to replenish connection: {e}")
+                        break
+                    try:
+                        self.connections.put_nowait(conn)
+                    except Full:
+                        conn.close()
+                        with self._lock:
+                            self.active_connections = max(0, self.active_connections - 1)
                         break
 
     @contextmanager
@@ -447,23 +462,35 @@ class AsyncPostgreSQLPool:
                     async with self._lock:
                         self.active_connections = max(0, self.active_connections - 1)
 
-            # Ensure minimum connections
+            # Ensure minimum connections — but never mint past max_connections. qsize() counts
+            # only IDLE connections; checked-out connections are not in the queue, so gating on
+            # queue size alone mints fresh backends on every tick while the pool is saturated and
+            # blows past the shared PgBouncer session-mode backend cap. Reserve the slot under the
+            # lock first (active_connections < max_connections), mirroring the checkout path.
             current_size = self.connections.qsize()
             if current_size < self.min_connections:
                 logger.info(f"🔄 Replenishing connection pool ({current_size}/{self.min_connections} connections)")
                 for _ in range(self.min_connections - current_size):
+                    reserved = False
+                    async with self._lock:
+                        if self.active_connections < self.max_connections:
+                            self.active_connections += 1
+                            reserved = True
+                    if not reserved:
+                        break
                     try:
                         conn = await self._create_connection()
-                        if conn:
-                            try:
-                                self.connections.put_nowait(conn)
-                            except asyncio.QueueFull:
-                                await conn.close()
-                                break
-                            async with self._lock:
-                                self.active_connections += 1
                     except Exception as e:
+                        async with self._lock:
+                            self.active_connections = max(0, self.active_connections - 1)
                         logger.warning(f"⚠️ Failed to replenish connection: {e}")
+                        break
+                    try:
+                        self.connections.put_nowait(conn)
+                    except asyncio.QueueFull:
+                        await conn.close()
+                        async with self._lock:
+                            self.active_connections = max(0, self.active_connections - 1)
                         break
 
     @asynccontextmanager

--- a/common/postgres_resilient.py
+++ b/common/postgres_resilient.py
@@ -519,6 +519,12 @@ class AsyncPostgreSQLPool:
                     logger.warning("⚠️ Got unhealthy connection from pool, creating new one")
                     with contextlib.suppress(Exception):
                         await conn.close()
+                    # Drop the stale reference before attempting a replacement. If the
+                    # replacement create fails on every retry, `conn` must stay falsy so the
+                    # post-loop `if not conn` guard fires and raises the intended "Failed to
+                    # get PostgreSQL connection" error instead of yielding a CLOSED connection
+                    # (which would also cause active_connections to be decremented twice).
+                    conn = None
                     # Replace unhealthy connection — no net change to active_connections
                     # Keep counter stable to prevent TOCTOU races
                     try:

--- a/common/postgres_resilient.py
+++ b/common/postgres_resilient.py
@@ -184,14 +184,32 @@ class ResilientPostgreSQLPool:
                     conn = self.connections.get_nowait()
                 except Empty:
                     # Create new connection if pool is not at max
+                    created = False
                     with self._lock:
                         if self.active_connections < self.max_connections:
                             self.active_connections += 1
-                            try:
-                                conn = self._create_connection()
-                            except Exception:
-                                self.active_connections -= 1
-                                raise
+                            created = True
+                    if created:
+                        try:
+                            conn = self._create_connection()
+                        except Exception:
+                            with self._lock:
+                                self.active_connections = max(0, self.active_connections - 1)
+                            raise
+                    else:
+                        # Pool exhausted — block for a returned connection instead of
+                        # busy-spinning at 100% CPU. Without this branch neither a connection nor an
+                        # exception is produced, so retry_count never advances and max_retries is
+                        # unreachable. On timeout, count a retry and continue (mirrors the async pool).
+                        try:
+                            conn = self.connections.get(timeout=self.backoff.get_delay(retry_count))
+                        except Empty:
+                            retry_count += 1
+                            if retry_count < self.max_retries:
+                                logger.warning(
+                                    f"⚠️ Connection pool exhausted (attempt {retry_count}/{self.max_retries}), waiting for available connection..."
+                                )
+                            continue
 
                 # Test connection health
                 if conn and not self._test_connection(conn):

--- a/common/postgres_resilient.py
+++ b/common/postgres_resilient.py
@@ -254,6 +254,12 @@ class ResilientPostgreSQLPool:
             logger.warning(f"⚠️ Connection error during operation: {e}")
             with contextlib.suppress(Exception):
                 conn.close()
+            # Decrement for the destroyed connection BEFORE clearing `conn`: once `conn` is None
+            # neither finally branch runs, so without this the slot is leaked permanently — after
+            # max_connections such failures the pool believes it is full while holding no live
+            # connections. Mirrors the async pool. (This is the last read of `conn`.)
+            with self._lock:
+                self.active_connections = max(0, self.active_connections - 1)
             conn = None
             raise
         finally:

--- a/common/postgres_resilient.py
+++ b/common/postgres_resilient.py
@@ -495,9 +495,13 @@ class AsyncPostgreSQLPool:
                     if created:
                         try:
                             conn = await self._create_connection()
-                        except Exception:
+                        except BaseException:
+                            # BaseException (not just Exception) so asyncio.CancelledError —
+                            # which derives from BaseException in Python 3.13 and can land inside
+                            # AsyncConnection.connect() when the caller task is cancelled — also
+                            # rolls back the reserved slot instead of leaking capacity permanently.
                             async with self._lock:
-                                self.active_connections -= 1
+                                self.active_connections = max(0, self.active_connections - 1)
                             raise
                     else:
                         # Pool exhausted - wait for a connection to be returned
@@ -514,8 +518,21 @@ class AsyncPostgreSQLPool:
                                 )
                             continue
 
-                # Test connection health
-                if conn and not await self._test_connection(conn):
+                # Test connection health. Guard the probe against BaseException
+                # (e.g. asyncio.CancelledError): if the acquiring task is cancelled while
+                # health-checking a checked-out connection, close it and release its slot so
+                # the capacity is not stranded (active_connections leaked) forever.
+                try:
+                    healthy = True if conn is None else await self._test_connection(conn)
+                except BaseException:
+                    if conn is not None:
+                        with contextlib.suppress(Exception):
+                            await conn.close()
+                        async with self._lock:
+                            self.active_connections = max(0, self.active_connections - 1)
+                        conn = None
+                    raise
+                if conn and not healthy:
                     logger.warning("⚠️ Got unhealthy connection from pool, creating new one")
                     with contextlib.suppress(Exception):
                         await conn.close()
@@ -526,10 +543,12 @@ class AsyncPostgreSQLPool:
                     # (which would also cause active_connections to be decremented twice).
                     conn = None
                     # Replace unhealthy connection — no net change to active_connections
-                    # Keep counter stable to prevent TOCTOU races
+                    # Keep counter stable to prevent TOCTOU races. Catch BaseException so a
+                    # CancelledError landing in the replacement create also releases the slot
+                    # that belonged to the discarded connection instead of leaking it.
                     try:
                         conn = await self._create_connection()
-                    except Exception:
+                    except BaseException:
                         async with self._lock:
                             self.active_connections = max(0, self.active_connections - 1)
                         raise

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -61,6 +61,11 @@ def _get_or_create_counter(name: str, description: str, labels: list[str]) -> Co
 WEBSOCKET_CONNECTIONS = _get_or_create_gauge("dashboard_websocket_connections", "Number of active WebSocket connections")
 API_REQUESTS = _get_or_create_counter("dashboard_api_requests", "Total API requests", ["endpoint", "method"])
 
+# Per-client cap on how long broadcast_metrics waits on a single websocket.send_text().
+# send_text applies TCP backpressure and can block indefinitely for a stalled client
+# (sleeping laptop, zero-window peer); this bounds the blast radius to that one client.
+_WS_SEND_TIMEOUT_SECONDS = 5.0
+
 
 class ServiceStatus(BaseModel):
     """Model for service status information."""
@@ -476,17 +481,30 @@ class DashboardApp:
 
         if self._ws_lock is None:
             self._ws_lock = asyncio.Lock()
-        async with self._ws_lock:
-            disconnected = set()
-            for websocket in list(self.websocket_connections):
-                try:
-                    await websocket.send_text(message)
-                except Exception:
-                    disconnected.add(websocket)
 
-            # Remove disconnected websockets
-            self.websocket_connections -= disconnected
-            WEBSOCKET_CONNECTIONS.set(len(self.websocket_connections))
+        # Snapshot the connection set under the lock only (cheap, non-blocking).
+        # send_text is done OUTSIDE the lock: it applies TCP backpressure and can
+        # block on a stalled client, and holding the lock across that await would
+        # also block new /ws registrations (websocket_endpoint) and stall the 2s
+        # collect_metrics_loop for every other client, not just the stalled one.
+        async with self._ws_lock:
+            targets = list(self.websocket_connections)
+
+        async def _send(websocket: WebSocket) -> WebSocket | None:
+            try:
+                await asyncio.wait_for(websocket.send_text(message), timeout=_WS_SEND_TIMEOUT_SECONDS)
+            except Exception:
+                return websocket
+            return None
+
+        results = await asyncio.gather(*(_send(websocket) for websocket in targets))
+        disconnected = {websocket for websocket in results if websocket is not None}
+
+        if disconnected:
+            # Re-acquire the lock only to discard the failed sockets.
+            async with self._ws_lock:
+                self.websocket_connections -= disconnected
+                WEBSOCKET_CONNECTIONS.set(len(self.websocket_connections))
 
 
 # Create the dashboard app instance

--- a/dashboard/static/admin.js
+++ b/dashboard/static/admin.js
@@ -1,15 +1,35 @@
 'use strict';
 
-const DLQ_NAMES = [
-    'graphinator-artists-dlq', 'graphinator-labels-dlq',
-    'graphinator-masters-dlq', 'graphinator-releases-dlq',
-    'tableinator-artists-dlq', 'tableinator-labels-dlq',
-    'tableinator-masters-dlq', 'tableinator-releases-dlq',
-    'brainzgraphinator-artists-dlq', 'brainzgraphinator-labels-dlq',
-    'brainzgraphinator-releases-dlq', 'brainzgraphinator-release-groups-dlq',
-    'brainztableinator-artists-dlq', 'brainztableinator-labels-dlq',
-    'brainztableinator-releases-dlq', 'brainztableinator-release-groups-dlq',
+// DLQ naming contract MUST mirror the backend's _VALID_DLQ_NAMES construction
+// (api/routers/admin.py): f"{source-exchange-prefix}-{consumer}-{data_type}.dlq".
+// Keep these prefixes/types in lockstep with common/config.py's
+// DISCOGS_EXCHANGE_PREFIX / MUSICBRAINZ_EXCHANGE_PREFIX / DATA_TYPES /
+// MUSICBRAINZ_DATA_TYPES defaults — a drift here reproduces the "every Purge
+// button 404s" bug (discogsography-cu2.35).
+const DLQ_SOURCE_PREFIXES = {
+    discogs: 'discogsography-discogs',
+    musicbrainz: 'discogsography-musicbrainz',
+};
+
+const DLQ_CONSUMER_GROUPS = [
+    { source: 'discogs', consumer: 'graphinator', types: ['artists', 'labels', 'masters', 'releases'] },
+    { source: 'discogs', consumer: 'tableinator', types: ['artists', 'labels', 'masters', 'releases'] },
+    { source: 'musicbrainz', consumer: 'brainzgraphinator', types: ['artists', 'labels', 'release-groups', 'releases'] },
+    { source: 'musicbrainz', consumer: 'brainztableinator', types: ['artists', 'labels', 'release-groups', 'releases'] },
 ];
+
+// Structured items (queue/service/type) generated directly — NOT parsed back
+// out of the queue name string, which is brittle against multi-segment
+// prefixes (e.g. "discogsography-discogs-graphinator-artists.dlq").
+const DLQ_ITEMS = DLQ_CONSUMER_GROUPS.flatMap(({ source, consumer, types }) =>
+    types.map(type => ({
+        queue: `${DLQ_SOURCE_PREFIXES[source]}-${consumer}-${type}.dlq`,
+        service: consumer,
+        type,
+    }))
+);
+
+const DLQ_NAMES = DLQ_ITEMS.map(item => item.queue);
 
 const QUEUE_CHART_COLORS = [
     '#818cf8', '#34d399', '#f59e0b', '#f87171',
@@ -473,11 +493,7 @@ class AdminDashboard {
         const container = document.getElementById('dlq-list');
         if (!container) return;
 
-        const items = DLQ_NAMES.map(queue => {
-            const parts = queue.replace('-dlq', '').split('-');
-            const service = parts[0];
-            const type = parts[1];
-
+        const items = DLQ_ITEMS.map(({ queue, service, type }) => {
             const row = document.createElement('div');
             row.className = 'flex items-center justify-between py-3.5 border-b b-row';
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -259,6 +259,9 @@ services:
       # BREVO_SENDER_NAME: "${BREVO_SENDER_NAME:-Discogsography}"
       # Encryption master key (optional — required for TOTP 2FA, derives OAuth + TOTP keys via HKDF)
       # ENCRYPTION_MASTER_KEY: "${ENCRYPTION_MASTER_KEY:-}"
+      # Shared secret gating the internal /api/internal/insights/* router. MUST match the
+      # insights service. Override with a random value in production.
+      INSIGHTS_INTERNAL_SECRET: "${INSIGHTS_INTERNAL_SECRET:-dev-internal-insights-secret-change-in-production}"
     ports:
       - "8004:8004"      # Auth API
       - "8005:8005"      # Health check
@@ -732,6 +735,9 @@ services:
       PYTHONUNBUFFERED: "1"
       REDIS_HOST: redis
       STARTUP_DELAY: "10"
+      # Shared secret for authenticating to the API's /api/internal/insights/* router.
+      # MUST match the api service's value.
+      INSIGHTS_INTERNAL_SECRET: "${INSIGHTS_INTERNAL_SECRET:-dev-internal-insights-secret-change-in-production}"
       # INSIGHTS_MILESTONE_YEARS: "25,30,40,50,75,100"
     depends_on:
       api:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -298,11 +298,14 @@ services:
     build:
       context: .
       dockerfile: extractor/Dockerfile
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
     image: discogsography/extractor:latest
     container_name: discogsography-extractor-discogs
     hostname: extractor-discogs
     command: ["--source", "discogs"]
-    user: "1000:1000"
+    user: "${UID:-1000}:${GID:-1000}"
     environment:
       DISCOGS_ROOT: /discogs-data
       FORCE_REPROCESS: "false"
@@ -340,11 +343,14 @@ services:
     build:
       context: .
       dockerfile: extractor/Dockerfile
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
     image: discogsography/extractor:latest
     container_name: discogsography-extractor-musicbrainz
     hostname: extractor-musicbrainz
     command: ["--source", "musicbrainz"]
-    user: "1000:1000"
+    user: "${UID:-1000}:${GID:-1000}"
     environment:
       DISCOGS_HEALTH_URL: "http://extractor-discogs:8000/health"
       LOG_LEVEL: info

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -598,6 +598,14 @@ DISCOGS_USER_AGENT="Discogsography/1.0 +https://github.com/SimplicityGuy/discogs
 # In production, supply via ENCRYPTION_MASTER_KEY_FILE (Docker secret)
 ENCRYPTION_MASTER_KEY="your-master-key-here"
 
+# Shared secret gating the internal /api/internal/insights/* router.
+# These endpoints are mounted on the public app and reachable through the explore proxy,
+# so the /api/internal prefix alone provides NO isolation. Callers must present this value
+# as the X-Internal-Secret header; the insights service is configured with the same value.
+# When unset, the router fails closed (rejects every caller). Supply via
+# INSIGHTS_INTERNAL_SECRET_FILE (Docker secret) in production.
+INSIGHTS_INTERNAL_SECRET="change-me-in-production"
+
 # Optional — Brevo transactional email for password reset notifications
 # When not set, password reset links are logged to stdout instead of emailed.
 # Get your API key from https://app.brevo.com/settings/keys/api
@@ -797,6 +805,13 @@ POSTGRES_DATABASE="discogsography"
 
 # Optional - Redis Caching
 REDIS_HOST="localhost"                        # Redis hostname for result caching (default: localhost)
+
+# Internal API authentication — MUST match the API service's INSIGHTS_INTERNAL_SECRET.
+# The API's /api/internal/insights/* router is mounted on the public app and reachable
+# through the explore proxy, so it is gated by this shared secret (sent as the
+# X-Internal-Secret header). When unset on the API, the router fails closed (rejects all
+# callers); when unset here, the insights service cannot fetch its computation data.
+INSIGHTS_INTERNAL_SECRET="change-me-in-production"
 
 # Optional - Scheduler
 INSIGHTS_SCHEDULE_HOURS=24                    # Computation interval in hours (default: 24)

--- a/explore/__tests__/app.test.js
+++ b/explore/__tests__/app.test.js
@@ -2076,6 +2076,37 @@ describe('ExploreApp helper methods', () => {
             // d3 mock's selectAll and each should be called
             expect(app.graph.g.selectAll).toHaveBeenCalledWith('g');
         });
+
+        it('should not throw on undated container <g> elements and should still highlight matching nodes (regression discogsography-cu2.36)', () => {
+            const app = new ExploreApp();
+            const classedSpy = vi.fn();
+
+            // graph.js's _render() creates two undated wrapper <g> containers
+            // (links, nodes) alongside the real per-node <g> elements bound to
+            // data via .data(this.nodes). selectAll('g') matches all three.
+            const iterations = [
+                { d: undefined, el: { classed: classedSpy } }, // link container
+                { d: undefined, el: { classed: classedSpy } }, // node container
+                { d: { type: 'genre', name: 'Electronic' }, el: { classed: classedSpy } },
+                { d: { type: 'artist', name: 'Radiohead' }, el: { classed: classedSpy } },
+            ];
+            app.graph.g.selectAll = vi.fn(() => ({
+                each(callback) {
+                    for (const { d, el } of iterations) callback.call(el, d);
+                    return this;
+                },
+            }));
+            const originalSelect = globalThis.d3.select;
+            globalThis.d3.select = vi.fn((node) => node);
+
+            try {
+                expect(() => app._onGenreEmergence(['Electronic'])).not.toThrow();
+                expect(classedSpy).toHaveBeenCalledWith('node-emergence', true);
+                expect(classedSpy).toHaveBeenCalledTimes(1);
+            } finally {
+                globalThis.d3.select = originalSelect;
+            }
+        });
     });
 
     describe('ExploreApp._loadTrends - compare mode', () => {

--- a/explore/__tests__/genre-tree.test.js
+++ b/explore/__tests__/genre-tree.test.js
@@ -198,5 +198,17 @@ describe('GenreTreeView', () => {
             expect(window.exploreApp._setSearchType).toHaveBeenCalledWith('style');
             expect(window.exploreApp._onSearch).toHaveBeenCalledWith('Alternative Rock');
         });
+
+        it('should switch to the explore pane BEFORE calling _onSearch (regression discogsography-cu2.37)', () => {
+            // _onSearch is pane-sensitive: it loads Trends unless activePane
+            // is already 'explore' at the moment it runs. Calling it before
+            // _switchPane('explore') silently routes the click into the
+            // hidden Trends pane instead of populating the Explore graph.
+            window.genreTreeView._navigateTo('Rock', 'genre');
+
+            const switchPaneOrder = window.exploreApp._switchPane.mock.invocationCallOrder[0];
+            const onSearchOrder = window.exploreApp._onSearch.mock.invocationCallOrder[0];
+            expect(switchPaneOrder).toBeLessThan(onSearchOrder);
+        });
     });
 });

--- a/explore/__tests__/graph.test.js
+++ b/explore/__tests__/graph.test.js
@@ -221,6 +221,25 @@ describe('GraphVisualization', () => {
 
             expect(window.apiClient.expand).toHaveBeenCalledWith('Radiohead', 'artist', 'releases', 30, 0, null);
         });
+
+        it('should reset a stale beforeYear from a prior timeline scrub (regression discogsography-cu2.38)', async () => {
+            graph.beforeYear = 1980;
+
+            const dataWithCount = {
+                center: { id: 'radiohead', name: 'Radiohead', type: 'artist' },
+                categories: [
+                    { id: 'cat-releases', name: 'Releases', category: 'releases', count: 5 },
+                ],
+            };
+            graph.setExploreData(dataWithCount);
+
+            expect(graph.beforeYear).toBeNull();
+
+            await new Promise(r => setTimeout(r, 10));
+            // The new entity's category expansion must not silently inherit
+            // the previous session's year filter.
+            expect(window.apiClient.expand).toHaveBeenCalledWith('Radiohead', 'artist', 'releases', 30, 0, null);
+        });
     });
 
     describe('_addLoadMoreNode', () => {
@@ -330,6 +349,14 @@ describe('GraphVisualization', () => {
             graph.restoreSnapshot([], { id: 'Test', type: 'artist' });
 
             expect(placeholder.classList.contains('hidden')).toBe(true);
+        });
+
+        it('should reset a stale beforeYear from a prior timeline scrub (regression discogsography-cu2.38)', () => {
+            graph.beforeYear = 1980;
+
+            graph.restoreSnapshot([{ id: 'Radiohead', type: 'artist' }], { id: 'Radiohead', type: 'artist' });
+
+            expect(graph.beforeYear).toBeNull();
         });
     });
 

--- a/explore/__tests__/nlq-action-applier.test.js
+++ b/explore/__tests__/nlq-action-applier.test.js
@@ -80,6 +80,42 @@ describe('NlqActionApplier', () => {
         expect(callArg.entities).toHaveLength(1);
         expect(result.applied).toBe(1);
     });
+
+    describe('appliedTypes (regression discogsography-cu2.39)', () => {
+        it('includes only genuinely-applied action types, not sanitizer-rejected ones', () => {
+            const handlers = mockHandlers();
+            const applier = new NlqActionApplier({ handlers, snapshotter: mockSnapshotter() });
+            const result = applier.apply([
+                { type: 'switch_pane', pane: 'nonsense' }, // sanitizer rejects -> skipped
+                { type: 'focus_node', name: 'Kraftwerk', entity_type: 'artist' }, // applies
+            ]);
+            expect(result.appliedTypes).toEqual(['focus_node']);
+            expect(result.applied).toBe(1);
+            expect(result.skipped).toBe(1);
+        });
+
+        it('excludes types whose handler throws', () => {
+            const handlers = mockHandlers();
+            handlers.seedGraph.mockImplementation(() => { throw new Error('boom'); });
+            const applier = new NlqActionApplier({ handlers, snapshotter: mockSnapshotter() });
+            const result = applier.apply([{ type: 'seed_graph', entities: [{ name: 'K', entity_type: 'artist' }] }]);
+            expect(result.appliedTypes).toEqual([]);
+        });
+
+        it('excludes unknown action types', () => {
+            const handlers = mockHandlers();
+            const applier = new NlqActionApplier({ handlers, snapshotter: mockSnapshotter() });
+            const result = applier.apply([{ type: 'nonsense' }]);
+            expect(result.appliedTypes).toEqual([]);
+        });
+
+        it('is empty when no handler is registered for a sanitized action', () => {
+            const applier = new NlqActionApplier({ handlers: {}, snapshotter: mockSnapshotter() });
+            const result = applier.apply([{ type: 'focus_node', name: 'Kraftwerk', entity_type: 'artist' }]);
+            expect(result.appliedTypes).toEqual([]);
+            expect(result.skipped).toBe(1);
+        });
+    });
 });
 
 describe('NlqActionApplier — sanitizer coverage', () => {

--- a/explore/__tests__/nlq-orchestrator.test.js
+++ b/explore/__tests__/nlq-orchestrator.test.js
@@ -193,6 +193,28 @@ describe('initNlq orchestrator', () => {
         }
     });
 
+    it('does not show a sanitizer-rejected action as "✓ applied" or offer Undo for it (regression discogsography-cu2.39)', async () => {
+        const apiClient = makeApiClient({
+            enabled: true,
+            streamMode: 'result',
+            // sanitizeSwitchPane rejects an unknown pane -> counts as skipped,
+            // and nothing else in this action list actually applies.
+            result: { summary: 'done', entities: [], actions: [{ type: 'switch_pane', pane: 'nonsense' }] },
+        });
+        const app = makeApp();
+        initNlq({ app, apiClient, mountId: 'nlqPillMount' });
+        await flush();
+
+        openAndSubmit('switch to nonsense pane');
+
+        const answerSlot = document.querySelector('[data-testid="nlq-pill-answer"]');
+        expect(answerSlot.textContent).not.toContain('✓ switch_pane');
+        expect(answerSlot.textContent).toContain('1 action(s) skipped');
+        expect(app._switchPane).not.toHaveBeenCalledWith('nonsense');
+        // Nothing was actually applied, so no Undo affordance should render.
+        expect(document.querySelector('[data-testid="nlq-answer-undo"]')).toBeNull();
+    });
+
     it('collapsing after an answer leaves a receipt that reopens the answer', async () => {
         const apiClient = makeApiClient({
             enabled: true,

--- a/explore/__tests__/nlq-suggestions.test.js
+++ b/explore/__tests__/nlq-suggestions.test.js
@@ -84,4 +84,42 @@ describe('NlqSuggestions', () => {
         const rows = container.querySelectorAll('.nlq-chip-row');
         expect(rows.length).toBe(0);
     });
+
+    describe('addRecent storage failure resilience (regression discogsography-cu2.64)', () => {
+        it('does not throw when localStorage.setItem raises QuotaExceededError', () => {
+            const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+                throw new DOMException('quota exceeded', 'QuotaExceededError');
+            });
+            try {
+                expect(() => NlqSuggestions.addRecent('a query that cannot be persisted')).not.toThrow();
+            } finally {
+                setItemSpy.mockRestore();
+            }
+        });
+
+        it('does not throw when localStorage.setItem raises SecurityError (storage denied)', () => {
+            const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+                throw new DOMException('storage access denied', 'SecurityError');
+            });
+            try {
+                expect(() => NlqSuggestions.addRecent('another query')).not.toThrow();
+            } finally {
+                setItemSpy.mockRestore();
+            }
+        });
+
+        it('does not throw when loadRecent needs to clear storage but removeItem also throws (total storage denial)', () => {
+            const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockReturnValue('not json');
+            const removeItemSpy = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+                throw new DOMException('storage access denied', 'SecurityError');
+            });
+            try {
+                expect(() => NlqSuggestions.loadRecent()).not.toThrow();
+                expect(NlqSuggestions.loadRecent()).toEqual([]);
+            } finally {
+                getItemSpy.mockRestore();
+                removeItemSpy.mockRestore();
+            }
+        });
+    });
 });

--- a/explore/__tests__/settings.test.js
+++ b/explore/__tests__/settings.test.js
@@ -188,6 +188,57 @@ describe('SettingsPane', () => {
             window.settingsPane.init();
             expect(document.getElementById('settingsEmail').textContent).toBe('');
         });
+
+        describe('transient 2FA flow preservation (regression discogsography-cu2.40)', () => {
+            it('should NOT clobber the recovery state on re-activation, even once totp_enabled flips true', () => {
+                window.settingsPane.init();
+                window.settingsPane._twoFaState = 'recovery';
+                window.settingsPane._recoveryCodes = ['code1', 'code2'];
+
+                // Simulate _confirmSetup's real effect: the user record now
+                // reports totp_enabled = true.
+                window.authManager.getUser.mockReturnValue({ id: 1, email: 'user@test.com', totp_enabled: true });
+
+                // Re-activating Settings (e.g. clicking another nav item and
+                // back) calls init() -> _loadProfile() again.
+                window.settingsPane.init();
+
+                expect(window.settingsPane._twoFaState).toBe('recovery');
+                expect(window.settingsPane._recoveryCodes).toEqual(['code1', 'code2']);
+            });
+
+            it('should NOT clobber the setup state on re-activation', () => {
+                window.settingsPane.init();
+                window.settingsPane._twoFaState = 'setup';
+                window.settingsPane._setupData = { secret: 'JBSWY3DPEHPK3PXP', otpauth_uri: 'otpauth://totp/test' };
+
+                window.settingsPane.init();
+
+                expect(window.settingsPane._twoFaState).toBe('setup');
+            });
+
+            it('should NOT clobber the disableConfirm state on re-activation', () => {
+                window.authManager.getUser.mockReturnValue({ id: 1, email: 'user@test.com', totp_enabled: true });
+                window.settingsPane.init();
+                window.settingsPane._twoFaState = 'disableConfirm';
+
+                window.settingsPane.init();
+
+                expect(window.settingsPane._twoFaState).toBe('disableConfirm');
+            });
+
+            it('should still derive state from totp_enabled once no transient flow is active', () => {
+                window.settingsPane.init();
+                window.settingsPane._twoFaState = 'recovery';
+
+                window.authManager.getUser.mockReturnValue({ id: 1, email: 'user@test.com', totp_enabled: true });
+                window.settingsPane._twoFaState = 'enabled'; // flow completed normally
+
+                window.settingsPane.init();
+
+                expect(window.settingsPane._twoFaState).toBe('enabled');
+            });
+        });
     });
 
     // ------------------------------------------------------------------ //

--- a/explore/explore.py
+++ b/explore/explore.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 import httpx
 import structlog
@@ -90,6 +90,10 @@ async def health_check() -> JSONResponse:
 
 _PROXY_SKIP_HEADERS = frozenset({"host", "content-length", "transfer-encoding"})
 
+# Content-Type prefix used by sse_starlette's EventSourceResponse (see
+# api/routers/nlq.py) for the NLQ 'Ask' streaming endpoint.
+_STREAMING_CONTENT_TYPE_PREFIX = "text/event-stream"
+
 _http_client: httpx.AsyncClient | None = None
 
 
@@ -102,31 +106,78 @@ def _get_http_client() -> httpx.AsyncClient:
 
 @app.api_route("/api/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
 async def proxy_api(path: str, request: Request) -> Response:
-    """Proxy /api/* requests to the API service."""
+    """Proxy /api/* requests to the API service.
+
+    Uses a streamed httpx request/response instead of the non-streaming
+    client.request()/.content, which used to buffer the ENTIRE upstream body
+    before returning. That broke Server-Sent-Event endpoints (e.g. the NLQ 'Ask'
+    endpoint /api/nlq/query): events were held back until the whole stream
+    finished, and a long-running answer that went quiet between events for
+    longer than the client's fixed total timeout was aborted with a 504,
+    discarding an otherwise-successful response. text/event-stream responses are
+    now forwarded chunk-by-chunk via StreamingResponse with the read timeout
+    disabled; every other response is still read fully and returned as before.
+    """
     client = _get_http_client()
     url = f"/api/{path}"
     forward_headers = {k: v for k, v in request.headers.items() if k.lower() not in _PROXY_SKIP_HEADERS}
+
+    req = client.build_request(
+        method=request.method,
+        url=url,
+        # request.query_params is a Starlette multi-dict — wrapping it in
+        # dict() keeps only the LAST value per repeated key (e.g.
+        # ?formats=Vinyl&formats=CD collapses to formats=CD), silently
+        # dropping multi-value filters. Build an httpx.QueryParams from
+        # the multi-item list so every repeated key is preserved.
+        params=httpx.QueryParams(tuple(request.query_params.multi_items())),
+        content=await request.body(),
+        headers=forward_headers,
+        # Disable the read timeout: an SSE response may legitimately go quiet
+        # between events for longer than the client's total 150s timeout without
+        # being stalled (e.g. a long Anthropic generation phase). Connect/write/pool
+        # timeouts are unchanged so a genuinely dead upstream is still caught.
+        timeout=httpx.Timeout(150.0, read=None),
+    )
+
     try:
-        proxied = await client.request(
-            method=request.method,
-            url=url,
-            # request.query_params is a Starlette multi-dict — wrapping it in
-            # dict() keeps only the LAST value per repeated key (e.g.
-            # ?formats=Vinyl&formats=CD collapses to formats=CD), silently
-            # dropping multi-value filters. Build an httpx.QueryParams from
-            # the multi-item list so every repeated key is preserved.
-            params=httpx.QueryParams(tuple(request.query_params.multi_items())),
-            content=await request.body(),
-            headers=forward_headers,
-        )
+        proxied = await client.send(req, stream=True)
     except httpx.TimeoutException:
         logger.warning("⚠️ Proxy request timed out", path=path)
         return JSONResponse(content={"error": "Request timed out"}, status_code=504)
     except httpx.HTTPError as exc:
         logger.error("❌ Proxy request failed", path=path, error=str(exc))
         return JSONResponse(content={"error": "Upstream service error"}, status_code=502)
+
     skip_response_headers = {"content-encoding", "transfer-encoding", "content-length"}
     response_headers = {k: v for k, v in proxied.headers.items() if k.lower() not in skip_response_headers}
+    content_type = proxied.headers.get("content-type", "")
+
+    if content_type.startswith(_STREAMING_CONTENT_TYPE_PREFIX):
+
+        async def _forward_stream() -> AsyncGenerator[bytes]:
+            try:
+                async for chunk in proxied.aiter_raw():
+                    yield chunk
+            except httpx.HTTPError as exc:
+                logger.warning("⚠️ Proxy stream interrupted", path=path, error=str(exc))
+            finally:
+                await proxied.aclose()
+
+        return StreamingResponse(_forward_stream(), status_code=proxied.status_code, headers=response_headers, media_type=content_type)
+
+    try:
+        await proxied.aread()
+    except httpx.TimeoutException:
+        await proxied.aclose()
+        logger.warning("⚠️ Proxy request timed out", path=path)
+        return JSONResponse(content={"error": "Request timed out"}, status_code=504)
+    except httpx.HTTPError as exc:
+        await proxied.aclose()
+        logger.error("❌ Proxy request failed", path=path, error=str(exc))
+        return JSONResponse(content={"error": "Upstream service error"}, status_code=502)
+    await proxied.aclose()
+
     return Response(content=proxied.content, status_code=proxied.status_code, headers=response_headers)
 
 

--- a/explore/explore.py
+++ b/explore/explore.py
@@ -110,7 +110,12 @@ async def proxy_api(path: str, request: Request) -> Response:
         proxied = await client.request(
             method=request.method,
             url=url,
-            params=dict(request.query_params),
+            # request.query_params is a Starlette multi-dict — wrapping it in
+            # dict() keeps only the LAST value per repeated key (e.g.
+            # ?formats=Vinyl&formats=CD collapses to formats=CD), silently
+            # dropping multi-value filters. Build an httpx.QueryParams from
+            # the multi-item list so every repeated key is preserved.
+            params=httpx.QueryParams(tuple(request.query_params.multi_items())),
             content=await request.body(),
             headers=forward_headers,
         )

--- a/explore/static/js/app.js
+++ b/explore/static/js/app.js
@@ -1005,10 +1005,15 @@ class ExploreApp {
     }
 
     _onGenreEmergence(newGenres) {
-        // Highlight genre/style nodes that just appeared
+        // Highlight genre/style nodes that just appeared.
+        // this.graph.g.selectAll('g') also matches the undated link/node
+        // container <g> elements created in graph.js's _render(), which have
+        // no bound datum (d === undefined) — guard against those before
+        // touching d.type, or the very first iteration throws.
         const genreSet = new Set(newGenres.map(n => n.toLowerCase()));
         this.graph.g.selectAll('g').each(function(d) {
-            if ((d.type === 'genre' || d.type === 'style') && genreSet.has(d.name.toLowerCase())) {
+            if (!d || (d.type !== 'genre' && d.type !== 'style')) return;
+            if (genreSet.has(d.name.toLowerCase())) {
                 d3.select(this).classed('node-emergence', true);
                 setTimeout(() => d3.select(this).classed('node-emergence', false), 2000);
             }

--- a/explore/static/js/genre-tree.js
+++ b/explore/static/js/genre-tree.js
@@ -103,9 +103,12 @@ class GenreTreeView {
     _navigateTo(name, type) {
         if (window.exploreApp) {
             window.exploreApp._setSearchType(type);
-            window.exploreApp._onSearch(name);
-            // Switch to explore pane
+            // Switch to the explore pane BEFORE calling _onSearch — _onSearch
+            // is pane-sensitive (it branches on activePane to decide between
+            // _loadExplore and _loadTrends), so switching after would leave
+            // it targeting whichever pane the user navigated from.
             window.exploreApp._switchPane('explore');
+            window.exploreApp._onSearch(name);
         }
     }
 }

--- a/explore/static/js/graph.js
+++ b/explore/static/js/graph.js
@@ -186,6 +186,10 @@ class GraphVisualization {
         this.expandedCategories.clear();
         this._pendingExpands = 0;
         this._categoryMeta.clear();
+        // A fresh explore session must not inherit a timeline scrub from the
+        // previous session — timeline.init() resets the UI label to 'All'
+        // but does not itself clear graph state (discogsography-cu2.38).
+        this.beforeYear = null;
 
         // Reset zoom to identity
         this.svg.call(this.zoom.transform, d3.zoomIdentity);
@@ -615,6 +619,11 @@ class GraphVisualization {
         this.links = [];
         this.expandedCategories.clear();
         this._pendingExpands = 0;
+        this._categoryMeta.clear();
+        // Same stale-filter leak as setExploreData (discogsography-cu2.38):
+        // a snapshot restore must not carry over a beforeYear scrubbed
+        // during the prior session.
+        this.beforeYear = null;
 
         this.svg.call(this.zoom.transform, d3.zoomIdentity);
 

--- a/explore/static/js/nlq-action-applier.js
+++ b/explore/static/js/nlq-action-applier.js
@@ -67,6 +67,11 @@ export class NlqActionApplier {
         this._lastSnapshot = this.snapshotter.capture();
         let applied = 0;
         let skipped = 0;
+        // Types of actions that were ACTUALLY applied — the caller must use
+        // this (not a map over the raw input) to render the "✓ applied" log,
+        // or a sanitizer-rejected/failed action shows as applied while also
+        // being counted as skipped (discogsography-cu2.39).
+        const appliedTypes = [];
 
         for (const raw of sorted) {
             const sanitizer = SANITIZERS[raw.type];
@@ -89,13 +94,14 @@ export class NlqActionApplier {
                 const { type: _type, ...payload } = clean;
                 handler(payload);
                 applied += 1;
+                appliedTypes.push(clean.type);
             } catch (err) {
                 console.error('❌ NLQ action handler failed', clean.type, err);
                 skipped += 1;
             }
         }
 
-        return { applied, skipped };
+        return { applied, skipped, appliedTypes };
     }
 
     _handlerFor(type) {

--- a/explore/static/js/nlq-suggestions.js
+++ b/explore/static/js/nlq-suggestions.js
@@ -48,19 +48,30 @@ export class NlqSuggestions {
         this.container.appendChild(row);
     }
 
+    /** Best-effort removeItem — storage access can be fully denied (e.g. a
+     * sandboxed iframe), in which case even removeItem throws. Never let
+     * cleanup itself become an unhandled throw. */
+    static _clearStorage() {
+        try {
+            localStorage.removeItem(STORAGE_KEY);
+        } catch {
+            // storage access denied entirely — nothing more we can do
+        }
+    }
+
     static loadRecent() {
         try {
             const raw = localStorage.getItem(STORAGE_KEY);
             if (!raw) return [];
             const parsed = JSON.parse(raw);
             if (!Array.isArray(parsed)) {
-                localStorage.removeItem(STORAGE_KEY);
+                NlqSuggestions._clearStorage();
                 console.info('ℹ️ NLQ history reset (not an array)');
                 return [];
             }
             return parsed;
         } catch {
-            localStorage.removeItem(STORAGE_KEY);
+            NlqSuggestions._clearStorage();
             console.info('ℹ️ NLQ history reset (corrupt)');
             return [];
         }
@@ -72,6 +83,14 @@ export class NlqSuggestions {
         const current = NlqSuggestions.loadRecent().filter((q) => q !== trimmed);
         current.unshift(trimmed);
         const capped = current.slice(0, HISTORY_CAP);
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(capped));
+        // localStorage.setItem throws QuotaExceededError when storage is
+        // full and SecurityError when storage access is denied. This runs
+        // in the query-submit path BEFORE the query is dispatched — an
+        // uncaught throw here must never drop the submit. Log and continue.
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(capped));
+        } catch (err) {
+            console.warn('🤷 NLQ recent-history save failed', err);
+        }
     }
 }

--- a/explore/static/js/nlq.js
+++ b/explore/static/js/nlq.js
@@ -37,8 +37,6 @@ export function initNlq({ app, apiClient, mountId = 'nlqPillMount' }) {
 function _submit({ query, app, apiClient, applier, pill }) {
     pill.setLoading();
 
-    const appliedActionTypes = [];
-
     apiClient.askNlqStream(
         query,
         {
@@ -48,12 +46,15 @@ function _submit({ query, app, apiClient, applier, pill }) {
         () => {},
         (result) => {
             const actions = result.actions || [];
-            appliedActionTypes.push(...actions.map((a) => a.type));
             const counts = applier.apply(actions);
             pill.setAnswer({
                 summary: result.summary || '',
                 entities: result.entities || [],
-                appliedActions: appliedActionTypes,
+                // Use the applier's own record of what it actually applied —
+                // NOT a map over the raw stream payload — or a
+                // sanitizer-rejected/failed action renders as "✓ applied"
+                // while simultaneously counted in "N skipped".
+                appliedActions: counts.appliedTypes,
                 skipped: counts.skipped,
             });
         },

--- a/explore/static/js/settings.js
+++ b/explore/static/js/settings.js
@@ -71,8 +71,15 @@ class SettingsPane {
             }
         }
 
-        // Derive initial 2FA state from user data
-        this._twoFaState = user.totp_enabled ? 'enabled' : 'disabled';
+        // Derive 2FA state from user data — but never while a transient flow
+        // (setup / recovery / disableConfirm) is in progress. init() runs on
+        // EVERY pane activation, so re-entering Settings mid-flow would
+        // otherwise clobber the one-time recovery-codes screen (codes are
+        // returned once by /2fa/setup and cannot be re-fetched), mirroring
+        // the 'revealing' guard in _loadAppTokens above.
+        if (!['setup', 'recovery', 'disableConfirm'].includes(this._twoFaState)) {
+            this._twoFaState = user.totp_enabled ? 'enabled' : 'disabled';
+        }
     }
 
     // ------------------------------------------------------------------ //

--- a/extractor/Dockerfile
+++ b/extractor/Dockerfile
@@ -32,6 +32,10 @@ RUN touch src/main.rs && \
 # Runtime stage
 FROM debian:13-slim
 
+# Build arguments for configurable UID/GID (must match the compose `user:` override)
+ARG UID=1000
+ARG GID=1000
+
 # Install runtime dependencies
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -40,8 +44,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user
-RUN groupadd -r extractor && useradd -r -g extractor extractor
+# Create non-root user with a fixed UID/GID so file ownership matches the
+# runtime user regardless of any `useradd -r` system-UID auto-allocation.
+RUN groupadd -r -g ${GID} extractor && useradd -r -l -u ${UID} -g extractor extractor
 
 # Create necessary directories
 RUN mkdir -p /discogs-data /musicbrainz-data /logs && \
@@ -51,7 +56,7 @@ RUN mkdir -p /discogs-data /musicbrainz-data /logs && \
 COPY --from=builder /app/target/release/extractor /usr/local/bin/extractor
 
 # Switch to non-root user
-USER extractor
+USER extractor:extractor
 
 # Set environment variables
 ENV LOG_LEVEL=INFO

--- a/extractor/src/discogs_downloader.rs
+++ b/extractor/src/discogs_downloader.rs
@@ -134,6 +134,18 @@ impl Downloader {
                     Ok(downloaded_size) => {
                         info!("✅ Successfully downloaded: {}", filename);
 
+                        // Persist metadata immediately so a later file's failure can't
+                        // discard this file's checksum. download_file only records the
+                        // checksum in the in-memory metadata map; without this incremental
+                        // save the durable .discogs_metadata.json is written once, after
+                        // the whole loop — so a failure on file N loses the checksums of
+                        // files 1..N-1, forcing full multi-GB re-downloads on restart
+                        // (discogsography-cu2.65). Best-effort: a save failure only costs a
+                        // re-download next run, so warn and continue rather than abort.
+                        if let Err(e) = self.save_metadata() {
+                            warn!("⚠️ Failed to persist metadata after downloading {}: {}", filename, e);
+                        }
+
                         // Track file download in state marker with actual downloaded size
                         if let Some(ref mut marker) = self.state_marker {
                             marker.file_downloaded(filename, downloaded_size);

--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -183,6 +183,21 @@ pub async fn process_discogs_data(
         state_marker.processing_phase.files_total = data_files.len();
         state_marker.save(&marker_path).await?;
         info!("🔄 Resuming processing phase: {} total files, {} already completed", data_files.len(), state_marker.processing_phase.files_processed);
+
+        // Rehydrate the per-run progress counters from the persisted per-file progress so the
+        // /health endpoint reports true totals for types already completed before the crash.
+        // Those files are skipped (pending_files) and never re-incremented this run, so without
+        // this they would surface as 0 on the dashboard. (cu2.92)
+        {
+            let mut s = state.write().await;
+            for (file_name, file_state) in &state_marker.processing_phase.progress_by_file {
+                if file_state.status == PhaseStatus::Completed
+                    && let Some(dt) = extract_data_type(file_name)
+                {
+                    s.extraction_progress.add(dt, file_state.records_extracted);
+                }
+            }
+        }
     }
 
     // Use the ORIGINAL processing start time persisted in the state marker for the
@@ -339,15 +354,25 @@ pub async fn process_discogs_data(
         info!("📊 Final statistics: {} total records extracted", s.extraction_progress.total());
 
         if success {
-            // Build per-type record counts from extraction progress
-            let mut record_counts = HashMap::new();
-            record_counts.insert("artists".to_string(), s.extraction_progress.artists);
-            record_counts.insert("labels".to_string(), s.extraction_progress.labels);
-            record_counts.insert("masters".to_string(), s.extraction_progress.masters);
-            record_counts.insert("releases".to_string(), s.extraction_progress.releases);
+            // Build per-type record counts from the PERSISTED per-file progress, NOT the
+            // per-run ExtractionProgress. That counter is reset at the top of every
+            // process_discogs_data call and only tallies files processed in THIS run, so
+            // after a crash-and-resume the types completed in an earlier session (skipped
+            // via pending_files) would report 0. progress_by_file holds the true totals for
+            // every completed file — matching the all-files-already-processed early path. (cu2.92)
+            drop(s); // Release read lock before locking the state marker / async MQ operations
+            let record_counts = {
+                let state_marker = state_marker_arc.lock().await;
+                let mut rc = HashMap::new();
+                for (file_name, file_state) in &state_marker.processing_phase.progress_by_file {
+                    if let Some(dt) = extract_data_type(file_name) {
+                        rc.insert(dt.to_string(), file_state.records_extracted);
+                    }
+                }
+                rc
+            };
 
             // Send extraction_complete to all consumer queues
-            drop(s); // Release read lock before async MQ operations
             match mq_factory.create(&config.amqp_connection, &config.discogs_exchange_prefix).await {
                 Ok(mq) => {
                     if let Err(e) = mq.send_extraction_complete(&version, processing_started_at, record_counts, &DataType::discogs()).await {
@@ -1144,6 +1169,21 @@ pub async fn process_musicbrainz_data(
             "🔄 Resuming MusicBrainz processing phase: {} dump file(s), {} already completed",
             file_count, state_marker.processing_phase.files_processed
         );
+
+        // Rehydrate the per-run progress counters from the persisted per-file progress so the
+        // /health endpoint reports true totals for types already completed before the crash.
+        // MB dump filenames don't parse via extract_data_type, so map through dump_files. (cu2.92)
+        {
+            let mut s = state.write().await;
+            for (dt, path) in &dump_files {
+                if let Some(fname) = path.file_name().and_then(|n| n.to_str())
+                    && let Some(file_state) = state_marker.processing_phase.progress_by_file.get(fname)
+                    && file_state.status == PhaseStatus::Completed
+                {
+                    s.extraction_progress.add(*dt, file_state.records_extracted);
+                }
+            }
+        }
     }
 
     // Use the ORIGINAL processing start time persisted in the state marker (never this
@@ -1186,6 +1226,10 @@ pub async fn process_musicbrainz_data(
                 && status.status == PhaseStatus::Completed
             {
                 info!("✅ Skipping already-completed file: {}", file_name);
+                // Still report the persisted count so a resumed run's extraction_complete
+                // carries true totals for types completed in an earlier session. Without this
+                // the skipped type's key is omitted from the message entirely. (cu2.92)
+                record_counts.insert(data_type.to_string(), status.records_extracted);
                 continue;
             }
         }

--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -203,29 +203,49 @@ pub async fn process_discogs_data(
         // Only send extraction_complete on the first completion, not on
         // subsequent periodic checks where the version is already complete.
         if state_marker.summary.overall_status != PhaseStatus::Completed {
+            // Mark processing (files are genuinely all done) but NOT extraction yet —
+            // extraction is only "complete" once the extraction_complete broadcast lands.
+            // Committing the marker fully Completed here (before the AMQP send) is a
+            // split-commit ordering bug: a single AMQP failure would flip the marker to
+            // Completed, every later cycle would Skip, and the completion signal would be
+            // lost forever. Mirror the normal completion path: send first, finalize on
+            // success, and on failure leave overall_status non-Completed so the next
+            // cycle re-enters via Continue and retries. (cu2.42)
             state_marker.complete_processing();
-            state_marker.complete_extraction();
             state_marker.save(&marker_path).await?;
 
-            // Send extraction_complete with actual record counts from state marker
-            // Use data type names (e.g., "artists") as keys — consistent with the normal
-            // completion path (lines 288-292) so consumers can look up counts reliably.
+            // Build record counts from the persisted per-file progress. Use data type
+            // names (e.g., "artists") as keys — consistent with the normal completion
+            // path so consumers can look up counts reliably.
             let mut record_counts = HashMap::new();
             for (file_name, file_state) in &state_marker.processing_phase.progress_by_file {
                 if let Some(dt) = extract_data_type(file_name) {
                     record_counts.insert(dt.to_string(), file_state.records_extracted);
                 }
             }
+
+            let mut sent = false;
             match mq_factory.create(&config.amqp_connection, &config.discogs_exchange_prefix).await {
                 Ok(mq) => {
-                    if let Err(e) = mq.send_extraction_complete(&version, processing_started_at, record_counts, &DataType::discogs()).await {
-                        error!("❌ Failed to send extraction_complete message: {}", e);
+                    match mq.send_extraction_complete(&version, processing_started_at, record_counts, &DataType::discogs()).await {
+                        Ok(_) => sent = true,
+                        Err(e) => error!("❌ Failed to send extraction_complete message: {}", e),
                     }
                     let _ = mq.close().await;
                 }
                 Err(e) => {
                     error!("❌ Failed to connect to AMQP for extraction_complete: {}", e);
                 }
+            }
+
+            if sent {
+                // Broadcast succeeded — now it is safe to durably mark extraction complete.
+                state_marker.complete_extraction();
+                state_marker.save(&marker_path).await?;
+            } else {
+                // Leave overall_status non-Completed so should_process() returns Continue and
+                // the next cycle retries the broadcast instead of Skipping forever.
+                error!("❌ extraction_complete not sent — leaving version incomplete to retry on next cycle");
             }
         }
 

--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -448,6 +448,11 @@ pub async fn process_single_file(
     let file_base_name = Path::new(file_name).file_name().and_then(|n| n.to_str()).unwrap_or(file_name); // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
     let version = extract_version_from_filename(file_base_name).unwrap_or_else(|| "unknown".to_string());
 
+    // Always-on normalization/hashing stage sits between the (optional) validator / parser and
+    // the batcher, so published records carry the normalized shape and a real sha256 in BOTH the
+    // rules and no-rules pipelines. (cu2.43)
+    let (normalized_sender, normalized_receiver) = mpsc::channel::<DataMessage>(config.queue_size);
+
     let validator_handle = if let Some(rules) = compiled_rules {
         let (validated_sender, validated_receiver) = mpsc::channel::<DataMessage>(config.queue_size);
         let rules = rules.clone();
@@ -460,6 +465,9 @@ pub async fn process_single_file(
                 async move { message_validator(parse_receiver, validated_sender, rules, &data_type_str, &discogs_root, &version_clone).await },
             );
 
+        // parser -> validator (skip/filter/rules) -> normalizer (normalize + hash) -> batcher
+        let normalizer_handle = tokio::spawn(async move { message_normalizer(validated_receiver, normalized_sender, data_type).await });
+
         let batcher_config = BatcherConfig {
             batch_size: config.batch_size,
             data_type,
@@ -469,7 +477,7 @@ pub async fn process_single_file(
             file_name: file_name.to_string(),
             state_save_interval: config.state_save_interval,
         };
-        let batcher_handle = tokio::spawn(async move { message_batcher(validated_receiver, batch_sender, batcher_config).await });
+        let batcher_handle = tokio::spawn(async move { message_batcher(normalized_receiver, batch_sender, batcher_config).await });
 
         let parser_handle = tokio::spawn({
             let file_path = config.discogs_root.join(file_name); // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
@@ -485,10 +493,11 @@ pub async fn process_single_file(
             async move { message_publisher(batch_receiver, mq, data_type, state).await }
         });
 
-        let (parser_result, validator_result, batcher_result, publisher_result) =
-            tokio::try_join!(parser_handle, handle, batcher_handle, publisher_handle)?;
+        let (parser_result, validator_result, normalizer_result, batcher_result, publisher_result) =
+            tokio::try_join!(parser_handle, handle, normalizer_handle, batcher_handle, publisher_handle)?;
         let total_count = parser_result?;
         let report: QualityReport = validator_result?;
+        normalizer_result?;
         batcher_result?;
         publisher_result?;
 
@@ -503,6 +512,8 @@ pub async fn process_single_file(
 
         Some(total_count)
     } else {
+        // parser -> normalizer (normalize + hash) -> batcher — no validator, but normalization
+        // and hashing still happen so consumers receive the same shape as the rules path. (cu2.43)
         let parser_handle = tokio::spawn({
             let file_path = config.discogs_root.join(file_name);
             async move {
@@ -510,6 +521,8 @@ pub async fn process_single_file(
                 parser.parse_file(&file_path).await
             }
         });
+
+        let normalizer_handle = tokio::spawn(async move { message_normalizer(parse_receiver, normalized_sender, data_type).await });
 
         let batcher_config = BatcherConfig {
             batch_size: config.batch_size,
@@ -520,7 +533,7 @@ pub async fn process_single_file(
             file_name: file_name.to_string(),
             state_save_interval: config.state_save_interval,
         };
-        let batcher_handle = tokio::spawn(async move { message_batcher(parse_receiver, batch_sender, batcher_config).await });
+        let batcher_handle = tokio::spawn(async move { message_batcher(normalized_receiver, batch_sender, batcher_config).await });
 
         let publisher_handle = tokio::spawn({
             let mq = mq.clone();
@@ -529,6 +542,7 @@ pub async fn process_single_file(
         });
 
         let total_count = parser_handle.await??;
+        normalizer_handle.await??;
         batcher_handle.await??;
         publisher_handle.await??;
 
@@ -681,18 +695,13 @@ pub async fn message_validator(
             );
         }
 
-        // Evaluate rules on pre-normalized (XML-shaped) data — rules use
-        // dot-notation paths like "genres.genre" that match the XML structure.
+        // Evaluate rules on XML-shaped (pre-normalization) data — rules use dot-notation
+        // paths like "genres.genre" that match the raw XML structure. Normalization and
+        // content hashing are NOT done here anymore: they run unconditionally in
+        // `message_normalizer`, downstream of this optional stage, so they happen even when
+        // DATA_QUALITY_RULES is unset and this validator never runs. (cu2.43)
         let violations = evaluate_rules(&rules, data_type, &message.data);
 
-        // Normalize XML-shaped JSON into flat, consumer-ready format.
-        // Runs after both filters and rules (which operate on XML shape)
-        // and before hash calculation (so hash reflects what consumers see).
-        crate::normalize::normalize_record(data_type, &mut message.data);
-
-        // Compute content hash from post-normalization data so consumers
-        // detect changes caused by filter or normalization updates.
-        message.sha256 = calculate_content_hash(&message.data);
         for violation in &violations {
             report.record_violation(data_type, &violation.rule_name, &violation.severity);
             let capture_files = matches!(violation.severity, Severity::Error | Severity::Warning);
@@ -707,6 +716,32 @@ pub async fn message_validator(
     writer.flush();
     writer.write_report(&report, version);
     Ok(report)
+}
+
+/// Normalize XML-shaped records into the flat, consumer-ready shape and compute the content
+/// hash — UNCONDITIONALLY, as an always-on pipeline stage between the parser/validator and the
+/// batcher.
+///
+/// Previously `normalize_record` + `calculate_content_hash` ran only inside `message_validator`,
+/// which is spawned only when DATA_QUALITY_RULES is set. Without that env var the no-rules
+/// pipeline published raw xmltodict-shaped records (`@`-prefixed keys, `{"name": [...]}`
+/// container wrappers) with an empty `sha256`. That crashed graphinator (AttributeError iterating
+/// container dicts) and defeated change detection (`"" == ""` skips every future update). Running
+/// this stage in both branches keeps the published shape identical regardless of rules config.
+/// (cu2.43)
+pub async fn message_normalizer(mut receiver: mpsc::Receiver<DataMessage>, sender: mpsc::Sender<DataMessage>, data_type: DataType) -> Result<()> {
+    let data_type_str = data_type.as_str();
+    while let Some(mut message) = receiver.recv().await {
+        // Normalize the XML-shaped JSON into the flat, consumer-ready format, then compute the
+        // content hash from the post-normalization data so consumers detect real changes.
+        crate::normalize::normalize_record(data_type_str, &mut message.data);
+        message.sha256 = calculate_content_hash(&message.data);
+        if sender.send(message).await.is_err() {
+            warn!("⚠️ Normalizer: downstream receiver dropped");
+            break;
+        }
+    }
+    Ok(())
 }
 
 /// Publish batched messages to AMQP

--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -913,6 +913,29 @@ fn spawn_shutdown_flag_monitor(shutdown: Arc<tokio::sync::Notify>) -> Arc<Atomic
     flag
 }
 
+/// Decide the outcome of an initial (first-run) extraction from whether processing succeeded and
+/// whether a shutdown was requested.
+///
+/// The processing functions collapse "interrupted by shutdown" and "processing error" into a single
+/// `success: bool` — both surface as `Ok(false)`. Only the initial-run call sites promote `Ok(false)`
+/// to `Err`, which sends main into `apply_failure_cooldown` (default 600s) + `exit(1)`. An
+/// operator-requested SIGTERM would then be logged as a failure and hang ~10 min — long past Docker's
+/// stop grace period, so the container is SIGKILLed instead of stopping cleanly, and orchestrators
+/// that key on exit code may restart the service being stopped. A shutdown must therefore
+/// short-circuit to `Ok(())` BEFORE the failure check. Shared by the Discogs and MusicBrainz initial
+/// runs. (cu2.45)
+fn initial_run_outcome(success: bool, shutdown_requested: bool, source_label: &str) -> Result<()> {
+    if shutdown_requested {
+        info!("🛑 Shutdown requested during initial {source_label} processing — exiting cleanly");
+        return Ok(());
+    }
+    if !success {
+        error!("❌ Initial {source_label} processing failed");
+        return Err(anyhow::anyhow!("Initial {source_label} processing failed"));
+    }
+    Ok(())
+}
+
 /// Main extraction loop with periodic checks
 pub async fn run_extraction_loop(
     config: Arc<ExtractorConfig>,
@@ -945,17 +968,9 @@ pub async fn run_extraction_loop(
     )
     .await?;
 
-    // A shutdown during the initial run is a clean exit, not a failure — returning Err here would
-    // send main into the failure cooldown + non-zero exit. (cu2.44)
-    if shutdown_flag.load(Ordering::SeqCst) {
-        info!("🛑 Shutdown requested during initial Discogs processing — exiting cleanly");
-        return Ok(());
-    }
-
-    if !success {
-        error!("❌ Initial data processing failed");
-        return Err(anyhow::anyhow!("Initial data processing failed"));
-    }
+    // A shutdown during the initial run is a clean exit, not a failure — returning Err would send
+    // main into the failure cooldown + non-zero exit. Short-circuit shutdown to Ok. (cu2.44/cu2.45)
+    initial_run_outcome(success, shutdown_flag.load(Ordering::SeqCst), "Discogs")?;
 
     info!("✅ Initial data processing completed successfully");
 
@@ -1125,10 +1140,10 @@ pub async fn run_musicbrainz_loop(
         process_musicbrainz_data(config.clone(), state.clone(), shutdown_flag.clone(), force_reprocess, mq_factory.clone(), compiled_rules.clone())
             .await?;
 
-    if !success {
-        error!("❌ Initial MusicBrainz processing failed");
-        return Err(anyhow::anyhow!("Initial MusicBrainz processing failed"));
-    }
+    // `process_musicbrainz_data` returns Ok(false) for BOTH a real failure and a between-files
+    // shutdown; only this initial path promoted Ok(false) to Err. Short-circuit shutdown to Ok(())
+    // so an operator-requested SIGTERM does not trigger the 600s failure cooldown + exit(1). (cu2.45)
+    initial_run_outcome(success, shutdown_flag.load(Ordering::SeqCst), "MusicBrainz")?;
 
     info!("✅ Initial MusicBrainz processing completed successfully");
 

--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -185,6 +185,15 @@ pub async fn process_discogs_data(
         info!("🔄 Resuming processing phase: {} total files, {} already completed", data_files.len(), state_marker.processing_phase.files_processed);
     }
 
+    // Use the ORIGINAL processing start time persisted in the state marker for the
+    // extraction_complete signal — NOT this (possibly resumed) process's start time.
+    // On a resumed run, files already completed in an earlier session are not re-sent,
+    // so their rows retain updated_at from that earlier session. Broadcasting the
+    // resumed process's now() would make the downstream stale-row purge delete every
+    // row written before the restart (mass data loss). start_processing() sets this on
+    // the first run and it is preserved (never reset) across InProgress resumes.
+    let processing_started_at = state_marker.processing_phase.started_at.unwrap_or(extraction_started_at);
+
     // Get list of files that still need processing
     let pending_files = state_marker.pending_files(&data_files);
 
@@ -209,7 +218,7 @@ pub async fn process_discogs_data(
             }
             match mq_factory.create(&config.amqp_connection, &config.discogs_exchange_prefix).await {
                 Ok(mq) => {
-                    if let Err(e) = mq.send_extraction_complete(&version, extraction_started_at, record_counts, &DataType::discogs()).await {
+                    if let Err(e) = mq.send_extraction_complete(&version, processing_started_at, record_counts, &DataType::discogs()).await {
                         error!("❌ Failed to send extraction_complete message: {}", e);
                     }
                     let _ = mq.close().await;
@@ -321,7 +330,7 @@ pub async fn process_discogs_data(
             drop(s); // Release read lock before async MQ operations
             match mq_factory.create(&config.amqp_connection, &config.discogs_exchange_prefix).await {
                 Ok(mq) => {
-                    if let Err(e) = mq.send_extraction_complete(&version, extraction_started_at, record_counts, &DataType::discogs()).await {
+                    if let Err(e) = mq.send_extraction_complete(&version, processing_started_at, record_counts, &DataType::discogs()).await {
                         error!("❌ Failed to send extraction_complete message: {}", e);
                         success = false;
                     }
@@ -1116,6 +1125,13 @@ pub async fn process_musicbrainz_data(
             file_count, state_marker.processing_phase.files_processed
         );
     }
+
+    // Use the ORIGINAL processing start time persisted in the state marker (never this
+    // possibly-resumed process's now()). On resume, already-completed files are skipped
+    // and not re-sent, so their rows keep updated_at from the earlier session; sending
+    // the resumed now() would make brainztableinator's stale-row purge wipe those rows.
+    let processing_started_at = state_marker.processing_phase.started_at.unwrap_or(extraction_started_at);
+
     let state_marker = Arc::new(tokio::sync::Mutex::new(state_marker));
 
     // First pass: build MBID→Discogs ID map for artist relationship target resolution
@@ -1275,7 +1291,7 @@ pub async fn process_musicbrainz_data(
     // Send extraction_complete to MusicBrainz exchanges only (no masters) — only if all succeeded
     if success {
         let mb_types = DataType::musicbrainz();
-        if let Err(e) = mq.send_extraction_complete(&version, extraction_started_at, record_counts, &mb_types).await {
+        if let Err(e) = mq.send_extraction_complete(&version, processing_started_at, record_counts, &mb_types).await {
             error!("❌ Failed to send extraction_complete: {}", e);
             success = false;
         }

--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -850,6 +850,23 @@ async fn wait_for_trigger(trigger: &Arc<tokio::sync::Mutex<Option<bool>>>) -> bo
 }
 
 /// Main extraction loop with periodic checks
+/// Reset a stuck `Running` extraction status to `Failed` after a periodic or API-triggered
+/// check returns `Err`.
+///
+/// `process_discogs_data` / `process_musicbrainz_data` set the status to `Running` up-front but
+/// only reset it on their fall-through tail; any early `?` error short-circuits before that reset,
+/// leaving the status at `Running`. The periodic loops swallow the `Err` and sleep for
+/// `periodic_check_days`, so without this backstop the status stays `Running` for the entire sleep —
+/// wedging the manual `/trigger` recovery (health.rs returns 409 `already_running` before enqueuing
+/// the trigger), starving the MusicBrainz extractor's `wait_for_discogs_idle` (which treats
+/// `running` as busy), and misreporting `/health`. `Failed` is a terminal, non-`Running` state that
+/// the periodic loop preserves (it only rewrites `Completed` -> `Waiting`) until the next successful
+/// run. (cu2.41)
+async fn reset_status_after_failed_check(state: &Arc<RwLock<ExtractorState>>) {
+    let mut s = state.write().await;
+    s.extraction_status = ExtractionStatus::Failed;
+}
+
 pub async fn run_extraction_loop(
     config: Arc<ExtractorConfig>,
     state: Arc<RwLock<ExtractorState>>,
@@ -918,6 +935,10 @@ pub async fn run_extraction_loop(
                     }
                     Err(e) => {
                         error!("❌ Periodic check failed: {}", e);
+                        // Backstop: an early `?` in process_discogs_data leaves status at Running.
+                        // Reset to Failed so /trigger recovery and the MusicBrainz idle-wait unblock
+                        // instead of staying wedged for the whole periodic sleep. (cu2.41)
+                        reset_status_after_failed_check(&state).await;
                     }
                 }
             }
@@ -934,7 +955,10 @@ pub async fn run_extraction_loop(
                 match process_discogs_data(config.clone(), state.clone(), shutdown.clone(), trigger_force_reprocess, &mut downloader, mq_factory.clone(), compiled_rules.clone()).await {
                     Ok(true) => info!("✅ Triggered extraction completed successfully in {:?}", start.elapsed()),
                     Ok(false) => error!("❌ Triggered extraction completed with errors"),
-                    Err(e) => error!("❌ Triggered extraction failed: {}", e),
+                    Err(e) => {
+                        error!("❌ Triggered extraction failed: {}", e);
+                        reset_status_after_failed_check(&state).await; // (cu2.41)
+                    }
                 }
             }
             _ = shutdown.notified() => {
@@ -1083,6 +1107,7 @@ pub async fn run_musicbrainz_loop(
                     }
                     Err(e) => {
                         error!("❌ Periodic MusicBrainz check failed: {}", e);
+                        reset_status_after_failed_check(&state).await; // (cu2.41)
                     }
                 }
             }
@@ -1096,7 +1121,10 @@ pub async fn run_musicbrainz_loop(
                 match process_musicbrainz_data(config.clone(), state.clone(), shutdown_flag.clone(), trigger_force_reprocess, mq_factory.clone(), compiled_rules.clone()).await {
                     Ok(true) => info!("✅ Triggered MusicBrainz extraction completed in {:?}", start.elapsed()),
                     Ok(false) => error!("❌ Triggered MusicBrainz extraction completed with errors"),
-                    Err(e) => error!("❌ Triggered MusicBrainz extraction failed: {}", e),
+                    Err(e) => {
+                        error!("❌ Triggered MusicBrainz extraction failed: {}", e);
+                        reset_status_after_failed_check(&state).await; // (cu2.41)
+                    }
                 }
             }
             _ = shutdown.notified() => {

--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -86,6 +86,9 @@ pub async fn process_discogs_data(
     config: Arc<ExtractorConfig>,
     state: Arc<RwLock<ExtractorState>>,
     shutdown: Arc<tokio::sync::Notify>,
+    // Pollable shutdown flag (set by the loop's monitor task on SIGTERM/SIGINT). Checked between
+    // files so a signal delivered mid-run stops starting new files instead of being lost. (cu2.44)
+    shutdown_flag: Arc<AtomicBool>,
     force_reprocess: bool,
     downloader: &mut dyn DataSource,
     mq_factory: Arc<dyn MessageQueueFactory>,
@@ -288,9 +291,18 @@ pub async fn process_discogs_data(
         let state_marker_arc = state_marker_arc.clone();
         let mq_factory = mq_factory.clone();
         let compiled_rules = compiled_rules.clone();
+        let shutdown_flag = shutdown_flag.clone();
 
         let task: tokio::task::JoinHandle<Result<()>> = tokio::spawn(async move {
             let _permit = semaphore.acquire().await?;
+            // Graceful shutdown: stop starting new files once a SIGTERM/SIGINT arrives. Files
+            // already past this guard run to completion; skipped files never call
+            // start_file_processing, so they stay pending in the state marker and a restart
+            // resumes them. (cu2.44)
+            if shutdown_flag.load(Ordering::SeqCst) {
+                info!("🛑 Shutdown requested — skipping not-yet-started file: {}", file);
+                return Ok(());
+            }
             let mq = mq_factory
                 .create(&config.amqp_connection, &config.discogs_exchange_prefix)
                 .await
@@ -332,6 +344,16 @@ pub async fn process_discogs_data(
 
     reporter.abort();
 
+    // A shutdown signal delivered mid-run is a graceful stop, not a processing failure: in-flight
+    // files (already past the per-task guard) finish, but files skipped by that guard stay pending.
+    // Fold it into `success` so the completion/broadcast/status logic below does NOT finalize the
+    // run — while logging it as a shutdown rather than an error. (cu2.44)
+    let shutdown_requested = shutdown_flag.load(Ordering::SeqCst);
+    if shutdown_requested {
+        warn!("🛑 Shutdown requested during Discogs processing — saving progress for resume, not finalizing this run");
+        success = false;
+    }
+
     // Only mark processing as complete if all tasks succeeded
     {
         let mut state_marker = state_marker_arc.lock().await;
@@ -343,7 +365,11 @@ pub async fn process_discogs_data(
         } else {
             // Save current progress without marking complete — allows restart to resume
             state_marker.save(&marker_path).await?;
-            error!("❌ Processing phase finished with errors — not marking complete");
+            if shutdown_requested {
+                info!("🛑 Processing interrupted by shutdown — progress saved for resume, not marking complete");
+            } else {
+                error!("❌ Processing phase finished with errors — not marking complete");
+            }
         }
     } // Drop state_marker lock before re-acquiring below
 
@@ -388,7 +414,11 @@ pub async fn process_discogs_data(
             }
         } else {
             drop(s);
-            error!("❌ Skipping extraction_complete broadcast — processing had failures");
+            if shutdown_requested {
+                info!("🛑 Skipping extraction_complete broadcast — shutdown in progress");
+            } else {
+                error!("❌ Skipping extraction_complete broadcast — processing had failures");
+            }
         }
     }
 
@@ -849,7 +879,6 @@ async fn wait_for_trigger(trigger: &Arc<tokio::sync::Mutex<Option<bool>>>) -> bo
     }
 }
 
-/// Main extraction loop with periodic checks
 /// Reset a stuck `Running` extraction status to `Failed` after a periodic or API-triggered
 /// check returns `Err`.
 ///
@@ -867,6 +896,24 @@ async fn reset_status_after_failed_check(state: &Arc<RwLock<ExtractorState>>) {
     s.extraction_status = ExtractionStatus::Failed;
 }
 
+/// Spawn a task that watches `shutdown` and flips an `AtomicBool` when it fires.
+///
+/// `Notify::notified()` consumes its permit and `notify_waiters()` stores none, so long-running
+/// processing code cannot await the `Notify` directly without stealing the signal from the loop's
+/// outer `select!`. The monitor parks on the `Notify` once (before any multi-hour work) and records
+/// the shutdown in a flag that processing code polls between files without side effects. Shared by
+/// both the Discogs and MusicBrainz loops. (cu2.44)
+fn spawn_shutdown_flag_monitor(shutdown: Arc<tokio::sync::Notify>) -> Arc<AtomicBool> {
+    let flag = Arc::new(AtomicBool::new(false));
+    let flag_for_monitor = flag.clone();
+    tokio::spawn(async move {
+        shutdown.notified().await;
+        flag_for_monitor.store(true, Ordering::SeqCst);
+    });
+    flag
+}
+
+/// Main extraction loop with periodic checks
 pub async fn run_extraction_loop(
     config: Arc<ExtractorConfig>,
     state: Arc<RwLock<ExtractorState>>,
@@ -878,18 +925,32 @@ pub async fn run_extraction_loop(
 ) -> Result<()> {
     info!("📥 Starting initial data processing...");
 
+    // Convert the one-shot shutdown Notify into a pollable flag. Without this a SIGTERM delivered
+    // during process_discogs_data (hours of multi-GB XML) is lost: notify_waiters() wakes only
+    // currently-parked waiters and stores no permit, so the periodic loop's fresh shutdown arm
+    // never fires and the process enters the multi-day sleep, unstoppable. (cu2.44)
+    let shutdown_flag = spawn_shutdown_flag_monitor(shutdown.clone());
+
     // Process initial data
     let mut downloader = Downloader::new(config.discogs_root.clone()).await?;
     let success = process_discogs_data(
         config.clone(),
         state.clone(),
         shutdown.clone(),
+        shutdown_flag.clone(),
         force_reprocess,
         &mut downloader,
         mq_factory.clone(),
         compiled_rules.clone(),
     )
     .await?;
+
+    // A shutdown during the initial run is a clean exit, not a failure — returning Err here would
+    // send main into the failure cooldown + non-zero exit. (cu2.44)
+    if shutdown_flag.load(Ordering::SeqCst) {
+        info!("🛑 Shutdown requested during initial Discogs processing — exiting cleanly");
+        return Ok(());
+    }
 
     if !success {
         error!("❌ Initial data processing failed");
@@ -900,6 +961,14 @@ pub async fn run_extraction_loop(
 
     // Start periodic check loop
     loop {
+        // If a shutdown arrived during processing (or between iterations), stop before sleeping.
+        // The periodic select! below also has a shutdown arm for signals that arrive mid-sleep,
+        // but this poll catches signals delivered while process_discogs_data was running. (cu2.44)
+        if shutdown_flag.load(Ordering::SeqCst) {
+            info!("🛑 Shutdown detected, exiting Discogs periodic check loop");
+            break;
+        }
+
         // Transition Completed → Waiting before sleeping so downstream observers
         // (MusicBrainz extractor, admin dashboard tracker) can tell the difference
         // between "just finished" and "on periodic schedule". Failed is preserved
@@ -926,7 +995,7 @@ pub async fn run_extraction_loop(
                         continue;
                     }
                 };
-                match process_discogs_data(config.clone(), state.clone(), shutdown.clone(), false, &mut downloader, mq_factory.clone(), compiled_rules.clone()).await {
+                match process_discogs_data(config.clone(), state.clone(), shutdown.clone(), shutdown_flag.clone(), false, &mut downloader, mq_factory.clone(), compiled_rules.clone()).await {
                     Ok(true) => {
                         info!("✅ Periodic check completed successfully in {:?}", start.elapsed());
                     }
@@ -952,7 +1021,7 @@ pub async fn run_extraction_loop(
                         continue;
                     }
                 };
-                match process_discogs_data(config.clone(), state.clone(), shutdown.clone(), trigger_force_reprocess, &mut downloader, mq_factory.clone(), compiled_rules.clone()).await {
+                match process_discogs_data(config.clone(), state.clone(), shutdown.clone(), shutdown_flag.clone(), trigger_force_reprocess, &mut downloader, mq_factory.clone(), compiled_rules.clone()).await {
                     Ok(true) => info!("✅ Triggered extraction completed successfully in {:?}", start.elapsed()),
                     Ok(false) => error!("❌ Triggered extraction completed with errors"),
                     Err(e) => {
@@ -1042,17 +1111,10 @@ pub async fn run_musicbrainz_loop(
     trigger: Arc<tokio::sync::Mutex<Option<bool>>>,
     compiled_rules: Option<Arc<CompiledRulesConfig>>,
 ) -> Result<()> {
-    // AtomicBool for non-consuming shutdown checks. Notify::notified() consumes the
-    // permit, so polling it inside process_musicbrainz_data would steal the signal from
-    // the outer select!. The monitor task listens on the Notify and sets the flag;
-    // process_musicbrainz_data polls the flag without side effects.
-    let shutdown_flag = Arc::new(AtomicBool::new(false));
-    let flag_for_monitor = shutdown_flag.clone();
-    let shutdown_for_monitor = shutdown.clone();
-    tokio::spawn(async move {
-        shutdown_for_monitor.notified().await;
-        flag_for_monitor.store(true, Ordering::SeqCst);
-    });
+    // AtomicBool for non-consuming shutdown checks — see spawn_shutdown_flag_monitor. The monitor
+    // parks on the Notify and sets the flag; process_musicbrainz_data polls the flag without side
+    // effects, so the outer select! keeps its own shutdown arm.
+    let shutdown_flag = spawn_shutdown_flag_monitor(shutdown.clone());
 
     info!("🎵 Starting MusicBrainz extraction...");
 

--- a/extractor/src/jsonl_parser.rs
+++ b/extractor/src/jsonl_parser.rs
@@ -387,9 +387,12 @@ pub fn parse_mb_jsonl_file(
     for line_result in reader.lines() {
         let line = match line_result {
             Ok(l) => l,
+            // A read error from a compressed stream (XzDecoder) is *persistent*, not
+            // transient: a corrupt/truncated `.jsonl.xz` returns the same `Err` on every
+            // subsequent read, so `continue` here would busy-loop forever at 100% CPU.
+            // Treat it as fatal so the caller can fail the run instead of wedging.
             Err(e) => {
-                debug!("⚠️ Failed to read line: {e}");
-                continue;
+                return Err(e).context(format!("Failed to read line while parsing MusicBrainz JSONL from {:?}", path));
             }
         };
         let trimmed = line.trim();

--- a/extractor/src/jsonl_parser.rs
+++ b/extractor/src/jsonl_parser.rs
@@ -268,9 +268,12 @@ pub fn build_mbid_discogs_map_from_file(path: &Path, entity_type: &str) -> Resul
     for line_result in reader.lines() {
         let line = match line_result {
             Ok(l) => l,
+            // A read error from a compressed stream (XzDecoder) is *persistent*, not
+            // transient: a corrupt/truncated `.jsonl.xz` returns the same `Err` on every
+            // subsequent read, so `continue` here would busy-loop forever at 100% CPU.
+            // Treat it as fatal so the caller can fail the run instead of wedging.
             Err(e) => {
-                debug!("⚠️ Failed to read line during MBID map build: {e}");
-                continue;
+                return Err(e).context(format!("Failed to read line during MBID map build from {:?}", path));
             }
         };
         let trimmed = line.trim();

--- a/extractor/src/musicbrainz_downloader.rs
+++ b/extractor/src/musicbrainz_downloader.rs
@@ -255,6 +255,11 @@ impl MbDownloader {
 
     /// Check whether a version directory contains all expected entity JSONL files.
     /// Recognizes both uncompressed `.jsonl` and compressed `.jsonl.xz` variants.
+    ///
+    /// Existence is a sufficient completeness signal *because* the download path never
+    /// materializes a final `{entity}.jsonl.xz` until it is fully extracted and SHA256-verified:
+    /// [`Self::stream_download_verify_extract`] streams to a `.tmp` sibling and atomically renames
+    /// only on success. A crashed run leaves a `.tmp` (ignored here), never a truncated final file.
     pub(crate) fn is_version_complete(&self, version_dir: &Path) -> bool {
         if !version_dir.is_dir() {
             return false;
@@ -276,12 +281,18 @@ impl MbDownloader {
         use futures::TryStreamExt;
         use tokio_util::io::{StreamReader, SyncIoBridge};
 
+        // Durability: never write the compressed output at its FINAL path while it is still
+        // partial/unverified. Stream to a sibling `.tmp` and atomically rename to `out_path`
+        // only after SHA256 passes. A hard crash (OOM/SIGKILL/power loss) mid-extraction then
+        // leaves only a `{entity}.jsonl.xz.tmp` — which is_version_complete does NOT accept —
+        // instead of a truncated `{entity}.jsonl.xz` that would be forever trusted as complete.
+        let tmp_path = tmp_download_path(out_path);
         let mut last_error: Option<anyhow::Error> = None;
 
         for attempt in 1..=MB_MAX_DOWNLOAD_RETRIES {
             if attempt > 1 {
-                if out_path.exists() {
-                    let _ = fs::remove_file(out_path).await;
+                if tmp_path.exists() {
+                    let _ = fs::remove_file(&tmp_path).await;
                 }
                 let delay_ms = MB_RETRY_BASE_DELAY_MS * (1u64 << (attempt - 2));
                 warn!("🔄 Retry {}/{} for {} (waiting {}ms)...", attempt - 1, MB_MAX_DOWNLOAD_RETRIES - 1, entity, delay_ms);
@@ -315,7 +326,7 @@ impl MbDownloader {
 
             let entity_owned = entity.to_string();
             let expected_hash_owned = expected_sha256.to_string();
-            let out_path_owned = out_path.to_path_buf();
+            let out_path_owned = tmp_path.to_path_buf();
             let attempt_start = std::time::Instant::now();
 
             let extract_result = tokio::task::spawn_blocking(move || -> Result<(u64, u64)> {
@@ -347,6 +358,15 @@ impl MbDownloader {
 
             match extract_result {
                 Ok((total_bytes, compressed_out)) => {
+                    // SHA256 verified inside the blocking task — now atomically publish the
+                    // fully-written, checksum-verified file at its final path.
+                    if let Err(e) = fs::rename(&tmp_path, out_path).await {
+                        let msg = format!("Failed to atomically rename {:?} -> {:?}: {}", tmp_path, out_path, e);
+                        warn!("⚠️ {}", msg);
+                        last_error = Some(anyhow::anyhow!(msg));
+                        let _ = fs::remove_file(&tmp_path).await;
+                        continue;
+                    }
                     let elapsed = attempt_start.elapsed().as_secs_f64();
                     let speed = if elapsed > 0.0 { (total_bytes as f64 / 1_048_576.0) / elapsed } else { 0.0 };
                     info!(
@@ -363,8 +383,8 @@ impl MbDownloader {
                 Err(e) => {
                     warn!("⚠️ Attempt {}/{} failed for {}: {}", attempt, MB_MAX_DOWNLOAD_RETRIES, entity, e);
                     last_error = Some(e);
-                    if out_path.exists() {
-                        let _ = fs::remove_file(out_path).await;
+                    if tmp_path.exists() {
+                        let _ = fs::remove_file(&tmp_path).await;
                     }
                     continue;
                 }
@@ -436,15 +456,33 @@ pub fn parse_sha256sums(content: &str) -> HashMap<String, String> {
         .collect()
 }
 
+/// Derive the temporary staging path for a final `{entity}.jsonl.xz` output.
+///
+/// Appends a `.tmp` suffix so the in-progress file never matches the `.jsonl` / `.jsonl.xz`
+/// existence check in [`MbDownloader::is_version_complete`]. A crash mid-write therefore leaves
+/// a `.tmp` artifact that is correctly treated as incomplete, and the final path only ever
+/// appears via an atomic rename after full extraction and (for the network path) SHA256 verification.
+fn tmp_download_path(out_path: &Path) -> PathBuf {
+    let mut name = out_path.as_os_str().to_os_string();
+    name.push(".tmp");
+    PathBuf::from(name)
+}
+
 /// Extract `mbdump/<entity>` from a `.tar.xz` file on disk into a compressed `.jsonl.xz`
 /// output file. Thin wrapper around [`extract_entity_from_reader`] — kept as a stable public
 /// entry point so existing disk-based tests and any standalone callers keep working.
+///
+/// Writes to a `.tmp` sibling and atomically renames to `out_path` only after extraction
+/// completes, so an interrupted run never leaves a truncated file at the final path.
 #[allow(dead_code)]
 pub fn extract_entity_from_tarball(tar_path: &Path, entity: &str, out_path: &Path) -> Result<()> {
     // `tar_path` and `out_path` come from operator-controlled config (CLI/env var), not HTTP input.
     let file = std::fs::File::open(tar_path) // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
         .with_context(|| format!("Failed to open tarball: {:?}", tar_path))?;
-    extract_entity_from_reader(file, entity, out_path).map(|_| ())
+    let tmp_path = tmp_download_path(out_path);
+    extract_entity_from_reader(file, entity, &tmp_path).map(|_| ())?;
+    std::fs::rename(&tmp_path, out_path).with_context(|| format!("Failed to rename {:?} -> {:?}", tmp_path, out_path))?;
+    Ok(())
 }
 
 /// Core extraction: pull a `.tar.xz` byte stream through an XZ decoder, locate

--- a/extractor/src/parser.rs
+++ b/extractor/src/parser.rs
@@ -1,7 +1,8 @@
 use anyhow::{Context, Result};
 use flate2::read::GzDecoder;
-use quick_xml::Reader;
+use quick_xml::encoding::Decoder;
 use quick_xml::events::Event;
+use quick_xml::{Reader, XmlVersion};
 use serde_json::{Map, Value};
 use std::fs::File;
 use std::io::BufReader;
@@ -24,12 +25,22 @@ impl ElementContext {
         Self { attributes: Map::new(), children: Map::new(), text_content: String::new() }
     }
 
-    /// Create a new element context, parsing attributes from an XML element
-    fn with_attributes(e: &quick_xml::events::BytesStart<'_>) -> Self {
+    /// Create a new element context, parsing attributes from an XML element.
+    ///
+    /// Attribute values are decoded and entity-unescaped through quick-xml's
+    /// unescape API so `&amp;`, `&lt;`, numeric char refs, etc. resolve the
+    /// same way they do for element text (see the `Event::GeneralRef`
+    /// handling in `parse_file`). Falls back to a raw, non-unescaped decode
+    /// if the escape sequence is malformed, so a single bad attribute cannot
+    /// abort parsing of an otherwise-valid record.
+    fn with_attributes(e: &quick_xml::events::BytesStart<'_>, decoder: Decoder) -> Self {
         let mut ctx = Self::new();
         for attr in e.attributes().flatten() {
             let key = String::from_utf8_lossy(attr.key.as_ref()).to_string();
-            let value = String::from_utf8_lossy(&attr.value).to_string();
+            let value = attr.decoded_and_normalized_value(XmlVersion::Implicit1_0, decoder).map(|c| c.into_owned()).unwrap_or_else(|err| {
+                warn!("⚠️ Failed to unescape XML attribute '{}': {}", key, err);
+                String::from_utf8_lossy(&attr.value).into_owned()
+            });
             ctx.attributes.insert(key, Value::String(value));
         }
         ctx
@@ -153,7 +164,7 @@ impl XmlParser {
                     }
 
                     if in_target_element {
-                        element_stack.push(ElementContext::with_attributes(&e));
+                        element_stack.push(ElementContext::with_attributes(&e, reader.decoder()));
                     }
                 }
 
@@ -167,7 +178,7 @@ impl XmlParser {
                         element_stack.clear();
 
                         // Send immediately since it's self-closing
-                        let record = ElementContext::with_attributes(&e).into_value();
+                        let record = ElementContext::with_attributes(&e, reader.decoder()).into_value();
                         if let Value::Object(ref obj) = record {
                             let id = obj.get("@id").or_else(|| obj.get("id")).and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
                             let raw_xml = if self.capture_raw_xml {
@@ -187,7 +198,7 @@ impl XmlParser {
                         in_target_element = false;
                     } else if in_target_element {
                         // Self-closing child element
-                        let child_value = ElementContext::with_attributes(&e).into_value();
+                        let child_value = ElementContext::with_attributes(&e, reader.decoder()).into_value();
 
                         // Add to parent if we have one
                         if let Some(parent) = element_stack.last_mut() {

--- a/extractor/src/polite_http.rs
+++ b/extractor/src/polite_http.rs
@@ -40,6 +40,11 @@ pub struct PoliteConfig {
     pub max_throttle_retries: u32,
     /// Per-request HTTP timeout.
     pub request_timeout: Duration,
+    /// Idle/read timeout applied to each body read, resetting after a successful
+    /// read. Bounds a mid-stream stall (a peer that stops sending bytes without
+    /// closing the socket) so the download retry loop can recover, without
+    /// bounding a legitimately long multi-GB transfer (discogsography-cu2.66).
+    pub read_timeout: Duration,
 }
 
 impl PoliteConfig {
@@ -52,6 +57,7 @@ impl PoliteConfig {
             max_retry_after: Duration::from_secs(2 * 60 * 60),
             max_throttle_retries: 5,
             request_timeout: Duration::from_secs(120),
+            read_timeout: Duration::from_secs(120),
         }
     }
 
@@ -63,6 +69,7 @@ impl PoliteConfig {
             max_retry_after: Duration::from_secs(30 * 60),
             max_throttle_retries: 5,
             request_timeout: Duration::from_secs(120),
+            read_timeout: Duration::from_secs(120),
         }
     }
 }
@@ -80,16 +87,23 @@ impl PoliteClient {
     }
 
     pub fn with_user_agent(cfg: PoliteConfig, user_agent: &str) -> Result<Self> {
-        // No per-request `timeout` — the prior call sites used `reqwest::get`
-        // which has no default timeout, and integration tests using
-        // `tokio::test(start_paused = true)` advance virtual time past any
-        // wall-clock timeout, firing it spuriously. We rely on:
-        //   * `connect_timeout` to bound TCP setup,
-        //   * the polite-client retry loop to handle transient errors,
-        //   * the existing per-attempt MAX_DOWNLOAD_RETRIES to bound retries.
+        // No overall per-request `timeout` — a total deadline would fire
+        // spuriously on legitimately long multi-GB downloads, and integration
+        // tests using `tokio::test(start_paused = true)` advance virtual time
+        // past any wall-clock deadline. Instead we bound the two failure modes
+        // separately:
+        //   * `connect_timeout` bounds TCP/TLS setup,
+        //   * `read_timeout` bounds each body read and resets after a successful
+        //     read — catching a silent mid-stream stall (half-open TCP, LB
+        //     idle-drop with no RST) that would otherwise hang `stream.next()`
+        //     forever with neither an Ok nor an Err for the retry loop to act on
+        //     (discogsography-cu2.66),
+        //   * the polite-client retry loop handles transient errors,
+        //   * the existing per-attempt MAX_DOWNLOAD_RETRIES bounds retries.
         let client = Client::builder()
             .user_agent(user_agent)
             .connect_timeout(cfg.request_timeout)
+            .read_timeout(cfg.read_timeout)
             .build()
             .context("Failed to build polite HTTP client")?;
         Ok(Self { client, cfg, last_request: Arc::new(Mutex::new(None)) })
@@ -174,6 +188,7 @@ mod tests {
             max_retry_after: Duration::from_millis(50),
             max_throttle_retries: 3,
             request_timeout: Duration::from_secs(5),
+            read_timeout: Duration::from_secs(5),
         }
     }
 
@@ -187,6 +202,7 @@ mod tests {
             max_retry_after: Duration::from_millis(50),
             max_throttle_retries: 2,
             request_timeout: Duration::from_secs(5),
+            read_timeout: Duration::from_secs(5),
         };
         let client = PoliteClient::new(cfg).unwrap();
         let url = format!("{}/x", server.url());
@@ -272,6 +288,7 @@ mod tests {
             max_retry_after: Duration::from_millis(50),
             max_throttle_retries: 2,
             request_timeout: Duration::from_secs(5),
+            read_timeout: Duration::from_secs(5),
         };
         let client = PoliteClient::new(cfg).unwrap();
         let url = Arc::new(format!("{}/x", server.url()));
@@ -296,5 +313,56 @@ mod tests {
         assert_eq!(counter.load(Ordering::SeqCst), 3);
         // 3 requests with 100ms gap → at least ~200ms total (first runs immediately).
         assert!(elapsed >= Duration::from_millis(180), "concurrent requests should serialize, took {:?}", elapsed);
+    }
+
+    #[tokio::test]
+    async fn read_timeout_fires_on_mid_stream_stall() {
+        // Regression for discogsography-cu2.66: a peer that sends response
+        // headers and a few body bytes and then goes silent — without closing
+        // the socket (half-open TCP / LB idle-drop with no RST) — used to hang
+        // the body read forever, since `stream.next().await` never resolved to
+        // either Ok or Err for the retry loop to act on. With a bounded
+        // `read_timeout` the stalled read must surface an error instead.
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            // Drain the request bytes so the client's write completes.
+            let mut buf = [0u8; 1024];
+            let _ = sock.read(&mut buf).await;
+            // Promise a large body but send only a few bytes, then hold the
+            // connection open indefinitely — the silent mid-stream stall.
+            let _ = sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 1048576\r\n\r\nhello").await;
+            let _ = sock.flush().await;
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+        });
+
+        let cfg = PoliteConfig {
+            min_gap: Duration::from_millis(1),
+            max_retry_after: Duration::from_millis(50),
+            max_throttle_retries: 1,
+            request_timeout: Duration::from_secs(5),
+            read_timeout: Duration::from_millis(200),
+        };
+        let client = PoliteClient::new(cfg).unwrap();
+        let url = format!("http://{}/stall", addr);
+
+        // Headers arrive, so the GET itself succeeds...
+        let response = client.get(&url).await.unwrap();
+
+        // ...but consuming the stalled body must error via the read timeout
+        // rather than hang forever.
+        let start = Instant::now();
+        let body_result = response.bytes().await;
+        let elapsed = start.elapsed();
+
+        assert!(body_result.is_err(), "stalled body read should error, not hang");
+        assert!(elapsed < Duration::from_secs(4), "read timeout should fire promptly, took {:?}", elapsed);
+
+        server.abort();
     }
 }

--- a/extractor/src/rules.rs
+++ b/extractor/src/rules.rs
@@ -425,29 +425,52 @@ pub fn apply_filters(config: &CompiledRulesConfig, data_type: &str, record: &mut
                     }
                 };
 
-                // Get the array at the leaf key
-                let arr = match parent {
-                    Value::Object(map) => match map.get_mut(leaf) {
-                        Some(Value::Array(arr)) => arr,
-                        _ => continue,
-                    },
+                // Navigate to the leaf-bearing object.
+                let map = match parent {
+                    Value::Object(map) => map,
                     _ => continue,
                 };
 
-                let mut removed_values = Vec::new();
-                let original_len = arr.len();
-                arr.retain(|elem| {
-                    if let Value::String(s) = elem
-                        && remove_matching.is_match(s)
-                    {
-                        removed_values.push(s.clone());
-                        return false;
+                // The XML parser (parser.rs `add_child`) only produces an array when a
+                // child name repeats; a single occurrence stays a scalar string. Handle
+                // both shapes so single-genre/style records aren't silently skipped.
+                match map.get_mut(leaf) {
+                    // Multi-value field: retain only the non-matching elements.
+                    Some(Value::Array(arr)) => {
+                        let mut removed_values = Vec::new();
+                        let original_len = arr.len();
+                        arr.retain(|elem| {
+                            if let Value::String(s) = elem
+                                && remove_matching.is_match(s)
+                            {
+                                removed_values.push(s.clone());
+                                return false;
+                            }
+                            true
+                        });
+                        let removed_count = original_len - arr.len();
+                        if removed_count > 0 {
+                            actions.push(FilterAction { field: field.clone(), removed_count, removed_values, reason: reason.clone() });
+                        }
                     }
-                    true
-                });
-                let removed_count = original_len - arr.len();
-                if removed_count > 0 {
-                    actions.push(FilterAction { field: field.clone(), removed_count, removed_values, reason: reason.clone() });
+                    // Single-value field: a lone occurrence is a scalar string. If it
+                    // matches, drop the key entirely — same net effect as filtering the
+                    // only element out of an array. Without this, records with exactly
+                    // one genre/style keep the bad value while multi-valued records get
+                    // filtered — inconsistent, incomplete cleaning (discogsography-cu2.47).
+                    Some(Value::String(s)) => {
+                        if remove_matching.is_match(s) {
+                            let removed = s.clone();
+                            map.remove(leaf);
+                            actions.push(FilterAction {
+                                field: field.clone(),
+                                removed_count: 1,
+                                removed_values: vec![removed],
+                                reason: reason.clone(),
+                            });
+                        }
+                    }
+                    _ => continue,
                 }
             }
             CompiledFilterCondition::NullifyWhen { field, below, above, reason } => {

--- a/extractor/src/rules.rs
+++ b/extractor/src/rules.rs
@@ -5,7 +5,7 @@
 use anyhow::{Context, Result};
 use regex::Regex;
 use serde::Deserialize;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt;
 use std::fs;
 use std::io::{BufWriter, Write};
@@ -808,15 +808,42 @@ impl FlaggedRecordWriter {
         }
     }
 
+    /// Write the data-quality summary to a **per-data-type** report file
+    /// (`base_dir/<data_type>/report.txt`).
+    ///
+    /// The four Discogs types are validated by separate concurrent
+    /// `FlaggedRecordWriter`s, each with the same version-keyed `base_dir`.
+    /// Writing a single shared `base_dir/report.txt` was a lost-update: whichever
+    /// validator finished last truncated the file, destroying the other three
+    /// types' summaries (a clean file could even overwrite a report full of
+    /// errors with "No data quality violations found"). Scoping the report to a
+    /// per-type subdir — alongside that type's existing `violations.jsonl` —
+    /// removes the collision entirely (discogsography-cu2.48).
     pub fn write_report(&self, report: &QualityReport, version: &str) {
-        if let Err(e) = fs::create_dir_all(&self.base_dir) {
-            tracing::warn!("⚠️ Failed to create flagged directory: {}", e);
+        // A per-file validator's report carries exactly one data type, but be
+        // robust to a merged multi-type report by writing one file per type.
+        let mut data_types: BTreeSet<&str> = BTreeSet::new();
+        data_types.extend(report.counts.keys().map(String::as_str));
+        data_types.extend(report.total_records.keys().map(String::as_str));
+        data_types.extend(report.skipped.keys().map(String::as_str));
+
+        if data_types.is_empty() {
             return;
         }
-        // `self.base_dir` is built from operator config in `new()` — not user input.
-        let report_path = self.base_dir.join("report.txt"); // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
-        if let Err(e) = fs::write(&report_path, report.format_summary(version)) {
-            tracing::warn!("⚠️ Failed to write quality report: {}", e);
+
+        let summary = report.format_summary(version);
+        for data_type in data_types {
+            // `data_type` originates from validated enum variants, and `base_dir`
+            // is built from operator config in `new()` — neither is user input.
+            let type_dir = self.base_dir.join(data_type); // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
+            if let Err(e) = fs::create_dir_all(&type_dir) {
+                tracing::warn!("⚠️ Failed to create flagged directory {:?}: {}", type_dir, e);
+                continue;
+            }
+            let report_path = type_dir.join("report.txt"); // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
+            if let Err(e) = fs::write(&report_path, &summary) {
+                tracing::warn!("⚠️ Failed to write quality report {:?}: {}", report_path, e);
+            }
         }
     }
 }

--- a/extractor/src/tests/downloader_tests.rs
+++ b/extractor/src/tests/downloader_tests.rs
@@ -825,3 +825,72 @@ async fn test_year_directory_non_success_skipped_other_years_succeed() {
     assert!(!files.is_empty(), "expected files from the working year");
     assert!(files.iter().all(|f| f.name.contains("2025")), "should not have any 2026 files; got {:?}", files);
 }
+
+#[tokio::test]
+async fn test_download_metadata_persisted_incrementally_on_mid_batch_failure() {
+    // Regression for discogsography-cu2.65: metadata was persisted only after
+    // ALL files succeeded, so a failure on a later file discarded the checksums
+    // of the files that already completed — forcing full multi-GB re-downloads
+    // on restart. Each successful download must now persist metadata immediately.
+    let temp_dir = TempDir::new().unwrap();
+
+    let mut server = mockito::Server::new_async().await;
+    let base_url = format!("{}/", server.url());
+
+    let main_page_html = r#"<html><body>
+        <a href="?prefix=data%2F2026%2F">2026/</a>
+    </body></html>"#;
+    let _main_mock = server.mock("GET", "/").with_status(200).with_body(main_page_html).create_async().await;
+
+    let year_page_html = r#"<html><body>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_artists.xml.gz">artists</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_labels.xml.gz">labels</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_masters.xml.gz">masters</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_releases.xml.gz">releases</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_CHECKSUM.txt">checksum</a>
+    </body></html>"#;
+    let _year_mock = server.mock("GET", "/?prefix=data%2F2026%2F").with_status(200).with_body(year_page_html).create_async().await;
+
+    // The three earlier files download successfully...
+    let mut _ok_mocks = Vec::new();
+    for file_type in ["artists", "labels", "masters"] {
+        let download_path = format!("/?download=data%2F2026%2Fdiscogs_20260101_{}.xml.gz", file_type);
+        let mock = server
+            .mock("GET", download_path.as_str())
+            .with_status(200)
+            .with_body(format!("fake {} data", file_type))
+            .create_async()
+            .await;
+        _ok_mocks.push(mock);
+    }
+    // ...but the last file (releases) fails on every attempt, aborting the batch.
+    let _fail_mock = server
+        .mock("GET", "/?download=data%2F2026%2Fdiscogs_20260101_releases.xml.gz")
+        .with_status(500)
+        .with_body("boom")
+        .create_async()
+        .await;
+
+    let mut downloader = Downloader::new_with_base_url(temp_dir.path().to_path_buf(), base_url).await.unwrap();
+    let result = downloader.download_discogs_data().await;
+
+    // The batch fails on the releases download.
+    assert!(result.is_err(), "expected the batch to fail on the releases download");
+
+    // A fresh Downloader loads the durable metadata written during the failed run.
+    // Before the fix this file was written only after full success, so it would be
+    // empty and every completed file would be re-downloaded.
+    let reloaded = Downloader::new_with_base_url(temp_dir.path().to_path_buf(), "http://unused".to_string()).await.unwrap();
+    assert!(!reloaded.metadata.is_empty(), "completed files' checksums must be persisted after a mid-batch failure");
+    assert!(
+        reloaded.metadata.contains_key("discogs_20260101_artists.xml.gz"),
+        "the first completed file's checksum must survive; got {:?}",
+        reloaded.metadata.keys().collect::<Vec<_>>()
+    );
+    // The failed file left no persisted metadata entry.
+    assert!(!reloaded.metadata.contains_key("discogs_20260101_releases.xml.gz"), "the failed file must not be recorded as complete");
+
+    // The persisted checksum means the completed file is not re-downloaded next run.
+    let completed = S3FileInfo { name: "discogs_20260101_artists.xml.gz".to_string(), size: "fake artists data".len() as u64 };
+    assert!(!reloaded.should_download(&completed).await.unwrap(), "a completed, persisted file must not be re-downloaded");
+}

--- a/extractor/src/tests/extractor_tests.rs
+++ b/extractor/src/tests/extractor_tests.rs
@@ -916,6 +916,70 @@ rules:
     assert_eq!(report.total_records["artists"], 1);
 }
 
+// ── message_normalizer tests (cu2.43) ───────────────────────────────
+
+/// Regression for cu2.43: normalization + hashing must run unconditionally, not only inside
+/// the optional validator stage. Feeds the normalizer the raw xmltodict shape the parser emits
+/// (container-wrapped `members`, `@`-prefixed keys, empty sha256) and asserts the output carries
+/// the flat consumer-ready shape and a populated content hash — the exact guarantees the no-rules
+/// (else-branch) pipeline previously dropped.
+#[tokio::test]
+async fn test_message_normalizer_normalizes_and_hashes_without_rules() {
+    let (in_sender, in_receiver) = mpsc::channel::<DataMessage>(10);
+    let (out_sender, mut out_receiver) = mpsc::channel::<DataMessage>(10);
+
+    let msg = DataMessage {
+        id: "1".to_string(),
+        sha256: String::new(), // parser emits an empty hash — normalizer must fill it in
+        data: serde_json::json!({
+            "id": "1",
+            "name": "Aphex Twin",
+            "members": {"name": [{"@id": "7", "#text": "Richard D. James"}]}
+        }),
+        raw_xml: None,
+    };
+    in_sender.send(msg).await.unwrap();
+    drop(in_sender);
+
+    message_normalizer(in_receiver, out_sender, DataType::Artists).await.unwrap();
+
+    let got = out_receiver.recv().await.unwrap();
+
+    // Content hash is now populated so downstream change detection works.
+    assert!(!got.sha256.is_empty(), "normalizer must populate sha256");
+
+    // members is unwrapped into a flat array of objects with `@`/`#text` keys stripped —
+    // the shape graphinator's `[m for m in members if m.get('id')]` requires.
+    let members = got.data.get("members").expect("members present").as_array().expect("members is array");
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0].get("id").unwrap(), "7");
+    assert_eq!(members[0].get("name").unwrap(), "Richard D. James");
+    assert!(members[0].get("@id").is_none(), "@-prefixed keys must be stripped");
+
+    // No more messages.
+    assert!(out_receiver.recv().await.is_none());
+}
+
+/// The normalizer must produce byte-identical output regardless of which upstream stage feeds it,
+/// so the rules and no-rules pipelines converge on the same published record + hash.
+#[tokio::test]
+async fn test_message_normalizer_hash_is_deterministic() {
+    async fn normalize_one(record: serde_json::Value) -> DataMessage {
+        let (in_sender, in_receiver) = mpsc::channel::<DataMessage>(1);
+        let (out_sender, mut out_receiver) = mpsc::channel::<DataMessage>(1);
+        in_sender.send(DataMessage { id: "1".to_string(), sha256: String::new(), data: record, raw_xml: None }).await.unwrap();
+        drop(in_sender);
+        message_normalizer(in_receiver, out_sender, DataType::Artists).await.unwrap();
+        out_receiver.recv().await.unwrap()
+    }
+
+    let record = serde_json::json!({"id": "1", "name": "Aphex Twin", "members": {"name": [{"@id": "7", "#text": "Richard"}]}});
+    let a = normalize_one(record.clone()).await;
+    let b = normalize_one(record).await;
+    assert_eq!(a.sha256, b.sha256);
+    assert!(!a.sha256.is_empty());
+}
+
 // ── wait_for_trigger tests ──────────────────────────────────────────
 
 #[tokio::test(start_paused = true)]

--- a/extractor/src/tests/extractor_tests.rs
+++ b/extractor/src/tests/extractor_tests.rs
@@ -836,9 +836,10 @@ rules:
     assert!(flagged_dir.join("77.json").exists(), "Flagged JSON should be written");
     assert!(flagged_dir.join("violations.jsonl").exists(), "Violations JSONL should be written");
 
-    // Check report file
-    let report_path = temp_dir.path().join("flagged").join("20260301").join("report.txt");
-    assert!(report_path.exists(), "Report file should be written");
+    // Check report file — now scoped to the data type's subdir so concurrent
+    // per-file validators no longer overwrite a shared report (discogsography-cu2.48).
+    let report_path = temp_dir.path().join("flagged").join("20260301").join("artists").join("report.txt");
+    assert!(report_path.exists(), "Per-type report file should be written");
 }
 
 #[tokio::test]

--- a/extractor/src/tests/extractor_tests.rs
+++ b/extractor/src/tests/extractor_tests.rs
@@ -916,6 +916,39 @@ rules:
     assert_eq!(report.total_records["artists"], 1);
 }
 
+// ── failed-check status reset tests (cu2.41) ────────────────────────
+
+/// Regression for cu2.41: after a periodic/triggered extraction returns `Err`, the loop must
+/// reset a stuck `Running` status to `Failed`. Without this the status set up-front in
+/// `process_discogs_data` survives an early-`?` error for the whole multi-day periodic sleep,
+/// wedging `/trigger` recovery and starving the MusicBrainz idle-wait.
+#[tokio::test]
+async fn test_reset_status_after_failed_check_clears_running() {
+    let state = Arc::new(RwLock::new(ExtractorState::default()));
+
+    // Simulate the stuck state: process_discogs_data set Running, then an early `?` propagated.
+    state.write().await.extraction_status = ExtractionStatus::Running;
+
+    reset_status_after_failed_check(&state).await;
+
+    assert_eq!(state.read().await.extraction_status, ExtractionStatus::Failed, "a failed check must not leave the status stuck at Running");
+}
+
+/// The reset lands on `Failed` (not `Running`, not `Completed`) so downstream consumers treat it
+/// as a terminal, recoverable state: health.rs stops returning 409 `already_running`, and
+/// `wait_for_discogs_idle` (which treats only `running` as busy) proceeds.
+#[tokio::test]
+async fn test_reset_status_after_failed_check_is_not_running() {
+    for start in [ExtractionStatus::Running, ExtractionStatus::Completed, ExtractionStatus::Waiting] {
+        let state = Arc::new(RwLock::new(ExtractorState::default()));
+        state.write().await.extraction_status = start;
+        reset_status_after_failed_check(&state).await;
+        let got = state.read().await.extraction_status;
+        assert_eq!(got, ExtractionStatus::Failed);
+        assert_ne!(got, ExtractionStatus::Running);
+    }
+}
+
 // ── message_normalizer tests (cu2.43) ───────────────────────────────
 
 /// Regression for cu2.43: normalization + hashing must run unconditionally, not only inside

--- a/extractor/src/tests/extractor_tests.rs
+++ b/extractor/src/tests/extractor_tests.rs
@@ -949,6 +949,36 @@ async fn test_reset_status_after_failed_check_is_not_running() {
     }
 }
 
+// ── initial-run outcome tests (cu2.45) ──────────────────────────────
+
+/// Regression for cu2.45: a between-files shutdown makes `process_musicbrainz_data` return
+/// `Ok(false)`, indistinguishable from a real failure. The initial-run path used to promote that
+/// to `Err`, sending main into the 600s failure cooldown + `exit(1)` on a clean operator shutdown.
+/// `initial_run_outcome` must return `Ok(())` whenever a shutdown was requested, regardless of the
+/// success flag — and only return `Err` for a genuine (non-shutdown) failure.
+#[test]
+fn test_initial_run_outcome_shutdown_is_not_failure() {
+    // Genuine failure, no shutdown → Err (main applies cooldown as intended).
+    assert!(initial_run_outcome(false, false, "MusicBrainz").is_err());
+
+    // Shutdown with success == false (the exact cu2.45 scenario) → Ok, NOT a failure.
+    assert!(initial_run_outcome(false, true, "MusicBrainz").is_ok());
+
+    // Shutdown with success == true → Ok.
+    assert!(initial_run_outcome(true, true, "MusicBrainz").is_ok());
+
+    // Clean success → Ok.
+    assert!(initial_run_outcome(true, false, "MusicBrainz").is_ok());
+}
+
+/// The same helper governs the Discogs initial run (fix-one-fix-all with cu2.44): a shutdown there
+/// must likewise short-circuit to Ok so it never trips the failure cooldown.
+#[test]
+fn test_initial_run_outcome_discogs_shutdown_is_ok() {
+    assert!(initial_run_outcome(false, true, "Discogs").is_ok());
+    assert!(initial_run_outcome(false, false, "Discogs").is_err());
+}
+
 // ── shutdown-flag monitor tests (cu2.44) ────────────────────────────
 
 /// Regression for cu2.44: the Discogs path lost SIGTERM/SIGINT delivered mid-run because nothing

--- a/extractor/src/tests/extractor_tests.rs
+++ b/extractor/src/tests/extractor_tests.rs
@@ -949,6 +949,46 @@ async fn test_reset_status_after_failed_check_is_not_running() {
     }
 }
 
+// ── shutdown-flag monitor tests (cu2.44) ────────────────────────────
+
+/// Regression for cu2.44: the Discogs path lost SIGTERM/SIGINT delivered mid-run because nothing
+/// converted the one-shot `Notify` into a pollable flag. `spawn_shutdown_flag_monitor` must flip
+/// its `AtomicBool` when the `Notify` fires, so processing code can observe a shutdown between
+/// files without consuming the signal the outer `select!` needs.
+#[tokio::test]
+async fn test_spawn_shutdown_flag_monitor_flips_on_notify() {
+    let shutdown = Arc::new(tokio::sync::Notify::new());
+    let flag = spawn_shutdown_flag_monitor(shutdown.clone());
+
+    assert!(!flag.load(Ordering::SeqCst), "flag starts clear");
+
+    // notify_waiters() wakes only currently-parked waiters and stores no permit, so retry until
+    // the monitor task has parked and observed the signal (or fail after a bounded wait).
+    let mut fired = false;
+    for _ in 0..200 {
+        shutdown.notify_waiters();
+        tokio::task::yield_now().await;
+        if flag.load(Ordering::SeqCst) {
+            fired = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+
+    assert!(fired, "monitor must set the shutdown flag once the Notify fires");
+}
+
+/// The flag stays clear until the signal actually fires — a spurious early poll must not report a
+/// shutdown, otherwise the first file would be skipped on every run.
+#[tokio::test]
+async fn test_spawn_shutdown_flag_monitor_stays_clear_without_signal() {
+    let shutdown = Arc::new(tokio::sync::Notify::new());
+    let flag = spawn_shutdown_flag_monitor(shutdown);
+    tokio::task::yield_now().await;
+    tokio::time::sleep(Duration::from_millis(5)).await;
+    assert!(!flag.load(Ordering::SeqCst), "flag must remain clear until shutdown fires");
+}
+
 // ── message_normalizer tests (cu2.43) ───────────────────────────────
 
 /// Regression for cu2.43: normalization + hashing must run unconditionally, not only inside

--- a/extractor/src/tests/jsonl_parser_tests.rs
+++ b/extractor/src/tests/jsonl_parser_tests.rs
@@ -709,3 +709,35 @@ fn test_build_mbid_discogs_map_truncated_xz_is_fatal_not_busyloop() {
         Err(_) => panic!("build_mbid_discogs_map_from_file busy-looped on a truncated xz stream (never returned)"),
     }
 }
+
+#[test]
+fn test_parse_mb_jsonl_file_truncated_xz_is_fatal_not_busyloop() {
+    use std::io::Write;
+    use std::sync::mpsc as std_mpsc;
+    use std::time::Duration;
+    use tempfile::NamedTempFile;
+    use tokio::sync::mpsc;
+
+    let line = r#"{"id":"mbid-1","name":"Artist","sort-name":"Artist","type":"Person","gender":null,"life-span":{"begin":null,"end":null,"ended":false},"area":null,"begin-area":null,"end-area":null,"disambiguation":"","aliases":[],"tags":[],"relations":[]}"#;
+    let content = std::iter::repeat_n(line, 500).collect::<Vec<_>>().join("\n") + "\n";
+
+    let mut temp_file = NamedTempFile::new().unwrap();
+    temp_file.write_all(&truncated_xz_bytes(&content)).unwrap();
+    temp_file.flush().unwrap();
+    let path = temp_file.path().to_path_buf();
+
+    let (tx, rx) = std_mpsc::channel();
+    std::thread::spawn(move || {
+        // Generous channel so blocking_send never blocks; we want the read error, not backpressure.
+        let (sender, _receiver) = mpsc::channel(100_000);
+        // Keep the receiver alive for the duration of the parse.
+        let result = parse_mb_jsonl_file(&path, DataType::Artists, sender, None);
+        let _ = tx.send(result.is_err());
+        drop(_receiver);
+    });
+
+    match rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(is_err) => assert!(is_err, "truncated xz must yield Err, not Ok"),
+        Err(_) => panic!("parse_mb_jsonl_file busy-looped on a truncated xz stream (never returned)"),
+    }
+}

--- a/extractor/src/tests/jsonl_parser_tests.rs
+++ b/extractor/src/tests/jsonl_parser_tests.rs
@@ -656,3 +656,56 @@ fn test_parse_mb_jsonl_file_receiver_dropped() {
     // Count should be 0 since the very first blocking_send should fail (receiver dropped)
     assert_eq!(count, 0);
 }
+
+// ─── truncated/corrupt .jsonl.xz: read errors must be fatal, not busy-loop ──────
+//
+// Regression for discogsography-cu2.14 (parse_mb_jsonl_file) and
+// discogsography-cu2.46 (build_mbid_discogs_map_from_file). A corrupt or truncated
+// xz stream makes XzDecoder return the *same* io::Error on every subsequent read;
+// the old `continue` arm spun forever at 100% CPU. Both functions must instead
+// surface the error. Each test runs the call on a worker thread and asserts it
+// TERMINATES within a timeout — a reintroduced busy-loop would never return and
+// fail the recv_timeout rather than hanging CI indefinitely.
+
+/// Build a valid xz stream from `content`, then truncate the compressed bytes so
+/// the decoder hits a premature-EOF error partway through the stream.
+fn truncated_xz_bytes(content: &str) -> Vec<u8> {
+    use std::io::Write;
+    use xz2::write::XzEncoder;
+
+    let mut encoder = XzEncoder::new(Vec::new(), 1);
+    encoder.write_all(content.as_bytes()).unwrap();
+    let compressed = encoder.finish().unwrap();
+    // Drop the trailing quarter of the stream (index + footer + tail of the block)
+    // so the decoder never reaches StreamEnd and returns a persistent read error.
+    let keep = (compressed.len() * 3) / 4;
+    compressed[..keep].to_vec()
+}
+
+#[test]
+fn test_build_mbid_discogs_map_truncated_xz_is_fatal_not_busyloop() {
+    use std::io::Write;
+    use std::sync::mpsc;
+    use std::time::Duration;
+    use tempfile::NamedTempFile;
+
+    // Many lines so the compressed stream is large enough to truncate mid-body.
+    let line = r#"{"id":"mbid-x","relations":[{"type":"discogs","target-type":"url","url":{"resource":"https://www.discogs.com/artist/42"}}]}"#;
+    let content = std::iter::repeat_n(line, 500).collect::<Vec<_>>().join("\n") + "\n";
+
+    let mut temp_file = NamedTempFile::new().unwrap();
+    temp_file.write_all(&truncated_xz_bytes(&content)).unwrap();
+    temp_file.flush().unwrap();
+    let path = temp_file.path().to_path_buf();
+
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let result = build_mbid_discogs_map_from_file(&path, "artist");
+        let _ = tx.send(result.is_err());
+    });
+
+    match rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(is_err) => assert!(is_err, "truncated xz must yield Err, not Ok"),
+        Err(_) => panic!("build_mbid_discogs_map_from_file busy-looped on a truncated xz stream (never returned)"),
+    }
+}

--- a/extractor/src/tests/musicbrainz_downloader_tests.rs
+++ b/extractor/src/tests/musicbrainz_downloader_tests.rs
@@ -1048,3 +1048,106 @@ async fn test_download_latest_sha256sums_non_success_returns_error() {
     let msg = format!("{:#}", err);
     assert!(msg.contains("404") || msg.contains("MusicBrainz SHA256SUMS returned"), "unexpected error: {}", msg);
 }
+
+// ── cu2.15: atomic tmp+rename so a crash never leaves a truncated final file ──────
+
+/// A crash mid-extraction leaves a `{entity}.jsonl.xz.tmp`, NOT a truncated
+/// `{entity}.jsonl.xz`. is_version_complete keys on the final name only, so the
+/// partial `.tmp` is correctly treated as incomplete and the version is re-downloaded
+/// instead of being trusted forever. Regression for discogsography-cu2.15.
+#[test]
+fn test_is_version_complete_ignores_partial_tmp_file() {
+    let dir = TempDir::new().unwrap();
+    let version_dir = dir.path().join("20260322-001001");
+    std::fs::create_dir(&version_dir).unwrap();
+    // Three entities completed (final files), release crashed mid-write (only a .tmp).
+    std::fs::write(version_dir.join("artist.jsonl.xz"), b"data").unwrap();
+    std::fs::write(version_dir.join("label.jsonl.xz"), b"data").unwrap();
+    std::fs::write(version_dir.join("release-group.jsonl.xz"), b"data").unwrap();
+    std::fs::write(version_dir.join("release.jsonl.xz.tmp"), b"truncated-partial").unwrap();
+
+    let downloader = MbDownloader::new(dir.path().to_path_buf(), "http://unused".to_string());
+    // The partial `.tmp` must NOT satisfy completeness — otherwise the truncated dump
+    // would be accepted as AlreadyCurrent and never re-downloaded.
+    assert!(!downloader.is_version_complete(&version_dir));
+
+    // Once the release extraction finishes and atomically renames into place, it's complete.
+    std::fs::rename(version_dir.join("release.jsonl.xz.tmp"), version_dir.join("release.jsonl.xz")).unwrap();
+    assert!(downloader.is_version_complete(&version_dir));
+}
+
+/// A failed extraction must leave NEITHER a final file NOR a leftover `.tmp` at the
+/// destination — so is_version_complete cannot later be fooled by a partial artifact.
+#[test]
+fn test_extract_entity_from_tarball_failure_leaves_no_final_or_tmp() {
+    let dir = TempDir::new().unwrap();
+    let tar_path = dir.path().join("artist.tar.xz");
+    let out_path = dir.path().join("artist.jsonl.xz");
+    let tmp_path = dir.path().join("artist.jsonl.xz.tmp");
+
+    // Tarball without the requested entity → extraction fails after (possibly) creating tmp.
+    let mut tar_data = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_data);
+        let content = b"readme only";
+        let mut header = tar::Header::new_gnu();
+        header.set_path("artist/README").unwrap();
+        header.set_size(content.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append(&header, &content[..]).unwrap();
+        builder.finish().unwrap();
+    }
+    let mut xz_file = std::fs::File::create(&tar_path).unwrap();
+    let mut encoder = xz2::write::XzEncoder::new(Vec::new(), 1);
+    encoder.write_all(&tar_data).unwrap();
+    let compressed = encoder.finish().unwrap();
+    xz_file.write_all(&compressed).unwrap();
+    drop(xz_file);
+
+    let result = extract_entity_from_tarball(&tar_path, "artist", &out_path);
+    assert!(result.is_err());
+    // Neither the final nor the staging file may survive a failed extraction.
+    assert!(!out_path.exists(), "final path must not exist after a failed extraction");
+    assert!(!tmp_path.exists(), "staging .tmp must be cleaned up after a failed extraction");
+}
+
+/// A successful extraction publishes the final file and leaves no `.tmp` behind.
+#[test]
+fn test_extract_entity_from_tarball_success_leaves_no_tmp() {
+    let dir = TempDir::new().unwrap();
+    let tar_path = dir.path().join("label.tar.xz");
+    let out_path = dir.path().join("label.jsonl.xz");
+    let tmp_path = dir.path().join("label.jsonl.xz.tmp");
+
+    let original_content = "{\"id\":\"abc-123\",\"name\":\"Test Label\"}\n";
+    let mut tar_data = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_data);
+        let content = original_content.as_bytes();
+        let mut header = tar::Header::new_gnu();
+        header.set_path("label/mbdump/label").unwrap();
+        header.set_size(content.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append(&header, content).unwrap();
+        builder.finish().unwrap();
+    }
+    let mut xz_file = std::fs::File::create(&tar_path).unwrap();
+    let mut encoder = xz2::write::XzEncoder::new(Vec::new(), 1);
+    encoder.write_all(&tar_data).unwrap();
+    let compressed = encoder.finish().unwrap();
+    xz_file.write_all(&compressed).unwrap();
+    drop(xz_file);
+
+    extract_entity_from_tarball(&tar_path, "label", &out_path).unwrap();
+    assert!(out_path.exists(), "final file must exist after success");
+    assert!(!tmp_path.exists(), "staging .tmp must be renamed away on success");
+
+    // Round-trip integrity of the atomically-published file.
+    let file = std::fs::File::open(&out_path).unwrap();
+    let mut decoder = xz2::read::XzDecoder::new(file);
+    let mut decompressed = String::new();
+    decoder.read_to_string(&mut decompressed).unwrap();
+    assert_eq!(decompressed, original_content);
+}

--- a/extractor/src/tests/parser_tests.rs
+++ b/extractor/src/tests/parser_tests.rs
@@ -504,6 +504,98 @@ async fn test_parse_with_unknown_entity_reference() {
 }
 
 #[tokio::test]
+async fn test_parse_attribute_entity_references() {
+    // Regression test for discogsography-cu2.16: attribute values must be
+    // entity-unescaped the same way element text is. Reproduces the exact
+    // failure scenario from the bead: a label name containing "&".
+    let xml_content = r#"<?xml version="1.0" encoding="UTF-8"?>
+<releases>
+    <release id="1">
+        <labels>
+            <label name="Rhythm &amp; Blues Records" catno="RB-1"/>
+        </labels>
+    </release>
+</releases>"#;
+
+    let mut temp_file = NamedTempFile::new().unwrap();
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(xml_content.as_bytes()).unwrap();
+    let compressed = encoder.finish().unwrap();
+    temp_file.write_all(&compressed).unwrap();
+    temp_file.flush().unwrap();
+
+    let (sender, mut receiver) = mpsc::channel(10);
+    let parser = XmlParser::new(DataType::Releases, sender);
+    let count = parser.parse_file(temp_file.path()).await.unwrap();
+
+    assert_eq!(count, 1);
+
+    let message = receiver.recv().await.unwrap();
+    let label = &message.data["labels"]["label"];
+    assert_eq!(label["@name"], json!("Rhythm & Blues Records"));
+    assert_eq!(label["@catno"], json!("RB-1"));
+}
+
+#[tokio::test]
+async fn test_parse_attribute_numeric_and_mixed_entity_references() {
+    // Attribute values should resolve numeric char refs and mixed predefined
+    // entities identically to element text.
+    let xml_content = r#"<?xml version="1.0" encoding="UTF-8"?>
+<releases>
+    <release id="1">
+        <labels>
+            <label name="Rock &amp; Roll &#x266A;" catno="&lt;R&amp;R&gt;"/>
+        </labels>
+    </release>
+</releases>"#;
+
+    let mut temp_file = NamedTempFile::new().unwrap();
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(xml_content.as_bytes()).unwrap();
+    let compressed = encoder.finish().unwrap();
+    temp_file.write_all(&compressed).unwrap();
+    temp_file.flush().unwrap();
+
+    let (sender, mut receiver) = mpsc::channel(10);
+    let parser = XmlParser::new(DataType::Releases, sender);
+    let count = parser.parse_file(temp_file.path()).await.unwrap();
+
+    assert_eq!(count, 1);
+
+    let message = receiver.recv().await.unwrap();
+    let label = &message.data["labels"]["label"];
+    assert_eq!(label["@name"], json!("Rock & Roll ♪"));
+    assert_eq!(label["@catno"], json!("<R&R>"));
+}
+
+#[tokio::test]
+async fn test_parse_self_closing_target_attribute_entity_references() {
+    // Same unescaping must apply on the self-closing-target-element path
+    // (Event::Empty at depth 2), which builds attributes via a separate
+    // ElementContext::with_attributes call site than nested children.
+    let xml_content = r#"<?xml version="1.0" encoding="UTF-8"?>
+<artists>
+    <artist id="1" name="Tom &amp; Jerry" />
+</artists>"#;
+
+    let mut temp_file = NamedTempFile::new().unwrap();
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(xml_content.as_bytes()).unwrap();
+    let compressed = encoder.finish().unwrap();
+    temp_file.write_all(&compressed).unwrap();
+    temp_file.flush().unwrap();
+
+    let (sender, mut receiver) = mpsc::channel(10);
+    let parser = XmlParser::new(DataType::Artists, sender);
+    let count = parser.parse_file(temp_file.path()).await.unwrap();
+
+    assert_eq!(count, 1);
+
+    let message = receiver.recv().await.unwrap();
+    assert_eq!(message.data["@name"], json!("Tom & Jerry"));
+}
+
+#[tokio::test]
 async fn test_parse_file_not_found() {
     let (sender, _receiver) = mpsc::channel(10);
     let parser = XmlParser::new(DataType::Artists, sender);

--- a/extractor/src/tests/rules_tests.rs
+++ b/extractor/src/tests/rules_tests.rs
@@ -1279,7 +1279,7 @@ filters:
 }
 
 #[test]
-fn test_filter_single_string_genre_not_array() {
+fn test_filter_single_string_genre_matching_removed() {
     let config = compile_filter_yaml(
         r#"
 filters:
@@ -1289,11 +1289,35 @@ filters:
       reason: "Numeric genres"
 "#,
     );
-    // genre is a single string, not an array — should be left untouched
+    // genre is a single string (one occurrence in the XML) that matches the
+    // filter — the key must be stripped, mirroring array-element removal
+    // (discogsography-cu2.47). Previously this scalar shape was silently skipped.
     let mut record = json!({"genres": {"genre": "123"}});
     let actions = apply_filters(&config, "releases", &mut record);
+    assert_eq!(actions.len(), 1);
+    assert_eq!(actions[0].removed_count, 1);
+    assert_eq!(actions[0].removed_values, vec!["123"]);
+    // The matching leaf key is removed; the parent object remains.
+    assert!(record["genres"].get("genre").is_none());
+    assert_eq!(record["genres"], json!({}));
+}
+
+#[test]
+fn test_filter_single_string_genre_non_matching_preserved() {
+    let config = compile_filter_yaml(
+        r#"
+filters:
+  releases:
+    - field: genres.genre
+      remove_matching: "^\\d+$"
+      reason: "Numeric genres"
+"#,
+    );
+    // A single, non-matching scalar genre is left untouched.
+    let mut record = json!({"genres": {"genre": "Rock"}});
+    let actions = apply_filters(&config, "releases", &mut record);
     assert!(actions.is_empty());
-    assert_eq!(record["genres"]["genre"], json!("123"));
+    assert_eq!(record["genres"]["genre"], json!("Rock"));
 }
 
 // ── Task 4: QualityReport — Skipped Records Tracking ────────────────

--- a/extractor/src/tests/rules_tests.rs
+++ b/extractor/src/tests/rules_tests.rs
@@ -803,11 +803,53 @@ fn test_flagged_writer_write_report() {
 
     writer.write_report(&report, "20260301");
 
-    let report_path = temp_dir.path().join("flagged").join("20260301").join("report.txt");
-    assert!(report_path.exists(), "Report file should be created");
+    // The report is scoped to its data type's subdir (discogsography-cu2.48).
+    let report_path = temp_dir.path().join("flagged").join("20260301").join("releases").join("report.txt");
+    assert!(report_path.exists(), "Per-type report file should be created");
     let content = std::fs::read_to_string(report_path).unwrap();
     assert!(content.contains("test-rule"));
     assert!(content.contains("1 errors"));
+}
+
+#[test]
+fn test_flagged_writer_reports_do_not_overwrite_across_types() {
+    // Regression for discogsography-cu2.48: four concurrent per-file validators
+    // each construct their own FlaggedRecordWriter with the same version-keyed
+    // base_dir and call write_report with only their own type's data. When the
+    // report was a single shared base_dir/report.txt, whichever validator
+    // finished last truncated the others — including a clean file wiping out a
+    // report full of errors. Per-type report files must coexist.
+    use crate::rules::{FlaggedRecordWriter, QualityReport, Severity};
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let base = temp_dir.path().join("flagged").join("20260301");
+
+    // "releases" validator: 5000-ish violations, finishes first.
+    let releases_writer = FlaggedRecordWriter::new(temp_dir.path(), "20260301");
+    let mut releases_report = QualityReport::new();
+    releases_report.record_violation("releases", "bad-genre", &Severity::Error);
+    releases_report.increment_total("releases");
+    releases_writer.write_report(&releases_report, "20260301");
+
+    // "labels" validator: zero violations, finishes LAST (would have truncated
+    // the shared report with "No data quality violations found").
+    let labels_writer = FlaggedRecordWriter::new(temp_dir.path(), "20260301");
+    let mut labels_report = QualityReport::new();
+    labels_report.increment_total("labels");
+    labels_writer.write_report(&labels_report, "20260301");
+
+    // The releases error report must survive the later clean labels write.
+    let releases_report_txt = std::fs::read_to_string(base.join("releases").join("report.txt")).unwrap();
+    assert!(releases_report_txt.contains("bad-genre"), "releases report lost: {releases_report_txt}");
+    assert!(releases_report_txt.contains("1 errors"));
+
+    // And the clean labels report lands in its own file without a collision.
+    let labels_report_txt = std::fs::read_to_string(base.join("labels").join("report.txt")).unwrap();
+    assert!(labels_report_txt.contains("No data quality violations found"), "labels report wrong: {labels_report_txt}");
+
+    // No shared top-level report.txt is written (would be the collision point).
+    assert!(!base.join("report.txt").exists(), "shared report.txt must not exist");
 }
 
 // ── QualityReport edge cases ─────────────────────────────────────────

--- a/extractor/src/tests/state_marker_tests.rs
+++ b/extractor/src/tests/state_marker_tests.rs
@@ -366,3 +366,73 @@ fn test_complete_extraction_without_download_start() {
     assert!(marker.summary.total_duration_seconds.is_none());
     assert_eq!(marker.summary.overall_status, PhaseStatus::Completed);
 }
+
+// Regression: discogsography-cu2.2 — a resumed extraction must broadcast the ORIGINAL
+// processing start time, not the restarted process's now(). If it used a fresh start
+// time, the tableinator stale-row purge would delete every row written before the
+// restart (mass data loss). The extractor derives the start time it sends from
+// processing_phase.started_at, so this test pins that the field survives a resume
+// (persist -> restart -> continue) unchanged and is NOT reset for an InProgress marker.
+#[tokio::test]
+async fn test_resume_preserves_original_processing_start_time() {
+    // Session 1: begin processing four files, finish only artists, then "crash".
+    let mut marker = StateMarker::new("20260101".to_string());
+    marker.start_processing(4);
+    let original_started_at = marker.processing_phase.started_at.expect("started_at set on start_processing");
+    marker.start_file_processing("discogs_20260101_artists.xml.gz");
+    marker.complete_file_processing("discogs_20260101_artists.xml.gz", 9_000_000);
+
+    // Marker is still InProgress — releases/labels/masters never finished.
+    assert_eq!(marker.processing_phase.status, PhaseStatus::InProgress);
+
+    // Persist across the restart (serialize -> deserialize like load/save on disk).
+    let json = serde_json::to_string_pretty(&marker).unwrap();
+    let mut resumed: StateMarker = serde_json::from_str(&json).unwrap();
+
+    // The original start time must survive the roundtrip.
+    assert_eq!(resumed.processing_phase.started_at, Some(original_started_at));
+
+    // Session 2 (resume): extractor.rs only calls start_processing() when the phase is
+    // Pending. For an InProgress marker it just refreshes files_total, so started_at is
+    // left untouched. Simulate exactly that resume branch.
+    assert_eq!(resumed.processing_phase.status, PhaseStatus::InProgress);
+    resumed.processing_phase.files_total = 4; // resume branch: update total, do not reset
+
+    // The value the extractor propagates into extraction_complete is still the original.
+    let propagated = resumed.processing_phase.started_at.unwrap();
+    assert_eq!(propagated, original_started_at);
+
+    // The already-completed artists file is not re-sent this session.
+    let all_files = vec![
+        "discogs_20260101_artists.xml.gz".to_string(),
+        "discogs_20260101_labels.xml.gz".to_string(),
+        "discogs_20260101_masters.xml.gz".to_string(),
+        "discogs_20260101_releases.xml.gz".to_string(),
+    ];
+    let pending = resumed.pending_files(&all_files);
+    assert!(!pending.contains(&"discogs_20260101_artists.xml.gz".to_string()));
+}
+
+// Regression: discogsography-cu2.2 — the "all files already processed" completion path
+// (a crash lands after every file finished but before the completion broadcast). On
+// restart, pending_files is empty and no data is re-sent, yet extraction_complete still
+// fires. It must carry the original processing start time so the purge stays sound.
+#[tokio::test]
+async fn test_all_files_complete_before_crash_keeps_original_start_time() {
+    let mut marker = StateMarker::new("20260101".to_string());
+    marker.start_processing(1);
+    let original_started_at = marker.processing_phase.started_at.unwrap();
+    marker.start_file_processing("discogs_20260101_artists.xml.gz");
+    marker.complete_file_processing("discogs_20260101_artists.xml.gz", 9_000_000);
+
+    // Persist and "restart" before the completion broadcast was sent.
+    let json = serde_json::to_string_pretty(&marker).unwrap();
+    let resumed: StateMarker = serde_json::from_str(&json).unwrap();
+
+    // No files remain to process — the "all files already processed" branch runs.
+    let all_files = vec!["discogs_20260101_artists.xml.gz".to_string()];
+    assert!(resumed.pending_files(&all_files).is_empty());
+
+    // extraction_complete on this branch must still use the original start time.
+    assert_eq!(resumed.processing_phase.started_at, Some(original_started_at));
+}

--- a/extractor/src/types.rs
+++ b/extractor/src/types.rs
@@ -113,6 +113,20 @@ impl ExtractionProgress {
         }
     }
 
+    /// Add `count` records to the given data type's tally at once.
+    ///
+    /// Used to rehydrate per-run progress from a persisted state marker on resume, so the
+    /// `/health` endpoint reports true totals for types completed before a crash rather than 0.
+    pub fn add(&mut self, data_type: DataType, count: u64) {
+        match data_type {
+            DataType::Artists => self.artists += count,
+            DataType::Labels => self.labels += count,
+            DataType::Masters => self.masters += count,
+            DataType::ReleaseGroups => self.release_groups += count,
+            DataType::Releases => self.releases += count,
+        }
+    }
+
     #[allow(dead_code)]
     pub fn get(&self, data_type: DataType) -> u64 {
         match data_type {

--- a/extractor/tests/extractor_di_test.rs
+++ b/extractor/tests/extractor_di_test.rs
@@ -6,7 +6,7 @@ use extractor::extractor::{
 };
 use extractor::message_queue::MockMessagePublisher;
 use extractor::rules::{CompiledRulesConfig, RulesConfig};
-use extractor::state_marker::StateMarker;
+use extractor::state_marker::{PhaseStatus, ProcessingDecision, StateMarker};
 use extractor::types::S3FileInfo;
 use extractor::types::{DataMessage, DataType, Source};
 use flate2::Compression;
@@ -414,6 +414,92 @@ async fn test_process_discogs_data_mq_factory_create_fails_on_all_processed() {
     // Should still succeed (extraction_complete failure is logged, not fatal)
     assert!(result.is_ok());
     assert!(result.unwrap());
+}
+
+/// Build a MockDataSource for the resumed all-files-already-processed Discogs path that
+/// hands `marker` back after the (no-op) download. Mirrors the fixtures used by the
+/// all-files-already-processed tests above.
+fn mock_dl_returning_marker(marker: StateMarker) -> MockDataSource {
+    let mut mock_dl = MockDataSource::new();
+    mock_dl.expect_list_s3_files().returning(|| {
+        Ok(vec![
+            S3FileInfo { name: "data/discogs_20260101_artists.xml.gz".to_string(), size: 1000 },
+            S3FileInfo { name: "data/discogs_20260101_labels.xml.gz".to_string(), size: 1000 },
+            S3FileInfo { name: "data/discogs_20260101_masters.xml.gz".to_string(), size: 1000 },
+            S3FileInfo { name: "data/discogs_20260101_releases.xml.gz".to_string(), size: 1000 },
+            S3FileInfo { name: "data/discogs_20260101_CHECKSUM.txt".to_string(), size: 100 },
+        ])
+    });
+    mock_dl.expect_get_latest_monthly_files().returning(|_| {
+        Ok(vec![
+            S3FileInfo { name: "discogs_20260101_artists.xml.gz".to_string(), size: 1000 },
+            S3FileInfo { name: "discogs_20260101_labels.xml.gz".to_string(), size: 1000 },
+            S3FileInfo { name: "discogs_20260101_masters.xml.gz".to_string(), size: 1000 },
+            S3FileInfo { name: "discogs_20260101_releases.xml.gz".to_string(), size: 1000 },
+        ])
+    });
+    mock_dl.expect_set_state_marker().times(1).returning(|_, _| ());
+    mock_dl.expect_download_discogs_data().times(1).returning(|| Ok(vec!["discogs_20260101_artists.xml.gz".to_string()]));
+    mock_dl.expect_take_state_marker().times(1).returning(move || Some(marker.clone()));
+    mock_dl
+}
+
+/// Regression for discogsography-cu2.42: on the resumed all-files-already-processed
+/// completion path, a failed extraction_complete broadcast must NOT flip the state marker
+/// to fully Completed — otherwise should_process() returns Skip forever and the completion
+/// signal is permanently lost. The marker must stay retryable, and a later successful send
+/// must then finalize it.
+#[tokio::test]
+async fn test_process_discogs_data_resumed_completion_amqp_failure_stays_retryable() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = Arc::new(test_config(temp_dir.path()));
+    let shutdown = Arc::new(tokio::sync::Notify::new());
+    let marker_path = StateMarker::file_path(&config.discogs_root, "20260101");
+
+    // Marker: processing started, the single file complete → resumed-empty branch,
+    // overall_status still InProgress (extraction not yet broadcast).
+    let mut marker = StateMarker::new("20260101".to_string());
+    marker.start_processing(1);
+    marker.start_file_processing("discogs_20260101_artists.xml.gz");
+    marker.complete_file_processing("discogs_20260101_artists.xml.gz", 1000);
+    assert_ne!(marker.summary.overall_status, PhaseStatus::Completed);
+
+    // Phase 1: AMQP broadcast fails (RabbitMQ restarting).
+    struct FailingMqFactory;
+    #[async_trait::async_trait]
+    impl extractor::extractor::MessageQueueFactory for FailingMqFactory {
+        async fn create(&self, _url: &str, _prefix: &str) -> anyhow::Result<Arc<dyn extractor::message_queue::MessagePublisher>> {
+            Err(anyhow::anyhow!("AMQP connection refused"))
+        }
+    }
+    let mut mock_dl = mock_dl_returning_marker(marker.clone());
+    let state = Arc::new(RwLock::new(ExtractorState::default()));
+    let result =
+        extractor::extractor::process_discogs_data(config.clone(), state, shutdown.clone(), false, &mut mock_dl, Arc::new(FailingMqFactory), None)
+            .await;
+    assert!(result.is_ok(), "a send failure is logged, not fatal");
+
+    let persisted = StateMarker::load(&marker_path).await.unwrap().expect("marker must be persisted");
+    assert_ne!(
+        persisted.summary.overall_status,
+        PhaseStatus::Completed,
+        "must not mark Completed when extraction_complete failed to send — it would Skip forever"
+    );
+    assert!(matches!(persisted.should_process(), ProcessingDecision::Continue), "unsent completion must remain retryable (Continue), not Skip");
+
+    // Phase 2: next cycle, RabbitMQ is back — the broadcast succeeds and finalizes the marker.
+    let mut mock_ok = MockMessagePublisher::new();
+    mock_ok.expect_send_extraction_complete().times(1).returning(|_, _, _, _| Ok(()));
+    mock_ok.expect_close().returning(|| Ok(()));
+    let ok_factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_ok) });
+
+    let mut mock_dl2 = mock_dl_returning_marker(persisted);
+    let state2 = Arc::new(RwLock::new(ExtractorState::default()));
+    let result2 = extractor::extractor::process_discogs_data(config.clone(), state2, shutdown, false, &mut mock_dl2, ok_factory, None).await;
+    assert!(result2.is_ok() && result2.unwrap());
+
+    let finalized = StateMarker::load(&marker_path).await.unwrap().expect("marker must be persisted");
+    assert_eq!(finalized.summary.overall_status, PhaseStatus::Completed, "a successful retry broadcast must finalize the marker as Completed");
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/extractor/tests/extractor_di_test.rs
+++ b/extractor/tests/extractor_di_test.rs
@@ -502,6 +502,76 @@ async fn test_process_discogs_data_resumed_completion_amqp_failure_stays_retryab
     assert_eq!(finalized.summary.overall_status, PhaseStatus::Completed, "a successful retry broadcast must finalize the marker as Completed");
 }
 
+/// Regression for discogsography-cu2.92: after a crash-and-resume, extraction_complete's
+/// record_counts must carry the TRUE per-type totals for types completed in an earlier
+/// session — not 0. The per-run ExtractionProgress is reset each run, so counts must come
+/// from the persisted progress_by_file. This also verifies the /health rehydration: the
+/// resumed run's ExtractionProgress reflects the pre-crash totals rather than 0.
+#[tokio::test]
+async fn test_process_discogs_data_resumed_record_counts_from_persisted_progress() {
+    use std::collections::HashMap;
+    use std::sync::Mutex as StdMutex;
+
+    let temp_dir = TempDir::new().unwrap();
+    let config = Arc::new(test_config(temp_dir.path()));
+    let state = Arc::new(RwLock::new(ExtractorState::default()));
+    let shutdown = Arc::new(tokio::sync::Notify::new());
+
+    // Marker from an earlier session: artists + labels completed (real counts), processing
+    // still InProgress (complete_processing was never reached before the crash).
+    let mut marker = StateMarker::new("20260101".to_string());
+    marker.start_processing(2);
+    marker.start_file_processing("discogs_20260101_artists.xml.gz");
+    marker.complete_file_processing("discogs_20260101_artists.xml.gz", 1000);
+    marker.start_file_processing("discogs_20260101_labels.xml.gz");
+    marker.complete_file_processing("discogs_20260101_labels.xml.gz", 2000);
+    assert_eq!(marker.processing_phase.status, PhaseStatus::InProgress);
+
+    let mut mock_dl = MockDataSource::new();
+    mock_dl.expect_list_s3_files().returning(|| {
+        Ok(vec![
+            S3FileInfo { name: "data/discogs_20260101_artists.xml.gz".to_string(), size: 1000 },
+            S3FileInfo { name: "data/discogs_20260101_labels.xml.gz".to_string(), size: 1000 },
+        ])
+    });
+    mock_dl.expect_get_latest_monthly_files().returning(|_| {
+        Ok(vec![
+            S3FileInfo { name: "discogs_20260101_artists.xml.gz".to_string(), size: 1000 },
+            S3FileInfo { name: "discogs_20260101_labels.xml.gz".to_string(), size: 1000 },
+        ])
+    });
+    mock_dl.expect_set_state_marker().times(1).returning(|_, _| ());
+    mock_dl
+        .expect_download_discogs_data()
+        .times(1)
+        .returning(|| Ok(vec!["discogs_20260101_artists.xml.gz".to_string(), "discogs_20260101_labels.xml.gz".to_string()]));
+    mock_dl.expect_take_state_marker().times(1).returning(move || Some(marker.clone()));
+
+    // Capture the record_counts actually broadcast.
+    let captured: Arc<StdMutex<Option<HashMap<String, u64>>>> = Arc::new(StdMutex::new(None));
+    let captured_clone = captured.clone();
+    let mut mock_mq = MockMessagePublisher::new();
+    mock_mq.expect_send_extraction_complete().times(1).returning(move |_version, _started, counts, _types| {
+        *captured_clone.lock().unwrap() = Some(counts);
+        Ok(())
+    });
+    mock_mq.expect_close().returning(|| Ok(()));
+    let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
+
+    let result = extractor::extractor::process_discogs_data(config, state.clone(), shutdown, false, &mut mock_dl, factory, None).await;
+    assert!(result.is_ok() && result.unwrap());
+
+    // The broadcast must report the true pre-crash totals, NOT 0.
+    let counts = captured.lock().unwrap().clone().expect("extraction_complete must have been sent");
+    assert_eq!(counts.get("artists").copied(), Some(1000), "artists count must come from persisted progress, not the reset per-run counter");
+    assert_eq!(counts.get("labels").copied(), Some(2000), "labels count must come from persisted progress, not the reset per-run counter");
+
+    // /health rehydration: the resumed run's ExtractionProgress reflects the pre-crash totals.
+    let s = state.read().await;
+    assert_eq!(s.extraction_progress.artists, 1000, "resume must rehydrate artists progress for /health");
+    assert_eq!(s.extraction_progress.labels, 2000, "resume must rehydrate labels progress for /health");
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // MusicBrainz pipeline tests
 // ──────────────────────────────────────────────────────────────────────────────

--- a/extractor/tests/extractor_di_test.rs
+++ b/extractor/tests/extractor_di_test.rs
@@ -120,7 +120,9 @@ async fn test_process_discogs_data_empty_files() {
     let mock_mq = MockMessagePublisher::new();
     let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
 
-    let result = extractor::extractor::process_discogs_data(config, state, shutdown, false, &mut mock_dl, factory, None).await;
+    let result =
+        extractor::extractor::process_discogs_data(config, state, shutdown, Arc::new(AtomicBool::new(false)), false, &mut mock_dl, factory, None)
+            .await;
 
     assert!(result.is_ok());
     assert!(result.unwrap());
@@ -162,7 +164,9 @@ async fn test_process_discogs_data_skip_when_already_complete() {
     let mock_mq = MockMessagePublisher::new();
     let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
 
-    let result = extractor::extractor::process_discogs_data(config, state, shutdown, false, &mut mock_dl, factory, None).await;
+    let result =
+        extractor::extractor::process_discogs_data(config, state, shutdown, Arc::new(AtomicBool::new(false)), false, &mut mock_dl, factory, None)
+            .await;
 
     assert!(result.is_ok());
     assert!(result.unwrap());
@@ -220,7 +224,9 @@ async fn test_process_discogs_data_force_reprocess_bypasses_skip() {
 
     let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
 
-    let result = extractor::extractor::process_discogs_data(config, state, shutdown, true, &mut mock_dl, factory, None).await;
+    let result =
+        extractor::extractor::process_discogs_data(config, state, shutdown, Arc::new(AtomicBool::new(false)), true, &mut mock_dl, factory, None)
+            .await;
 
     // Result may be Ok or Err — key assertion is download_discogs_data was called (verified by mock times(1))
     let _ = result;
@@ -270,7 +276,9 @@ async fn test_process_discogs_data_take_state_marker_none() {
     let mock_mq = MockMessagePublisher::new();
     let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
 
-    let result = extractor::extractor::process_discogs_data(config, state, shutdown, true, &mut mock_dl, factory, None).await;
+    let result =
+        extractor::extractor::process_discogs_data(config, state, shutdown, Arc::new(AtomicBool::new(false)), true, &mut mock_dl, factory, None)
+            .await;
 
     assert!(result.is_err());
     let err_msg = format!("{}", result.err().unwrap());
@@ -310,7 +318,9 @@ async fn test_process_discogs_data_no_data_files() {
     let mock_mq = MockMessagePublisher::new();
     let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
 
-    let result = extractor::extractor::process_discogs_data(config, state, shutdown, true, &mut mock_dl, factory, None).await;
+    let result =
+        extractor::extractor::process_discogs_data(config, state, shutdown, Arc::new(AtomicBool::new(false)), true, &mut mock_dl, factory, None)
+            .await;
 
     // Should return Ok(true) — "No data files to process"
     assert!(result.is_ok());
@@ -358,7 +368,9 @@ async fn test_process_discogs_data_all_files_already_processed() {
 
     let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
 
-    let result = extractor::extractor::process_discogs_data(config, state, shutdown, true, &mut mock_dl, factory, None).await;
+    let result =
+        extractor::extractor::process_discogs_data(config, state, shutdown, Arc::new(AtomicBool::new(false)), true, &mut mock_dl, factory, None)
+            .await;
 
     assert!(result.is_ok());
     assert!(result.unwrap());
@@ -409,7 +421,9 @@ async fn test_process_discogs_data_mq_factory_create_fails_on_all_processed() {
     }
     let factory = Arc::new(FailingMqFactory);
 
-    let result = extractor::extractor::process_discogs_data(config, state, shutdown, true, &mut mock_dl, factory, None).await;
+    let result =
+        extractor::extractor::process_discogs_data(config, state, shutdown, Arc::new(AtomicBool::new(false)), true, &mut mock_dl, factory, None)
+            .await;
 
     // Should still succeed (extraction_complete failure is logged, not fatal)
     assert!(result.is_ok());
@@ -474,9 +488,17 @@ async fn test_process_discogs_data_resumed_completion_amqp_failure_stays_retryab
     }
     let mut mock_dl = mock_dl_returning_marker(marker.clone());
     let state = Arc::new(RwLock::new(ExtractorState::default()));
-    let result =
-        extractor::extractor::process_discogs_data(config.clone(), state, shutdown.clone(), false, &mut mock_dl, Arc::new(FailingMqFactory), None)
-            .await;
+    let result = extractor::extractor::process_discogs_data(
+        config.clone(),
+        state,
+        shutdown.clone(),
+        Arc::new(AtomicBool::new(false)),
+        false,
+        &mut mock_dl,
+        Arc::new(FailingMqFactory),
+        None,
+    )
+    .await;
     assert!(result.is_ok(), "a send failure is logged, not fatal");
 
     let persisted = StateMarker::load(&marker_path).await.unwrap().expect("marker must be persisted");
@@ -495,7 +517,17 @@ async fn test_process_discogs_data_resumed_completion_amqp_failure_stays_retryab
 
     let mut mock_dl2 = mock_dl_returning_marker(persisted);
     let state2 = Arc::new(RwLock::new(ExtractorState::default()));
-    let result2 = extractor::extractor::process_discogs_data(config.clone(), state2, shutdown, false, &mut mock_dl2, ok_factory, None).await;
+    let result2 = extractor::extractor::process_discogs_data(
+        config.clone(),
+        state2,
+        shutdown,
+        Arc::new(AtomicBool::new(false)),
+        false,
+        &mut mock_dl2,
+        ok_factory,
+        None,
+    )
+    .await;
     assert!(result2.is_ok() && result2.unwrap());
 
     let finalized = StateMarker::load(&marker_path).await.unwrap().expect("marker must be persisted");
@@ -558,7 +590,17 @@ async fn test_process_discogs_data_resumed_record_counts_from_persisted_progress
     mock_mq.expect_close().returning(|| Ok(()));
     let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
 
-    let result = extractor::extractor::process_discogs_data(config, state.clone(), shutdown, false, &mut mock_dl, factory, None).await;
+    let result = extractor::extractor::process_discogs_data(
+        config,
+        state.clone(),
+        shutdown,
+        Arc::new(AtomicBool::new(false)),
+        false,
+        &mut mock_dl,
+        factory,
+        None,
+    )
+    .await;
     assert!(result.is_ok() && result.unwrap());
 
     // The broadcast must report the true pre-crash totals, NOT 0.
@@ -1372,7 +1414,7 @@ async fn test_process_discogs_data_all_processed_extraction_complete_send_fails(
 
     let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
 
-    let result = process_discogs_data(config, state, shutdown, true, &mut mock_dl, factory, None).await;
+    let result = process_discogs_data(config, state, shutdown, Arc::new(AtomicBool::new(false)), true, &mut mock_dl, factory, None).await;
 
     // Still returns Ok(true) — failure of extraction_complete is logged but not fatal in this path
     assert!(result.is_ok());
@@ -1593,7 +1635,7 @@ async fn test_process_discogs_data_reprocess_decision() {
 
     let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
 
-    let result = process_discogs_data(config, state, shutdown, false, &mut mock_dl, factory, None).await;
+    let result = process_discogs_data(config, state, shutdown, Arc::new(AtomicBool::new(false)), false, &mut mock_dl, factory, None).await;
 
     // Key assertion: download_discogs_data was called (Reprocess path taken)
     let _ = result;
@@ -1641,7 +1683,7 @@ async fn test_process_discogs_data_end_to_end_success() {
 
     let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
 
-    let result = process_discogs_data(config, state.clone(), shutdown, false, &mut mock_dl, factory, None).await;
+    let result = process_discogs_data(config, state.clone(), shutdown, Arc::new(AtomicBool::new(false)), false, &mut mock_dl, factory, None).await;
 
     assert!(result.is_ok(), "End-to-end processing should succeed: {:?}", result);
     assert!(result.unwrap(), "Should return true for successful processing");
@@ -1650,6 +1692,62 @@ async fn test_process_discogs_data_end_to_end_success() {
     assert_eq!(s.extraction_status, ExtractionStatus::Completed);
     assert!(s.completed_files.contains("discogs_20260101_artists.xml.gz"));
     assert_eq!(s.extraction_progress.artists, 1);
+}
+
+/// Regression for cu2.44: a shutdown flag already set when process_discogs_data reaches the file
+/// loop must stop it from starting (and therefore finalizing) the run. The not-yet-started file is
+/// skipped so it stays pending in the state marker for a clean resume, the run is NOT marked
+/// Completed, and it returns Ok(false) — never Err (which would send main into the failure
+/// cooldown). Mirrors test_process_discogs_data_end_to_end_success but with the flag pre-set.
+#[tokio::test]
+async fn test_process_discogs_data_shutdown_before_files_does_not_finalize() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let xml_content = r#"<?xml version="1.0" encoding="UTF-8"?>
+<artists>
+    <artist id="1">
+        <name>Test Artist</name>
+    </artist>
+</artists>"#;
+    create_gzipped_xml_file(temp_dir.path(), "discogs_20260101_artists.xml.gz", xml_content);
+
+    let config = Arc::new(test_config(temp_dir.path()));
+    let state = Arc::new(RwLock::new(ExtractorState::default()));
+    let shutdown = Arc::new(tokio::sync::Notify::new());
+
+    // Shutdown already requested by the time processing reaches the file loop.
+    let shutdown_flag = Arc::new(AtomicBool::new(true));
+
+    let mut mock_dl = MockDataSource::new();
+    mock_dl
+        .expect_list_s3_files()
+        .returning(|| Ok(vec![S3FileInfo { name: "data/discogs_20260101_artists.xml.gz".to_string(), size: 1000 }]));
+    mock_dl
+        .expect_get_latest_monthly_files()
+        .returning(|_| Ok(vec![S3FileInfo { name: "discogs_20260101_artists.xml.gz".to_string(), size: 1000 }]));
+    mock_dl.expect_set_state_marker().times(1).returning(|_, _| ());
+    mock_dl.expect_download_discogs_data().times(1).returning(|| Ok(vec!["discogs_20260101_artists.xml.gz".to_string()]));
+    mock_dl.expect_take_state_marker().times(1).returning(|| Some(StateMarker::new("20260101".to_string())));
+
+    let mut mock_mq = MockMessagePublisher::new();
+    mock_mq.expect_setup_exchange().returning(|_| Ok(()));
+    mock_mq.expect_publish_batch().returning(|_, _| Ok(()));
+    mock_mq.expect_send_file_complete().returning(|_, _, _| Ok(()));
+    mock_mq.expect_send_extraction_complete().returning(|_, _, _, _| Ok(()));
+    mock_mq.expect_close().returning(|| Ok(()));
+
+    let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
+
+    let result = process_discogs_data(config, state.clone(), shutdown, shutdown_flag, false, &mut mock_dl, factory, None).await;
+
+    // Not promoted to Err — a graceful shutdown must not trip main's failure cooldown.
+    assert!(result.is_ok(), "shutdown must not surface as Err: {:?}", result);
+    assert!(!result.unwrap(), "a shutdown-interrupted run must return false (not complete)");
+
+    let s = state.read().await;
+    // The pending file was skipped, so nothing completed and the run is not marked Completed.
+    assert_ne!(s.extraction_status, ExtractionStatus::Completed, "an interrupted run must not report Completed");
+    assert!(!s.completed_files.contains("discogs_20260101_artists.xml.gz"), "skipped file must not be marked completed");
 }
 
 #[tokio::test]
@@ -1702,7 +1800,8 @@ rules:
 "#,
     );
 
-    let result = process_discogs_data(config, state.clone(), shutdown, false, &mut mock_dl, factory, Some(rules)).await;
+    let result =
+        process_discogs_data(config, state.clone(), shutdown, Arc::new(AtomicBool::new(false)), false, &mut mock_dl, factory, Some(rules)).await;
 
     assert!(result.is_ok(), "End-to-end with rules should succeed: {:?}", result);
     assert!(result.unwrap());
@@ -1754,7 +1853,7 @@ async fn test_process_discogs_data_extraction_complete_failure() {
 
     let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
 
-    let result = process_discogs_data(config, state.clone(), shutdown, false, &mut mock_dl, factory, None).await;
+    let result = process_discogs_data(config, state.clone(), shutdown, Arc::new(AtomicBool::new(false)), false, &mut mock_dl, factory, None).await;
 
     // Should return Ok(false) — extraction_complete failure makes success=false
     assert!(result.is_ok());
@@ -1824,7 +1923,7 @@ async fn test_process_discogs_data_mq_factory_create_fails_at_extraction_complet
 
     let factory = Arc::new(CountingMqFactory { publisher: Arc::new(mock_mq), call_count });
 
-    let result = process_discogs_data(config, state.clone(), shutdown, false, &mut mock_dl, factory, None).await;
+    let result = process_discogs_data(config, state.clone(), shutdown, Arc::new(AtomicBool::new(false)), false, &mut mock_dl, factory, None).await;
 
     // Should return Ok(false) — extraction_complete MQ connection failure
     assert!(result.is_ok());
@@ -1887,7 +1986,7 @@ async fn test_process_discogs_data_multiple_files() {
 
     let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
 
-    let result = process_discogs_data(config, state.clone(), shutdown, false, &mut mock_dl, factory, None).await;
+    let result = process_discogs_data(config, state.clone(), shutdown, Arc::new(AtomicBool::new(false)), false, &mut mock_dl, factory, None).await;
 
     assert!(result.is_ok());
     assert!(result.unwrap());
@@ -1921,7 +2020,7 @@ async fn test_process_discogs_data_version_extraction_failure() {
     let mock_mq = MockMessagePublisher::new();
     let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
 
-    let result = process_discogs_data(config, state, shutdown, false, &mut mock_dl, factory, None).await;
+    let result = process_discogs_data(config, state, shutdown, Arc::new(AtomicBool::new(false)), false, &mut mock_dl, factory, None).await;
 
     assert!(result.is_err());
 }
@@ -1943,7 +2042,7 @@ async fn test_process_discogs_data_list_s3_files_failure() {
     let mock_mq = MockMessagePublisher::new();
     let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
 
-    let result = process_discogs_data(config, state, shutdown, false, &mut mock_dl, factory, None).await;
+    let result = process_discogs_data(config, state, shutdown, Arc::new(AtomicBool::new(false)), false, &mut mock_dl, factory, None).await;
 
     assert!(result.is_err());
 }
@@ -1972,7 +2071,7 @@ async fn test_process_discogs_data_download_failure() {
     let mock_mq = MockMessagePublisher::new();
     let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
 
-    let result = process_discogs_data(config, state, shutdown, false, &mut mock_dl, factory, None).await;
+    let result = process_discogs_data(config, state, shutdown, Arc::new(AtomicBool::new(false)), false, &mut mock_dl, factory, None).await;
 
     assert!(result.is_err());
 }

--- a/graphinator/batch_processor.py
+++ b/graphinator/batch_processor.py
@@ -33,6 +33,9 @@ class BatchConfig:
     backoff_max: float = 30.0  # Maximum backoff delay (seconds)
     backoff_multiplier: float = 2.0  # Exponential backoff multiplier
     max_flush_retries: int = 5  # Max retries per data type during flush_queue drain
+    max_poison_retries: int = (
+        5  # Consecutive non-transient failures before nacking a poison batch to the DLQ
+    )
 
 
 @dataclass
@@ -315,18 +318,62 @@ class Neo4jBatchProcessor:
                 return
 
             except Exception as e:
+                # A generic (non-transient) error is deterministic — a poison
+                # record (e.g. a data-induced Neo4j ClientError) fails every
+                # retry. Count consecutive failures so the local retry loop is
+                # BOUNDED; otherwise the identical batch is re-enqueued and
+                # retried forever, and once its unacked messages fill the
+                # prefetch window RabbitMQ stops delivering and the consumer is
+                # permanently wedged (never acked, never nacked).
+                self._consecutive_failures[data_type] = (
+                    self._consecutive_failures.get(data_type, 0) + 1
+                )
+
+                if (
+                    self._consecutive_failures[data_type]
+                    >= self.config.max_poison_retries
+                ):
+                    # Poison batch: stop re-enqueueing and nack the messages so
+                    # the quorum queue's x-delivery-limit / DLX routes the
+                    # persistent poison to the DLQ. _flush_queue is the single
+                    # ack/nack authority.
+                    logger.error(
+                        "❌ Poison batch — nacking to DLQ after repeated failures",
+                        data_type=data_type,
+                        batch_size=len(messages),
+                        consecutive_failures=self._consecutive_failures[data_type],
+                        error=str(e),
+                    )
+                    for msg in messages:
+                        try:
+                            await msg.nack_callback()
+                        except Exception as nack_err:
+                            logger.warning(
+                                "⚠️ Failed to nack message", error=str(nack_err)
+                            )
+                    # Reset per-data-type state so healthy batches behind the
+                    # poison resume normal processing.
+                    self._consecutive_failures[data_type] = 0
+                    self._backoff_until[data_type] = 0.0
+                    self._effective_batch_size[data_type] = self.config.batch_size
+                    return
+
                 logger.error(
                     "❌ Batch processing error",
                     data_type=data_type,
                     batch_size=len(messages),
+                    consecutive_failures=self._consecutive_failures[data_type],
                     error=str(e),
                 )
-                # Re-enqueue messages for local retry before AMQP nack
+                # Re-enqueue messages for local retry — bounded by the poison
+                # guard above so a deterministic error can no longer loop forever.
                 for msg in reversed(messages):
                     queue.appendleft(msg)
-                # Track failures for non-transient errors too, to enable backoff
-                self._consecutive_failures[data_type] = (
-                    self._consecutive_failures.get(data_type, 0) + 1
+                # Shrink the batch to isolate the poison record and cap DLQ
+                # collateral when the guard eventually fires.
+                self._effective_batch_size[data_type] = max(
+                    self.config.min_batch_size,
+                    self._effective_batch_size[data_type] // 2,
                 )
                 # Apply backoff to prevent tight retry loop on persistent errors
                 delay = min(

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -748,11 +748,27 @@ async def cleanup_stub_nodes(data_type: str) -> bool:
     if not label:
         return True
 
+    # Batch the deletion with CALL {} IN TRANSACTIONS so a large stub-node set
+    # (cross-type MERGEs can leave hundreds of thousands to millions of
+    # property-less stubs after a full import) does not run in one implicit
+    # transaction — a single unbatched DETACH DELETE blows the Neo4j
+    # transaction memory limit (dbms.memory.transaction.total.max) or the
+    # default 120s timeout, and the swallowed error would leave the stubs
+    # forever. Mirrors the compute_genre_style_stats batching in this file: the
+    # driving MATCH sits OUTSIDE the transactional subquery and the node is
+    # re-imported via WITH, so each inner transaction deletes at most one chunk.
+    cleanup_cypher = f"""
+    MATCH (n:{label})
+    WHERE n.sha256 IS NULL
+    CALL {{
+        WITH n
+        DETACH DELETE n
+    }} IN TRANSACTIONS OF 10000 ROWS
+    """
+
     try:
         async with graph.session(database="neo4j") as session:
-            result = await session.run(
-                f"MATCH (n:{label}) WHERE n.sha256 IS NULL DETACH DELETE n",
-            )
+            result = await session.run(cleanup_cypher)
             summary = await result.consume()
             deleted = summary.counters.nodes_deleted
 

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -525,13 +525,17 @@ async def compute_genre_style_stats() -> None:
     if graph is None:
         return
 
-    # Use CALL {} IN TRANSACTIONS OF 1 ROWS to process each genre/style
-    # in its own transaction.  This avoids the default 120s transaction
-    # timeout — each individual node takes ~10-30s (even for Electronic/Rock
-    # with millions of releases), well within the limit.
+    # Drive the batching with an outer MATCH so CALL {} IN TRANSACTIONS actually
+    # commits one inner transaction per node (OF 1 ROWS = one genre/style per
+    # transaction).  The driving MATCH MUST sit OUTSIDE the transactional
+    # subquery, with the node re-imported via WITH; otherwise nothing precedes
+    # the CALL, exactly one implicit input row drives it, and the entire update
+    # runs in a SINGLE transaction — defeating the batching and hitting the
+    # default 120s transaction timeout (each node takes ~10-30s).
     genre_cypher = """
+    MATCH (g:Genre)
     CALL {
-        MATCH (g:Genre)
+        WITH g
         CALL {
             WITH g
             MATCH (g)<-[:IS]-(r:Release)
@@ -565,8 +569,9 @@ async def compute_genre_style_stats() -> None:
     """
 
     style_cypher = """
+    MATCH (s:Style)
     CALL {
-        MATCH (s:Style)
+        WITH s
         CALL {
             WITH s
             MATCH (s)<-[:IS]-(r:Release)
@@ -604,8 +609,9 @@ async def compute_genre_style_stats() -> None:
     # but most labels have <100 releases so each batch computes quickly.
     # Use IN TRANSACTIONS OF 100 ROWS for throughput.
     label_cypher = """
+    MATCH (l:Label)
     CALL {
-        MATCH (l:Label)
+        WITH l
         CALL {
             WITH l
             MATCH (l)<-[:ON]-(r:Release)

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -702,6 +702,25 @@ async def compute_genre_style_stats() -> bool:
     return True
 
 
+async def cleanup_all_stub_nodes() -> bool:
+    """Clean up stub nodes for every entity label once all data is imported.
+
+    Called only after every data type has delivered extraction_complete, so no
+    consumer is still MERGEing cross-type stubs. Runs cleanup for all labels
+    (Artist, Label, Master, Release) rather than a single type, because release
+    batches create stubs of every other type.
+
+    Returns:
+        True if all label cleanups succeeded, False if any failed — so the
+        caller can nack and retry (each cleanup is idempotent).
+    """
+    ok = True
+    for data_type in DATA_TYPES:
+        if not await cleanup_stub_nodes(data_type):
+            ok = False
+    return ok
+
+
 async def cleanup_stub_nodes(data_type: str) -> bool:
     """Delete stub nodes that have no sha256 property.
 

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -1106,7 +1106,13 @@ def make_message_handler(
                     data_type,
                     record,
                     message.ack,
-                    lambda: message.nack(requeue=True),
+                    # requeue=False: this callback nacks permanently-invalid
+                    # input (unknown data_type, missing 'id', normalize failure,
+                    # poison batch) — send it straight to the DLQ instead of
+                    # cycling x-delivery-limit (20) futile redeliveries. Transient
+                    # failures are handled by _flush_queue's re-enqueue+backoff,
+                    # which never nacks.
+                    lambda: message.nack(requeue=False),
                 )
                 if accepted:
                     # Note: message_counts tracks received (not processed) messages in

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -461,6 +461,11 @@ async def _recover_consumers() -> None:
         active_connection = None  # noqa: F841
         active_channel = None  # noqa: F841
         queues = {}  # noqa: F841
+        # Clear stale consumer tags: any consumers registered before the error
+        # died with the now-closed connection. Leaving them behind would keep
+        # len(consumer_tags) > 0 forever, permanently gating off both recovery
+        # routes (stuck-check requires 0 tags) while health still reads healthy.
+        consumer_tags.clear()
 
 
 async def check_file_completion(

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -413,8 +413,14 @@ async def _recover_consumers() -> None:
                 await queue.bind(exchange)
                 queues[data_type] = queue
 
-            # Start consumers for queues with messages
-            for data_type, msg_count in queues_with_messages:
+            # Start consumers for ALL data types lacking one — not just those
+            # with a current backlog. A type whose queue was empty at the
+            # passive-declare instant still needs a consumer; otherwise messages
+            # that arrive later are never consumed, because once active_connection
+            # is set and consumer_tags is non-empty both periodic recovery routes
+            # are permanently gated off, silently starving that data type.
+            pending_counts = dict(queues_with_messages)
+            for data_type in DATA_TYPES:
                 if data_type in queues and data_type not in consumer_tags:
                     handler = HANDLERS.get(data_type)
                     if handler:
@@ -422,12 +428,14 @@ async def _recover_consumers() -> None:
                             handler, consumer_tag=f"graphinator-{data_type}"
                         )
                         consumer_tags[data_type] = consumer_tag
-                        # Remove from completed files so it will be processed
-                        completed_files.discard(data_type)
+                        # Only un-complete a type that actually has a backlog, so
+                        # genuinely-finished types stay marked complete.
+                        if data_type in pending_counts:
+                            completed_files.discard(data_type)
                         last_message_time[data_type] = time.time()
                         logger.info(
                             f"✅ Started consumer for {data_type} "
-                            f"(pending: {msg_count})"
+                            f"(pending: {pending_counts.get(data_type, 0)})"
                         )
 
             logger.info(

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -716,20 +716,20 @@ async def cleanup_stub_nodes(data_type: str) -> None:
         )
 
 
-def process_artist(tx: Any, record: dict[str, Any]) -> bool:
+async def process_artist(tx: Any, record: dict[str, Any]) -> bool:
     """Process artist within a single transaction for atomicity."""
-    existing_result = tx.run(
+    existing_result = await tx.run(
         "MATCH (a:Artist {id: $id}) RETURN a.sha256 AS hash",
         id=record["id"],
     )
-    existing_record = existing_result.single()
+    existing_record = await existing_result.single()
     if existing_record and existing_record["hash"] == record["sha256"]:
         return False  # No update needed
 
     resources: str = f"https://api.discogs.com/artists/{record['id']}"
     releases: str = f"{resources}/releases"
 
-    tx.run(
+    await tx.run(
         "MERGE (a:Artist {id: $id}) "
         "ON CREATE SET a.name = $name, a.resource_url = $resource_url, a.releases_url = $releases_url, a.sha256 = $sha256 "
         "ON MATCH SET a.name = $name, a.resource_url = $resource_url, a.releases_url = $releases_url, a.sha256 = $sha256",
@@ -745,7 +745,7 @@ def process_artist(tx: Any, record: dict[str, Any]) -> bool:
     if members:
         valid_members = [m for m in members if m.get("id")]
         if valid_members:
-            tx.run(
+            await tx.run(
                 "UNWIND $members AS member "
                 "MATCH (a:Artist {id: $artist_id}) "
                 "MERGE (m_a:Artist {id: member.id}) "
@@ -759,7 +759,7 @@ def process_artist(tx: Any, record: dict[str, Any]) -> bool:
     if groups:
         valid_groups = [g for g in groups if g.get("id")]
         if valid_groups:
-            tx.run(
+            await tx.run(
                 "UNWIND $groups AS group "
                 "MATCH (a:Artist {id: $artist_id}) "
                 "MERGE (g_a:Artist {id: group.id}) "
@@ -773,7 +773,7 @@ def process_artist(tx: Any, record: dict[str, Any]) -> bool:
     if aliases:
         valid_aliases = [a for a in aliases if a.get("id")]
         if valid_aliases:
-            tx.run(
+            await tx.run(
                 "UNWIND $aliases AS alias "
                 "MATCH (a:Artist {id: $artist_id}) "
                 "MERGE (a_a:Artist {id: alias.id}) "
@@ -785,16 +785,16 @@ def process_artist(tx: Any, record: dict[str, Any]) -> bool:
     return True  # Updated successfully
 
 
-def process_label(tx: Any, record: dict[str, Any]) -> bool:
+async def process_label(tx: Any, record: dict[str, Any]) -> bool:
     """Process label within a single transaction for atomicity."""
-    existing_result = tx.run(
+    existing_result = await tx.run(
         "MATCH (l:Label {id: $id}) RETURN l.sha256 AS hash", id=record["id"]
     )
-    existing_record = existing_result.single()
+    existing_record = await existing_result.single()
     if existing_record and existing_record["hash"] == record["sha256"]:
         return False  # No update needed
 
-    tx.run(
+    await tx.run(
         "MERGE (l:Label {id: $id}) "
         "ON CREATE SET l.name = $name, l.sha256 = $sha256 "
         "ON MATCH SET l.name = $name, l.sha256 = $sha256",
@@ -806,7 +806,7 @@ def process_label(tx: Any, record: dict[str, Any]) -> bool:
     # Handle parent label relationship (normalized to {"id": ...} dict)
     parent: dict[str, Any] | None = record.get("parentLabel")
     if parent and parent.get("id"):
-        tx.run(
+        await tx.run(
             "MATCH (l:Label {id: $id}) "
             "MERGE (p_l:Label {id: $p_id}) "
             "MERGE (l)-[:SUBLABEL_OF]->(p_l)",
@@ -819,7 +819,7 @@ def process_label(tx: Any, record: dict[str, Any]) -> bool:
     if sublabels:
         valid_sublabels = [s for s in sublabels if s.get("id")]
         if valid_sublabels:
-            tx.run(
+            await tx.run(
                 "UNWIND $sublabels AS sublabel "
                 "MATCH (l:Label {id: $label_id}) "
                 "MERGE (s_l:Label {id: sublabel.id}) "
@@ -831,17 +831,17 @@ def process_label(tx: Any, record: dict[str, Any]) -> bool:
     return True  # Updated successfully
 
 
-def process_master(tx: Any, record: dict[str, Any]) -> bool:
+async def process_master(tx: Any, record: dict[str, Any]) -> bool:
     """Process master within a single transaction for atomicity."""
-    existing_result = tx.run(
+    existing_result = await tx.run(
         "MATCH (m:Master {id: $id}) RETURN m.sha256 AS hash",
         id=record["id"],
     )
-    existing_record = existing_result.single()
+    existing_record = await existing_result.single()
     if existing_record and existing_record["hash"] == record["sha256"]:
         return False  # No update needed
 
-    tx.run(
+    await tx.run(
         "MERGE (m:Master {id: $id}) "
         "ON CREATE SET m.title = $title, m.year = $year, m.sha256 = $sha256 "
         "ON MATCH SET m.title = $title, m.year = $year, m.sha256 = $sha256",
@@ -856,7 +856,7 @@ def process_master(tx: Any, record: dict[str, Any]) -> bool:
     if artists:
         valid_artists = [a for a in artists if a.get("id")]
         if valid_artists:
-            tx.run(
+            await tx.run(
                 "UNWIND $artists AS artist "
                 "MATCH (m:Master {id: $master_id}) "
                 "MERGE (a_m:Artist {id: artist.id}) "
@@ -868,7 +868,7 @@ def process_master(tx: Any, record: dict[str, Any]) -> bool:
     # Handle genres and styles (normalized to string lists)
     genres_list: list[str] = record.get("genres", [])
     if genres_list:
-        tx.run(
+        await tx.run(
             "UNWIND $genres AS genre "
             "MATCH (m:Master {id: $master_id}) "
             "MERGE (g:Genre {name: genre.name}) "
@@ -879,7 +879,7 @@ def process_master(tx: Any, record: dict[str, Any]) -> bool:
 
     styles_list: list[str] = record.get("styles", [])
     if styles_list:
-        tx.run(
+        await tx.run(
             "UNWIND $styles AS style "
             "MATCH (m:Master {id: $master_id}) "
             "MERGE (s:Style {name: style.name}) "
@@ -890,7 +890,7 @@ def process_master(tx: Any, record: dict[str, Any]) -> bool:
 
     # Connect styles to genres if both exist
     if genres_list and styles_list:
-        tx.run(
+        await tx.run(
             "UNWIND $genre_style_pairs AS pair "
             "MERGE (g:Genre {name: pair.genre}) "
             "MERGE (s:Style {name: pair.style}) "
@@ -905,13 +905,13 @@ def process_master(tx: Any, record: dict[str, Any]) -> bool:
     return True  # Updated successfully
 
 
-def process_release(tx: Any, record: dict[str, Any]) -> bool:
+async def process_release(tx: Any, record: dict[str, Any]) -> bool:
     """Process release within a single transaction for atomicity."""
-    existing_result = tx.run(
+    existing_result = await tx.run(
         "MATCH (r:Release {id: $id}) RETURN r.sha256 AS hash",
         id=record["id"],
     )
-    existing_record = existing_result.single()
+    existing_record = await existing_result.single()
     if existing_record and existing_record["hash"] == record["sha256"]:
         return False  # No update needed
 
@@ -920,7 +920,7 @@ def process_release(tx: Any, record: dict[str, Any]) -> bool:
         for f in record.get("formats", [])
         if isinstance(f, dict) and "name" in f
     ]
-    tx.run(
+    await tx.run(
         "MERGE (r:Release {id: $id}) "
         "ON CREATE SET r.title = $title, r.year = $year, r.formats = $formats, r.sha256 = $sha256 "
         "ON MATCH SET r.title = $title, r.year = $year, r.formats = $formats, r.sha256 = $sha256",
@@ -936,7 +936,7 @@ def process_release(tx: Any, record: dict[str, Any]) -> bool:
     if artists:
         valid_artists = [a for a in artists if a.get("id")]
         if valid_artists:
-            tx.run(
+            await tx.run(
                 "UNWIND $artists AS artist "
                 "MATCH (r:Release {id: $release_id}) "
                 "MERGE (a_r:Artist {id: artist.id}) "
@@ -950,7 +950,7 @@ def process_release(tx: Any, record: dict[str, Any]) -> bool:
     if labels:
         valid_labels = [lbl for lbl in labels if lbl.get("id")]
         if valid_labels:
-            tx.run(
+            await tx.run(
                 "UNWIND $labels AS label "
                 "MATCH (r:Release {id: $release_id}) "
                 "MERGE (l_r:Label {id: label.id}) "
@@ -962,7 +962,7 @@ def process_release(tx: Any, record: dict[str, Any]) -> bool:
     # Handle master relationship (normalized to string)
     master_id = record.get("master_id")
     if master_id:
-        tx.run(
+        await tx.run(
             "MATCH (r:Release {id: $id}) "
             "MERGE (m_r:Master {id: $m_id}) "
             "MERGE (r)-[:DERIVED_FROM]->(m_r)",
@@ -973,7 +973,7 @@ def process_release(tx: Any, record: dict[str, Any]) -> bool:
     # Handle genres and styles (normalized to string lists)
     genres_list: list[str] = record.get("genres", [])
     if genres_list:
-        tx.run(
+        await tx.run(
             "UNWIND $genres AS genre "
             "MATCH (r:Release {id: $release_id}) "
             "MERGE (g:Genre {name: genre.name}) "
@@ -984,7 +984,7 @@ def process_release(tx: Any, record: dict[str, Any]) -> bool:
 
     styles_list: list[str] = record.get("styles", [])
     if styles_list:
-        tx.run(
+        await tx.run(
             "UNWIND $styles AS style "
             "MATCH (r:Release {id: $release_id}) "
             "MERGE (s:Style {name: style.name}) "
@@ -995,7 +995,7 @@ def process_release(tx: Any, record: dict[str, Any]) -> bool:
 
     # Connect styles to genres if both exist
     if genres_list and styles_list:
-        tx.run(
+        await tx.run(
             "UNWIND $genre_style_pairs AS pair "
             "MERGE (g:Genre {name: pair.genre}) "
             "MERGE (s:Style {name: pair.style}) "
@@ -1028,7 +1028,7 @@ def process_release(tx: Any, record: dict[str, Any]) -> bool:
                 credit_data.append(entry)
         if credit_data:
             # Create Person nodes and CREDITED_ON relationships
-            tx.run(
+            await tx.run(
                 "UNWIND $credits AS credit "
                 "MATCH (r:Release {id: credit.release_id}) "
                 "MERGE (p:Person {name: credit.name}) "
@@ -1038,7 +1038,7 @@ def process_release(tx: Any, record: dict[str, Any]) -> bool:
             # Create SAME_AS relationships for credited people who are also performing artists
             artist_credits = [c for c in credit_data if c.get("artist_id")]
             if artist_credits:
-                tx.run(
+                await tx.run(
                     "UNWIND $credits AS credit "
                     "MATCH (p:Person {name: credit.name}) "
                     "MATCH (a:Artist {id: credit.artist_id}) "
@@ -1111,8 +1111,8 @@ def make_message_handler(
 
             async with graph.session(database="neo4j") as session:
 
-                def tx_fn(tx: Any) -> bool:
-                    return bool(process_fn(tx, record))
+                async def tx_fn(tx: Any) -> bool:
+                    return bool(await process_fn(tx, record))
 
                 updated = await session.execute_write(tx_fn)
 

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -40,6 +40,11 @@ message_counts = {"artists": 0, "labels": 0, "masters": 0, "releases": 0}
 progress_interval = 100  # Log progress every 100 messages
 last_message_time = {"artists": 0.0, "labels": 0.0, "masters": 0.0, "releases": 0.0}
 completed_files: set[str] = set()  # Track which files have completed processing
+# Track which data types have delivered an extraction_complete signal. Stub
+# cleanup and aggregate stats are deferred until EVERY type has signalled, so
+# cross-type stub creation (release batches MERGE Artist/Label/Master stubs)
+# has fully stopped before we DETACH DELETE.
+extraction_complete_signals: set[str] = set()
 current_task = None
 current_progress = 0.0
 
@@ -504,21 +509,49 @@ async def check_file_completion(
         if batch_processor is not None:
             await batch_processor.flush_queue(data_type)
 
+        # Record this type's completion signal (idempotent — safe under
+        # nack/requeue redelivery).
+        extraction_complete_signals.add(data_type)
+
+        # Defer stub cleanup and stats until EVERY data type has signalled
+        # extraction_complete. The four fanout queues drain at very different
+        # rates (releases is by far the largest and finishes last), and every
+        # release batch MERGEs sha256-less Artist/Label/Master stubs for
+        # dangling references. Cleaning per-type as each queue completes would
+        # race those still-running release writers: stubs re-created after an
+        # early cleanup persist forever, and DETACH DELETE can interleave with
+        # freshly written release edges. Running once — after all four signals
+        # — guarantees no consumer is still creating stubs.
+        if not extraction_complete_signals.issuperset(DATA_TYPES):
+            logger.info(
+                "⏳ Deferring stub cleanup until all data types complete",
+                data_type=data_type,
+                received=sorted(extraction_complete_signals),
+                pending=sorted(set(DATA_TYPES) - extraction_complete_signals),
+            )
+            await message.ack()
+            return True
+
+        logger.info(
+            "🏁 All data types complete — running post-import maintenance",
+            received=sorted(extraction_complete_signals),
+        )
+
         # Post-import maintenance is coupled to the extraction_complete ack:
         # both steps are idempotent, so on failure we nack(requeue=True) to
         # retry rather than acking (and silently skipping) the sole trigger.
         maintenance_ok = True
 
-        # Clean up stub nodes created by cross-type MERGE operations
-        if graph is not None and not await cleanup_stub_nodes(data_type):
+        # Clean up stub nodes created by cross-type MERGE operations, across
+        # EVERY entity label — not just this type's — because release batches
+        # create Artist/Label/Master stubs regardless of which signal arrived
+        # last.
+        if graph is not None and not await cleanup_all_stub_nodes():
             maintenance_ok = False
 
-        # After releases are fully imported, compute aggregate stats on Genre/Style nodes
-        if (
-            graph is not None
-            and data_type == "releases"
-            and not await compute_genre_style_stats()
-        ):
+        # All releases are now imported — compute aggregate stats on
+        # Genre/Style/Label nodes.
+        if graph is not None and not await compute_genre_style_stats():
             maintenance_ok = False
 
         if maintenance_ok:

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -491,21 +491,37 @@ async def check_file_completion(
         if batch_processor is not None:
             await batch_processor.flush_queue(data_type)
 
+        # Post-import maintenance is coupled to the extraction_complete ack:
+        # both steps are idempotent, so on failure we nack(requeue=True) to
+        # retry rather than acking (and silently skipping) the sole trigger.
+        maintenance_ok = True
+
         # Clean up stub nodes created by cross-type MERGE operations
-        if graph is not None:
-            await cleanup_stub_nodes(data_type)
+        if graph is not None and not await cleanup_stub_nodes(data_type):
+            maintenance_ok = False
 
         # After releases are fully imported, compute aggregate stats on Genre/Style nodes
-        if graph is not None and data_type == "releases":
-            await compute_genre_style_stats()
+        if (
+            graph is not None
+            and data_type == "releases"
+            and not await compute_genre_style_stats()
+        ):
+            maintenance_ok = False
 
-        await message.ack()
+        if maintenance_ok:
+            await message.ack()
+        else:
+            logger.error(
+                "❌ Post-import maintenance failed, nacking extraction_complete for retry",
+                data_type=data_type,
+            )
+            await message.nack(requeue=True)
         return True
 
     return False
 
 
-async def compute_genre_style_stats() -> None:
+async def compute_genre_style_stats() -> bool:
     """Pre-compute aggregate counts and first_year on Genre, Style, and Label nodes.
 
     Sets release_count, artist_count, label_count, style_count/genre_count,
@@ -521,9 +537,13 @@ async def compute_genre_style_stats() -> None:
       traversal (for Reprise Records with 55K releases) with ~3 DB hits.
 
     Should be called after all releases have been imported.
+
+    Returns:
+        True if all stats were computed (or there is no driver / no work),
+        False if the computation failed — so the caller can nack and retry.
     """
     if graph is None:
-        return
+        return True
 
     # Drive the batching with an outer MATCH so CALL {} IN TRANSACTIONS actually
     # commits one inner transaction per node (OF 1 ROWS = one genre/style per
@@ -664,18 +684,25 @@ async def compute_genre_style_stats() -> None:
             "❌ Failed to compute genre/style/label stats",
             error=str(e),
         )
+        return False
+
+    return True
 
 
-async def cleanup_stub_nodes(data_type: str) -> None:
+async def cleanup_stub_nodes(data_type: str) -> bool:
     """Delete stub nodes that have no sha256 property.
 
     During extraction, MERGE operations in relationship queries create
     skeleton nodes for cross-referenced entities (e.g., a release referencing
     an artist that hasn't been processed yet). Primary records always set
     sha256, so nodes without it are stubs that were never filled.
+
+    Returns:
+        True if cleanup succeeded (or there is nothing to do), False if the
+        DETACH DELETE failed — so the caller can nack and retry (idempotent).
     """
     if graph is None:
-        return
+        return True
 
     # Map data types to their Neo4j labels
     label_map = {
@@ -687,7 +714,7 @@ async def cleanup_stub_nodes(data_type: str) -> None:
 
     label = label_map.get(data_type)
     if not label:
-        return
+        return True
 
     try:
         async with graph.session(database="neo4j") as session:
@@ -714,6 +741,9 @@ async def cleanup_stub_nodes(data_type: str) -> None:
             data_type=data_type,
             error=str(e),
         )
+        return False
+
+    return True
 
 
 async def process_artist(tx: Any, record: dict[str, Any]) -> bool:

--- a/insights/insights.py
+++ b/insights/insights.py
@@ -127,8 +127,14 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     await _pool.initialize()
     logger.info("🐘 PostgreSQL pool initialized")
 
-    # Initialize HTTP client for API service
-    _http_client = httpx.AsyncClient(base_url=_config.api_base_url, timeout=300.0)
+    # Initialize HTTP client for API service. The API's /api/internal/insights/*
+    # endpoints are gated by a shared secret; present it on every request.
+    _client_headers: dict[str, str] = {}
+    if _config.internal_secret:
+        _client_headers["X-Internal-Secret"] = _config.internal_secret
+    else:
+        logger.warning("⚠️ INSIGHTS_INTERNAL_SECRET is not set — internal API calls will be rejected by the API")
+    _http_client = httpx.AsyncClient(base_url=_config.api_base_url, timeout=300.0, headers=_client_headers)
     logger.info("🔧 API HTTP client initialized", base_url=_config.api_base_url)
 
     # Initialize Redis cache

--- a/mcp-server/mcp_server/server.py
+++ b/mcp-server/mcp_server/server.py
@@ -308,7 +308,7 @@ async def find_path(
         from_type: Type of starting entity (artist, genre, label, style).
         to_name: Name of the destination entity.
         to_type: Type of destination entity (artist, genre, label, style).
-        max_depth: Maximum path length to search (1-15, default 10).
+        max_depth: Maximum path length to search (1-10, default 10).
     """
     from_type_lower = from_type.lower()
     to_type_lower = to_type.lower()
@@ -325,7 +325,9 @@ async def find_path(
         from_type=from_type_lower,
         to_name=to_name,
         to_type=to_type_lower,
-        max_depth=min(max(int(max_depth) if str(max_depth).lstrip("-").isdigit() else 3, 1), 15),
+        # Clamp to the API's real ceiling (api/routers/explore.py:_MAX_PATH_DEPTH=10) —
+        # advertising a wider range here just makes 11-15 always fail with HTTP 422.
+        max_depth=min(max(int(max_depth) if str(max_depth).lstrip("-").isdigit() else 10, 1), 10),
     )
 
 

--- a/tableinator/batch_processor.py
+++ b/tableinator/batch_processor.py
@@ -33,6 +33,9 @@ class BatchConfig:
     backoff_max: float = 30.0  # Maximum backoff delay (seconds)
     backoff_multiplier: float = 2.0  # Exponential backoff multiplier
     max_flush_retries: int = 5  # Max retries per data type during flush_queue drain
+    max_poison_retries: int = (
+        5  # Consecutive non-transient failures before nacking a poison batch to the DLQ
+    )
 
 
 @dataclass
@@ -309,18 +312,61 @@ class PostgreSQLBatchProcessor:
                 return
 
             except Exception as e:
+                # A generic (non-transient) error is deterministic — a poison
+                # record fails every retry. Count consecutive failures so the
+                # local retry loop is BOUNDED; otherwise the identical batch is
+                # re-enqueued and retried forever, and once its unacked messages
+                # fill the prefetch window RabbitMQ stops delivering and the
+                # consumer is permanently wedged (never acked, never nacked).
+                self._consecutive_failures[data_type] = (
+                    self._consecutive_failures.get(data_type, 0) + 1
+                )
+
+                if (
+                    self._consecutive_failures[data_type]
+                    >= self.config.max_poison_retries
+                ):
+                    # Poison batch: stop re-enqueueing and nack the messages so
+                    # the quorum queue's x-delivery-limit / DLX routes the
+                    # persistent poison to the DLQ. _flush_queue is the single
+                    # ack/nack authority.
+                    logger.error(
+                        "❌ Poison batch — nacking to DLQ after repeated failures",
+                        data_type=data_type,
+                        batch_size=len(messages),
+                        consecutive_failures=self._consecutive_failures[data_type],
+                        error=str(e),
+                    )
+                    for msg in messages:
+                        try:
+                            await msg.nack_callback()
+                        except Exception as nack_err:
+                            logger.warning(
+                                "⚠️ Failed to nack message", error=str(nack_err)
+                            )
+                    # Reset per-data-type state so healthy batches behind the
+                    # poison resume normal processing.
+                    self._consecutive_failures[data_type] = 0
+                    self._backoff_until[data_type] = 0.0
+                    self._effective_batch_size[data_type] = self.config.batch_size
+                    return
+
                 logger.error(
                     "❌ Batch processing error",
                     data_type=data_type,
                     batch_size=len(messages),
+                    consecutive_failures=self._consecutive_failures[data_type],
                     error=str(e),
                 )
-                # Re-enqueue messages for local retry before AMQP nack
+                # Re-enqueue messages for local retry — bounded by the poison
+                # guard above so a deterministic error can no longer loop forever.
                 for msg in reversed(messages):
                     queue.appendleft(msg)
-                # Track failures for non-transient errors too, to enable backoff
-                self._consecutive_failures[data_type] = (
-                    self._consecutive_failures.get(data_type, 0) + 1
+                # Shrink the batch to isolate the poison record and cap DLQ
+                # collateral when the guard eventually fires.
+                self._effective_batch_size[data_type] = max(
+                    self.config.min_batch_size,
+                    self._effective_batch_size[data_type] // 2,
                 )
                 # Apply backoff to prevent tight retry loop on persistent errors
                 delay = min(

--- a/tableinator/tableinator.py
+++ b/tableinator/tableinator.py
@@ -484,6 +484,11 @@ async def _recover_consumers() -> None:
         active_connection = None  # noqa: F841
         active_channel = None  # noqa: F841
         queues = {}  # noqa: F841
+        # Clear stale consumer tags: any consumers registered before the error
+        # died with the now-closed connection. Leaving them behind would keep
+        # len(consumer_tags) > 0 forever, permanently gating off both recovery
+        # routes (stuck-check requires 0 tags) while health still reads healthy.
+        consumer_tags.clear()
 
 
 async def purge_stale_rows(

--- a/tableinator/tableinator.py
+++ b/tableinator/tableinator.py
@@ -53,6 +53,16 @@ CONSUMER_CANCEL_DELAY = int(
     os.environ.get("CONSUMER_CANCEL_DELAY", "300")
 )  # Default 5 minutes
 
+# Safety cap for the stale-row purge. A resumed extraction skips files completed in an
+# earlier session, so those data types receive zero messages this run while still getting
+# an extraction_complete signal. Purging then would delete every row written before the
+# restart. If a purge would remove at least this fraction of a non-empty table, it is
+# almost certainly a resumed-extraction artifact (Discogs dumps grow, they do not shrink
+# by ~100%), so we veto it rather than wipe the table.
+PURGE_MAX_DELETE_FRACTION = float(
+    os.environ.get("PURGE_MAX_DELETE_FRACTION", "0.90")
+)  # Default 90% - refuse purges that would delete this share or more of a table
+
 # Periodic queue checking settings
 QUEUE_CHECK_INTERVAL = int(
     os.environ.get("QUEUE_CHECK_INTERVAL", "3600")
@@ -468,12 +478,26 @@ async def _recover_consumers() -> None:
         queues = {}  # noqa: F841
 
 
-async def purge_stale_rows(data_type: str, started_at: str) -> None:
+async def purge_stale_rows(
+    data_type: str, started_at: str, record_count: int | None = None
+) -> None:
     """Delete rows from prior extractions that were not updated in the current run.
 
     The extraction_complete message includes started_at — the time the extraction
     began. Any row with updated_at < started_at was not touched by the current
     extraction and is stale (removed from the Discogs dump or from a prior run).
+
+    Defense-in-depth against resumed extractions (see PURGE_MAX_DELETE_FRACTION): a
+    restarted extractor skips files completed in an earlier session, so this data type
+    can receive an extraction_complete signal while zero records were streamed this run.
+    Purging blindly would then delete every row written before the restart. Two guards
+    prevent that mass data loss:
+
+    1. If the extractor reported zero records for this type this session, skip entirely —
+       nothing this run could have refreshed, so there is no safe basis to purge.
+    2. If the purge would delete at least PURGE_MAX_DELETE_FRACTION of a non-empty table,
+       veto it — a near-total wipe is the resumed-extraction signature, not a real dump
+       shrink.
     """
     if connection_pool is None:
         return
@@ -481,6 +505,17 @@ async def purge_stale_rows(data_type: str, started_at: str) -> None:
     if not started_at:
         logger.warning(
             "⚠️ No started_at in extraction_complete, skipping stale row purge",
+            data_type=data_type,
+        )
+        return
+
+    # Guard 1: the extractor streamed zero records for this type this session. On a
+    # resumed run this means the type's file was already completed earlier and not
+    # re-sent, so every current row predates started_at — purging would wipe the table.
+    if record_count == 0:
+        logger.warning(
+            "⚠️ Skipping stale row purge — extractor reported 0 records this session "
+            "(resumed extraction?)",
             data_type=data_type,
         )
         return
@@ -495,6 +530,53 @@ async def purge_stale_rows(data_type: str, started_at: str) -> None:
             await conn.set_autocommit(False)
             async with conn.transaction():
                 async with conn.cursor() as cursor:
+                    # Count the table and the would-be-deleted rows BEFORE deleting so a
+                    # near-total wipe can be vetoed inside the same transaction.
+                    await cursor.execute(  # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query  # safe: psycopg2 sql.Identifier parameterizes the identifier, not user input
+                        sql.SQL("SELECT count(*) FROM {table}").format(
+                            table=sql.Identifier(data_type)
+                        )
+                    )
+                    total_row = await cursor.fetchone()
+                    total_count = total_row[0] if total_row else 0
+
+                    if total_count == 0:
+                        logger.info(
+                            f"✅ No {data_type} rows to purge (table empty)",
+                            data_type=data_type,
+                        )
+                        return
+
+                    await cursor.execute(  # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query  # safe: psycopg2 sql.Identifier parameterizes the identifier, not user input
+                        sql.SQL(
+                            "SELECT count(*) FROM {table} WHERE updated_at < %s"
+                        ).format(table=sql.Identifier(data_type)),
+                        (started_at_dt,),
+                    )
+                    stale_row = await cursor.fetchone()
+                    stale_count = stale_row[0] if stale_row else 0
+
+                    if stale_count == 0:
+                        logger.info(
+                            f"✅ No stale {data_type} rows to purge",
+                            data_type=data_type,
+                        )
+                        return
+
+                    # Guard 2: veto near-total wipes — the resumed-extraction signature.
+                    delete_fraction = stale_count / total_count
+                    if delete_fraction >= PURGE_MAX_DELETE_FRACTION:
+                        logger.error(
+                            f"🛡️ Refusing to purge {stale_count}/{total_count} "
+                            f"{data_type} rows ({delete_fraction:.1%} of table) — exceeds "
+                            f"safety cap, likely a resumed extraction not a dump shrink",
+                            data_type=data_type,
+                            stale=stale_count,
+                            total=total_count,
+                            fraction=round(delete_fraction, 4),
+                        )
+                        return
+
                     await cursor.execute(  # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query  # safe: psycopg2 sql.Identifier parameterizes the identifier, not user input
                         sql.SQL(
                             "DELETE FROM {table} WHERE updated_at < %s RETURNING data_id"
@@ -504,18 +586,12 @@ async def purge_stale_rows(data_type: str, started_at: str) -> None:
                     deleted_rows = await cursor.fetchall()
                     deleted_count = len(deleted_rows)
 
-                    if deleted_count > 0:
-                        logger.info(
-                            f"🧹 Purged {deleted_count} stale {data_type} rows "
-                            f"(not updated since extraction started)",
-                            data_type=data_type,
-                            deleted=deleted_count,
-                        )
-                    else:
-                        logger.info(
-                            f"✅ No stale {data_type} rows to purge",
-                            data_type=data_type,
-                        )
+                    logger.info(
+                        f"🧹 Purged {deleted_count} stale {data_type} rows "
+                        f"(not updated since extraction started)",
+                        data_type=data_type,
+                        deleted=deleted_count,
+                    )
     except Exception as e:
         logger.error(
             f"❌ Failed to purge stale {data_type} rows",
@@ -583,7 +659,12 @@ async def on_data_message(message: AbstractIncomingMessage, data_type: str) -> N
             purge_ok = True
             if connection_pool is not None:
                 try:
-                    await purge_stale_rows(data_type, data.get("started_at", ""))
+                    record_counts = data.get("record_counts", {})
+                    await purge_stale_rows(
+                        data_type,
+                        data.get("started_at", ""),
+                        record_counts.get(data_type),
+                    )
                 except Exception as purge_exc:
                     logger.error(
                         "❌ Purge failed, nacking extraction_complete for retry",

--- a/tableinator/tableinator.py
+++ b/tableinator/tableinator.py
@@ -437,19 +437,27 @@ async def _recover_consumers() -> None:
                 await queue.bind(exchange)
                 queues[data_type] = queue
 
-            # Start consumers for queues with messages
-            for data_type, msg_count in queues_with_messages:
+            # Start consumers for ALL data types lacking one — not just those
+            # with a current backlog. A type whose queue was empty at the
+            # passive-declare instant still needs a consumer; otherwise messages
+            # that arrive later are never consumed, because once active_connection
+            # is set and consumer_tags is non-empty both periodic recovery routes
+            # are permanently gated off, silently starving that data type.
+            pending_counts = dict(queues_with_messages)
+            for data_type in DATA_TYPES:
                 if data_type in queues and data_type not in consumer_tags:
                     handler = make_data_handler(data_type)
                     consumer_tag = await queues[data_type].consume(handler)
                     consumer_tags[data_type] = consumer_tag
-                    # Remove from completed files so it will be processed
-                    completed_files.discard(data_type)
+                    # Only un-complete a type that actually has a backlog, so
+                    # genuinely-finished types stay marked complete.
+                    if data_type in pending_counts:
+                        completed_files.discard(data_type)
                     last_message_time[data_type] = time.time()
                     logger.info(
                         f"✅ Started consumer for {data_type}",
                         data_type=data_type,
-                        pending_messages=msg_count,
+                        pending_messages=pending_counts.get(data_type, 0),
                     )
 
             logger.info(

--- a/tableinator/tableinator.py
+++ b/tableinator/tableinator.py
@@ -691,7 +691,13 @@ async def on_data_message(message: AbstractIncomingMessage, data_type: str) -> N
                 data_type=data_type,
                 data=data,
                 ack_callback=message.ack,
-                nack_callback=lambda: message.nack(requeue=True),
+                # requeue=False: this callback nacks permanently-invalid input
+                # (unknown data_type, missing 'id', normalize failure, poison
+                # batch) — send it straight to the DLQ instead of cycling
+                # x-delivery-limit (20) futile redeliveries. Matches the
+                # non-batch validation path above. Transient failures are handled
+                # by _flush_queue's re-enqueue+backoff, which never nacks.
+                nack_callback=lambda: message.nack(requeue=False),
             )
 
             # Only update progress tracking when message was actually accepted

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -37,6 +37,7 @@ _TEST_MASTER_KEY = base64.urlsafe_b64encode(b"test-master-key-padded-to-32!!").d
 TEST_JWT_SECRET = "test-jwt-secret-for-unit-tests"
 TEST_USER_ID = "00000000-0000-0000-0000-000000000001"
 TEST_USER_EMAIL = "test@example.com"
+TEST_INTERNAL_SECRET = "test-internal-insights-secret"  # nosec B105
 
 
 def make_test_jwt(
@@ -130,6 +131,7 @@ def test_api_config() -> ApiConfig:
         neo4j_host="bolt://localhost:7687",
         neo4j_username="neo4j",
         neo4j_password="testpassword",  # noqa: S106
+        insights_internal_secret=TEST_INTERNAL_SECRET,
     )
 
 
@@ -196,7 +198,7 @@ def test_client(
 
     _search_router.configure(mock_pool, mock_redis)
     _recommend_router.configure(mock_neo4j, test_api_config.jwt_secret_key, mock_redis)
-    _insights_compute_router.configure(mock_neo4j, mock_pool, mock_redis)
+    _insights_compute_router.configure(mock_neo4j, mock_pool, mock_redis, test_api_config)
     _admin_router.configure(mock_pool, mock_redis, test_api_config, neo4j_driver=mock_neo4j)
     import api.routers.extraction_analysis as _extraction_analysis_router
 
@@ -259,7 +261,10 @@ def test_client(
         notification_channel=LogNotificationChannel(),
     )
 
-    with TestClient(app, raise_server_exceptions=False) as client:
+    # Default the internal-insights shared secret on every request so the existing
+    # /api/internal/insights/* tests keep passing; the header is ignored by all
+    # other routers. Tests that assert rejection build their own bare client.
+    with TestClient(app, raise_server_exceptions=False, headers={"X-Internal-Secret": TEST_INTERNAL_SECRET}) as client:
         yield client
 
     # Restore original state

--- a/tests/api/nlq/test_nlq_router.py
+++ b/tests/api/nlq/test_nlq_router.py
@@ -290,6 +290,48 @@ class TestNLQSSE:
 
         assert response.status_code == 200
 
+    def test_sse_stream_replays_cache_hit_as_events(self, test_client: TestClient) -> None:
+        """discogsography-cu2.27: a streaming request whose query is already cached
+        (written by a prior JSON request) must receive an SSE event stream, not a
+        plain JSON body — otherwise the Ask UI's SSE parser finds no events and
+        the spinner hangs. The engine must not run for a cache hit.
+        """
+        original_config = nlq_router._nlq_config
+        original_engine = nlq_router._engine
+        original_redis = nlq_router._redis
+        try:
+            nlq_router._nlq_config = MagicMock(is_available=True, max_query_length=500)
+            mock_engine = MagicMock()
+            mock_engine.run = AsyncMock(side_effect=AssertionError("engine must not run on a cache hit"))
+            nlq_router._engine = mock_engine
+            cached_data = {
+                "query": "who produced Thriller",
+                "summary": "Quincy Jones",
+                "entities": [],
+                "tools_used": ["search"],
+                "actions": [],
+                "cached": True,
+            }
+            nlq_router._redis = AsyncMock()
+            nlq_router._redis.get = AsyncMock(return_value=json.dumps(cached_data))
+
+            response = test_client.post(
+                "/api/nlq/query",
+                json={"query": "who produced Thriller"},
+                headers={"Accept": "text/event-stream"},
+            )
+        finally:
+            nlq_router._nlq_config = original_config
+            nlq_router._engine = original_engine
+            nlq_router._redis = original_redis
+
+        assert response.status_code == 200
+        assert "text/event-stream" in response.headers["content-type"]
+        body = response.text
+        assert "event: result" in body
+        assert "Quincy Jones" in body
+        mock_engine.run.assert_not_called()
+
 
 class TestSSEStreamErrorHandling:
     """Test SSE streaming error handling."""

--- a/tests/api/test_admin_endpoints.py
+++ b/tests/api/test_admin_endpoints.py
@@ -1352,3 +1352,105 @@ class TestAdminAuthSecurity:
             assert resp.status_code == 403
         finally:
             deps._pool = original_pool
+
+
+class TestTrackExtractionResilience:
+    """discogsography-cu2.57: the tracker polls every 10s for up to 24h and does
+    resp.json() + PG writes inside the loop. A transient error (non-JSON body,
+    PG disconnect) that is not an httpx.RequestError must NOT kill the task and
+    leave the extraction_history row stuck in 'running' forever.
+    """
+
+    @staticmethod
+    def _pool(execute_side_effect: Any = None) -> tuple[MagicMock, AsyncMock]:
+        mock_cur = AsyncMock()
+        if execute_side_effect is not None:
+            mock_cur.execute = AsyncMock(side_effect=execute_side_effect)
+        else:
+            mock_cur.execute = AsyncMock()
+        mock_conn = AsyncMock()
+        cur_ctx = AsyncMock()
+        cur_ctx.__aenter__ = AsyncMock(return_value=mock_cur)
+        cur_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_conn.cursor = MagicMock(return_value=cur_ctx)
+        conn_ctx = AsyncMock()
+        conn_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+        conn_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_pool = MagicMock()
+        mock_pool.connection = MagicMock(return_value=conn_ctx)
+        return mock_pool, mock_cur
+
+    @pytest.mark.asyncio
+    async def test_non_json_body_does_not_kill_tracker(self) -> None:
+        """A 200 body that isn't valid JSON is counted as a failure; after the
+        consecutive-failure gate trips, a terminal 'failed' status is written —
+        the row never stays 'running'."""
+        import api.routers.admin as admin_mod
+
+        mock_pool, mock_cur = self._pool()
+        mock_config = MagicMock(extractor_host="localhost", extractor_health_port=8000)
+        original_pool, original_config = admin_mod._pool, admin_mod._config
+        admin_mod._pool, admin_mod._config = mock_pool, mock_config
+
+        try:
+            with (
+                patch("api.routers.admin.asyncio.sleep", new_callable=AsyncMock),
+                patch("api.routers.admin.httpx.AsyncClient") as mock_client_cls,
+            ):
+                mock_response = MagicMock()
+                mock_response.status_code = 200
+                mock_response.json.side_effect = ValueError("not json")
+                mock_client = AsyncMock()
+                mock_client.get = AsyncMock(return_value=mock_response)
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                mock_client_cls.return_value = mock_client
+
+                await admin_mod._track_extraction(str(uuid4()))
+        finally:
+            admin_mod._pool, admin_mod._config = original_pool, original_config
+
+        executed = [call.args[0] for call in mock_cur.execute.await_args_list]
+        terminal = [sql for sql in executed if "status = 'failed'" in sql and "completed_at = NOW()" in sql]
+        assert terminal, "tracker must write a terminal 'failed' status, not leave the row running"
+
+    @pytest.mark.asyncio
+    async def test_unexpected_crash_triggers_safety_net(self) -> None:
+        """If an unexpected exception escapes the poll loop entirely, the final
+        safety net marks the record 'failed' ('Tracking task crashed')."""
+        import api.routers.admin as admin_mod
+
+        executed_params: list[Any] = []
+
+        def flaky_execute(_sql: str, params: Any = None, *_args: Any, **_kwargs: Any) -> None:
+            executed_params.append(params)
+            # The max-failures terminal write blows up (e.g. transient PG error),
+            # escaping the loop and reaching the outer safety net.
+            if params and "Extractor became unreachable" in tuple(params):
+                raise RuntimeError("pool exhausted")
+            return None
+
+        mock_pool, _ = self._pool(execute_side_effect=flaky_execute)
+        mock_config = MagicMock(extractor_host="localhost", extractor_health_port=8000)
+        original_pool, original_config = admin_mod._pool, admin_mod._config
+        admin_mod._pool, admin_mod._config = mock_pool, mock_config
+
+        try:
+            with (
+                patch("api.routers.admin.asyncio.sleep", new_callable=AsyncMock),
+                patch("api.routers.admin.httpx.AsyncClient") as mock_client_cls,
+            ):
+                mock_client = AsyncMock()
+                # Unexpected (non-httpx) error on every poll → drives consecutive
+                # failures to the gate, whose terminal write then raises.
+                mock_client.get = AsyncMock(side_effect=RuntimeError("boom"))
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                mock_client_cls.return_value = mock_client
+
+                # Must not raise — the safety net swallows and records the crash.
+                await admin_mod._track_extraction(str(uuid4()))
+        finally:
+            admin_mod._pool, admin_mod._config = original_pool, original_config
+
+        assert any(p and "Tracking task crashed" in tuple(p) for p in executed_params), "safety net must mark the crashed extraction failed"

--- a/tests/api/test_admin_endpoints.py
+++ b/tests/api/test_admin_endpoints.py
@@ -1454,3 +1454,44 @@ class TestTrackExtractionResilience:
             admin_mod._pool, admin_mod._config = original_pool, original_config
 
         assert any(p and "Tracking task crashed" in tuple(p) for p in executed_params), "safety net must mark the crashed extraction failed"
+
+    @pytest.mark.asyncio
+    async def test_safety_net_db_failure_is_swallowed(self) -> None:
+        """If the outer safety net's own 'Tracking task crashed' UPDATE also fails
+        (e.g. the pool is still down), the error must be logged and swallowed — the
+        tracker must never propagate an exception out of _track_extraction."""
+        import api.routers.admin as admin_mod
+
+        executed_params: list[Any] = []
+
+        def flaky_execute(_sql: str, params: Any = None, *_args: Any, **_kwargs: Any) -> None:
+            executed_params.append(params)
+            # Both the max-failures terminal write AND the safety-net recovery
+            # write blow up, exercising the inner except of the safety net.
+            if params and ("Extractor became unreachable" in tuple(params) or "Tracking task crashed" in tuple(params)):
+                raise RuntimeError("pool exhausted")
+            return None
+
+        mock_pool, _ = self._pool(execute_side_effect=flaky_execute)
+        mock_config = MagicMock(extractor_host="localhost", extractor_health_port=8000)
+        original_pool, original_config = admin_mod._pool, admin_mod._config
+        admin_mod._pool, admin_mod._config = mock_pool, mock_config
+
+        try:
+            with (
+                patch("api.routers.admin.asyncio.sleep", new_callable=AsyncMock),
+                patch("api.routers.admin.httpx.AsyncClient") as mock_client_cls,
+            ):
+                mock_client = AsyncMock()
+                mock_client.get = AsyncMock(side_effect=RuntimeError("boom"))
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                mock_client_cls.return_value = mock_client
+
+                # Must not raise even though every recovery write fails.
+                await admin_mod._track_extraction(str(uuid4()))
+        finally:
+            admin_mod._pool, admin_mod._config = original_pool, original_config
+
+        # The safety net still attempted the recovery write before it failed.
+        assert any(p and "Tracking task crashed" in tuple(p) for p in executed_params)

--- a/tests/api/test_admin_setup.py
+++ b/tests/api/test_admin_setup.py
@@ -1,0 +1,165 @@
+"""Tests for the admin-setup CLI tool (api/admin_setup.py).
+
+Covers connection-string construction, the add/list admin operations, and the
+argparse-driven ``main`` entry point. All DB and config boundaries are mocked —
+no real PostgreSQL connection is ever opened.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api import admin_setup
+
+
+@contextmanager
+def _cm(value: Any):
+    """Minimal synchronous context manager yielding ``value``."""
+    yield value
+
+
+def _mock_connect(cursor: MagicMock) -> MagicMock:
+    """Build a ``psycopg.connect``-style mock whose cursor() yields ``cursor``."""
+    conn = MagicMock()
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+    conn.cursor = MagicMock(return_value=_cm(cursor))
+    connect = MagicMock(return_value=conn)
+    return connect
+
+
+# --------------------------------------------------------------------------- #
+# _build_conninfo
+# --------------------------------------------------------------------------- #
+def test_build_conninfo_uses_env_and_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POSTGRES_HOST", "db.example.com:6432")
+    monkeypatch.setenv("POSTGRES_DATABASE", "mydb")
+    monkeypatch.setattr(admin_setup, "get_secret", lambda name: {"POSTGRES_USERNAME": "alice", "POSTGRES_PASSWORD": "s3cret"}[name])
+
+    conninfo = admin_setup._build_conninfo()
+
+    assert "host=db.example.com" in conninfo
+    assert "port=6432" in conninfo
+    assert "user=alice" in conninfo
+    assert "password=s3cret" in conninfo
+    assert "dbname=mydb" in conninfo
+
+
+def test_build_conninfo_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("POSTGRES_HOST", "POSTGRES_PORT", "POSTGRES_DATABASE"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(admin_setup, "get_secret", lambda _name: None)
+
+    conninfo = admin_setup._build_conninfo()
+
+    assert "host=localhost" in conninfo
+    assert "port=5432" in conninfo
+    assert "user=postgres" in conninfo
+    assert "password=postgres" in conninfo
+    assert "dbname=discogsography" in conninfo
+
+
+def test_build_conninfo_blank_port_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POSTGRES_PORT", "")
+    monkeypatch.setenv("POSTGRES_HOST", "localhost")
+    monkeypatch.setattr(admin_setup, "get_secret", lambda _name: None)
+
+    conninfo = admin_setup._build_conninfo()
+
+    assert "port=5432" in conninfo
+
+
+# --------------------------------------------------------------------------- #
+# add_admin
+# --------------------------------------------------------------------------- #
+def test_add_admin_rejects_short_password() -> None:
+    with pytest.raises(ValueError, match="at least 8 characters"):
+        admin_setup.add_admin("conninfo", "admin@example.com", "short")
+
+
+def test_add_admin_upserts_and_normalizes_email(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    cursor = MagicMock()
+    connect = _mock_connect(cursor)
+    monkeypatch.setattr(admin_setup.psycopg, "connect", connect)
+    monkeypatch.setattr(admin_setup, "_hash_password", lambda pw: f"hashed:{pw}")
+
+    admin_setup.add_admin("conninfo-str", "  Admin@Example.COM  ", "longenoughpw")
+
+    connect.assert_called_once_with("conninfo-str")
+    sql, params = cursor.execute.call_args[0]
+    assert "INSERT INTO users" in sql
+    assert "ON CONFLICT (email)" in sql
+    # Email is stripped + lowercased; password is hashed.
+    assert params == ("admin@example.com", "hashed:longenoughpw")
+    assert "created/updated successfully" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# list_admins
+# --------------------------------------------------------------------------- #
+def test_list_admins_no_rows(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    cursor = MagicMock()
+    cursor.fetchall.return_value = []
+    monkeypatch.setattr(admin_setup.psycopg, "connect", _mock_connect(cursor))
+
+    admin_setup.list_admins("conninfo")
+
+    assert "No admin accounts found." in capsys.readouterr().out
+
+
+def test_list_admins_renders_rows(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    cursor = MagicMock()
+    cursor.fetchall.return_value = [
+        ("a@example.com", True, "2026-01-01"),
+        ("b@example.com", False, "2026-02-02"),
+    ]
+    monkeypatch.setattr(admin_setup.psycopg, "connect", _mock_connect(cursor))
+
+    admin_setup.list_admins("conninfo")
+
+    out = capsys.readouterr().out
+    assert "a@example.com" in out
+    assert "Yes" in out  # active account
+    assert "No" in out  # inactive account
+    assert "b@example.com" in out
+
+
+# --------------------------------------------------------------------------- #
+# main
+# --------------------------------------------------------------------------- #
+def _run_main(monkeypatch: pytest.MonkeyPatch, argv: list[str]) -> None:
+    monkeypatch.setattr(admin_setup.sys, "argv", ["admin-setup", *argv])
+    monkeypatch.setattr(admin_setup, "_build_conninfo", lambda: "fake-conninfo")
+
+
+def test_main_no_args_prints_help_and_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+    _run_main(monkeypatch, [])
+    with pytest.raises(SystemExit) as exc:
+        admin_setup.main()
+    assert exc.value.code == 1
+
+
+def test_main_short_password_exits(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _run_main(monkeypatch, ["--email", "a@example.com", "--password", "short"])
+    with pytest.raises(SystemExit) as exc:
+        admin_setup.main()
+    assert exc.value.code == 1
+    assert "at least 8 characters" in capsys.readouterr().out
+
+
+def test_main_list_calls_list_admins(monkeypatch: pytest.MonkeyPatch) -> None:
+    _run_main(monkeypatch, ["--list"])
+    with patch.object(admin_setup, "list_admins") as list_admins:
+        admin_setup.main()
+    list_admins.assert_called_once_with("fake-conninfo")
+
+
+def test_main_add_calls_add_admin(monkeypatch: pytest.MonkeyPatch) -> None:
+    _run_main(monkeypatch, ["--email", "a@example.com", "--password", "longenoughpw"])
+    with patch.object(admin_setup, "add_admin") as add_admin:
+        admin_setup.main()
+    add_admin.assert_called_once_with("fake-conninfo", "a@example.com", "longenoughpw")

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -824,6 +824,35 @@ class TestGetCurrentUser:
         response = test_client.get("/api/auth/me", headers={"Authorization": f"Bearer {token}"})
         assert response.status_code == 401
 
+    def test_get_current_user_challenge_token_401(
+        self,
+        test_client: TestClient,
+    ) -> None:
+        """Regression discogsography-cu2.1 — a 2FA challenge token must NOT authenticate _get_current_user endpoints."""
+        import base64
+        import hashlib
+        import hmac
+        import json
+
+        from tests.api.conftest import TEST_JWT_SECRET
+
+        def b64url(data: bytes) -> str:
+            return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+        header = b64url(json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode())
+        body = b64url(
+            json.dumps(
+                {"sub": "user-1", "email": "x@y.com", "exp": 9_999_999_999, "type": "2fa_challenge", "jti": "chal:me-test"},
+                separators=(",", ":"),
+            ).encode()
+        )
+        signing_input = f"{header}.{body}".encode("ascii")
+        sig = b64url(hmac.new(TEST_JWT_SECRET.encode("utf-8"), signing_input, hashlib.sha256).digest())
+        token = f"{header}.{body}.{sig}"
+
+        response = test_client.get("/api/auth/me", headers={"Authorization": f"Bearer {token}"})
+        assert response.status_code == 401
+
 
 class TestLoginServiceNotReady:
     """Test login 503 when pool/config is None."""

--- a/tests/api/test_auth_router.py
+++ b/tests/api/test_auth_router.py
@@ -727,7 +727,9 @@ class TestTwoFactorRecoveryFull:
 
         mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
         mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
-        mock_cur.fetchone = AsyncMock(return_value={"totp_recovery_codes": json.dumps(hashed_codes)})
+        # The atomic UPDATE ... WHERE totp_recovery_codes ? %s matches no row for
+        # an unknown code, so RETURNING yields nothing (fetchone -> None).
+        mock_cur.fetchone = AsyncMock(return_value=None)
 
         response = test_client.post(
             "/api/auth/2fa/recovery",
@@ -735,6 +737,8 @@ class TestTwoFactorRecoveryFull:
         )
         assert response.status_code == 401
         assert "Invalid recovery code" in response.json()["detail"]
+        # A rejected code must NOT burn the challenge — getdel is only called on success.
+        mock_redis.getdel.assert_not_called()
 
     def test_recovery_last_code_includes_warning(
         self,
@@ -752,7 +756,9 @@ class TestTwoFactorRecoveryFull:
         mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
         mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
         mock_redis.delete = AsyncMock()
-        mock_cur.fetchone = AsyncMock(return_value={"totp_recovery_codes": json.dumps(last_hashed)})
+        # After the atomic UPDATE removes the last code, RETURNING yields an empty array.
+        _ = last_hashed
+        mock_cur.fetchone = AsyncMock(return_value={"totp_recovery_codes": json.dumps([])})
 
         response = test_client.post(
             "/api/auth/2fa/recovery",
@@ -775,7 +781,8 @@ class TestTwoFactorRecoveryFull:
 
         mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
         mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
-        mock_cur.fetchone = AsyncMock(return_value={"totp_recovery_codes": None})
+        # No stored codes -> the guarded UPDATE matches no row -> RETURNING None.
+        mock_cur.fetchone = AsyncMock(return_value=None)
 
         response = test_client.post(
             "/api/auth/2fa/recovery",

--- a/tests/api/test_auth_router.py
+++ b/tests/api/test_auth_router.py
@@ -1072,31 +1072,38 @@ class TestTwoFactorVerifyEdgeCases:
         mock_redis: AsyncMock,
         mock_cur: AsyncMock,
     ) -> None:
-        """If challenge exists on get but is consumed by another request before getdel, return 401."""
-        import json
+        """A CORRECT code whose challenge is consumed by a concurrent request before getdel returns 401.
 
-        token = create_challenge_token(TEST_USER_ID, TEST_USER_EMAIL, TEST_JWT_SECRET)
+        The challenge is now consumed only after a successful verification
+        (verify-then-consume), so this race is only reachable on the success path.
+        """
+        secret, encrypted_secret = _make_encrypted_totp_secret()
+        token = _make_challenge_token()
 
-        async def redis_get(redis_key: str) -> str | None:
-            if "2fa_challenge:" in redis_key:
-                return json.dumps({"user_id": TEST_USER_ID})
-            return None
-
-        mock_redis.get = AsyncMock(side_effect=redis_get)
-        # getdel returns None — another request consumed the challenge between get and getdel
+        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        # getdel returns None — another request consumed the challenge between the
+        # existence check and this success-path consume.
         mock_redis.getdel = AsyncMock(return_value=None)
         mock_cur.fetchone = AsyncMock(
             return_value={
-                "totp_secret": "encrypted_secret",
+                "totp_secret": encrypted_secret,
                 "totp_failed_attempts": 0,
                 "totp_locked_until": None,
             }
         )
 
-        response = test_client.post(
-            "/api/auth/2fa/verify",
-            json={"challenge_token": token, "code": "123456"},
-        )
+        valid_code = pyotp.TOTP(secret).now()
+
+        original_config = auth_router._config
+        auth_router._config = replace(original_config, encryption_master_key=_TEST_MASTER_KEY)
+        try:
+            response = test_client.post(
+                "/api/auth/2fa/verify",
+                json={"challenge_token": token, "code": valid_code},
+            )
+        finally:
+            auth_router._config = original_config
+
         assert response.status_code == 401
         assert "expired" in response.json()["detail"].lower() or "used" in response.json()["detail"].lower()
 

--- a/tests/api/test_auth_router.py
+++ b/tests/api/test_auth_router.py
@@ -1169,6 +1169,34 @@ class TestTwoFactorStateMachineRegressions:
         # The live secret/recovery-code columns must NOT have been overwritten.
         assert not any("SET totp_secret" in sql for sql in self._executed_sql(mock_cur))
 
+    def test_setup_refuses_on_concurrent_enable_race(
+        self,
+        test_client: TestClient,
+        auth_headers: dict[str, str],
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """cu2.24: the SELECT sees 2FA disabled, but a concurrent enable wins the race so
+        the guarded UPDATE matches zero rows — setup must then reject with 400 rather
+        than returning a secret it never persisted."""
+        mock_redis.get = AsyncMock(return_value=None)
+        # SELECT totp_enabled -> FALSE (first guard passes), but the guarded UPDATE
+        # matches no row because a concurrent request enabled 2FA in between.
+        mock_cur.fetchone = AsyncMock(return_value={"totp_enabled": False})
+        mock_cur.rowcount = 0
+
+        original_config = auth_router._config
+        auth_router._config = replace(original_config, encryption_master_key=_TEST_MASTER_KEY)
+        try:
+            response = test_client.post("/api/auth/2fa/setup", headers=auth_headers)
+        finally:
+            auth_router._config = original_config
+
+        assert response.status_code == 400
+        assert "already enabled" in response.json()["detail"].lower()
+        # The UPDATE was attempted (the race is only detectable post-UPDATE).
+        assert any("SET totp_secret" in sql for sql in self._executed_sql(mock_cur))
+
     def test_setup_update_is_guarded_by_totp_enabled(
         self,
         test_client: TestClient,

--- a/tests/api/test_auth_router.py
+++ b/tests/api/test_auth_router.py
@@ -722,7 +722,7 @@ class TestTwoFactorRecoveryFull:
         mock_redis: AsyncMock,
     ) -> None:
         """Invalid recovery code should return 401."""
-        _plaintext_codes, hashed_codes = self._make_recovery_setup()
+        _plaintext_codes, _hashed_codes = self._make_recovery_setup()
         challenge_token = _make_challenge_token()
 
         mock_redis.get = AsyncMock(return_value=TEST_USER_ID)

--- a/tests/api/test_auth_router.py
+++ b/tests/api/test_auth_router.py
@@ -1137,6 +1137,177 @@ class TestTwoFactorRecoveryEdgeCases:
         assert response.status_code == 401
 
 
+class TestTwoFactorStateMachineRegressions:
+    """Regression tests for the 2FA state-machine bug-hunt fixes (cu2.24/25/58/59/60/96)."""
+
+    @staticmethod
+    def _executed_sql(mock_cur: AsyncMock) -> list[str]:
+        return [str(call) for call in mock_cur.execute.call_args_list]
+
+    def test_setup_refuses_when_already_enabled(
+        self,
+        test_client: TestClient,
+        auth_headers: dict[str, str],
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """cu2.24: setup must refuse to overwrite a live secret while 2FA is enabled."""
+        mock_redis.get = AsyncMock(return_value=None)
+        # SELECT totp_enabled -> TRUE; the guarded UPDATE also matches no row (rowcount 0).
+        mock_cur.fetchone = AsyncMock(return_value={"totp_enabled": True})
+        mock_cur.rowcount = 0
+
+        original_config = auth_router._config
+        auth_router._config = replace(original_config, encryption_master_key=_TEST_MASTER_KEY)
+        try:
+            response = test_client.post("/api/auth/2fa/setup", headers=auth_headers)
+        finally:
+            auth_router._config = original_config
+
+        assert response.status_code == 400
+        assert "already enabled" in response.json()["detail"].lower()
+        # The live secret/recovery-code columns must NOT have been overwritten.
+        assert not any("SET totp_secret" in sql for sql in self._executed_sql(mock_cur))
+
+    def test_setup_update_is_guarded_by_totp_enabled(
+        self,
+        test_client: TestClient,
+        auth_headers: dict[str, str],
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """cu2.24: the setup UPDATE carries a `totp_enabled IS NOT TRUE` guard against races."""
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_cur.fetchone = AsyncMock(return_value=make_sample_user_row())
+        mock_cur.rowcount = 1
+
+        original_config = auth_router._config
+        auth_router._config = replace(original_config, encryption_master_key=_TEST_MASTER_KEY)
+        try:
+            response = test_client.post("/api/auth/2fa/setup", headers=auth_headers)
+        finally:
+            auth_router._config = original_config
+
+        assert response.status_code == 200
+        update_sqls = [sql for sql in self._executed_sql(mock_cur) if "SET totp_secret" in sql]
+        assert update_sqls, "expected an UPDATE that writes totp_secret"
+        assert all("totp_enabled IS NOT TRUE" in sql for sql in update_sqls)
+
+    def test_verify_wrong_code_preserves_challenge(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """cu2.59: a wrong TOTP code must NOT consume the challenge (verify-then-consume)."""
+        _secret, encrypted_secret = _make_encrypted_totp_secret()
+        challenge_token = _make_challenge_token()
+
+        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
+        mock_cur.fetchone = AsyncMock(return_value={"totp_secret": encrypted_secret, "totp_failed_attempts": 0, "totp_locked_until": None})
+
+        original_config = auth_router._config
+        auth_router._config = replace(original_config, encryption_master_key=_TEST_MASTER_KEY)
+        try:
+            response = test_client.post(
+                "/api/auth/2fa/verify",
+                json={"challenge_token": challenge_token, "code": "000000"},
+            )
+        finally:
+            auth_router._config = original_config
+
+        assert response.status_code == 401
+        # The challenge must survive so the user can retry with the same token.
+        mock_redis.getdel.assert_not_called()
+
+    def test_verify_failure_increments_counter_atomically(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """cu2.25: the failure counter is incremented in SQL with RETURNING, not read-then-blind-write."""
+        _secret, encrypted_secret = _make_encrypted_totp_secret()
+        challenge_token = _make_challenge_token()
+
+        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
+        mock_cur.fetchone = AsyncMock(return_value={"totp_secret": encrypted_secret, "totp_failed_attempts": 0, "totp_locked_until": None})
+
+        original_config = auth_router._config
+        auth_router._config = replace(original_config, encryption_master_key=_TEST_MASTER_KEY)
+        try:
+            response = test_client.post(
+                "/api/auth/2fa/verify",
+                json={"challenge_token": challenge_token, "code": "000000"},
+            )
+        finally:
+            auth_router._config = original_config
+
+        assert response.status_code == 401
+        executed = " ".join(self._executed_sql(mock_cur))
+        assert "COALESCE(totp_failed_attempts, 0) + 1" in executed
+        assert "RETURNING totp_failed_attempts" in executed
+
+    def test_verify_failure_resets_counter_after_lock_expiry(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """cu2.96: a wrong code after an expired lock window starts the counter fresh, not at 5+1."""
+        _secret, encrypted_secret = _make_encrypted_totp_secret()
+        challenge_token = _make_challenge_token()
+
+        past = datetime.now(UTC) - timedelta(minutes=1)
+        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
+        mock_cur.fetchone = AsyncMock(return_value={"totp_secret": encrypted_secret, "totp_failed_attempts": 5, "totp_locked_until": past})
+
+        original_config = auth_router._config
+        auth_router._config = replace(original_config, encryption_master_key=_TEST_MASTER_KEY)
+        try:
+            response = test_client.post(
+                "/api/auth/2fa/verify",
+                json={"challenge_token": challenge_token, "code": "000000"},
+            )
+        finally:
+            auth_router._config = original_config
+
+        assert response.status_code == 401
+        executed = " ".join(self._executed_sql(mock_cur))
+        # The reset CASE keys off an elapsed lock window.
+        assert "totp_locked_until <= NOW()" in executed
+
+    def test_recovery_consumes_code_atomically(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """cu2.58/cu2.60: recovery-code consumption is a single guarded atomic UPDATE."""
+        plaintext_codes, _hashed_codes = generate_recovery_codes()
+        challenge_token = _make_challenge_token()
+
+        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
+        # RETURNING yields the array after the used code was removed atomically.
+        mock_cur.fetchone = AsyncMock(return_value={"totp_recovery_codes": json.dumps([])})
+
+        response = test_client.post(
+            "/api/auth/2fa/recovery",
+            json={"challenge_token": challenge_token, "code": plaintext_codes[0]},
+        )
+
+        assert response.status_code == 200
+        executed = " ".join(self._executed_sql(mock_cur))
+        # Set-based removal guarded by membership, in one statement with RETURNING.
+        assert "totp_recovery_codes - %s" in executed
+        assert "totp_recovery_codes ? %s" in executed
+        assert "RETURNING totp_recovery_codes" in executed
+
+
 class TestChangePassword:
     """Tests for POST /api/auth/change-password."""
 

--- a/tests/api/test_community_enrichment.py
+++ b/tests/api/test_community_enrichment.py
@@ -315,6 +315,107 @@ class TestEnrichReleasesFromDiscogs:
         assert result["enriched"] == 1
         assert result["errors"] == 0
 
+    @staticmethod
+    def _two_release_pool() -> MagicMock:
+        """Pool whose first release fetch yields two release ids + config rows."""
+        mock_pool = MagicMock()
+        mock_cur = AsyncMock()
+        call_count = 0
+
+        async def mock_fetchall() -> list[dict]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [{"release_id": 111}, {"release_id": 222}]
+            if call_count == 2:
+                return [
+                    {"key": "discogs_consumer_key", "value": "ck"},
+                    {"key": "discogs_consumer_secret", "value": "cs"},
+                ]
+            return []
+
+        mock_cur.fetchall = mock_fetchall
+        mock_cur.fetchone = AsyncMock(return_value={"access_token": "at", "access_secret": "as", "provider_username": "u"})
+        mock_cur.execute = AsyncMock()
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+        return mock_pool
+
+    @pytest.mark.asyncio
+    async def test_transient_httpx_error_counted_and_run_continues(self) -> None:
+        """discogsography-cu2.26: a transient transport error on one release must
+        be counted as an error and the run must continue to the next release,
+        not abort the whole invocation with an unhandled 500.
+        """
+        import httpx
+
+        from api.routers.insights_compute import _enrich_community_counts
+
+        mock_pool = self._two_release_pool()
+
+        ok_response = MagicMock()
+        ok_response.status_code = 200
+        ok_response.json = MagicMock(return_value={"community": {"have": 3, "want": 7}})
+
+        with (
+            patch("api.routers.insights_compute.decrypt_oauth_token", side_effect=lambda v, _k: v),
+            patch("api.routers.insights_compute._auth_header", return_value="OAuth ..."),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_client = AsyncMock()
+            # First release: transient read timeout; second: healthy 200.
+            mock_client.get = AsyncMock(side_effect=[httpx.ReadTimeout("boom"), ok_response])
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await _enrich_community_counts(mock_pool, None, None)
+
+        assert result["errors"] == 1
+        assert result["enriched"] == 1
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_body_counted_and_run_continues(self) -> None:
+        """discogsography-cu2.26: a 200 response with a non-JSON body must be
+        counted as an error, not raise out of the loop.
+        """
+        import json
+
+        from api.routers.insights_compute import _enrich_community_counts
+
+        mock_pool = self._two_release_pool()
+
+        bad_response = MagicMock()
+        bad_response.status_code = 200
+        bad_response.json = MagicMock(side_effect=json.JSONDecodeError("bad", "", 0))
+
+        ok_response = MagicMock()
+        ok_response.status_code = 200
+        ok_response.json = MagicMock(return_value={"community": {"have": 1, "want": 2}})
+
+        with (
+            patch("api.routers.insights_compute.decrypt_oauth_token", side_effect=lambda v, _k: v),
+            patch("api.routers.insights_compute._auth_header", return_value="OAuth ..."),
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch("httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=[bad_response, ok_response])
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await _enrich_community_counts(mock_pool, None, None)
+
+        assert result["errors"] == 1
+        assert result["enriched"] == 1
+
 
 class TestCommunityEnrichmentEndpoint:
     def test_community_enrichment_endpoint_not_ready(self, test_client: TestClient) -> None:

--- a/tests/api/test_credits_queries.py
+++ b/tests/api/test_credits_queries.py
@@ -191,6 +191,33 @@ class TestAutocompletePerson:
         await autocomplete_person(driver, "Bob*")
         # Should not add another wildcard
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "raw",
+        ["AC/DC", "C++", "Emerson, Lake (Palmer", "a:b", "foo~", "Jean-Michel"],
+    )
+    async def test_escapes_lucene_metacharacters(self, raw: str) -> None:
+        """cu2.3: crafted names with Lucene syntax must be escaped, not passed raw.
+
+        Regression for autocomplete_person handing user input straight to
+        db.index.fulltext.queryNodes, where metacharacters (/, +, :, ~, (, -)
+        trigger a Lucene ParseException surfaced as an unhandled 500.
+        """
+        driver = _make_mock_driver(query_returns=[])
+        await autocomplete_person(driver, raw)
+
+        session = driver.session().__aenter__.return_value
+        call_args = session.run.call_args
+        assert call_args is not None
+        # params dict is the 2nd positional arg to session.run(cypher, params, ...)
+        params = call_args[0][1]
+        sent = params["query"]
+        # Every Lucene special char that appears in the raw input must be
+        # backslash-escaped in the query actually sent to Neo4j.
+        for ch in raw:
+            if ch in '+-&|!(){}[]^"~*?:\\/':
+                assert f"\\{ch}" in sent, f"metacharacter {ch!r} was not escaped in {sent!r}"
+
 
 class TestGetPersonProfile:
     """Tests for get_person_profile."""

--- a/tests/api/test_dependencies.py
+++ b/tests/api/test_dependencies.py
@@ -561,3 +561,55 @@ class TestRequireUserTokenChecks:
         creds = _make_credentials(token)
         result = await require_user(creds)
         assert result["sub"] == "user-1"
+
+
+class TestChallengeTokenRejection:
+    """Regression tests for discogsography-cu2.1.
+
+    A 2FA challenge token (``type == "2fa_challenge"``) proves only the password.
+    It must NEVER authenticate a protected user endpoint — otherwise an attacker
+    with only the victim's password fully bypasses the TOTP second factor. Only
+    the dedicated 2FA verify/recovery endpoints may consume a challenge token.
+    """
+
+    @pytest.mark.asyncio
+    async def test_require_user_rejects_challenge_token(self) -> None:
+        """require_user must reject a 2FA challenge token with 401, not accept it."""
+        configure(TEST_SECRET)
+        from fastapi import HTTPException
+
+        token = _make_token_with_claims({"type": "2fa_challenge", "jti": "chal-1"})
+        creds = _make_credentials(token)
+        with pytest.raises(HTTPException) as exc_info:
+            await require_user(creds)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_get_optional_user_rejects_challenge_token(self) -> None:
+        """get_optional_user must resolve a 2FA challenge token to None, not a user."""
+        configure(TEST_SECRET)
+        token = _make_token_with_claims({"type": "2fa_challenge", "jti": "chal-2"})
+        creds = _make_credentials(token)
+        result = await get_optional_user(creds)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_require_user_rejects_unknown_token_type(self) -> None:
+        """Allowlist: any typed token (present but not an access token) is rejected."""
+        configure(TEST_SECRET)
+        from fastapi import HTTPException
+
+        token = _make_token_with_claims({"type": "some_future_type"})
+        creds = _make_credentials(token)
+        with pytest.raises(HTTPException) as exc_info:
+            await require_user(creds)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_require_user_still_accepts_plain_access_token(self) -> None:
+        """A pure access token (no ``type`` claim) is still accepted."""
+        configure(TEST_SECRET)
+        token = _make_token_with_claims({"jti": "access-1"})
+        creds = _make_credentials(token)
+        result = await require_user(creds)
+        assert result["sub"] == "user-1"

--- a/tests/api/test_dependencies.py
+++ b/tests/api/test_dependencies.py
@@ -613,3 +613,45 @@ class TestChallengeTokenRejection:
         creds = _make_credentials(token)
         result = await require_user(creds)
         assert result["sub"] == "user-1"
+
+
+class TestUnifiedAuthTouchesLastUsedAt:
+    """discogsography-cu2.22: the unified auth path (require_user_or_app_token)
+    is the ONLY path production app-token endpoints use, so it must perform the
+    same last_used_at bookkeeping as require_app_token — otherwise every token
+    reports 'never used' forever.
+    """
+
+    @pytest.mark.asyncio
+    async def test_app_token_path_spawns_touch_last_used_at(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import asyncio
+        from uuid import UUID
+
+        from api import dependencies as deps
+        from api.dependencies import require_user_or_app_token
+
+        token_id = "11111111-1111-1111-1111-111111111111"
+        row = {
+            "id": UUID(token_id),
+            "user_id": UUID("99999999-9999-9999-9999-999999999999"),
+            "name": "GRUVAX kiosk",
+            "scope": ["collection:read"],
+        }
+        monkeypatch.setattr(deps, "_lookup_active_token", AsyncMock(return_value=row))
+
+        touched: list[str] = []
+
+        async def fake_touch(tid: str) -> None:
+            touched.append(tid)
+
+        monkeypatch.setattr(deps, "_touch_last_used_at", fake_touch)
+
+        dependency = require_user_or_app_token(["collection:read"])
+        creds = _make_credentials("dscg_sometokenplaintext")
+        auth = await dependency(creds)
+
+        assert auth.via == "app_token"
+        assert auth.token_id == token_id
+        # Fire-and-forget task — let the loop run it, then assert bookkeeping fired.
+        await asyncio.sleep(0)
+        assert touched == [token_id]

--- a/tests/api/test_insights_compute.py
+++ b/tests/api/test_insights_compute.py
@@ -267,3 +267,61 @@ class TestAnniversariesValidation:
         response = test_client.get("/api/internal/insights/anniversaries?year=2025&month=3&milestones=25,abc,50")
         assert response.status_code == 422
         assert "milestones" in response.json()["error"].lower()
+
+
+class TestInternalInsightsAuth:
+    """cu2.8: the /api/internal/insights/* router must not be anonymously reachable."""
+
+    _PROTECTED_PATHS = (
+        "/api/internal/insights/artist-centrality",
+        "/api/internal/insights/genre-trends",
+        "/api/internal/insights/label-longevity",
+        "/api/internal/insights/anniversaries?year=2025&month=3",
+        "/api/internal/insights/data-completeness",
+        "/api/internal/insights/rarity-scores",
+        "/api/internal/insights/community-enrichment",
+    )
+
+    @staticmethod
+    def _bare_client() -> TestClient:
+        """A client WITHOUT the default X-Internal-Secret header, sharing app state."""
+        from api.api import app
+
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_all_endpoints_reject_missing_secret(self, test_client: TestClient) -> None:  # noqa: ARG002
+        """Without the shared secret every endpoint returns 401 — no anonymous access."""
+        bare = self._bare_client()
+        for path in self._PROTECTED_PATHS:
+            response = bare.get(path)
+            assert response.status_code == 401, f"{path} was reachable without the internal secret"
+
+    def test_endpoint_rejects_wrong_secret(self, test_client: TestClient) -> None:  # noqa: ARG002
+        """A wrong shared secret is rejected with 401."""
+        bare = self._bare_client()
+        response = bare.get(
+            "/api/internal/insights/artist-centrality",
+            headers={"X-Internal-Secret": "not-the-secret"},
+        )
+        assert response.status_code == 401
+
+    def test_endpoint_accepts_valid_secret(self, test_client: TestClient) -> None:
+        """The configured secret grants access (test_client sends it by default)."""
+        items = [{"artist_id": "1", "artist_name": "Miles Davis", "edge_count": 500}]
+        with patch("api.routers.insights_compute.query_artist_centrality", new_callable=AsyncMock, return_value=items):
+            response = test_client.get("/api/internal/insights/artist-centrality")
+        assert response.status_code == 200
+        assert response.json() == {"items": items}
+
+    def test_fails_closed_when_secret_not_configured(self, test_client: TestClient) -> None:  # noqa: ARG002
+        """When no secret is configured the router fails closed with 503 (never open)."""
+        import api.routers.insights_compute as mod
+
+        original = mod._config
+        mod._config = None
+        try:
+            bare = self._bare_client()
+            response = bare.get("/api/internal/insights/artist-centrality")
+            assert response.status_code == 503
+        finally:
+            mod._config = original

--- a/tests/api/test_neo4j_queries.py
+++ b/tests/api/test_neo4j_queries.py
@@ -1103,6 +1103,28 @@ class TestFindShortestPath:
         assert len(result["nodes"]) == 1
         assert result["rels"] == []
 
+    @pytest.mark.asyncio
+    async def test_node_id_coalesces_to_name_for_name_keyed_nodes(self) -> None:
+        """Genre/Style path nodes have no `id` property; the Cypher must coalesce
+        to `name` so path nodes never carry id=None (sibling of discogsography-cu2.5).
+        """
+        from api.queries.neo4j_queries import find_shortest_path
+
+        mock_driver = AsyncMock()
+        mock_session = AsyncMock()
+        mock_result = AsyncMock()
+        mock_result.single = AsyncMock(return_value=None)
+        mock_session.run = AsyncMock(return_value=mock_result)
+        mock_driver.session = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock()))
+
+        await find_shortest_path(mock_driver, "1", "Rock", max_depth=10, from_type="artist", to_type="genre")
+
+        sent_query = mock_session.run.call_args[0][0]
+        # find_shortest_path always passes timeout=120, so sent_query is a
+        # neo4j.Query wrapper (see api/queries/helpers.py) rather than a bare str.
+        cypher = sent_query.text if hasattr(sent_query, "text") else sent_query
+        assert "coalesce(node.id, node.name)" in cypher
+
 
 # ---------------------------------------------------------------------------
 # get_year_range

--- a/tests/api/test_nlq_sse.py
+++ b/tests/api/test_nlq_sse.py
@@ -39,3 +39,34 @@ async def test_sse_emits_actions_event_before_result() -> None:
     actions_event = events[actions_idx]
     payload = json.loads(actions_event["data"])
     assert payload["actions"][0]["type"] == "seed_graph"
+
+
+@pytest.mark.asyncio
+async def test_sse_replays_cached_result_without_running_engine() -> None:
+    """discogsography-cu2.27: when a streaming request hits a cache entry (written
+    by a prior JSON request), the cached result must be replayed as synthetic
+    actions/result SSE events — never run the engine, never emit a JSON body.
+    """
+    from api.routers import nlq as nlq_router
+
+    engine = MagicMock()
+    engine.run = AsyncMock(side_effect=AssertionError("engine must not run for a cache hit"))
+    nlq_router._engine = engine
+
+    cached = {
+        "query": "who produced Thriller",
+        "summary": "Quincy Jones",
+        "entities": [],
+        "tools_used": ["search"],
+        "actions": [{"type": "seed_graph"}],
+        "cached": True,
+    }
+    response = nlq_router._stream_response("who produced Thriller", None, None, cached=cached)
+    events = [event async for event in response.body_iterator]
+
+    kinds = [e.get("event") for e in events]
+    assert kinds == ["actions", "result"]
+    result_payload = json.loads(events[1]["data"])
+    assert result_payload["summary"] == "Quincy Jones"
+    assert result_payload["cached"] is True
+    engine.run.assert_not_called()

--- a/tests/api/test_nlq_sse.py
+++ b/tests/api/test_nlq_sse.py
@@ -70,3 +70,39 @@ async def test_sse_replays_cached_result_without_running_engine() -> None:
     assert result_payload["summary"] == "Quincy Jones"
     assert result_payload["cached"] is True
     engine.run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sse_cancels_engine_task_on_client_disconnect() -> None:
+    """discogsography-cu2.28: when the SSE client disconnects, the generator is
+    closed and the still-running engine task must be cancelled so the
+    Anthropic/Neo4j work does not leak and the pending task cannot be GC'd.
+    """
+    import asyncio
+
+    from api.routers import nlq as nlq_router
+
+    cancelled = asyncio.Event()
+
+    async def slow_run(_query: object, _ctx: object, on_status: object = None) -> None:
+        if on_status is not None:
+            await on_status("thinking")  # type: ignore[operator]
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    engine = MagicMock()
+    engine.run = slow_run
+    nlq_router._engine = engine
+
+    response = nlq_router._stream_response("slow question", None, None)
+    iterator = response.body_iterator
+    first = await iterator.__anext__()
+    assert first["event"] == "status"
+
+    # Simulate client disconnect — sse-starlette closes the generator.
+    await iterator.aclose()
+
+    assert cancelled.is_set()

--- a/tests/api/test_nlq_suggestions_endpoint.py
+++ b/tests/api/test_nlq_suggestions_endpoint.py
@@ -163,3 +163,51 @@ async def test_extract_user_id_returns_none_when_jwt_secret_is_none() -> None:
     call_args = mock_engine.run.call_args
     ctx = call_args[0][1]
     assert ctx.user_id is None
+
+
+def _sign_jwt(claims: dict, secret: str) -> str:
+    """Build a signed HS256 JWT for _extract_user_id tests."""
+    import base64
+    import hashlib
+    import hmac
+    import json
+
+    def b64url(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+    header = b64url(json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode())
+    body = b64url(json.dumps(claims, separators=(",", ":")).encode())
+    signing_input = f"{header}.{body}".encode("ascii")
+    sig = b64url(hmac.new(secret.encode("utf-8"), signing_input, hashlib.sha256).digest())
+    return f"{header}.{body}.{sig}"
+
+
+def _fake_request(token: str) -> object:
+    """Minimal object exposing the .headers.get() interface _extract_user_id uses."""
+
+    class _Headers:
+        def __init__(self, auth: str) -> None:
+            self._auth = auth
+
+        def get(self, key: str, default: str = "") -> str:
+            return self._auth if key.lower() == "authorization" else default
+
+    class _Req:
+        def __init__(self, auth: str) -> None:
+            self.headers = _Headers(auth)
+
+    return _Req(f"Bearer {token}")
+
+
+def test_extract_user_id_rejects_challenge_token() -> None:
+    """Regression discogsography-cu2.1 — _extract_user_id must not resolve a 2FA challenge token to a user."""
+    from api.routers import nlq as nlq_router
+
+    secret = "test-nlq-secret"
+    nlq_router.configure(nlq_router.NLQConfig(), engine=None, redis=None, jwt_secret=secret)
+
+    challenge = _sign_jwt({"sub": "user-1", "email": "x@y.com", "exp": 9_999_999_999, "type": "2fa_challenge"}, secret)
+    assert nlq_router._extract_user_id(_fake_request(challenge)) is None  # type: ignore[arg-type]
+
+    access = _sign_jwt({"sub": "user-1", "email": "x@y.com", "exp": 9_999_999_999}, secret)
+    assert nlq_router._extract_user_id(_fake_request(access)) == "user-1"  # type: ignore[arg-type]

--- a/tests/api/test_query_helpers.py
+++ b/tests/api/test_query_helpers.py
@@ -103,13 +103,32 @@ class TestRunQuery:
 
     @pytest.mark.asyncio
     async def test_passes_timeout(self) -> None:
+        from neo4j import Query
+
         from api.queries.helpers import run_query
 
         driver = _make_driver(records=[])
         await run_query(driver, "MATCH (n) RETURN n", timeout=30.0)
         session = driver.session.return_value
         _call_args = session.__aenter__.return_value.run.call_args
-        assert _call_args.kwargs.get("timeout") == 30.0
+        # timeout must NOT be forwarded as a session.run() kwarg — session.run
+        # has no timeout option and merges kwargs into the Cypher parameter
+        # map instead. It must be applied via a neo4j.Query wrapper.
+        assert "timeout" not in _call_args.kwargs
+        sent_query = _call_args.args[0]
+        assert isinstance(sent_query, Query)
+        assert sent_query.timeout == 30.0
+        assert sent_query.text == "MATCH (n) RETURN n"
+
+    @pytest.mark.asyncio
+    async def test_no_query_wrapper_without_timeout(self) -> None:
+        from api.queries.helpers import run_query
+
+        driver = _make_driver(records=[])
+        await run_query(driver, "MATCH (n) RETURN n")
+        session = driver.session.return_value
+        _call_args = session.__aenter__.return_value.run.call_args
+        assert _call_args.args[0] == "MATCH (n) RETURN n"
 
     @pytest.mark.asyncio
     async def test_passes_database(self) -> None:
@@ -201,13 +220,18 @@ class TestRunSingle:
 
     @pytest.mark.asyncio
     async def test_passes_timeout(self) -> None:
+        from neo4j import Query
+
         from api.queries.helpers import run_single
 
         driver = _make_driver(single={"id": "1"})
         await run_single(driver, "MATCH (a) RETURN a LIMIT 1", timeout=60.0)
         session = driver.session.return_value
         call_kwargs = session.__aenter__.return_value.run.call_args
-        assert call_kwargs.kwargs.get("timeout") == 60.0
+        assert "timeout" not in call_kwargs.kwargs
+        sent_query = call_kwargs.args[0]
+        assert isinstance(sent_query, Query)
+        assert sent_query.timeout == 60.0
 
     @pytest.mark.asyncio
     async def test_passes_database(self) -> None:
@@ -278,13 +302,18 @@ class TestRunCount:
 
     @pytest.mark.asyncio
     async def test_passes_timeout(self) -> None:
+        from neo4j import Query
+
         from api.queries.helpers import run_count
 
         driver = _make_driver(single={"total": 1})
         await run_count(driver, "RETURN count(*) AS total", timeout=30.0)
         session = driver.session.return_value
         call_kwargs = session.__aenter__.return_value.run.call_args
-        assert call_kwargs.kwargs.get("timeout") == 30.0
+        assert "timeout" not in call_kwargs.kwargs
+        sent_query = call_kwargs.args[0]
+        assert isinstance(sent_query, Query)
+        assert sent_query.timeout == 30.0
 
     @pytest.mark.asyncio
     async def test_passes_database(self) -> None:

--- a/tests/api/test_rarity_queries.py
+++ b/tests/api/test_rarity_queries.py
@@ -758,3 +758,69 @@ class TestFetchAllRaritySignals:
 
         assert len(results) == 1
         assert results[0]["collection_prevalence"] == 50.0
+
+
+class TestRarityPaginationTiebreaker:
+    """discogsography-cu2.55: rarity_score / hidden_gem_score are heavily
+    quantized (round(..., 1)), so OFFSET pagination without a unique tiebreaker
+    duplicates and skips rows across pages. Every paginated ORDER BY must append
+    the unique release_id column.
+    """
+
+    @staticmethod
+    def _pool_with_capture() -> tuple[MagicMock, AsyncMock]:
+        mock_cur = AsyncMock()
+        mock_cur.fetchall = AsyncMock(return_value=[])
+        mock_cur.fetchone = AsyncMock(return_value={"total": 0})
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool = MagicMock()
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+        return mock_pool, mock_cur
+
+    @staticmethod
+    def _first_order_by_sql(mock_cur: AsyncMock) -> str:
+        """The SQL of the first (paginated) execute — the count query is second."""
+        return str(mock_cur.execute.call_args_list[0].args[0])
+
+    @pytest.mark.asyncio
+    async def test_leaderboard_no_tier_has_tiebreaker(self) -> None:
+        mock_pool, mock_cur = self._pool_with_capture()
+        await get_rarity_leaderboard(mock_pool, page=1, page_size=20)
+        assert "ORDER BY rarity_score DESC, release_id" in self._first_order_by_sql(mock_cur)
+
+    @pytest.mark.asyncio
+    async def test_leaderboard_with_tier_has_tiebreaker(self) -> None:
+        mock_pool, mock_cur = self._pool_with_capture()
+        await get_rarity_leaderboard(mock_pool, page=1, page_size=20, tier="ultra-rare")
+        assert "ORDER BY rarity_score DESC, release_id" in self._first_order_by_sql(mock_cur)
+
+    @pytest.mark.asyncio
+    async def test_hidden_gems_has_tiebreaker(self) -> None:
+        mock_pool, mock_cur = self._pool_with_capture()
+        await get_rarity_hidden_gems(mock_pool, page=1, page_size=20, min_rarity=41.0)
+        assert "ORDER BY hidden_gem_score DESC, release_id" in self._first_order_by_sql(mock_cur)
+
+    @pytest.mark.asyncio
+    async def test_by_artist_has_tiebreaker(self) -> None:
+        mock_pool, mock_cur = self._pool_with_capture()
+        with patch(
+            "api.queries.rarity_queries.run_query",
+            new=AsyncMock(side_effect=[[{"id": "123", "name": "Artist"}], [{"release_id": "1"}]]),
+        ):
+            await get_rarity_by_artist(MagicMock(), mock_pool, "123")
+        assert "ORDER BY rarity_score DESC, release_id" in self._first_order_by_sql(mock_cur)
+
+    @pytest.mark.asyncio
+    async def test_by_label_has_tiebreaker(self) -> None:
+        mock_pool, mock_cur = self._pool_with_capture()
+        with patch(
+            "api.queries.rarity_queries.run_query",
+            new=AsyncMock(side_effect=[[{"id": "456", "name": "Label"}], [{"release_id": "1"}]]),
+        ):
+            await get_rarity_by_label(MagicMock(), mock_pool, "456")
+        assert "ORDER BY rarity_score DESC, release_id" in self._first_order_by_sql(mock_cur)

--- a/tests/api/test_recommend.py
+++ b/tests/api/test_recommend.py
@@ -257,6 +257,47 @@ class TestExploreFromHereCacheHit:
         finally:
             mod._cache = original_cache
 
+    def test_cache_key_includes_hops(self, test_client: TestClient, auth_headers: dict[str, str]) -> None:
+        """discogsography-cu2.29: the explore cache key must include the hops
+        parameter — hops changes the traversal depth (not merely truncation), so
+        omitting it serves results computed for a different depth for the TTL.
+        Different hops values MUST produce different cache keys.
+        """
+        import api.routers.recommend as mod
+
+        seen_keys: list[str] = []
+
+        async def record_get(key: str) -> None:
+            seen_keys.append(key)
+            return None
+
+        mock_cache = AsyncMock()
+        mock_cache.get = AsyncMock(side_effect=record_get)
+        mock_cache.set = AsyncMock()
+
+        original_cache = mod._cache
+        original_driver = mod._neo4j_driver
+        mod._cache = mock_cache
+        mod._neo4j_driver = AsyncMock()
+        try:
+            with (
+                patch("api.routers.recommend.get_explore_traversal", new=AsyncMock(return_value=[])),
+                patch("api.routers.recommend.get_taste_heatmap", new=AsyncMock(return_value=([], 0))),
+                patch("api.routers.recommend.get_blind_spots", new=AsyncMock(return_value=[])),
+            ):
+                r2 = test_client.get("/api/recommend/explore/artist/a1?hops=2", headers=auth_headers)
+                r3 = test_client.get("/api/recommend/explore/artist/a1?hops=3", headers=auth_headers)
+        finally:
+            mod._cache = original_cache
+            mod._neo4j_driver = original_driver
+
+        assert r2.status_code == 200
+        assert r3.status_code == 200
+        assert len(seen_keys) == 2
+        assert seen_keys[0].endswith(":2")
+        assert seen_keys[1].endswith(":3")
+        assert seen_keys[0] != seen_keys[1]
+
 
 class TestRecommenderModels:
     """Tests for recommender Pydantic models."""

--- a/tests/api/test_recommend_queries.py
+++ b/tests/api/test_recommend_queries.py
@@ -729,6 +729,19 @@ class TestGetExploreTraversal:
         assert "*1..2" in cypher
 
     @pytest.mark.asyncio
+    async def test_id_coalesces_to_name_for_genre_style_nodes(self) -> None:
+        """Genre/Style nodes have no id property; Cypher must coalesce to name
+        so name-keyed discoveries never come back with id=None (discogsography-cu2.5).
+        """
+        from api.queries.recommend_queries import get_explore_traversal
+
+        driver = _make_driver(records=[])
+        await get_explore_traversal(driver, "artist", "a1", hops=2)
+        call_args = driver.session.return_value.__aenter__.return_value.run.call_args
+        cypher = call_args[0][0]
+        assert "coalesce(discovered.id, discovered.name) AS id" in cypher
+
+    @pytest.mark.asyncio
     async def test_get_explore_traversal_rejects_invalid_entity_type(self) -> None:
         """Invalid entity_type returns [] without making any Neo4j call."""
         from api.queries.recommend_queries import get_explore_traversal
@@ -792,3 +805,25 @@ class TestScoreDiscoveries:
         discoveries = [{"id": "g1", "name": "Unknown", "type": "genre", "path_names": [], "rel_types": [], "dist": 1}]
         result = score_discoveries(discoveries, {"Rock": 0.8}, set(), limit=10)
         assert result[0]["score"] == 0.0
+
+    def test_genre_with_none_id_falls_back_to_name(self) -> None:
+        """Genre/Style nodes are name-keyed in Neo4j and come back with id=None.
+
+        dict.get("id", default) only falls back when the key is MISSING, not
+        when it is present with value None — so score_discoveries must use
+        `d.get("id") or d.get("name", "")` to avoid emitting id=None, which
+        fails DiscoveryNode(id: str) validation downstream (discogsography-cu2.5).
+        """
+        from api.queries.recommend_queries import score_discoveries
+
+        discoveries = [{"id": None, "name": "Jazz", "type": "genre", "path_names": ["Start", "Jazz"], "rel_types": ["IS"], "dist": 1}]
+        result = score_discoveries(discoveries, {}, {"Jazz"}, limit=10)
+        assert result[0]["id"] == "Jazz"
+        assert result[0]["id"] is not None
+
+    def test_style_with_none_id_falls_back_to_name(self) -> None:
+        from api.queries.recommend_queries import score_discoveries
+
+        discoveries = [{"id": None, "name": "Bossa Nova", "type": "style", "path_names": ["Start", "Bossa Nova"], "rel_types": ["IS"], "dist": 1}]
+        result = score_discoveries(discoveries, {}, {"Bossa Nova"}, limit=10)
+        assert result[0]["id"] == "Bossa Nova"

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -231,30 +231,83 @@ class TestSearchQueryModuleHelpers:
     def test_entity_select_without_per_table_limit(self) -> None:
         from api.queries.search_queries import _entity_select
 
-        frag = _entity_select("artist", "name", has_year=False, has_genres=False)
+        frag, params = _entity_select("artist", "name", has_year=False, has_genres=False)
         rendered = frag.as_string(None)
         assert "LIMIT" not in rendered
+        assert params == []
 
     def test_entity_select_with_per_table_limit(self) -> None:
         from api.queries.search_queries import _entity_select
 
-        frag = _entity_select("artist", "name", has_year=False, has_genres=False, per_table_limit=50)
+        frag, params = _entity_select("artist", "name", has_year=False, has_genres=False, per_table_limit=50)
         rendered = frag.as_string(None)
         assert "ORDER BY rank DESC LIMIT 50" in rendered
+        assert params == []
+
+    def test_entity_select_pushes_year_filter_before_limit(self) -> None:
+        """discogsography-cu2.6: year filter must land in the subquery WHERE,
+        BEFORE its ORDER BY rank LIMIT — not only in an outer WHERE applied
+        after the per-table cap.
+        """
+        from api.queries.search_queries import _entity_select
+
+        frag, params = _entity_select("release", "title", has_year=True, has_genres=True, per_table_limit=40, year_min=1960, year_max=1969)
+        rendered = frag.as_string(None)
+        where_idx = rendered.index("WHERE")
+        limit_idx = rendered.index("ORDER BY rank DESC LIMIT")
+        assert where_idx < limit_idx
+        # the year predicate text must appear before the LIMIT, not after
+        assert "year" in rendered[where_idx:limit_idx].lower()
+        assert params == [1960, 1969]
+
+    def test_entity_select_pushes_genre_filter_before_limit(self) -> None:
+        from api.queries.search_queries import _entity_select
+
+        frag, params = _entity_select("release", "title", has_year=True, has_genres=True, per_table_limit=40, genres=["Rock", "Jazz"])
+        rendered = frag.as_string(None)
+        where_idx = rendered.index("WHERE")
+        limit_idx = rendered.index("ORDER BY rank DESC LIMIT")
+        assert "?|" in rendered[where_idx:limit_idx]
+        assert params == [["Rock", "Jazz"]]
+
+    def test_entity_select_no_filter_clause_without_filters(self) -> None:
+        from api.queries.search_queries import _entity_select
+
+        frag, params = _entity_select("artist", "name", has_year=False, has_genres=False, per_table_limit=40)
+        rendered = frag.as_string(None)
+        # No filters given -> WHERE clause should only be the tsvector match,
+        # immediately followed by ORDER BY (no " AND (...)" filter tacked on).
+        assert "@@ q.tsq order by rank desc limit" in rendered.lower()
+        assert params == []
 
     def test_build_union_passes_per_table_limit(self) -> None:
         from api.queries.search_queries import _build_union
 
-        frag = _build_union(["artist"], per_table_limit=30)
+        frag, params = _build_union(["artist"], per_table_limit=30)
         rendered = frag.as_string(None)
         assert "LIMIT 30" in rendered
+        assert params == []
 
     def test_build_union_no_limit_by_default(self) -> None:
         from api.queries.search_queries import _build_union
 
-        frag = _build_union(["artist"])
+        frag, params = _build_union(["artist"])
         rendered = frag.as_string(None)
         assert "LIMIT" not in rendered
+        assert params == []
+
+    def test_build_union_collects_filter_params_per_type(self) -> None:
+        """Filter params must appear once per unioned subquery, in emission order,
+        since each subquery has its own WHERE with its own %s placeholders.
+        """
+        from api.queries.search_queries import _build_union
+
+        frag, params = _build_union(["artist", "release"], per_table_limit=40, year_min=1960)
+        rendered = frag.as_string(None)
+        # artist has no year column, so its clause is trivially satisfied but the
+        # param is still consumed there too (NULL::text IS NULL OR ... >= %s)
+        assert params == [1960, 1960]
+        assert rendered.count("UNION ALL") == 1
 
     def test_format_result_release_with_metadata(self) -> None:
         from api.queries.search_queries import _format_result
@@ -305,6 +358,54 @@ class TestSearchQueryModuleHelpers:
         rendered = executed_sql.as_string(None)
         assert "LIMIT 40" in rendered
 
+    @pytest.mark.asyncio
+    async def test_run_results_applies_year_genre_filter_before_per_table_limit(self) -> None:
+        """discogsography-cu2.6 regression: filtered search must not apply
+        year/genre WHERE after the per-table rank LIMIT — that silently
+        drops/empties results for high-cardinality terms whose top-ranked
+        rows fall outside the filter. Each per-table subquery's WHERE (before
+        its own LIMIT) must carry the filter, and every %s placeholder must
+        have a matching param (no param-count mismatch).
+        """
+        from api.queries.search_queries import _run_results
+
+        mock_cursor = AsyncMock()
+        mock_cursor.fetchall = AsyncMock(return_value=[])
+        mock_cursor.__aenter__ = AsyncMock(return_value=mock_cursor)
+        mock_cursor.__aexit__ = AsyncMock(return_value=False)
+
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cursor)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+
+        mock_pool = MagicMock()
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+
+        with patch("api.queries.search_queries.execute_sql", new_callable=AsyncMock) as mock_exec:
+            await _run_results(mock_pool, "love", ["release"], ["Rock"], 1960, 1969, 10, 0)
+
+        executed_sql = mock_exec.call_args[0][1]
+        executed_params = mock_exec.call_args[0][2]
+        rendered = executed_sql.as_string(None)
+
+        # The per-table subquery's own WHERE (with the filter) must precede its
+        # ORDER BY rank LIMIT — not a trailing outer WHERE applied after the cap.
+        subquery_where = rendered.index("WHERE")
+        subquery_limit = rendered.index("ORDER BY rank DESC LIMIT")
+        assert subquery_where < subquery_limit
+        assert "year" in rendered[subquery_where:subquery_limit].lower()
+        assert "?|" in rendered[subquery_where:subquery_limit]
+
+        # There must be no outer "WHERE ... AND ..." applied after the results CTE.
+        outer_select_idx = rendered.rindex("SELECT type, id, name, rank, highlight, year, genres")
+        outer_tail = rendered[outer_select_idx:]
+        assert "WHERE" not in outer_tail
+
+        # %s placeholder count must match param count exactly (q + year_min +
+        # year_max + genres + limit + offset).
+        assert rendered.count("%s") == len(executed_params)
+
     def test_build_union_raises_on_empty_types(self) -> None:
         from api.queries.search_queries import _build_union
 
@@ -314,7 +415,7 @@ class TestSearchQueryModuleHelpers:
     def test_build_union_multiple_types(self) -> None:
         from api.queries.search_queries import _build_union
 
-        frag = _build_union(["artist", "release"])
+        frag, _params = _build_union(["artist", "release"])
         rendered = frag.as_string(None)
         assert "UNION ALL" in rendered
 

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -674,3 +674,95 @@ class TestSearchQueryAsyncFunctions:
             result = await execute_search(mock_pool, None, "blue", ["artist"], [], None, None, 20, 0)
 
         assert result["query"] == "blue"
+
+    @staticmethod
+    def _db_mocks() -> MagicMock:
+        """A pool whose cursor returns empty result sets for every _run_* query."""
+        mock_cursor = AsyncMock()
+        mock_cursor.fetchall = AsyncMock(return_value=[])
+        mock_cursor.fetchone = AsyncMock(return_value={"total": 0})
+        mock_cursor.__aenter__ = AsyncMock(return_value=mock_cursor)
+        mock_cursor.__aexit__ = AsyncMock(return_value=False)
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cursor)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool = MagicMock()
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+        return mock_pool
+
+    @pytest.mark.asyncio
+    async def test_execute_search_degrades_when_redis_get_raises(self) -> None:
+        """discogsography-cu2.23: a Redis read outage must fall through to the DB,
+        not propagate a 500 — search is fully PostgreSQL-backed.
+        """
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        from api.queries.search_queries import execute_search
+
+        mock_pool = self._db_mocks()
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(side_effect=RedisConnectionError("Connection refused"))
+        mock_redis.setex = AsyncMock()
+
+        with patch("api.queries.search_queries.execute_sql", new_callable=AsyncMock):
+            result = await execute_search(mock_pool, mock_redis, "blue", ["artist"], [], None, None, 20, 0)
+
+        # Answered from PostgreSQL despite the Redis outage.
+        assert result["query"] == "blue"
+        assert result["total"] == 0
+        mock_redis.get.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_search_returns_when_redis_setex_raises(self) -> None:
+        """discogsography-cu2.23: a Redis write outage must not fail an otherwise
+        successful search response.
+        """
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        from api.queries.search_queries import execute_search
+
+        mock_pool = self._db_mocks()
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.setex = AsyncMock(side_effect=RedisConnectionError("Connection refused"))
+
+        with patch("api.queries.search_queries.execute_sql", new_callable=AsyncMock):
+            result = await execute_search(mock_pool, mock_redis, "blue", ["artist"], [], None, None, 20, 0)
+
+        assert result["query"] == "blue"
+        mock_redis.setex.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_search_treats_corrupt_cache_entry_as_miss(self) -> None:
+        """discogsography-cu2.23: a corrupt (non-JSON) cache entry must be treated
+        as a miss rather than raising.
+        """
+        from api.queries.search_queries import execute_search
+
+        mock_pool = self._db_mocks()
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value="{not valid json")
+        mock_redis.setex = AsyncMock()
+
+        with patch("api.queries.search_queries.execute_sql", new_callable=AsyncMock):
+            result = await execute_search(mock_pool, mock_redis, "blue", ["artist"], [], None, None, 20, 0)
+
+        assert result["query"] == "blue"
+
+    @pytest.mark.asyncio
+    async def test_run_results_final_order_has_unique_tiebreaker(self) -> None:
+        """discogsography-cu2.56: the outer paginated query must sort by a unique
+        secondary key so OFFSET pagination is page-consistent across executions.
+        """
+        from api.queries.search_queries import _run_results
+
+        mock_pool = self._db_mocks()
+        with patch("api.queries.search_queries.execute_sql", new_callable=AsyncMock) as mock_exec:
+            await _run_results(mock_pool, "Rock", ["artist"], [], None, None, 10, 10)
+
+        rendered = mock_exec.call_args[0][1].as_string(None)
+        # Final ordering carries the unique `id` tiebreaker; the per-table cap
+        # carries the unique `data_id` tiebreaker.
+        assert "ORDER BY rank DESC, id" in rendered
+        assert "ORDER BY rank DESC, data_id LIMIT" in rendered

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -241,7 +241,7 @@ class TestSearchQueryModuleHelpers:
 
         frag, params = _entity_select("artist", "name", has_year=False, has_genres=False, per_table_limit=50)
         rendered = frag.as_string(None)
-        assert "ORDER BY rank DESC LIMIT 50" in rendered
+        assert "ORDER BY rank DESC, data_id LIMIT 50" in rendered
         assert params == []
 
     def test_entity_select_pushes_year_filter_before_limit(self) -> None:
@@ -254,7 +254,7 @@ class TestSearchQueryModuleHelpers:
         frag, params = _entity_select("release", "title", has_year=True, has_genres=True, per_table_limit=40, year_min=1960, year_max=1969)
         rendered = frag.as_string(None)
         where_idx = rendered.index("WHERE")
-        limit_idx = rendered.index("ORDER BY rank DESC LIMIT")
+        limit_idx = rendered.index("ORDER BY rank DESC, data_id LIMIT")
         assert where_idx < limit_idx
         # the year predicate text must appear before the LIMIT, not after
         assert "year" in rendered[where_idx:limit_idx].lower()
@@ -266,7 +266,7 @@ class TestSearchQueryModuleHelpers:
         frag, params = _entity_select("release", "title", has_year=True, has_genres=True, per_table_limit=40, genres=["Rock", "Jazz"])
         rendered = frag.as_string(None)
         where_idx = rendered.index("WHERE")
-        limit_idx = rendered.index("ORDER BY rank DESC LIMIT")
+        limit_idx = rendered.index("ORDER BY rank DESC, data_id LIMIT")
         assert "?|" in rendered[where_idx:limit_idx]
         assert params == [["Rock", "Jazz"]]
 
@@ -277,7 +277,7 @@ class TestSearchQueryModuleHelpers:
         rendered = frag.as_string(None)
         # No filters given -> WHERE clause should only be the tsvector match,
         # immediately followed by ORDER BY (no " AND (...)" filter tacked on).
-        assert "@@ q.tsq order by rank desc limit" in rendered.lower()
+        assert "@@ q.tsq order by rank desc, data_id limit" in rendered.lower()
         assert params == []
 
     def test_build_union_passes_per_table_limit(self) -> None:
@@ -392,7 +392,7 @@ class TestSearchQueryModuleHelpers:
         # The per-table subquery's own WHERE (with the filter) must precede its
         # ORDER BY rank LIMIT — not a trailing outer WHERE applied after the cap.
         subquery_where = rendered.index("WHERE")
-        subquery_limit = rendered.index("ORDER BY rank DESC LIMIT")
+        subquery_limit = rendered.index("ORDER BY rank DESC, data_id LIMIT")
         assert subquery_where < subquery_limit
         assert "year" in rendered[subquery_where:subquery_limit].lower()
         assert "?|" in rendered[subquery_where:subquery_limit]

--- a/tests/api/test_snapshot.py
+++ b/tests/api/test_snapshot.py
@@ -262,6 +262,37 @@ class TestSnapshotTokenChecks:
         assert response.status_code == 403
         assert "admin" in response.json()["detail"].lower()
 
+    def test_challenge_token_rejected(self, test_client: TestClient) -> None:
+        """Regression discogsography-cu2.1 — a 2FA challenge token must NOT authenticate /api/snapshot."""
+        import base64
+        import hashlib
+        import hmac
+        import json
+
+        from tests.api.conftest import TEST_JWT_SECRET
+
+        def b64url(data: bytes) -> str:
+            return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+        header = b64url(json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode())
+        body_payload = b64url(
+            json.dumps(
+                {"sub": "user-1", "email": "user@test.com", "exp": 9_999_999_999, "type": "2fa_challenge", "jti": "chal:snap-test"},
+                separators=(",", ":"),
+            ).encode()
+        )
+        signing_input = f"{header}.{body_payload}".encode("ascii")
+        sig = b64url(hmac.new(TEST_JWT_SECRET.encode("utf-8"), signing_input, hashlib.sha256).digest())
+        challenge_token = f"{header}.{body_payload}.{sig}"
+
+        body = {"nodes": [{"id": "1", "type": "artist"}], "center": {"id": "1", "type": "artist"}}
+        response = test_client.post(
+            "/api/snapshot",
+            json=body,
+            headers={"Authorization": f"Bearer {challenge_token}"},
+        )
+        assert response.status_code == 401
+
     def test_password_changed_revocation(self, test_client: TestClient) -> None:
         """snapshot.py:56-65 — Token issued before password change is rejected with 401."""
         import base64

--- a/tests/api/test_sync.py
+++ b/tests/api/test_sync.py
@@ -139,6 +139,29 @@ class TestTriggerSyncEndpoint:
         response = test_client.post("/api/sync", headers={"Authorization": f"Bearer {token}"})
         assert response.status_code == 401
 
+    def test_trigger_sync_challenge_token_returns_401(self, test_client: TestClient) -> None:
+        """Regression discogsography-cu2.1 — a 2FA challenge token must NOT authenticate /api/sync."""
+        import base64
+        import hashlib
+        import hmac
+        import json
+
+        def b64url(data: bytes) -> str:
+            return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+        header = b64url(json.dumps({"alg": "HS256"}, separators=(",", ":")).encode())
+        body = b64url(
+            json.dumps(
+                {"sub": TEST_USER_ID, "email": TEST_USER_EMAIL, "exp": 9_999_999_999, "type": "2fa_challenge", "jti": "chal:sync-test"},
+                separators=(",", ":"),
+            ).encode()
+        )
+        signing_input = f"{header}.{body}".encode("ascii")
+        sig = b64url(hmac.new(TEST_JWT_SECRET.encode("utf-8"), signing_input, hashlib.sha256).digest())
+        token = f"{header}.{body}.{sig}"
+        response = test_client.post("/api/sync", headers={"Authorization": f"Bearer {token}"})
+        assert response.status_code == 401
+
 
 class TestSyncStatusEndpoint:
     """Tests for GET /api/sync/status."""

--- a/tests/api/test_syncer.py
+++ b/tests/api/test_syncer.py
@@ -7,6 +7,7 @@ import pytest
 
 from api.syncer import (
     MAX_RATE_LIMIT_RETRIES,
+    DiscogsSyncError,
     _auth_header,
     run_full_sync,
     sync_collection,
@@ -186,7 +187,9 @@ class TestSyncCollection:
 
         assert result == 1
         mock_pg_pool._mock_cur.executemany.assert_awaited_once()
-        mock_neo4j._mock_session.run.assert_awaited_once()
+        # 2 session.run calls: the per-page upsert MERGE, then the post-loop
+        # stale-row reconciliation DELETE (discogsography-cu2.9).
+        assert mock_neo4j._mock_session.run.await_count == 2
 
     @pytest.mark.asyncio
     async def test_rate_limited_429_retries(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
@@ -225,7 +228,9 @@ class TestSyncCollection:
 
     @pytest.mark.asyncio
     async def test_rate_limit_retries_exhausted(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
-        """Persistent 429 responses break the loop after MAX_RATE_LIMIT_RETRIES."""
+        """discogsography-cu2.30: persistent 429s must raise (not silently break)
+        so run_full_sync records the sync as 'failed', not 'completed'.
+        """
         rate_limited = MagicMock()
         rate_limited.status_code = 429
 
@@ -239,20 +244,23 @@ class TestSyncCollection:
             mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client
 
-            result = await sync_collection(
-                TEST_USER_UUID,
-                TEST_DISCOGS_USERNAME,
-                TEST_CONSUMER_KEY,
-                TEST_CONSUMER_SECRET,
-                TEST_ACCESS_TOKEN,
-                TEST_TOKEN_SECRET,
-                TEST_USER_AGENT,
-                mock_pg_pool,
-                mock_neo4j,
-            )
+            with pytest.raises(DiscogsSyncError, match="rate limit retries exhausted"):
+                await sync_collection(
+                    TEST_USER_UUID,
+                    TEST_DISCOGS_USERNAME,
+                    TEST_CONSUMER_KEY,
+                    TEST_CONSUMER_SECRET,
+                    TEST_ACCESS_TOKEN,
+                    TEST_TOKEN_SECRET,
+                    TEST_USER_AGENT,
+                    mock_pg_pool,
+                    mock_neo4j,
+                )
 
-        assert result == 0
         assert mock_sleep.await_count == MAX_RATE_LIMIT_RETRIES
+        # A raised sync must NOT trigger reconciliation deletes — the fetched
+        # data was incomplete, so we cannot tell what's genuinely stale.
+        mock_pg_pool._mock_cur.execute.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_rate_limit_counter_resets_on_success(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
@@ -297,7 +305,10 @@ class TestSyncCollection:
         assert result == 1
 
     @pytest.mark.asyncio
-    async def test_non_200_breaks_loop(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+    async def test_non_200_raises(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """discogsography-cu2.30: a non-200 response must raise (not silently
+        break) so run_full_sync records the sync as 'failed', not 'completed'.
+        """
         error_response = MagicMock()
         error_response.status_code = 500
 
@@ -308,19 +319,21 @@ class TestSyncCollection:
             mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client
 
-            result = await sync_collection(
-                TEST_USER_UUID,
-                TEST_DISCOGS_USERNAME,
-                TEST_CONSUMER_KEY,
-                TEST_CONSUMER_SECRET,
-                TEST_ACCESS_TOKEN,
-                TEST_TOKEN_SECRET,
-                TEST_USER_AGENT,
-                mock_pg_pool,
-                mock_neo4j,
-            )
+            with pytest.raises(DiscogsSyncError, match="status=500"):
+                await sync_collection(
+                    TEST_USER_UUID,
+                    TEST_DISCOGS_USERNAME,
+                    TEST_CONSUMER_KEY,
+                    TEST_CONSUMER_SECRET,
+                    TEST_ACCESS_TOKEN,
+                    TEST_TOKEN_SECRET,
+                    TEST_USER_AGENT,
+                    mock_pg_pool,
+                    mock_neo4j,
+                )
 
-        assert result == 0
+        # A raised sync must NOT trigger reconciliation deletes.
+        mock_pg_pool._mock_cur.execute.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_empty_releases_breaks_loop(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
@@ -455,6 +468,91 @@ class TestSyncCollection:
 
         assert result == 1
 
+    @pytest.mark.asyncio
+    async def test_reconciles_stale_rows_after_successful_sync(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """discogsography-cu2.9 regression: after a fully successful sync, stale
+        rows/edges (items removed from Discogs since the last sync, or orphaned
+        by a remove+re-add under a new instance_id) must be deleted — sync is
+        not allowed to stay upsert-only.
+        """
+        release = _make_release_item(123)
+        response_data = _make_collection_response([release], page=1, pages=1)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = response_data
+
+        with patch("api.syncer.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await sync_collection(
+                TEST_USER_UUID,
+                TEST_DISCOGS_USERNAME,
+                TEST_CONSUMER_KEY,
+                TEST_CONSUMER_SECRET,
+                TEST_ACCESS_TOKEN,
+                TEST_TOKEN_SECRET,
+                TEST_USER_AGENT,
+                mock_pg_pool,
+                mock_neo4j,
+            )
+
+        # PG: a DELETE ... WHERE updated_at < <sync_started> sweep.
+        mock_pg_pool._mock_cur.execute.assert_awaited_once()
+        pg_call = mock_pg_pool._mock_cur.execute.await_args
+        pg_sql = pg_call.args[0]
+        assert "DELETE FROM user_collections" in pg_sql
+        assert "updated_at" in pg_sql
+        assert str(TEST_USER_UUID) in pg_call.args[1]
+
+        # Neo4j: the reconciliation DELETE is the LAST session.run call (after
+        # the per-page upsert MERGE).
+        assert mock_neo4j._mock_session.run.await_count == 2
+        reconcile_call = mock_neo4j._mock_session.run.await_args_list[-1]
+        reconcile_cypher = reconcile_call[0][0]
+        reconcile_params = reconcile_call[0][1]
+        assert "DELETE c" in reconcile_cypher
+        assert "COLLECTED" in reconcile_cypher
+        assert reconcile_params["user_id"] == str(TEST_USER_UUID)
+        assert "sync_started" in reconcile_params
+
+    @pytest.mark.asyncio
+    async def test_no_reconciliation_when_rate_limit_exhausted(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """A raised sync (rate limit exhausted) must skip reconciliation entirely
+        — deleting rows based on an incomplete fetch would destroy valid data.
+        """
+        rate_limited = MagicMock()
+        rate_limited.status_code = 429
+
+        with (
+            patch("api.syncer.httpx.AsyncClient") as mock_client_cls,
+            patch("api.syncer.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=rate_limited)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(DiscogsSyncError):
+                await sync_collection(
+                    TEST_USER_UUID,
+                    TEST_DISCOGS_USERNAME,
+                    TEST_CONSUMER_KEY,
+                    TEST_CONSUMER_SECRET,
+                    TEST_ACCESS_TOKEN,
+                    TEST_TOKEN_SECRET,
+                    TEST_USER_AGENT,
+                    mock_pg_pool,
+                    mock_neo4j,
+                )
+
+        mock_pg_pool._mock_cur.execute.assert_not_awaited()
+        mock_neo4j._mock_session.run.assert_not_awaited()
+
 
 class TestSyncWantlist:
     """Tests for sync_wantlist."""
@@ -490,7 +588,9 @@ class TestSyncWantlist:
         assert mock_pg_pool._mock_cur.executemany.await_count == 1
         first_sql = mock_pg_pool._mock_cur.executemany.await_args_list[0].args[0]
         assert "user_wantlists" in first_sql
-        mock_neo4j._mock_session.run.assert_awaited_once()
+        # 2 session.run calls: the per-page upsert MERGE, then the post-loop
+        # stale-row reconciliation DELETE (discogsography-cu2.9).
+        assert mock_neo4j._mock_session.run.await_count == 2
 
     @pytest.mark.asyncio
     async def test_rate_limited_429(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
@@ -528,7 +628,9 @@ class TestSyncWantlist:
 
     @pytest.mark.asyncio
     async def test_rate_limit_retries_exhausted(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
-        """Persistent 429 responses break the wantlist loop after MAX_RATE_LIMIT_RETRIES."""
+        """discogsography-cu2.30: persistent 429s must raise (not silently
+        break) so run_full_sync records the sync as 'failed', not 'completed'.
+        """
         rate_limited = MagicMock()
         rate_limited.status_code = 429
 
@@ -542,23 +644,27 @@ class TestSyncWantlist:
             mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client
 
-            result = await sync_wantlist(
-                TEST_USER_UUID,
-                TEST_DISCOGS_USERNAME,
-                TEST_CONSUMER_KEY,
-                TEST_CONSUMER_SECRET,
-                TEST_ACCESS_TOKEN,
-                TEST_TOKEN_SECRET,
-                TEST_USER_AGENT,
-                mock_pg_pool,
-                mock_neo4j,
-            )
+            with pytest.raises(DiscogsSyncError, match="rate limit retries exhausted"):
+                await sync_wantlist(
+                    TEST_USER_UUID,
+                    TEST_DISCOGS_USERNAME,
+                    TEST_CONSUMER_KEY,
+                    TEST_CONSUMER_SECRET,
+                    TEST_ACCESS_TOKEN,
+                    TEST_TOKEN_SECRET,
+                    TEST_USER_AGENT,
+                    mock_pg_pool,
+                    mock_neo4j,
+                )
 
-        assert result == 0
         assert mock_sleep.await_count == MAX_RATE_LIMIT_RETRIES
+        mock_pg_pool._mock_cur.execute.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_non_200_breaks(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+    async def test_non_200_raises(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """discogsography-cu2.30: a non-200 response must raise (not silently
+        break) so run_full_sync records the sync as 'failed', not 'completed'.
+        """
         error = MagicMock()
         error.status_code = 403
 
@@ -569,19 +675,20 @@ class TestSyncWantlist:
             mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client
 
-            result = await sync_wantlist(
-                TEST_USER_UUID,
-                TEST_DISCOGS_USERNAME,
-                TEST_CONSUMER_KEY,
-                TEST_CONSUMER_SECRET,
-                TEST_ACCESS_TOKEN,
-                TEST_TOKEN_SECRET,
-                TEST_USER_AGENT,
-                mock_pg_pool,
-                mock_neo4j,
-            )
+            with pytest.raises(DiscogsSyncError, match="status=403"):
+                await sync_wantlist(
+                    TEST_USER_UUID,
+                    TEST_DISCOGS_USERNAME,
+                    TEST_CONSUMER_KEY,
+                    TEST_CONSUMER_SECRET,
+                    TEST_ACCESS_TOKEN,
+                    TEST_TOKEN_SECRET,
+                    TEST_USER_AGENT,
+                    mock_pg_pool,
+                    mock_neo4j,
+                )
 
-        assert result == 0
+        mock_pg_pool._mock_cur.execute.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_empty_wants_breaks(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
@@ -677,6 +784,46 @@ class TestSyncWantlist:
             )
 
         assert result == 1
+
+    @pytest.mark.asyncio
+    async def test_reconciles_stale_wants_after_successful_sync(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """discogsography-cu2.9 regression: after a fully successful wantlist
+        sync, items removed from the wantlist (e.g. after purchase) must be
+        deleted from both PostgreSQL and Neo4j, not persisted forever.
+        """
+        want = _make_want_item(456)
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = _make_wantlist_response([want])
+
+        with patch("api.syncer.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await sync_wantlist(
+                TEST_USER_UUID,
+                TEST_DISCOGS_USERNAME,
+                TEST_CONSUMER_KEY,
+                TEST_CONSUMER_SECRET,
+                TEST_ACCESS_TOKEN,
+                TEST_TOKEN_SECRET,
+                TEST_USER_AGENT,
+                mock_pg_pool,
+                mock_neo4j,
+            )
+
+        mock_pg_pool._mock_cur.execute.assert_awaited_once()
+        pg_sql = mock_pg_pool._mock_cur.execute.await_args.args[0]
+        assert "DELETE FROM user_wantlists" in pg_sql
+        assert "updated_at" in pg_sql
+
+        assert mock_neo4j._mock_session.run.await_count == 2
+        reconcile_call = mock_neo4j._mock_session.run.await_args_list[-1]
+        assert "DELETE wnt" in reconcile_call[0][0]
+        assert "WANTS" in reconcile_call[0][0]
 
 
 class TestRunFullSync:
@@ -776,6 +923,54 @@ class TestRunFullSync:
 
         assert result["status"] == "failed"
         assert result["error"] == "boom"
+
+    @pytest.mark.asyncio
+    async def test_revoked_oauth_token_records_failed_not_completed(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """discogsography-cu2.30 regression: a real (unmocked) sync_collection
+        hitting a 401 (revoked OAuth token) must leave run_full_sync's status
+        as 'failed' with a populated error — not silently 'completed' with
+        items_synced=0 and error=None, which would hide the failure from the
+        UI and never prompt re-authorization.
+        """
+        mock_pg_pool._mock_cur.fetchone.return_value = {
+            "access_token": "at",
+            "access_secret": "as",
+            "provider_username": "user",
+        }
+        mock_pg_pool._mock_cur.fetchall.return_value = [
+            {"key": "discogs_consumer_key", "value": "ck"},
+            {"key": "discogs_consumer_secret", "value": "cs"},
+        ]
+
+        unauthorized = MagicMock()
+        unauthorized.status_code = 401
+
+        with (
+            patch("api.syncer.httpx.AsyncClient") as mock_client_cls,
+            patch("api.syncer.decrypt_oauth_token", side_effect=lambda val, _key: val),
+        ):
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=unauthorized)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await run_full_sync(
+                TEST_USER_UUID,
+                "sync-401",
+                mock_pg_pool,
+                mock_neo4j,
+                TEST_USER_AGENT,
+            )
+
+        assert result["status"] == "failed"
+        assert result["error"] is not None
+        assert "401" in result["error"]
+        assert result["collection_count"] == 0
+        # sync_history UPDATE must record the failure, not silently 'completed'.
+        history_update = mock_pg_pool._mock_cur.execute.await_args_list[-1]
+        assert "sync_history" in history_update.args[0]
+        assert history_update.args[1][0] == "failed"
 
     @pytest.mark.asyncio
     async def test_sync_history_update_failure_handled(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
@@ -940,8 +1135,10 @@ class TestCatalogNumberCapture:
                 mock_neo4j,
             )
 
-        # Cypher params live in the second positional arg of session.run(cypher, params)
-        run_call = mock_neo4j._mock_session.run.await_args
+        # Cypher params live in the second positional arg of session.run(cypher, params).
+        # Call [0] is the per-page upsert MERGE; the post-loop reconciliation
+        # DELETE (discogsography-cu2.9) is the subsequent call.
+        run_call = mock_neo4j._mock_session.run.await_args_list[0]
         cypher_text = run_call[0][0]
         cypher_params = run_call[0][1]
         assert "r += rel.metadata" in cypher_text
@@ -978,7 +1175,7 @@ class TestCatalogNumberCapture:
 
         batch_params = mock_pg_pool._mock_cur.executemany.await_args[0][1]
         assert batch_params[0][11] is None
-        cypher_params = mock_neo4j._mock_session.run.await_args[0][1]
+        cypher_params = mock_neo4j._mock_session.run.await_args_list[0][0][1]
         assert cypher_params["releases"][0]["metadata"] == {}
 
     @pytest.mark.asyncio
@@ -1042,7 +1239,7 @@ class TestCatalogNumberCapture:
                 mock_neo4j,
             )
 
-        run_call = mock_neo4j._mock_session.run.await_args
+        run_call = mock_neo4j._mock_session.run.await_args_list[0]
         cypher_text = run_call[0][0]
         cypher_params = run_call[0][1]
         assert "r += w.metadata" in cypher_text
@@ -1078,5 +1275,5 @@ class TestCatalogNumberCapture:
                 mock_neo4j,
             )
 
-        cypher_params = mock_neo4j._mock_session.run.await_args[0][1]
+        cypher_params = mock_neo4j._mock_session.run.await_args_list[0][0][1]
         assert cypher_params["wants"][0]["metadata"] == {}

--- a/tests/api/test_user_queries.py
+++ b/tests/api/test_user_queries.py
@@ -428,6 +428,48 @@ class TestGetUserCollectionTimeline:
 
         assert result["timeline"][0]["year"] == 1980
 
+    @pytest.mark.asyncio
+    async def test_cypher_does_not_dedupe_genre_and_label_lists(self) -> None:
+        """discogsography-cu2.7 regression: collect(DISTINCT rg)/collect(DISTINCT rl)
+        dedupe identical per-release genre/label lists, corrupting per-bucket
+        counts (e.g. 20 Rock-only releases collapse to a single ["Rock"] entry).
+        The list-of-list collects must be plain collect(), not collect(DISTINCT).
+        Style dedup (collect(DISTINCT rs)) is harmless — styles are consumed as
+        a membership set — so it is intentionally left as DISTINCT.
+        """
+        from api.queries.user_queries import get_user_collection_timeline
+
+        driver = _simple_driver(records=[])
+        await get_user_collection_timeline(driver, "user-1")
+
+        cypher = driver.session.return_value.__aenter__.return_value.run.call_args[0][0]
+        assert "collect(DISTINCT rg)" not in cypher
+        assert "collect(DISTINCT rl)" not in cypher
+        assert "collect(rg) AS genre_lists" in cypher
+        assert "collect(rl) AS label_lists" in cypher
+        # Style dedup remains — it is not part of this defect.
+        assert "collect(DISTINCT rs) AS style_lists" in cypher
+
+    @pytest.mark.asyncio
+    async def test_duplicate_per_release_genre_lists_all_counted(self) -> None:
+        """End-to-end: many releases sharing an identical genre list must each
+        contribute to genre_counts/genre_totals, not collapse to one entry.
+        """
+        from api.queries.user_queries import get_user_collection_timeline
+
+        # Simulates the post-fix Cypher output: 20 Rock-only releases plus 2
+        # Jazz/Funk releases in the same bucket, all flattened via plain collect().
+        genres_flat = ["Rock"] * 20 + ["Jazz", "Funk"]
+        rows = [{"year": 1990, "count": 22, "genres": genres_flat, "styles": [], "labels": []}]
+        driver = _simple_driver(records=rows)
+        result = await get_user_collection_timeline(driver, "user-1")
+
+        genre_counts = result["timeline"][0]["genres"]
+        assert genre_counts["Rock"] == 20
+        assert genre_counts["Jazz"] == 1
+        assert genre_counts["Funk"] == 1
+        assert result["insights"]["dominant_genre"] == "Rock"
+
 
 # ---------------------------------------------------------------------------
 # get_user_collection_evolution

--- a/tests/brainzgraphinator/test_brainzgraphinator.py
+++ b/tests/brainzgraphinator/test_brainzgraphinator.py
@@ -1950,3 +1950,52 @@ class TestRecoverConsumersAllTypesBrainzgraphinator:
         bg.active_connection = None
         bg.active_channel = None
         bg.queues = {}
+
+
+class TestRecoverConsumersClearsTagsBrainzgraphinator:
+    """Regression (cu2.54): recovery errors after ≥1 consumer registered must
+    clear consumer_tags so the stuck-state detector can re-fire."""
+
+    @pytest.mark.asyncio
+    async def test_error_after_partial_registration_clears_consumer_tags(self) -> None:
+        import brainzgraphinator.brainzgraphinator as bg
+
+        types = ["artists", "labels", "release-groups", "releases"]
+        bg.active_connection = None
+        bg.active_channel = None
+        bg.consumer_tags = {}
+        bg.completed_files = set()
+        bg.queues = {}
+        bg.last_message_time = dict.fromkeys(types, 0.0)
+
+        def declare_queue(**kwargs: Any) -> Any:
+            name = kwargs.get("name", "")
+            if kwargs.get("passive"):
+                q = MagicMock()
+                q.declaration_result.message_count = 100
+                return q
+            q = AsyncMock()
+            q.bind = AsyncMock()
+            if name.endswith("-labels"):
+                q.consume = AsyncMock(side_effect=RuntimeError("channel closed mid-recovery"))
+            else:
+                q.consume = AsyncMock(return_value=f"tag-{name}")
+            return q
+
+        mock_channel = AsyncMock()
+        mock_channel.declare_queue = AsyncMock(side_effect=declare_queue)
+        mock_channel.declare_exchange = AsyncMock(return_value=AsyncMock())
+        mock_channel.set_qos = AsyncMock()
+        mock_connection = AsyncMock()
+        mock_connection.channel = AsyncMock(return_value=mock_channel)
+        mock_rmq = AsyncMock()
+        mock_rmq.connect = AsyncMock(return_value=mock_connection)
+
+        with patch.object(bg, "rabbitmq_manager", mock_rmq), patch.object(bg, "logger"):
+            await bg._recover_consumers()
+
+        assert bg.consumer_tags == {}, "stale consumer tags must be cleared"
+        assert bg.active_connection is None
+
+        bg.consumer_tags = {}
+        bg.queues = {}

--- a/tests/brainzgraphinator/test_brainzgraphinator.py
+++ b/tests/brainzgraphinator/test_brainzgraphinator.py
@@ -149,6 +149,20 @@ class TestEnrichArtist:
             mock_tx.run.assert_not_called()
             assert bgmod.enrichment_stats["entities_skipped_no_discogs_match"] == 1
 
+    @pytest.mark.asyncio
+    async def test_enrich_artist_coerces_discogs_id_to_string(self, mock_tx: AsyncMock) -> None:
+        """discogs_artist_id (a JSON int from the extractor) is coerced to str before
+        matching, since graphinator always writes Discogs node `id` as a String.
+        Regression test for discogsography-cu2.10.
+        """
+        record = {"mbid": "abc", "discogs_artist_id": 12345}
+        with patch.dict(bgmod.enrichment_stats, CLEAN_STATS):
+            await enrich_artist(mock_tx, record)
+
+        call_kwargs = mock_tx.run.call_args_list[0].kwargs
+        assert call_kwargs["discogs_id"] == "12345"
+        assert isinstance(call_kwargs["discogs_id"], str)
+
 
 class TestEnrichLabel:
     """Tests for enrich_label."""
@@ -192,6 +206,19 @@ class TestEnrichLabel:
             await enrich_label(mock_tx, record)
             assert bgmod.enrichment_stats["entities_skipped_no_discogs_match"] == 1
 
+    @pytest.mark.asyncio
+    async def test_enrich_label_coerces_discogs_id_to_string(self, mock_tx: AsyncMock) -> None:
+        """discogs_label_id is coerced to str before matching. Regression test for
+        discogsography-cu2.10.
+        """
+        record = {"mbid": "abc", "discogs_label_id": 54321}
+        with patch.dict(bgmod.enrichment_stats, CLEAN_STATS):
+            await enrich_label(mock_tx, record)
+
+        call_kwargs = mock_tx.run.call_args_list[0].kwargs
+        assert call_kwargs["discogs_id"] == "54321"
+        assert isinstance(call_kwargs["discogs_id"], str)
+
 
 class TestEnrichRelease:
     """Tests for enrich_release."""
@@ -234,6 +261,19 @@ class TestEnrichRelease:
             assert bgmod.enrichment_stats["entities_skipped_no_discogs_match"] == 1
             assert bgmod.enrichment_stats["entities_enriched"] == 0
 
+    @pytest.mark.asyncio
+    async def test_enrich_release_coerces_discogs_id_to_string(self, mock_tx: AsyncMock) -> None:
+        """discogs_release_id is coerced to str before matching. Regression test for
+        discogsography-cu2.10.
+        """
+        record = {"mbid": "abc", "discogs_release_id": 99999}
+        with patch.dict(bgmod.enrichment_stats, CLEAN_STATS):
+            await enrich_release(mock_tx, record)
+
+        call_kwargs = mock_tx.run.call_args_list[0].kwargs
+        assert call_kwargs["discogs_id"] == "99999"
+        assert isinstance(call_kwargs["discogs_id"], str)
+
 
 # ── Release-group enrichment tests ────────────────────────────────────────
 
@@ -275,6 +315,19 @@ class TestEnrichReleaseGroup:
         with patch.dict(bgmod.enrichment_stats, CLEAN_STATS):
             result = await enrich_release_group(mock_tx, record)
             assert result is True
+
+    @pytest.mark.asyncio
+    async def test_enrich_release_group_coerces_discogs_id_to_string(self, mock_tx: AsyncMock) -> None:
+        """discogs_master_id is coerced to str before matching. Regression test for
+        discogsography-cu2.10.
+        """
+        record = {"mbid": "abc", "discogs_master_id": 23853}
+        with patch.dict(bgmod.enrichment_stats, CLEAN_STATS):
+            await enrich_release_group(mock_tx, record)
+
+        call_kwargs = mock_tx.run.call_args_list[0].kwargs
+        assert call_kwargs["discogs_id"] == "23853"
+        assert isinstance(call_kwargs["discogs_id"], str)
 
 
 # ── Relationship edge tests ───────────────────────────────────────────────
@@ -391,6 +444,21 @@ class TestRelationshipEdges:
             await create_relationship_edges(mock_tx, 12345, relations)
             assert bgmod.enrichment_stats["relationships_skipped_missing_side"] == 1
             assert bgmod.enrichment_stats["relationships_created"] == 0
+
+    @pytest.mark.asyncio
+    async def test_create_edge_coerces_ids_to_string(self, mock_tx: AsyncMock) -> None:
+        """source_id/target_id are coerced to str to match the graph's String `id`
+        convention on Discogs nodes. Regression test for discogsography-cu2.10.
+        """
+        relations = [{"type": "member of band", "target_discogs_artist_id": 67890}]
+        with patch.dict(bgmod.enrichment_stats, CLEAN_STATS):
+            await create_relationship_edges(mock_tx, 12345, relations)
+
+        call_kwargs = mock_tx.run.call_args.kwargs
+        assert call_kwargs["source_id"] == "12345"
+        assert call_kwargs["target_id"] == "67890"
+        assert isinstance(call_kwargs["source_id"], str)
+        assert isinstance(call_kwargs["target_id"], str)
 
 
 # ── Message handling tests ────────────────────────────────────────────────

--- a/tests/brainzgraphinator/test_brainzgraphinator.py
+++ b/tests/brainzgraphinator/test_brainzgraphinator.py
@@ -460,6 +460,49 @@ class TestRelationshipEdges:
         assert isinstance(call_kwargs["source_id"], str)
         assert isinstance(call_kwargs["target_id"], str)
 
+    @pytest.mark.asyncio
+    async def test_create_edge_forward_direction_keeps_source_target(self, mock_tx: AsyncMock) -> None:
+        """direction == 'forward' (or absent) keeps the processed record as the
+        relationship source. Regression test for discogsography-cu2.20.
+        """
+        relations = [
+            {
+                "type": "member of band",
+                "target_discogs_artist_id": 67890,
+                "direction": "forward",
+            }
+        ]
+        with patch.dict(bgmod.enrichment_stats, CLEAN_STATS):
+            await create_relationship_edges(mock_tx, 12345, relations)
+
+        call_kwargs = mock_tx.run.call_args.kwargs
+        assert call_kwargs["source_id"] == "12345"
+        assert call_kwargs["target_id"] == "67890"
+
+    @pytest.mark.asyncio
+    async def test_create_edge_backward_direction_swaps_source_target(self, mock_tx: AsyncMock) -> None:
+        """direction == 'backward' means the processed record is the relationship's
+        TARGET, not its source — source/target must be swapped so e.g. a band's own
+        record (direction=backward, target=member) still creates
+        (member)-[:MEMBER_OF]->(band), not the inverse. Regression test for
+        discogsography-cu2.20.
+        """
+        relations = [
+            {
+                "type": "member of band",
+                "target_discogs_artist_id": 67890,
+                "direction": "backward",
+            }
+        ]
+        with patch.dict(bgmod.enrichment_stats, CLEAN_STATS):
+            await create_relationship_edges(mock_tx, 12345, relations)
+
+        call_kwargs = mock_tx.run.call_args.kwargs
+        # Swapped: the relation's target (67890) becomes the edge source,
+        # and the processed record (12345) becomes the edge target.
+        assert call_kwargs["source_id"] == "67890"
+        assert call_kwargs["target_id"] == "12345"
+
 
 # ── Message handling tests ────────────────────────────────────────────────
 

--- a/tests/brainzgraphinator/test_brainzgraphinator.py
+++ b/tests/brainzgraphinator/test_brainzgraphinator.py
@@ -1903,3 +1903,50 @@ class TestHealthDataAdditional:
         ):
             data = get_health_data()
             assert data["status"] == "unhealthy"
+
+
+class TestRecoverConsumersAllTypesBrainzgraphinator:
+    """Regression (cu2.53): _recover_consumers must start consumers for ALL
+    MusicBrainz data types, not just those with a backlog at the check instant."""
+
+    @pytest.mark.asyncio
+    async def test_recovers_all_types_not_just_backlogged(self) -> None:
+        import brainzgraphinator.brainzgraphinator as bg
+
+        expected = {"artists", "labels", "release-groups", "releases"}
+
+        bg.active_connection = None
+        bg.active_channel = None
+        bg.consumer_tags = {}
+        bg.completed_files = set()
+        bg.queues = {}
+        bg.last_message_time = dict.fromkeys(expected, 0.0)
+
+        def declare_queue(**kwargs: Any) -> Any:
+            if kwargs.get("passive"):
+                q = MagicMock()
+                q.declaration_result.message_count = 100 if kwargs["name"].endswith("-artists") else 0
+                return q
+            q = AsyncMock()
+            q.consume = AsyncMock(return_value=f"tag-{kwargs.get('name')}")
+            q.bind = AsyncMock()
+            return q
+
+        mock_channel = AsyncMock()
+        mock_channel.declare_queue = AsyncMock(side_effect=declare_queue)
+        mock_channel.declare_exchange = AsyncMock(return_value=AsyncMock())
+        mock_channel.set_qos = AsyncMock()
+        mock_connection = AsyncMock()
+        mock_connection.channel = AsyncMock(return_value=mock_channel)
+        mock_rmq = AsyncMock()
+        mock_rmq.connect = AsyncMock(return_value=mock_connection)
+
+        with patch.object(bg, "rabbitmq_manager", mock_rmq), patch.object(bg, "logger"):
+            await bg._recover_consumers()
+
+        assert set(bg.consumer_tags.keys()) == expected
+
+        bg.consumer_tags = {}
+        bg.active_connection = None
+        bg.active_channel = None
+        bg.queues = {}

--- a/tests/brainztableinator/test_brainztableinator.py
+++ b/tests/brainztableinator/test_brainztableinator.py
@@ -2871,3 +2871,50 @@ class TestMainEdgeCases:
         # Should have logged warning about pool close error
         warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
         assert any("pool" in c.lower() or "Pool" in c for c in warning_calls)
+
+
+class TestRecoverConsumersAllTypesBrainztableinator:
+    """Regression (cu2.53): _recover_consumers must start consumers for ALL
+    MusicBrainz data types, not just those with a backlog at the check instant."""
+
+    @pytest.mark.asyncio
+    async def test_recovers_all_types_not_just_backlogged(self) -> None:
+        import brainztableinator.brainztableinator as bt
+
+        expected = {"artists", "labels", "release-groups", "releases"}
+
+        bt.active_connection = None
+        bt.active_channel = None
+        bt.consumer_tags = {}
+        bt.completed_files = set()
+        bt.queues = {}
+        bt.last_message_time = dict.fromkeys(expected, 0.0)
+
+        def declare_queue(**kwargs: Any) -> Any:
+            if kwargs.get("passive"):
+                q = MagicMock()
+                q.declaration_result.message_count = 100 if kwargs["name"].endswith("-artists") else 0
+                return q
+            q = AsyncMock()
+            q.consume = AsyncMock(return_value=f"tag-{kwargs.get('name')}")
+            q.bind = AsyncMock()
+            return q
+
+        mock_channel = AsyncMock()
+        mock_channel.declare_queue = AsyncMock(side_effect=declare_queue)
+        mock_channel.declare_exchange = AsyncMock(return_value=AsyncMock())
+        mock_channel.set_qos = AsyncMock()
+        mock_connection = AsyncMock()
+        mock_connection.channel = AsyncMock(return_value=mock_channel)
+        mock_rmq = AsyncMock()
+        mock_rmq.connect = AsyncMock(return_value=mock_connection)
+
+        with patch.object(bt, "rabbitmq_manager", mock_rmq), patch.object(bt, "logger"):
+            await bt._recover_consumers()
+
+        assert set(bt.consumer_tags.keys()) == expected
+
+        bt.consumer_tags = {}
+        bt.active_connection = None
+        bt.active_channel = None
+        bt.queues = {}

--- a/tests/brainztableinator/test_brainztableinator.py
+++ b/tests/brainztableinator/test_brainztableinator.py
@@ -2918,3 +2918,52 @@ class TestRecoverConsumersAllTypesBrainztableinator:
         bt.active_connection = None
         bt.active_channel = None
         bt.queues = {}
+
+
+class TestRecoverConsumersClearsTagsBrainztableinator:
+    """Regression (cu2.54): recovery errors after ≥1 consumer registered must
+    clear consumer_tags so the stuck-state detector can re-fire."""
+
+    @pytest.mark.asyncio
+    async def test_error_after_partial_registration_clears_consumer_tags(self) -> None:
+        import brainztableinator.brainztableinator as bt
+
+        types = ["artists", "labels", "release-groups", "releases"]
+        bt.active_connection = None
+        bt.active_channel = None
+        bt.consumer_tags = {}
+        bt.completed_files = set()
+        bt.queues = {}
+        bt.last_message_time = dict.fromkeys(types, 0.0)
+
+        def declare_queue(**kwargs: Any) -> Any:
+            name = kwargs.get("name", "")
+            if kwargs.get("passive"):
+                q = MagicMock()
+                q.declaration_result.message_count = 100
+                return q
+            q = AsyncMock()
+            q.bind = AsyncMock()
+            if name.endswith("-labels"):
+                q.consume = AsyncMock(side_effect=RuntimeError("channel closed mid-recovery"))
+            else:
+                q.consume = AsyncMock(return_value=f"tag-{name}")
+            return q
+
+        mock_channel = AsyncMock()
+        mock_channel.declare_queue = AsyncMock(side_effect=declare_queue)
+        mock_channel.declare_exchange = AsyncMock(return_value=AsyncMock())
+        mock_channel.set_qos = AsyncMock()
+        mock_connection = AsyncMock()
+        mock_connection.channel = AsyncMock(return_value=mock_channel)
+        mock_rmq = AsyncMock()
+        mock_rmq.connect = AsyncMock(return_value=mock_connection)
+
+        with patch.object(bt, "rabbitmq_manager", mock_rmq), patch.object(bt, "logger"):
+            await bt._recover_consumers()
+
+        assert bt.consumer_tags == {}, "stale consumer tags must be cleared"
+        assert bt.active_connection is None
+
+        bt.consumer_tags = {}
+        bt.queues = {}

--- a/tests/brainztableinator/test_brainztableinator.py
+++ b/tests/brainztableinator/test_brainztableinator.py
@@ -348,6 +348,60 @@ class TestInsertRelationships:
         mock_cursor.execute.assert_not_called()
         mock_cursor.executemany.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_insert_relationships_forward_direction_keeps_source(self):
+        """direction == 'forward' (or absent) keeps the processed entity as the
+        row's source. Regression test for discogsography-cu2.31.
+        """
+        mock_conn, mock_cursor = _make_mock_conn()
+        rels = [
+            {
+                "target_mbid": "target-mbid-1",
+                "target_type": "artist",
+                "type": "member of band",
+                "direction": "forward",
+            }
+        ]
+
+        await _insert_relationships(mock_conn, "source-mbid-1", "artist", rels)
+
+        params = mock_cursor.executemany.call_args[0][1]
+        row = params[0]
+        # (source_mbid, source_entity_type, target_mbid, target_entity_type, ...)
+        assert row[0] == "source-mbid-1"
+        assert row[1] == "artist"
+        assert row[2] == "target-mbid-1"
+        assert row[3] == "artist"
+
+    @pytest.mark.asyncio
+    async def test_insert_relationships_backward_direction_swaps_source_target(self):
+        """direction == 'backward' means the processed entity is the relation's
+        TARGET, not its source. Persisting it unswapped would store a
+        semantically inverted relationship (e.g. a band's own record, direction
+        backward, target=member, would otherwise assert the band is a member of
+        the member). Regression test for discogsography-cu2.31.
+        """
+        mock_conn, mock_cursor = _make_mock_conn()
+        rels = [
+            {
+                "target_mbid": "target-mbid-1",
+                "target_type": "artist",
+                "type": "member of band",
+                "direction": "backward",
+            }
+        ]
+
+        await _insert_relationships(mock_conn, "source-mbid-1", "artist", rels)
+
+        params = mock_cursor.executemany.call_args[0][1]
+        row = params[0]
+        # Swapped: the relation's target becomes the row's source, and the
+        # processed entity becomes the row's target.
+        assert row[0] == "target-mbid-1"
+        assert row[1] == "artist"
+        assert row[2] == "source-mbid-1"
+        assert row[3] == "artist"
+
 
 class TestInsertExternalLinks:
     """Tests for _insert_external_links (batched executemany)."""

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -582,6 +582,32 @@ class TestApiConfig:
 
         assert config.insights_internal_secret == "shared-internal-secret"
 
+    def test_extractor_host_defaults_to_extractor_discogs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """discogsography-cu2.32: no service named bare 'extractor' exists (the extractor
+        runs split as extractor-discogs / extractor-musicbrainz); the default must resolve
+        to a real hostname so the admin extractor status/trigger panel works out of the box.
+        """
+        from common.config import ApiConfig
+
+        monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+        monkeypatch.delenv("EXTRACTOR_HOST", raising=False)
+
+        config = ApiConfig.from_env()
+
+        assert config.extractor_host == "extractor-discogs"
+        assert config.extractor_host != "extractor"
+
+    def test_extractor_host_read_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """discogsography-cu2.32: EXTRACTOR_HOST remains overridable."""
+        from common.config import ApiConfig
+
+        monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+        monkeypatch.setenv("EXTRACTOR_HOST", "extractor-musicbrainz")
+
+        config = ApiConfig.from_env()
+
+        assert config.extractor_host == "extractor-musicbrainz"
+
     def test_discogs_oauth_callback_url_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """DISCOGS_OAUTH_CALLBACK_URL is read into the config."""
         from common.config import ApiConfig

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -560,6 +560,28 @@ class TestApiConfig:
 
         assert config.discogs_oauth_callback_url is None
 
+    def test_insights_internal_secret_defaults_to_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """cu2.8: without INSIGHTS_INTERNAL_SECRET the field is None (router fails closed)."""
+        from common.config import ApiConfig
+
+        monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+        monkeypatch.delenv("INSIGHTS_INTERNAL_SECRET", raising=False)
+
+        config = ApiConfig.from_env()
+
+        assert config.insights_internal_secret is None
+
+    def test_insights_internal_secret_read_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """cu2.8: INSIGHTS_INTERNAL_SECRET is read into ApiConfig for the internal-router gate."""
+        from common.config import ApiConfig
+
+        monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+        monkeypatch.setenv("INSIGHTS_INTERNAL_SECRET", "shared-internal-secret")
+
+        config = ApiConfig.from_env()
+
+        assert config.insights_internal_secret == "shared-internal-secret"
+
     def test_discogs_oauth_callback_url_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """DISCOGS_OAUTH_CALLBACK_URL is read into the config."""
         from common.config import ApiConfig
@@ -1100,6 +1122,26 @@ class TestInsightsConfig:
 
         config = InsightsConfig.from_env()
         assert config.api_base_url == "http://api:8004"
+
+    def test_internal_secret_read_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """cu2.8: INSIGHTS_INTERNAL_SECRET is read so the service can authenticate to the API."""
+        _set_insights_env(monkeypatch)
+        monkeypatch.setenv("INSIGHTS_INTERNAL_SECRET", "shared-internal-secret")
+
+        from common.config import InsightsConfig
+
+        config = InsightsConfig.from_env()
+        assert config.internal_secret == "shared-internal-secret"
+
+    def test_internal_secret_defaults_to_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """cu2.8: without the env var the field is None (calls will be rejected, flow made explicit)."""
+        _set_insights_env(monkeypatch)
+        monkeypatch.delenv("INSIGHTS_INTERNAL_SECRET", raising=False)
+
+        from common.config import InsightsConfig
+
+        config = InsightsConfig.from_env()
+        assert config.internal_secret is None
 
     def test_default_milestone_years(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _set_insights_env(monkeypatch)

--- a/tests/common/test_db_resilience.py
+++ b/tests/common/test_db_resilience.py
@@ -369,6 +369,16 @@ class TestResilientConnection:
         mock_conn.close.assert_called_once()
         assert manager._connection is None
 
+    def test_close_connection_none_is_noop(self) -> None:
+        """_close_connection(None) returns early without dispatching a close."""
+        from common.db_resilience import ResilientConnection
+
+        manager = ResilientConnection(Mock(), Mock(return_value=True))
+
+        # Must not raise when the current connection is None (e.g. replacing a
+        # never-established connection).
+        manager._close_connection(None)
+
 
 class TestAsyncResilientConnection:
     """Tests for AsyncResilientConnection class."""
@@ -508,6 +518,16 @@ class TestAsyncResilientConnection:
 
         # Connection should still be None even if close failed
         assert manager._connection is None
+
+    @pytest.mark.asyncio
+    async def test_aclose_connection_none_is_noop(self) -> None:
+        """_aclose_connection(None) returns early without dispatching a close."""
+        from common.db_resilience import AsyncResilientConnection
+
+        manager = AsyncResilientConnection(Mock(), Mock(return_value=True))
+
+        # Must not raise when the current connection is None.
+        await manager._aclose_connection(None)
 
     @pytest.mark.asyncio
     async def test_mixed_sync_async_factory_and_test(self) -> None:

--- a/tests/common/test_db_resilience.py
+++ b/tests/common/test_db_resilience.py
@@ -1092,3 +1092,78 @@ class TestAsyncLazyLockInit:
         assert isinstance(breaker._async_lock, asyncio.Lock)
         assert breaker.failure_count == 1
         assert breaker.last_failure_time is not None
+
+
+class _FakeAsyncConn:
+    """Minimal async connection stub: has an async close() but no aclose()."""
+
+    def __init__(self) -> None:
+        self.closed_count = 0
+
+    async def close(self) -> None:
+        self.closed_count += 1
+
+
+class TestResilientConnectionCloseOnReplace:
+    """Regression tests for discogsography-cu2.33 (close-on-replace leak)."""
+
+    def test_cu2_33_sync_closes_old_connection_on_replace(self) -> None:
+        """The old unhealthy connection must be closed before a replacement overwrites it."""
+        from common.db_resilience import ResilientConnection
+
+        old_conn = Mock()
+        new_conn = Mock()
+        connection_factory = Mock(side_effect=[old_conn, new_conn])
+        connection_test = Mock(side_effect=[True, False, True])  # fresh-ok, then unhealthy, then new-ok
+
+        manager = ResilientConnection(connection_factory, connection_test)
+        assert manager.get_connection() is old_conn
+        assert manager.get_connection() is new_conn
+
+        old_conn.close.assert_called_once()
+
+    def test_cu2_33_sync_closes_failed_fresh_connection(self) -> None:
+        """A freshly built connection that fails its own health test must be closed, not orphaned."""
+        from common.db_resilience import ResilientConnection
+
+        bad_conn = Mock()
+        good_conn = Mock()
+        connection_factory = Mock(side_effect=[bad_conn, good_conn])
+        connection_test = Mock(side_effect=[False, True])  # fresh conn fails, retry succeeds
+
+        manager = ResilientConnection(connection_factory, connection_test, max_retries=3)
+        assert manager.get_connection() is good_conn
+
+        bad_conn.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cu2_33_async_closes_old_connection_on_replace(self) -> None:
+        """Async: the old unhealthy connection must be closed before reconnecting."""
+        from common.db_resilience import AsyncResilientConnection
+
+        old_conn = _FakeAsyncConn()
+        new_conn = _FakeAsyncConn()
+        connection_factory = Mock(side_effect=[old_conn, new_conn])
+        connection_test = Mock(side_effect=[True, False, True])
+
+        manager = AsyncResilientConnection(connection_factory, connection_test)
+        assert await manager.get_connection() is old_conn
+        assert await manager.get_connection() is new_conn
+
+        assert old_conn.closed_count == 1
+        assert manager._connection is new_conn
+
+    @pytest.mark.asyncio
+    async def test_cu2_33_async_closes_failed_fresh_connection(self) -> None:
+        """Async: a freshly built connection failing its own health test must be closed."""
+        from common.db_resilience import AsyncResilientConnection
+
+        bad_conn = _FakeAsyncConn()
+        good_conn = _FakeAsyncConn()
+        connection_factory = Mock(side_effect=[bad_conn, good_conn])
+        connection_test = Mock(side_effect=[False, True])
+
+        manager = AsyncResilientConnection(connection_factory, connection_test, max_retries=3)
+        assert await manager.get_connection() is good_conn
+
+        assert bad_conn.closed_count == 1

--- a/tests/common/test_health_server.py
+++ b/tests/common/test_health_server.py
@@ -1,13 +1,16 @@
 """Tests for the health check server."""
 
 from http.client import HTTPConnection
+from http.server import ThreadingHTTPServer
 import json
+import socket
 import threading
+import time
 from unittest.mock import Mock, patch
 
 import pytest
 
-from common.health_server import HealthServer
+from common.health_server import HealthHandler, HealthServer
 
 
 class TestHealthServerInit:
@@ -34,6 +37,27 @@ class TestHealthServerInit:
             assert server.server_address[1] > 0
         finally:
             server.server_close()
+
+    def test_server_is_threading_http_server(self) -> None:
+        """discogsography-cu2.61: HealthServer must be a ThreadingHTTPServer (not the
+        single-threaded HTTPServer) so one blocked connection cannot wedge the accept
+        loop for every other client.
+        """
+        health_func = Mock(return_value={"status": "healthy"})
+
+        server = HealthServer(0, health_func)
+        try:
+            assert isinstance(server, ThreadingHTTPServer)
+            assert server.daemon_threads is True
+        finally:
+            server.server_close()
+
+    def test_handler_has_socket_timeout(self) -> None:
+        """discogsography-cu2.61: HealthHandler must bound how long it will block on
+        rfile.readline() for a connected-but-silent peer (e.g. a TCP-connect port scan
+        or a half-open connection), instead of blocking indefinitely.
+        """
+        assert HealthHandler.timeout == 5
 
 
 class TestHealthServerGetHealthData:
@@ -312,3 +336,47 @@ class TestHealthServerMetricsEndpoint:
         assert response.status == 200
         body = json.loads(response.read())
         assert body["status"] == "healthy"
+
+
+class TestHealthServerConcurrency:
+    """discogsography-cu2.61: an idle/half-open connection must not wedge the server."""
+
+    @pytest.fixture
+    def running_server(self):
+        """Start a HealthServer in a background thread and yield it."""
+        health_func = Mock(return_value={"status": "healthy"})
+        server = HealthServer(0, health_func)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        yield server
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    def test_silent_connection_does_not_block_other_clients(self, running_server: HealthServer) -> None:
+        """Reproduces the failure scenario: a client completes the TCP handshake but
+        never sends a request (a port scan / half-open connection). With the
+        single-threaded HTTPServer this wedges the accept loop and every subsequent
+        /health request hangs. With ThreadingHTTPServer + a bounded handler timeout,
+        a second, well-behaved client must still get served promptly.
+        """
+        port = running_server.server_address[1]
+
+        # Open a TCP connection and send nothing — simulates the wedging peer.
+        silent_sock = socket.create_connection(("127.0.0.1", port), timeout=5)
+        try:
+            # A concurrent, well-behaved client must not be blocked by the silent peer.
+            start = time.monotonic()
+            conn = HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("GET", "/health")
+            response = conn.getresponse()
+            elapsed = time.monotonic() - start
+
+            assert response.status == 200
+            body = json.loads(response.read())
+            assert body["status"] == "healthy"
+            # Must be served immediately, well under the silent handler's own timeout.
+            assert elapsed < 2
+            conn.close()
+        finally:
+            silent_sock.close()

--- a/tests/common/test_postgres_resilient.py
+++ b/tests/common/test_postgres_resilient.py
@@ -2261,3 +2261,55 @@ class TestAsyncHealthCheckQueueEmpty:
         pool.connections.qsize = asyncio.Queue.qsize.__get__(pool.connections)  # type: ignore[attr-defined]
 
         await pool.close()
+
+
+def _make_async_conn(*, healthy: bool = True) -> AsyncMock:
+    """Build a mock async psycopg connection whose health probe returns ``healthy``."""
+    conn = AsyncMock()
+    conn.closed = False
+    conn.set_autocommit = AsyncMock()
+    conn.close = AsyncMock()
+    cursor = AsyncMock()
+    cursor.execute = AsyncMock()
+    cursor.fetchone = AsyncMock(return_value=(1,) if healthy else (0,))
+    cursor.__aenter__ = AsyncMock(return_value=cursor)
+    cursor.__aexit__ = AsyncMock(return_value=None)
+    conn.cursor = Mock(return_value=cursor)
+    return conn
+
+
+class TestPgPoolBatchRegressions:
+    """Regression tests for the batch:pg-pool defect sweep (discogsography-cu2.*)."""
+
+    @pytest.fixture
+    def connection_params(self) -> dict:
+        return {"host": "localhost", "port": 5432, "dbname": "test", "user": "u", "password": "p"}
+
+    @pytest.mark.asyncio
+    async def test_cu2_34_failed_replacement_does_not_yield_closed_conn(self, connection_params: dict) -> None:
+        """discogsography-cu2.34: a failed replacement must raise, not yield a stale CLOSED connection.
+
+        A pooled connection fails its health check and every replacement create fails. The pool must
+        surface 'Failed to get PostgreSQL connection...' rather than yielding the closed connection,
+        and active_connections must be decremented exactly once (no double-decrement below the true count).
+        """
+        pool = AsyncPostgreSQLPool(connection_params=connection_params, min_connections=0, max_connections=5, max_retries=3)
+        await pool.initialize()
+        pool.backoff.get_delay = Mock(return_value=0)  # type: ignore[method-assign]
+
+        bad_conn = _make_async_conn(healthy=False)
+        pool.connections.put_nowait(bad_conn)
+        # Simulate 3 live connections: the bad one in the queue plus 2 held elsewhere.
+        pool.active_connections = 3
+
+        pool._create_connection = AsyncMock(side_effect=OperationalError("db down"))  # type: ignore[method-assign]
+
+        with pytest.raises(Exception, match="Failed to get PostgreSQL connection"):
+            async with pool.connection():
+                pytest.fail("connection() must not yield a connection when all replacements fail")
+
+        # The bad connection's slot is released exactly once; the 2 unrelated live slots survive.
+        assert pool.active_connections == 2
+        bad_conn.close.assert_awaited()
+
+        await pool.close()

--- a/tests/common/test_postgres_resilient.py
+++ b/tests/common/test_postgres_resilient.py
@@ -2313,3 +2313,47 @@ class TestPgPoolBatchRegressions:
         bad_conn.close.assert_awaited()
 
         await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_cu2_21_cancel_during_create_rolls_back_slot(self, connection_params: dict) -> None:
+        """discogsography-cu2.21: cancellation while creating a connection must not leak a slot.
+
+        The empty-pool path reserves a slot (active_connections += 1) before awaiting
+        _create_connection(). In Python 3.13 asyncio.CancelledError derives from BaseException, so an
+        `except Exception` guard would skip the rollback and strand the slot forever. The reservation
+        must be released on cancellation too.
+        """
+        pool = AsyncPostgreSQLPool(connection_params=connection_params, min_connections=0, max_connections=5)
+        await pool.initialize()
+        assert pool.active_connections == 0
+
+        pool._create_connection = AsyncMock(side_effect=asyncio.CancelledError())  # type: ignore[method-assign]
+
+        with pytest.raises(asyncio.CancelledError):
+            async with pool.connection():
+                pytest.fail("connection() must not yield when creation is cancelled")
+
+        assert pool.active_connections == 0
+
+        await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_cu2_21_cancel_during_health_test_releases_conn(self, connection_params: dict) -> None:
+        """discogsography-cu2.21: cancellation during the health probe must release the checked-out slot."""
+        pool = AsyncPostgreSQLPool(connection_params=connection_params, min_connections=0, max_connections=5)
+        await pool.initialize()
+
+        held = _make_async_conn(healthy=True)
+        pool.connections.put_nowait(held)
+        pool.active_connections = 1
+
+        pool._test_connection = AsyncMock(side_effect=asyncio.CancelledError())  # type: ignore[method-assign]
+
+        with pytest.raises(asyncio.CancelledError):
+            async with pool.connection():
+                pytest.fail("connection() must not yield when the health probe is cancelled")
+
+        assert pool.active_connections == 0
+        held.close.assert_awaited()
+
+        await pool.close()

--- a/tests/common/test_postgres_resilient.py
+++ b/tests/common/test_postgres_resilient.py
@@ -2434,3 +2434,37 @@ class TestPgPoolBatchRegressions:
 
         assert create_mock.call_count == 0
         assert pool.active_connections == 3
+
+    def test_cu2_81_sync_exhausted_pool_raises_not_spins(self, connection_params: dict) -> None:
+        """discogsography-cu2.81: an exhausted sync pool must raise after max_retries, not busy-spin.
+
+        When the queue is Empty and active_connections >= max_connections, no branch produced a
+        connection or an exception, so retry_count never advanced and connection() spun a CPU core
+        forever. It must now block on get(timeout=...), count retries, and raise the terminal error.
+        """
+        import threading as _threading
+
+        with patch("common.postgres_resilient.threading.Thread"), patch("common.postgres_resilient.psycopg.connect"):
+            pool = ResilientPostgreSQLPool(
+                connection_params=connection_params, min_connections=0, max_connections=1, max_retries=3, health_check_interval=999
+            )
+
+        pool.backoff.get_delay = Mock(return_value=0.001)  # type: ignore[method-assign]
+        pool.active_connections = 1  # at cap, queue empty -> exhausted
+
+        result: dict[str, object] = {}
+
+        def worker() -> None:
+            try:
+                with pool.connection():
+                    result["yielded"] = True
+            except Exception as e:
+                result["error"] = e
+
+        t = _threading.Thread(target=worker, daemon=True)
+        t.start()
+        t.join(timeout=5)
+
+        assert not t.is_alive(), "connection() busy-spun / hung on an exhausted pool"
+        assert "yielded" not in result
+        assert "Failed to get PostgreSQL connection" in str(result.get("error"))

--- a/tests/common/test_postgres_resilient.py
+++ b/tests/common/test_postgres_resilient.py
@@ -1203,6 +1203,50 @@ class TestAsyncPostgreSQLPool:
 
     @pytest.mark.asyncio
     @patch("common.postgres_resilient.psycopg.AsyncConnection.connect")
+    async def test_body_exception_propagates_when_set_autocommit_fails_on_release(self, mock_connect: Mock, connection_params: dict) -> None:
+        """Regression: a `return` in connection()'s finally block would silently swallow
+        any exception raised inside the caller's `async with` body when set_autocommit
+        also fails on release. The body exception MUST still propagate, and the
+        connection must still be discarded with the active slot released.
+        """
+        from psycopg import OperationalError
+
+        conn = AsyncMock()
+        conn.closed = False
+        conn.close = AsyncMock()
+        # Succeeds on creation, fails on release — the discard path that used `return`.
+        conn.set_autocommit = AsyncMock(side_effect=[None, OperationalError("connection lost")])
+        cursor = AsyncMock()
+        cursor.execute = AsyncMock()
+        cursor.fetchone = AsyncMock(return_value=(1,))
+        cursor.__aenter__ = AsyncMock(return_value=cursor)
+        cursor.__aexit__ = AsyncMock(return_value=None)
+        conn.cursor = Mock(return_value=cursor)
+
+        mock_connect.return_value = conn
+
+        pool = AsyncPostgreSQLPool(connection_params=connection_params, min_connections=0, max_connections=5)
+        await pool.initialize()
+
+        class BodyError(RuntimeError):
+            pass
+
+        # The caller's body raises; set_autocommit then fails during release.
+        with pytest.raises(BodyError, match="boom from body"):
+            async with pool.connection():
+                raise BodyError("boom from body")
+
+        await asyncio.sleep(0.1)
+
+        # Body exception survived the finally block AND the connection was discarded.
+        assert pool.connections.qsize() == 0
+        assert pool.active_connections == 0
+        conn.close.assert_called()
+
+        await pool.close()
+
+    @pytest.mark.asyncio
+    @patch("common.postgres_resilient.psycopg.AsyncConnection.connect")
     async def test_connection_pool_exhaustion_wait(self, mock_connect: Mock, connection_params: dict, mock_async_connection: AsyncMock) -> None:
         """Test waiting for connection when pool is exhausted."""
 
@@ -2037,6 +2081,52 @@ class TestSyncHealthCheckLoopDirect:
 
         # Pool should have been replenished to min_connections
         assert pool.connections.qsize() == 2
+        pool.close()
+
+    @patch("common.postgres_resilient.psycopg.connect")
+    @patch("common.postgres_resilient.threading.Thread")
+    def test_health_check_loop_direct_replenish_queue_full_closes_and_decrements(
+        self, _mock_thread: Mock, mock_connect: Mock, connection_params: dict, mock_connection: Mock
+    ) -> None:
+        """Lines 164-168: during replenishment, if put_nowait raises Full the fresh
+        connection is closed, the reserved active slot is released, and the loop breaks.
+        """
+        from queue import Full
+
+        mock_connect.return_value = mock_connection
+
+        pool = ResilientPostgreSQLPool(connection_params=connection_params, min_connections=2, max_connections=5, health_check_interval=1)
+
+        # Drain the pool so replenishment runs; the empty queue means no healthy
+        # connections are returned, so the only put_nowait calls come from replenishment.
+        while not pool.connections.empty():
+            try:
+                pool.connections.get_nowait()
+            except Exception:
+                break
+        pool.active_connections = 0
+
+        fresh_conn = Mock()
+        fresh_conn.close = Mock()
+        pool._create_connection = Mock(return_value=fresh_conn)  # type: ignore[method-assign]
+
+        original_put_nowait = pool.connections.put_nowait
+        original_qsize = pool.connections.qsize
+        pool.connections.put_nowait = Mock(side_effect=Full)  # type: ignore[method-assign]
+
+        def sleep_then_close(_interval: float) -> None:
+            pool._closed = True
+
+        with patch("common.postgres_resilient.time.sleep", side_effect=sleep_then_close):
+            pool._health_check_loop()
+
+        # The connection minted for replenishment must be closed on Full, and the
+        # reserved slot released (break stops after the first Full).
+        fresh_conn.close.assert_called_once()
+        assert pool.active_connections == 0
+
+        pool.connections.put_nowait = original_put_nowait  # type: ignore[method-assign]
+        pool.connections.qsize = original_qsize  # type: ignore[method-assign]
         pool.close()
 
     @patch("common.postgres_resilient.psycopg.connect")

--- a/tests/common/test_postgres_resilient.py
+++ b/tests/common/test_postgres_resilient.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from contextlib import suppress
+from queue import Empty as Empty_
 import time
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -2357,3 +2358,79 @@ class TestPgPoolBatchRegressions:
         held.close.assert_awaited()
 
         await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_cu2_11_async_replenish_respects_max_connections(self, connection_params: dict) -> None:
+        """discogsography-cu2.11: the async health-check replenisher must not mint past max_connections.
+
+        When the pool is saturated (all connections checked out) the queue is empty, so the
+        replenish branch fires every tick. Without a cap check it mints min_connections fresh
+        backends per tick, blowing past the shared PgBouncer session-mode cap. Reserve the slot
+        under the lock (active_connections < max_connections) before creating.
+        """
+        pool = AsyncPostgreSQLPool(connection_params=connection_params, min_connections=2, max_connections=3, health_check_interval=0)
+        # Manually stand up the primitives (skip initialize() so no background task races us).
+        pool.connections = asyncio.Queue(maxsize=3)
+        pool._lock = asyncio.Lock()
+        pool.active_connections = 3  # saturated & at cap; every connection checked out (queue empty)
+
+        create_mock = AsyncMock(return_value=_make_async_conn())
+        pool._create_connection = create_mock  # type: ignore[method-assign]
+
+        task = asyncio.create_task(pool._health_check_loop())
+        await asyncio.sleep(0.05)
+        pool._closed = True
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+        assert create_mock.call_count == 0
+        assert pool.active_connections == 3
+
+    @pytest.mark.asyncio
+    async def test_cu2_11_async_replenish_still_fills_up_to_max(self, connection_params: dict) -> None:
+        """discogsography-cu2.11: the cap gate must not block legitimate replenishment below max."""
+        pool = AsyncPostgreSQLPool(connection_params=connection_params, min_connections=2, max_connections=3, health_check_interval=0)
+        pool.connections = asyncio.Queue(maxsize=3)
+        pool._lock = asyncio.Lock()
+        pool.active_connections = 0  # empty pool, room to grow
+
+        create_mock = AsyncMock(side_effect=lambda: _make_async_conn())
+        pool._create_connection = create_mock  # type: ignore[method-assign]
+
+        task = asyncio.create_task(pool._health_check_loop())
+        await asyncio.sleep(0.05)
+        pool._closed = True
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+        # Replenished exactly up to min_connections and never past max_connections.
+        assert pool.active_connections == 2
+        assert pool.active_connections <= pool.max_connections
+
+    def test_cu2_11_sync_replenish_respects_max_connections(self, connection_params: dict) -> None:
+        """discogsography-cu2.11 (fix-one-fix-all): sync replenisher must also honor max_connections."""
+        import threading as _threading
+
+        with patch("common.postgres_resilient.threading.Thread"), patch("common.postgres_resilient.psycopg.connect") as mock_connect:
+            mock_connect.return_value = Mock(closed=False, autocommit=True)
+            pool = ResilientPostgreSQLPool(connection_params=connection_params, min_connections=2, max_connections=3, health_check_interval=0)
+
+        # Drain the queue (simulate all connections checked out) and pin at the cap.
+        with suppress(Empty_):
+            while True:
+                pool.connections.get_nowait()
+        pool.active_connections = 3
+
+        create_mock = Mock(return_value=Mock(closed=False))
+        pool._create_connection = create_mock  # type: ignore[method-assign]
+
+        t = _threading.Thread(target=pool._health_check_loop, daemon=True)
+        t.start()
+        time.sleep(0.05)
+        pool._closed = True
+        t.join(timeout=1)
+
+        assert create_mock.call_count == 0
+        assert pool.active_connections == 3

--- a/tests/common/test_postgres_resilient.py
+++ b/tests/common/test_postgres_resilient.py
@@ -2264,6 +2264,21 @@ class TestAsyncHealthCheckQueueEmpty:
         await pool.close()
 
 
+def _make_sync_conn(*, healthy: bool = True) -> Mock:
+    """Build a mock sync psycopg connection whose health probe returns ``healthy``."""
+    conn = Mock()
+    conn.closed = False
+    conn.autocommit = True
+    conn.close = Mock()
+    cursor = Mock()
+    cursor.execute = Mock()
+    cursor.fetchone = Mock(return_value=(1,) if healthy else (0,))
+    cursor.__enter__ = Mock(return_value=cursor)
+    cursor.__exit__ = Mock(return_value=None)
+    conn.cursor = Mock(return_value=cursor)
+    return conn
+
+
 def _make_async_conn(*, healthy: bool = True) -> AsyncMock:
     """Build a mock async psycopg connection whose health probe returns ``healthy``."""
     conn = AsyncMock()
@@ -2468,3 +2483,24 @@ class TestPgPoolBatchRegressions:
         assert not t.is_alive(), "connection() busy-spun / hung on an exhausted pool"
         assert "yielded" not in result
         assert "Failed to get PostgreSQL connection" in str(result.get("error"))
+
+    def test_cu2_82_sync_conn_death_during_use_decrements(self, connection_params: dict) -> None:
+        """discogsography-cu2.82: a connection dying mid-use must decrement active_connections.
+
+        The except (InterfaceError, OperationalError) block closed the connection and set conn=None
+        before the finally block, so neither finally branch ran and the slot was leaked forever.
+        After max_connections such failures the pool believes it is full while holding zero real
+        connections (and then degenerates into the exhaustion busy-spin). Decrement in the handler.
+        """
+        with patch("common.postgres_resilient.threading.Thread"), patch("common.postgres_resilient.psycopg.connect"):
+            pool = ResilientPostgreSQLPool(connection_params=connection_params, min_connections=0, max_connections=5, health_check_interval=999)
+
+        conn = _make_sync_conn(healthy=True)
+        pool.connections.put_nowait(conn)
+        pool.active_connections = 1
+
+        with pytest.raises(OperationalError), pool.connection():
+            raise OperationalError("connection lost mid-query")
+
+        assert pool.active_connections == 0
+        conn.close.assert_called()

--- a/tests/dashboard/test_admin_dlq_names_contract.py
+++ b/tests/dashboard/test_admin_dlq_names_contract.py
@@ -20,9 +20,7 @@ _SOURCE_PREFIXES = {
     "musicbrainz": MUSICBRAINZ_EXCHANGE_PREFIX,
 }
 
-_GROUP_RE = re.compile(
-    r"\{\s*source:\s*'(?P<source>\w+)',\s*consumer:\s*'(?P<consumer>[\w-]+)',\s*types:\s*\[(?P<types>[^\]]+)\]\s*\}"
-)
+_GROUP_RE = re.compile(r"\{\s*source:\s*'(?P<source>\w+)',\s*consumer:\s*'(?P<consumer>[\w-]+)',\s*types:\s*\[(?P<types>[^\]]+)\]\s*\}")
 _TYPE_RE = re.compile(r"'([\w-]+)'")
 
 

--- a/tests/dashboard/test_admin_dlq_names_contract.py
+++ b/tests/dashboard/test_admin_dlq_names_contract.py
@@ -1,0 +1,65 @@
+"""Regression test for discogsography-cu2.35.
+
+Pins dashboard/static/admin.js's DLQ name generation to the backend contract
+in api/routers/admin.py::_VALID_DLQ_NAMES so the two lists can never silently
+drift apart again (they previously used incompatible naming shapes, causing
+every DLQ purge button to 404).
+"""
+
+from pathlib import Path
+import re
+
+from api.routers.admin import _VALID_DLQ_NAMES
+from common.config import DISCOGS_EXCHANGE_PREFIX, MUSICBRAINZ_EXCHANGE_PREFIX
+
+
+ADMIN_JS_PATH = Path(__file__).parent.parent.parent / "dashboard" / "static" / "admin.js"
+
+_SOURCE_PREFIXES = {
+    "discogs": DISCOGS_EXCHANGE_PREFIX,
+    "musicbrainz": MUSICBRAINZ_EXCHANGE_PREFIX,
+}
+
+_GROUP_RE = re.compile(
+    r"\{\s*source:\s*'(?P<source>\w+)',\s*consumer:\s*'(?P<consumer>[\w-]+)',\s*types:\s*\[(?P<types>[^\]]+)\]\s*\}"
+)
+_TYPE_RE = re.compile(r"'([\w-]+)'")
+
+
+def _parse_dlq_names_from_admin_js() -> set[str]:
+    """Extract the DLQ_CONSUMER_GROUPS definition from admin.js and reconstruct queue names."""
+    source = ADMIN_JS_PATH.read_text(encoding="utf-8")
+    matches = _GROUP_RE.findall(source)
+    assert matches, "DLQ_CONSUMER_GROUPS not found (or shape changed) in dashboard/static/admin.js"
+
+    names: set[str] = set()
+    for group_source, consumer, types_blob in matches:
+        prefix = _SOURCE_PREFIXES[group_source]
+        for data_type in _TYPE_RE.findall(types_blob):
+            names.add(f"{prefix}-{consumer}-{data_type}.dlq")
+    return names
+
+
+def test_admin_js_dlq_names_match_backend_valid_dlq_names() -> None:
+    """admin.js's generated DLQ names must exactly equal the backend's _VALID_DLQ_NAMES.
+
+    Regression for discogsography-cu2.35: the frontend previously hardcoded
+    bare `{consumer}-{type}-dlq` names while the backend required
+    `{source-exchange-prefix}-{consumer}-{type}.dlq`, so no Purge button could
+    ever succeed.
+    """
+    frontend_names = _parse_dlq_names_from_admin_js()
+
+    assert frontend_names, "Failed to reconstruct any DLQ names from admin.js"
+    assert frontend_names == _VALID_DLQ_NAMES, (
+        f"admin.js DLQ names drifted from backend _VALID_DLQ_NAMES.\n"
+        f"Only in admin.js: {sorted(frontend_names - _VALID_DLQ_NAMES)}\n"
+        f"Only in backend:  {sorted(_VALID_DLQ_NAMES - frontend_names)}"
+    )
+
+
+def test_admin_js_dlq_names_all_valid_path_segments() -> None:
+    """Every generated DLQ name must satisfy the proxy's safe-path-segment regex."""
+    safe_segment = re.compile(r"^[a-zA-Z0-9._-]+$")
+    for name in _parse_dlq_names_from_admin_js():
+        assert safe_segment.match(name), f"DLQ name {name!r} would be rejected by admin_proxy._validate_path_segment"

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -408,6 +408,78 @@ class TestDashboardAppBroadcast:
             assert mock_ws_working in app.websocket_connections
             assert mock_ws_failing not in app.websocket_connections
 
+    @pytest.mark.asyncio
+    async def test_broadcast_metrics_stalled_client_does_not_block_others(self) -> None:
+        """discogsography-cu2.62: broadcast_metrics used to hold _ws_lock while awaiting
+        send_text serially, so one stalled client (e.g. a sleeping laptop applying TCP
+        backpressure) blocked delivery to every other client. A stalled send must not
+        delay a well-behaved client's send, and the stalled client must still be
+        dropped afterwards.
+        """
+        mock_config = Mock()
+
+        with patch("dashboard.dashboard.get_config", return_value=mock_config):
+            app = DashboardApp()
+
+            fast_ws = AsyncMock()
+            stalled_ws = AsyncMock()
+
+            async def _hang(_message: str) -> None:
+                # Simulate TCP backpressure: never resolves within the send timeout.
+                await asyncio.sleep(3600)
+
+            stalled_ws.send_text.side_effect = _hang
+
+            app.websocket_connections.add(fast_ws)
+            app.websocket_connections.add(stalled_ws)
+
+            metrics = SystemMetrics(pipelines={}, databases=[], timestamp=datetime.now())
+
+            with patch("dashboard.dashboard._WS_SEND_TIMEOUT_SECONDS", 0.05):
+                start = asyncio.get_event_loop().time()
+                await app.broadcast_metrics(metrics)
+                elapsed = asyncio.get_event_loop().time() - start
+
+            # Bounded by the per-client send timeout, not the stalled client's hang.
+            assert elapsed < 1
+            fast_ws.send_text.assert_called_once()
+            assert fast_ws in app.websocket_connections
+            assert stalled_ws not in app.websocket_connections
+
+    @pytest.mark.asyncio
+    async def test_broadcast_metrics_sends_outside_the_lock(self) -> None:
+        """discogsography-cu2.62: the lock must only guard the connection-set snapshot
+        and cleanup, not the network sends — a new /ws registration (which needs the
+        same lock) must be able to proceed concurrently with an in-flight broadcast.
+        """
+        mock_config = Mock()
+
+        with patch("dashboard.dashboard.get_config", return_value=mock_config):
+            app = DashboardApp()
+
+            send_started = asyncio.Event()
+            release_send = asyncio.Event()
+
+            async def _send_text(_message: str) -> None:
+                send_started.set()
+                await release_send.wait()
+
+            slow_ws = AsyncMock()
+            slow_ws.send_text.side_effect = _send_text
+            app.websocket_connections.add(slow_ws)
+
+            metrics = SystemMetrics(pipelines={}, databases=[], timestamp=datetime.now())
+            broadcast_task = asyncio.create_task(app.broadcast_metrics(metrics))
+
+            await asyncio.wait_for(send_started.wait(), timeout=1)
+
+            # The lock must be free while the send is in flight.
+            assert app._ws_lock is not None
+            assert not app._ws_lock.locked()
+
+            release_send.set()
+            await asyncio.wait_for(broadcast_task, timeout=1)
+
 
 class TestDashboardAppDataCollection:
     """Test data collection methods."""

--- a/tests/explore/test_explore_api.py
+++ b/tests/explore/test_explore_api.py
@@ -1295,3 +1295,80 @@ class TestExploreServiceEndpoints:
         # The buffering .aread() path must NOT be used for streaming responses.
         mock_proxied.aread.assert_not_called()
         mock_proxied.aclose.assert_awaited_once()
+
+    def test_proxy_stream_interrupted_closes_upstream(self, explore_client: TestClient) -> None:
+        """An httpx error raised mid-stream must be swallowed (logged, not propagated)
+        and the upstream response must still be closed via the finally block, so a
+        dropped SSE connection does not leak the upstream response.
+        """
+        import httpx
+
+        async def _chunks():
+            yield b"event: status\ndata: {}\n\n"
+            raise httpx.ReadError("upstream connection dropped")
+
+        mock_proxied = MagicMock()
+        mock_proxied.status_code = 200
+        mock_proxied.headers = {"content-type": "text/event-stream"}
+        mock_proxied.aiter_raw = MagicMock(return_value=_chunks())
+        mock_proxied.aread = AsyncMock()
+        mock_proxied.aclose = AsyncMock()
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.build_request = MagicMock(return_value=MagicMock())
+        mock_client.send = AsyncMock(return_value=mock_proxied)
+
+        with patch("explore.explore._get_http_client", return_value=mock_client):
+            response = explore_client.get("/api/nlq/query?q=test", headers={"Accept": "text/event-stream"})
+
+        assert response.status_code == 200
+        # The partial chunk delivered before the error must still reach the client,
+        # and the mid-stream error must not surface as a 500.
+        assert response.content == b"event: status\ndata: {}\n\n"
+        mock_proxied.aclose.assert_awaited_once()
+
+    def test_proxy_buffered_read_timeout_returns_504(self, explore_client: TestClient) -> None:
+        """A timeout while buffering a non-SSE response body returns 504 and closes
+        the upstream response.
+        """
+        import httpx
+
+        mock_proxied = MagicMock()
+        mock_proxied.status_code = 200
+        mock_proxied.headers = {"content-type": "application/json"}
+        mock_proxied.aread = AsyncMock(side_effect=httpx.TimeoutException("read timed out"))
+        mock_proxied.aclose = AsyncMock()
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.build_request = MagicMock(return_value=MagicMock())
+        mock_client.send = AsyncMock(return_value=mock_proxied)
+
+        with patch("explore.explore._get_http_client", return_value=mock_client):
+            response = explore_client.get("/api/autocomplete?q=radio")
+
+        assert response.status_code == 504
+        assert response.json()["error"] == "Request timed out"
+        mock_proxied.aclose.assert_awaited_once()
+
+    def test_proxy_buffered_read_error_returns_502(self, explore_client: TestClient) -> None:
+        """An HTTP error while buffering a non-SSE response body returns 502 and closes
+        the upstream response.
+        """
+        import httpx
+
+        mock_proxied = MagicMock()
+        mock_proxied.status_code = 200
+        mock_proxied.headers = {"content-type": "application/json"}
+        mock_proxied.aread = AsyncMock(side_effect=httpx.ReadError("connection reset"))
+        mock_proxied.aclose = AsyncMock()
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.build_request = MagicMock(return_value=MagicMock())
+        mock_client.send = AsyncMock(return_value=mock_proxied)
+
+        with patch("explore.explore._get_http_client", return_value=mock_client):
+            response = explore_client.get("/api/autocomplete?q=radio")
+
+        assert response.status_code == 502
+        assert response.json()["error"] == "Upstream service error"
+        mock_proxied.aclose.assert_awaited_once()

--- a/tests/explore/test_explore_api.py
+++ b/tests/explore/test_explore_api.py
@@ -1132,29 +1132,75 @@ class TestExploreServiceEndpoints:
         assert data["service"] == "explore"
         assert "timestamp" in data
 
-    def test_proxy_success(self, explore_client: TestClient) -> None:
-        """Successful proxy returns upstream response."""
+    @staticmethod
+    def _mock_buffered_proxy_client(status_code: int, content: bytes, headers: dict[str, str]) -> AsyncMock:
+        """Build a mock httpx.AsyncClient that mimics the streamed
+        build_request()/send(..., stream=True)/aread()/aclose() call chain used by
+        proxy_api for a non-SSE (buffered) response.
+        """
         import httpx
 
         mock_proxied = MagicMock()
-        mock_proxied.status_code = 200
-        mock_proxied.content = b'{"artists": []}'
-        mock_proxied.headers = {"content-type": "application/json"}
+        mock_proxied.status_code = status_code
+        mock_proxied.content = content
+        mock_proxied.headers = headers
+        mock_proxied.aread = AsyncMock()
+        mock_proxied.aclose = AsyncMock()
 
         mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.request = AsyncMock(return_value=mock_proxied)
+        mock_client.build_request = MagicMock(return_value=MagicMock())
+        mock_client.send = AsyncMock(return_value=mock_proxied)
+        return mock_client
+
+    def test_proxy_success(self, explore_client: TestClient) -> None:
+        """Successful proxy returns upstream response."""
+        mock_client = self._mock_buffered_proxy_client(200, b'{"artists": []}', {"content-type": "application/json"})
 
         with patch("explore.explore._get_http_client", return_value=mock_client):
             response = explore_client.get("/api/autocomplete?q=radio&type=artist")
 
         assert response.status_code == 200
 
+    def test_proxy_uses_streamed_send(self, explore_client: TestClient) -> None:
+        """discogsography-cu2.63: the proxy must send with stream=True (not the
+        non-streaming client.request(), which buffers the whole response before
+        returning) so it can special-case SSE responses.
+        """
+        mock_client = self._mock_buffered_proxy_client(200, b"{}", {"content-type": "application/json"})
+
+        with patch("explore.explore._get_http_client", return_value=mock_client):
+            response = explore_client.get("/api/autocomplete?q=radio&type=artist")
+
+        assert response.status_code == 200
+        mock_client.send.assert_awaited_once()
+        _req, send_kwargs = mock_client.send.call_args
+        assert send_kwargs["stream"] is True
+
+    def test_proxy_disables_read_timeout(self, explore_client: TestClient) -> None:
+        """discogsography-cu2.63: the per-request read timeout must be disabled so a
+        long-running SSE response isn't aborted just because the upstream goes quiet
+        between events for longer than the total request timeout.
+        """
+        import httpx
+
+        mock_client = self._mock_buffered_proxy_client(200, b"{}", {"content-type": "application/json"})
+
+        with patch("explore.explore._get_http_client", return_value=mock_client):
+            response = explore_client.get("/api/autocomplete?q=radio&type=artist")
+
+        assert response.status_code == 200
+        _method_args, build_kwargs = mock_client.build_request.call_args
+        timeout = build_kwargs["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.read is None
+
     def test_proxy_timeout_returns_504(self, explore_client: TestClient) -> None:
         """Proxy timeout returns 504 with error message."""
         import httpx
 
         mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.request = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+        mock_client.build_request = MagicMock(return_value=MagicMock())
+        mock_client.send = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
 
         with patch("explore.explore._get_http_client", return_value=mock_client):
             response = explore_client.get("/api/autocomplete?q=radio&type=artist")
@@ -1167,7 +1213,8 @@ class TestExploreServiceEndpoints:
         import httpx
 
         mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.request = AsyncMock(side_effect=httpx.HTTPError("connection failed"))
+        mock_client.build_request = MagicMock(return_value=MagicMock())
+        mock_client.send = AsyncMock(side_effect=httpx.HTTPError("connection failed"))
 
         with patch("explore.explore._get_http_client", return_value=mock_client):
             response = explore_client.get("/api/autocomplete?q=radio&type=artist")
@@ -1181,21 +1228,13 @@ class TestExploreServiceEndpoints:
         multi-value filters) must ALL reach the upstream API — dict()-ing a
         Starlette multi-dict silently keeps only the last value.
         """
-        import httpx
-
-        mock_proxied = MagicMock()
-        mock_proxied.status_code = 200
-        mock_proxied.content = b"{}"
-        mock_proxied.headers = {"content-type": "application/json"}
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.request = AsyncMock(return_value=mock_proxied)
+        mock_client = self._mock_buffered_proxy_client(200, b"{}", {"content-type": "application/json"})
 
         with patch("explore.explore._get_http_client", return_value=mock_client):
             response = explore_client.get("/api/collection/gaps/label/42?formats=Vinyl&formats=CD")
 
         assert response.status_code == 200
-        forwarded_params = mock_client.request.call_args.kwargs["params"]
+        forwarded_params = mock_client.build_request.call_args.kwargs["params"]
         # Must be an httpx.QueryParams (or equivalent multi-value structure)
         # preserving every repeated key — NOT a plain dict, which would
         # collapse "formats" down to a single value.
@@ -1207,19 +1246,15 @@ class TestExploreServiceEndpoints:
 
     def test_proxy_strips_hop_headers(self, explore_client: TestClient) -> None:
         """Proxy does not forward content-encoding / transfer-encoding in response."""
-        import httpx
-
-        mock_proxied = MagicMock()
-        mock_proxied.status_code = 200
-        mock_proxied.content = b'{"ok": true}'
-        mock_proxied.headers = {
-            "content-type": "application/json",
-            "content-encoding": "gzip",
-            "transfer-encoding": "chunked",
-        }
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.request = AsyncMock(return_value=mock_proxied)
+        mock_client = self._mock_buffered_proxy_client(
+            200,
+            b'{"ok": true}',
+            {
+                "content-type": "application/json",
+                "content-encoding": "gzip",
+                "transfer-encoding": "chunked",
+            },
+        )
 
         with patch("explore.explore._get_http_client", return_value=mock_client):
             response = explore_client.get("/api/test")
@@ -1227,3 +1262,36 @@ class TestExploreServiceEndpoints:
         assert response.status_code == 200
         assert "content-encoding" not in response.headers
         assert "transfer-encoding" not in response.headers
+
+    def test_proxy_streams_sse_response(self, explore_client: TestClient) -> None:
+        """discogsography-cu2.63: text/event-stream responses (the NLQ 'Ask'
+        endpoint) must be forwarded chunk-by-chunk via StreamingResponse instead of
+        being buffered whole, so the browser receives events incrementally.
+        """
+
+        async def _chunks():
+            yield b"event: status\ndata: {}\n\n"
+            yield b"event: result\ndata: {}\n\n"
+
+        mock_proxied = MagicMock()
+        mock_proxied.status_code = 200
+        mock_proxied.headers = {"content-type": "text/event-stream"}
+        mock_proxied.aiter_raw = MagicMock(return_value=_chunks())
+        mock_proxied.aread = AsyncMock()
+        mock_proxied.aclose = AsyncMock()
+
+        import httpx
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.build_request = MagicMock(return_value=MagicMock())
+        mock_client.send = AsyncMock(return_value=mock_proxied)
+
+        with patch("explore.explore._get_http_client", return_value=mock_client):
+            response = explore_client.get("/api/nlq/query?q=test", headers={"Accept": "text/event-stream"})
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        assert response.content == b"event: status\ndata: {}\n\nevent: result\ndata: {}\n\n"
+        # The buffering .aread() path must NOT be used for streaming responses.
+        mock_proxied.aread.assert_not_called()
+        mock_proxied.aclose.assert_awaited_once()

--- a/tests/explore/test_explore_api.py
+++ b/tests/explore/test_explore_api.py
@@ -1175,6 +1175,36 @@ class TestExploreServiceEndpoints:
         assert response.status_code == 502
         assert response.json()["error"] == "Upstream service error"
 
+    def test_proxy_forwards_repeated_query_params(self, explore_client: TestClient) -> None:
+        """discogsography-cu2.12 regression: repeated query keys (e.g.
+        ?formats=Vinyl&formats=CD, as sent by the Explore frontend for
+        multi-value filters) must ALL reach the upstream API — dict()-ing a
+        Starlette multi-dict silently keeps only the last value.
+        """
+        import httpx
+
+        mock_proxied = MagicMock()
+        mock_proxied.status_code = 200
+        mock_proxied.content = b"{}"
+        mock_proxied.headers = {"content-type": "application/json"}
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.request = AsyncMock(return_value=mock_proxied)
+
+        with patch("explore.explore._get_http_client", return_value=mock_client):
+            response = explore_client.get("/api/collection/gaps/label/42?formats=Vinyl&formats=CD")
+
+        assert response.status_code == 200
+        forwarded_params = mock_client.request.call_args.kwargs["params"]
+        # Must be an httpx.QueryParams (or equivalent multi-value structure)
+        # preserving every repeated key — NOT a plain dict, which would
+        # collapse "formats" down to a single value.
+        assert not isinstance(forwarded_params, dict)
+        pairs = forwarded_params.multi_items() if hasattr(forwarded_params, "multi_items") else list(forwarded_params)
+        assert ("formats", "Vinyl") in pairs
+        assert ("formats", "CD") in pairs
+        assert sum(1 for k, _v in pairs if k == "formats") == 2
+
     def test_proxy_strips_hop_headers(self, explore_client: TestClient) -> None:
         """Proxy does not forward content-encoding / transfer-encoding in response."""
         import httpx

--- a/tests/extractor/test_dockerfile_uid.py
+++ b/tests/extractor/test_dockerfile_uid.py
@@ -1,0 +1,134 @@
+"""Regression tests for discogsography-cu2.13.
+
+The extractor image used to create its runtime user with a bare
+``useradd -r`` (no ``-u``), which allocates an auto-assigned *system* UID
+(<1000) — never the ``1000`` that docker-compose.yml hardcoded via
+``user: "1000:1000"``. On a fresh named volume, Docker chowns the volume
+root to the image's file owner (~999), so the UID-1000 runtime process
+gets EACCES on its first write under /discogs-data, /musicbrainz-data, or
+/logs and crash-loops, ingesting nothing.
+
+These tests assert the extractor Dockerfile follows the same
+"ARG UID/GID + useradd -u ${UID}" pattern already used by every other
+service Dockerfile in this repo, and that docker-compose.yml passes
+matching build args and a matching (non-hardcoded) `user:` override, so
+the image-file owner and the runtime UID can never diverge again.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+from typing import Any
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+EXTRACTOR_DOCKERFILE = REPO_ROOT / "extractor" / "Dockerfile"
+COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
+
+# Every other service Dockerfile already follows this pattern; used as a
+# reference so the extractor sweep target doesn't silently drift again.
+OTHER_SERVICE_DOCKERFILES = [
+    "api/Dockerfile",
+    "dashboard/Dockerfile",
+    "explore/Dockerfile",
+    "graphinator/Dockerfile",
+    "insights/Dockerfile",
+    "schema-init/Dockerfile",
+    "tableinator/Dockerfile",
+    "brainzgraphinator/Dockerfile",
+    "brainztableinator/Dockerfile",
+]
+
+
+def _dockerfile_text(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_extractor_dockerfile_declares_uid_gid_args() -> None:
+    """The runtime stage must accept ARG UID / ARG GID, defaulting to 1000."""
+    text = EXTRACTOR_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert re.search(r"^ARG UID=1000\s*$", text, re.MULTILINE), "extractor/Dockerfile must declare `ARG UID=1000`"
+    assert re.search(r"^ARG GID=1000\s*$", text, re.MULTILINE), "extractor/Dockerfile must declare `ARG GID=1000`"
+
+
+def _command_lines(text: str, keyword: str) -> list[str]:
+    """Return non-comment lines that actually invoke `keyword` as a command."""
+    return [line for line in text.splitlines() if re.search(rf"(^|&&|\s){re.escape(keyword)}\s", line) and not line.strip().startswith("#")]
+
+
+def test_extractor_dockerfile_useradd_uses_explicit_uid() -> None:
+    """useradd must pin the explicit UID — a bare `useradd -r` (no -u) is the
+    exact defect: it allocates an auto-assigned system UID, not 1000."""
+    text = EXTRACTOR_DOCKERFILE.read_text(encoding="utf-8")
+
+    useradd_lines = _command_lines(text, "useradd")
+    assert useradd_lines, "extractor/Dockerfile must create a runtime user via useradd"
+
+    for line in useradd_lines:
+        assert "-u ${UID}" in line, f"useradd must pin -u ${{UID}} to avoid an auto-allocated system UID: {line!r}"
+
+    groupadd_lines = _command_lines(text, "groupadd")
+    assert groupadd_lines, "extractor/Dockerfile must create a runtime group via groupadd"
+    for line in groupadd_lines:
+        assert "-g ${GID}" in line, f"groupadd must pin -g ${{GID}}: {line!r}"
+
+
+def test_extractor_dockerfile_final_user_matches_created_account() -> None:
+    """USER must select the account whose UID/GID we just pinned (not a bare
+    username that could resolve differently across stages)."""
+    text = EXTRACTOR_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert re.search(r"^USER extractor:extractor\s*$", text, re.MULTILINE), (
+        "extractor/Dockerfile must `USER extractor:extractor` to match the chowned data/log dirs"
+    )
+
+
+def test_extractor_matches_other_service_useradd_pattern() -> None:
+    """Fix-one-fix-all sanity check: every other service Dockerfile already
+    uses `useradd -r -l -u ${UID} ...` — confirm the extractor now matches
+    the same convention rather than introducing a new one."""
+    for relative_path in OTHER_SERVICE_DOCKERFILES:
+        text = _dockerfile_text(relative_path)
+        useradd_lines = _command_lines(text, "useradd")
+        assert useradd_lines, f"{relative_path} must create a runtime user via useradd"
+        for line in useradd_lines:
+            assert "-u ${UID}" in line, f"{relative_path} unexpectedly diverges from the -u ${{UID}} convention: {line!r}"
+
+    extractor_text = EXTRACTOR_DOCKERFILE.read_text(encoding="utf-8")
+    extractor_useradd = next(iter(_command_lines(extractor_text, "useradd")))
+    assert "-u ${UID}" in extractor_useradd
+
+
+def _load_compose_service(name: str) -> dict[str, Any]:
+    with COMPOSE_FILE.open(encoding="utf-8") as f:
+        compose: dict[str, Any] = yaml.safe_load(f)
+    services: dict[str, Any] = compose["services"]
+    result: dict[str, Any] = services[name]
+    return result
+
+
+def test_compose_extractor_services_pass_uid_gid_build_args() -> None:
+    """docker-compose.yml must pass UID/GID build args to the extractor
+    image, or the built image's file owner can never match the configured
+    runtime user."""
+    for service_name in ("extractor-discogs", "extractor-musicbrainz"):
+        service = _load_compose_service(service_name)
+        build_args = service["build"]["args"]
+        assert build_args["UID"] == "${UID:-1000}", f"{service_name} build.args.UID must be parameterized"
+        assert build_args["GID"] == "${GID:-1000}", f"{service_name} build.args.GID must be parameterized"
+
+
+def test_compose_extractor_services_user_is_parameterized_not_hardcoded() -> None:
+    """The regression: `user: "1000:1000"` was hardcoded while the image's
+    useradd allocated a system UID (<1000) with no build args wired up at
+    all — guaranteeing the two never matched. The user: override must now
+    reference the same UID/GID vars passed as build args."""
+    for service_name in ("extractor-discogs", "extractor-musicbrainz"):
+        service = _load_compose_service(service_name)
+        assert service["user"] == "${UID:-1000}:${GID:-1000}", (
+            f"{service_name} user: must be parameterized to match build.args.UID/GID, not hardcoded"
+        )

--- a/tests/graphinator/conftest.py
+++ b/tests/graphinator/conftest.py
@@ -14,3 +14,20 @@ def disable_batch_mode():
     """
     with patch("graphinator.graphinator.BATCH_MODE", False), patch("graphinator.graphinator.batch_processor", None):
         yield
+
+
+@pytest.fixture(autouse=True)
+def reset_extraction_complete_signals():
+    """Reset the extraction_complete signal latch between tests.
+
+    check_file_completion defers stub cleanup until every data type has
+    signalled extraction_complete, tracked in a module-level set. Leaking that
+    set across tests would let one test's partial signals trigger (or suppress)
+    cleanup in another.
+    """
+    import graphinator.graphinator as g
+
+    saved = set(g.extraction_complete_signals)
+    g.extraction_complete_signals = set()
+    yield
+    g.extraction_complete_signals = saved

--- a/tests/graphinator/test_batch_processor.py
+++ b/tests/graphinator/test_batch_processor.py
@@ -372,6 +372,43 @@ class TestFlushQueue:
         assert acks == [], "poison messages must never be acked"
 
     @pytest.mark.asyncio
+    async def test_poison_batch_nack_failure_is_logged_and_swallowed(self) -> None:
+        """A failing nack_callback on the poison path must be caught and logged (not
+        raised), so a broken channel while routing poison to the DLQ does not crash
+        the flush loop or leave per-data-type state un-reset.
+        """
+        mock_driver = MagicMock()
+        config = BatchConfig(
+            batch_size=5,
+            max_poison_retries=1,
+            backoff_initial=0.0,
+            min_batch_size=1,
+        )
+        processor = Neo4jBatchProcessor(mock_driver, config)
+
+        processor._process_artists_batch = AsyncMock(  # type: ignore[method-assign]
+            side_effect=ValueError("data-induced ClientError")
+        )
+
+        async def failing_nack() -> None:
+            raise RuntimeError("channel closed")
+
+        processor.queues["artists"].append(PendingMessage("artists", {"id": "0", "name": "x", "sha256": "h"}, AsyncMock(), failing_nack))
+
+        with patch("graphinator.batch_processor.logger") as mock_logger:
+            for _ in range(10):
+                if not processor.queues["artists"]:
+                    break
+                processor._backoff_until["artists"] = 0.0
+                await processor._flush_queue("artists")
+
+        # The nack failure was logged as a warning, not propagated.
+        assert any("Failed to nack message" in str(c.args[0]) for c in mock_logger.warning.call_args_list)
+        # State was still reset and the queue drained despite the nack failure.
+        assert not processor.queues["artists"]
+        assert processor._consecutive_failures["artists"] == 0
+
+    @pytest.mark.asyncio
     async def test_flush_labels_batch_success(self) -> None:
         """Test successfully flushing labels batch."""
         mock_driver, _mock_session = create_async_session_mock()

--- a/tests/graphinator/test_batch_processor.py
+++ b/tests/graphinator/test_batch_processor.py
@@ -323,6 +323,55 @@ class TestFlushQueue:
         assert processor.batch_counts["artists"] == 1
 
     @pytest.mark.asyncio
+    async def test_poison_batch_nacked_to_dlq_not_wedged(self) -> None:
+        """Regression (cu2.19): a deterministic (non-transient) batch error must
+        not be retried forever.
+
+        Before the fix, the generic except path re-enqueued the batch and backed
+        off without ever nacking, so a poison record (e.g. a data-induced Neo4j
+        ClientError) retried indefinitely; once its unacked deliveries filled the
+        prefetch window the consumer wedged permanently. After the fix, bounded
+        consecutive failures trigger a nack so the poison batch is routed to the
+        DLQ and the queue drains.
+        """
+        mock_driver = MagicMock()
+        config = BatchConfig(
+            batch_size=5,
+            max_poison_retries=3,
+            backoff_initial=0.0,
+            min_batch_size=1,
+        )
+        processor = Neo4jBatchProcessor(mock_driver, config)
+
+        # Deterministic non-transient failure on every batch.
+        processor._process_artists_batch = AsyncMock(  # type: ignore[method-assign]
+            side_effect=ValueError("data-induced ClientError")
+        )
+
+        acks: list[int] = []
+        nacks: list[int] = []
+
+        async def ack() -> None:
+            acks.append(1)
+
+        async def nack() -> None:
+            nacks.append(1)
+
+        for i in range(2):
+            processor.queues["artists"].append(PendingMessage("artists", {"id": str(i), "name": "x", "sha256": "h"}, ack, nack))
+
+        # Drive flushes; without the fix this loop never drains the queue.
+        for _ in range(50):
+            if not processor.queues["artists"]:
+                break
+            processor._backoff_until["artists"] = 0.0  # skip backoff sleeps in test
+            await processor._flush_queue("artists")
+
+        assert not processor.queues["artists"], "poison batch permanently wedged the queue"
+        assert len(nacks) == 2, "both poison messages must be nacked to the DLQ"
+        assert acks == [], "poison messages must never be acked"
+
+    @pytest.mark.asyncio
     async def test_flush_labels_batch_success(self) -> None:
         """Test successfully flushing labels batch."""
         mock_driver, _mock_session = create_async_session_mock()

--- a/tests/graphinator/test_graphinator.py
+++ b/tests/graphinator/test_graphinator.py
@@ -4302,3 +4302,57 @@ class TestRecoverConsumersClearsTags:
 
         g.consumer_tags = {}
         g.queues = {}
+
+
+class TestStubCleanupBatchAndOrdering:
+    """Regression tests for the stub-cleanup batch.
+
+    Covers three linked defects in graphinator stub cleanup:
+      - cu2.68: the DETACH DELETE ran in one unbounded transaction (no batching)
+      - cu2.49 / cu2.67: per-type cleanup raced still-draining release batches
+        that re-create Artist/Label/Master stubs, leaving permanent phantoms.
+    """
+
+    @staticmethod
+    def _make_graph_mock(fail: bool = False) -> tuple[MagicMock, list[str]]:
+        """Return (graph_mock, run_calls) recording every cypher passed to run()."""
+        run_calls: list[str] = []
+
+        class _Result:
+            async def consume(self) -> MagicMock:
+                summary = MagicMock()
+                summary.counters.nodes_deleted = 5
+                return summary
+
+        class _Session:
+            async def __aenter__(self) -> "_Session":
+                return self
+
+            async def __aexit__(self, *args: Any) -> None:
+                return None
+
+            async def run(self, cypher: str, *_args: Any, **_kwargs: Any) -> "_Result":
+                run_calls.append(cypher)
+                if fail:
+                    raise RuntimeError("transaction memory limit exceeded")
+                return _Result()
+
+        graph_mock = MagicMock()
+        graph_mock.session = MagicMock(return_value=_Session())
+        return graph_mock, run_calls
+
+    @pytest.mark.asyncio
+    async def test_cleanup_all_covers_every_entity_label(self) -> None:
+        """cu2.49: cleanup runs across all labels, not just the completed type."""
+        import graphinator.graphinator as g
+
+        graph_mock, run_calls = self._make_graph_mock()
+        with patch.object(g, "graph", graph_mock):
+            ok = await g.cleanup_all_stub_nodes()
+
+        assert ok is True
+        assert len(run_calls) == 4
+        joined = "\n".join(run_calls)
+        for label in ("Artist", "Label", "Master", "Release"):
+            assert label in joined, f"cleanup must cover {label} stubs"
+

--- a/tests/graphinator/test_graphinator.py
+++ b/tests/graphinator/test_graphinator.py
@@ -37,10 +37,11 @@ class TestOnArtistMessage:
 
         # Mock transaction to indicate new artist
         mock_tx = MagicMock()
+        mock_tx.run = AsyncMock()
 
         async def mock_tx_func(func: Any) -> Any:
-            mock_tx.run.return_value.single.return_value = None  # No existing artist
-            return func(mock_tx)
+            mock_tx.run.return_value.single = AsyncMock(return_value=None)  # No existing artist
+            return await func(mock_tx)
 
         mock_session.execute_write.side_effect = mock_tx_func
 
@@ -52,6 +53,56 @@ class TestOnArtistMessage:
 
         # Verify session was used
         mock_session.execute_write.assert_called()
+
+    @pytest.mark.asyncio
+    @patch("graphinator.graphinator.shutdown_requested", False)
+    async def test_non_batch_mode_awaits_async_transaction(self, sample_artist_data: dict[str, Any], mock_neo4j_driver: MagicMock) -> None:
+        """Regression (cu2.18): non-batch mode must await tx.run()/result.single().
+
+        The service runs on AsyncResilientNeo4jDriver, whose execute_write hands
+        the tx function a real AsyncManagedTransaction where ``tx.run()`` is a
+        coroutine. The old sync ``process_artist`` did ``tx.run(...).single()``
+        with no await, raising ``AttributeError: 'coroutine' object has no
+        attribute 'single'`` on the first statement of every message — nacking
+        the whole dataset to the DLQ. This test drives the real handler with a
+        faithful async transaction and asserts the message is acked (written),
+        never nacked.
+        """
+        import inspect
+
+        from graphinator.graphinator import process_artist
+
+        # process_artist must be a coroutine function so tx_fn can await it.
+        assert inspect.iscoroutinefunction(process_artist)
+
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        mock_message.body = json.dumps(sample_artist_data).encode()
+
+        mock_context_manager = mock_neo4j_driver.session(database="neo4j")
+        mock_session = await mock_context_manager.__aenter__()
+
+        # Faithful AsyncManagedTransaction: run() is an async def, so calling it
+        # WITHOUT await yields a coroutine (as the real driver does). The single()
+        # on the awaited result is also a coroutine.
+        async def async_run(*_args: Any, **_kwargs: Any) -> Any:
+            result = MagicMock()
+            result.single = AsyncMock(return_value=None)  # no existing artist
+            return result
+
+        real_tx = MagicMock()
+        real_tx.run = MagicMock(side_effect=async_run)
+
+        async def execute_write(tx_fn: Any, *_a: Any, **_k: Any) -> Any:
+            # AsyncSession.execute_write awaits the (async) tx function.
+            return await tx_fn(real_tx)
+
+        mock_session.execute_write.side_effect = execute_write
+
+        with patch("graphinator.graphinator.graph", mock_neo4j_driver), patch("graphinator.graphinator.BATCH_MODE", False):
+            await on_artist_message(mock_message)
+
+        mock_message.ack.assert_called_once()
+        mock_message.nack.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("graphinator.graphinator.shutdown_requested", False)
@@ -67,11 +118,12 @@ class TestOnArtistMessage:
 
         # Mock transaction to return existing hash
         mock_tx = MagicMock()
+        mock_tx.run = AsyncMock()
 
         async def mock_tx_func(func: Any) -> Any:
             # Return existing artist with same hash
-            mock_tx.run.return_value.single.return_value = {"hash": sample_artist_data["sha256"]}
-            return func(mock_tx)
+            mock_tx.run.return_value.single = AsyncMock(return_value={"hash": sample_artist_data["sha256"]})
+            return await func(mock_tx)
 
         mock_session.execute_write.side_effect = mock_tx_func
 
@@ -1072,16 +1124,13 @@ class TestComputeGenreStyleStats:
             call_idx = query.index("CALL {")
             # Driving MATCH must appear before the transactional CALL block.
             assert match_idx < call_idx, (
-                f"driving MATCH {driving_match!r} must precede 'CALL {{' — "
-                "otherwise the whole update runs in one transaction"
+                f"driving MATCH {driving_match!r} must precede 'CALL {{' — otherwise the whole update runs in one transaction"
             )
             # The transactional subquery must import the node with WITH, not
             # re-MATCH the full label set inside the CALL.
             after_call = query[call_idx + len("CALL {") :]
             first_stmt = after_call.strip().split("\n", 1)[0].strip()
-            assert first_stmt.startswith("WITH "), (
-                f"first statement inside 'CALL {{' should be a WITH import, got {first_stmt!r}"
-            )
+            assert first_stmt.startswith("WITH "), f"first statement inside 'CALL {{' should be a WITH import, got {first_stmt!r}"
             assert "IN TRANSACTIONS" in query
 
         # Reset
@@ -1375,12 +1424,13 @@ class TestLabelTransactionLogic:
 
         # Create a mock transaction function that will be called
         mock_tx = MagicMock()
+        mock_tx.run = AsyncMock()
         # Return existing hash that matches
-        mock_tx.run.return_value.single.return_value = {"hash": sample_label_data["sha256"]}
+        mock_tx.run.return_value.single = AsyncMock(return_value={"hash": sample_label_data["sha256"]})
 
         # When execute_write is called, execute the transaction function
         async def execute_tx(tx_func: Any) -> Any:
-            return tx_func(mock_tx)
+            return await tx_func(mock_tx)
 
         mock_session.execute_write.side_effect = execute_tx
 
@@ -1415,11 +1465,12 @@ class TestLabelTransactionLogic:
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
+        mock_tx.run = AsyncMock()
         # No existing label
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         async def execute_tx(tx_func: Any) -> Any:
-            return tx_func(mock_tx)
+            return await tx_func(mock_tx)
 
         mock_session.execute_write.side_effect = execute_tx
 
@@ -1457,10 +1508,11 @@ class TestLabelTransactionLogic:
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         async def execute_tx(tx_func: Any) -> Any:
-            return tx_func(mock_tx)
+            return await tx_func(mock_tx)
 
         mock_session.execute_write.side_effect = execute_tx
 
@@ -1495,10 +1547,11 @@ class TestLabelTransactionLogic:
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         async def execute_tx(tx_func: Any) -> Any:
-            return tx_func(mock_tx)
+            return await tx_func(mock_tx)
 
         mock_session.execute_write.side_effect = execute_tx
 
@@ -1527,10 +1580,11 @@ class TestMasterTransactionLogic:
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = {"hash": sample_master_data["sha256"]}
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value={"hash": sample_master_data["sha256"]})
 
         async def execute_tx(tx_func: Any) -> Any:
-            return tx_func(mock_tx)
+            return await tx_func(mock_tx)
 
         mock_session.execute_write.side_effect = execute_tx
 
@@ -1567,10 +1621,11 @@ class TestMasterTransactionLogic:
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         async def execute_tx(tx_func: Any) -> Any:
-            return tx_func(mock_tx)
+            return await tx_func(mock_tx)
 
         mock_session.execute_write.side_effect = execute_tx
 
@@ -1610,10 +1665,11 @@ class TestMasterTransactionLogic:
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         async def execute_tx(tx_func: Any) -> Any:
-            return tx_func(mock_tx)
+            return await tx_func(mock_tx)
 
         mock_session.execute_write.side_effect = execute_tx
 
@@ -1642,10 +1698,11 @@ class TestReleaseTransactionLogic:
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = {"hash": sample_release_data["sha256"]}
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value={"hash": sample_release_data["sha256"]})
 
         async def execute_tx(tx_func: Any) -> Any:
-            return tx_func(mock_tx)
+            return await tx_func(mock_tx)
 
         mock_session.execute_write.side_effect = execute_tx
 
@@ -1683,10 +1740,11 @@ class TestReleaseTransactionLogic:
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         async def execute_tx(tx_func: Any) -> Any:
-            return tx_func(mock_tx)
+            return await tx_func(mock_tx)
 
         mock_session.execute_write.side_effect = execute_tx
 
@@ -1730,10 +1788,11 @@ class TestReleaseTransactionLogic:
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         async def execute_tx(tx_func: Any) -> Any:
-            return tx_func(mock_tx)
+            return await tx_func(mock_tx)
 
         mock_session.execute_write.side_effect = execute_tx
 
@@ -1778,10 +1837,11 @@ class TestReleaseTransactionLogic:
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         async def execute_tx(tx_func: Any) -> Any:
-            return tx_func(mock_tx)
+            return await tx_func(mock_tx)
 
         mock_session.execute_write.side_effect = execute_tx
 
@@ -1814,10 +1874,11 @@ class TestReleaseTransactionLogic:
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         async def execute_tx(tx_func: Any) -> Any:
-            return tx_func(mock_tx)
+            return await tx_func(mock_tx)
 
         mock_session.execute_write.side_effect = execute_tx
 
@@ -2156,10 +2217,11 @@ class TestArtistTransactionEdgeCases:
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         async def execute_tx(tx_func: Any) -> Any:
-            return tx_func(mock_tx)
+            return await tx_func(mock_tx)
 
         mock_session.execute_write.side_effect = execute_tx
 
@@ -2192,10 +2254,11 @@ class TestArtistTransactionEdgeCases:
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         async def execute_tx(tx_func: Any) -> Any:
-            return tx_func(mock_tx)
+            return await tx_func(mock_tx)
 
         mock_session.execute_write.side_effect = execute_tx
 
@@ -2227,10 +2290,11 @@ class TestArtistTransactionEdgeCases:
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         async def execute_tx(tx_func: Any) -> Any:
-            return tx_func(mock_tx)
+            return await tx_func(mock_tx)
 
         mock_session.execute_write.side_effect = execute_tx
 
@@ -2304,10 +2368,11 @@ class TestLabelTransactionEdgeCases:
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         async def execute_tx(tx_func: Any) -> Any:
-            return tx_func(mock_tx)
+            return await tx_func(mock_tx)
 
         mock_session.execute_write.side_effect = execute_tx
 
@@ -2339,10 +2404,11 @@ class TestLabelTransactionEdgeCases:
         mock_session = await mock_context_manager.__aenter__()
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         async def execute_tx(tx_func: Any) -> Any:
-            return tx_func(mock_tx)
+            return await tx_func(mock_tx)
 
         mock_session.execute_write.side_effect = execute_tx
 
@@ -2689,12 +2755,14 @@ class TestRecoverConsumersEdgeCases:
 class TestProcessArtistEdgeCases:
     """Test process_artist edge cases with normalized data."""
 
-    def test_member_with_id_creates_relationship(self) -> None:
+    @pytest.mark.asyncio
+    async def test_member_with_id_creates_relationship(self) -> None:
         """Test normalized member with ID creates MEMBER_OF relationship."""
         from graphinator.graphinator import process_artist
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         record = {
             "id": "artist-1",
@@ -2703,17 +2771,19 @@ class TestProcessArtistEdgeCases:
             "members": [{"id": "string-member-id"}],
         }
 
-        result = process_artist(mock_tx, record)
+        result = await process_artist(mock_tx, record)
         assert result is True
         calls = [str(c) for c in mock_tx.run.call_args_list]
         assert any("MEMBER_OF" in c for c in calls)
 
-    def test_member_without_id_skipped(self) -> None:
+    @pytest.mark.asyncio
+    async def test_member_without_id_skipped(self) -> None:
         """Test normalized member without ID is silently skipped."""
         from graphinator.graphinator import process_artist
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         record = {
             "id": "artist-1",
@@ -2722,17 +2792,19 @@ class TestProcessArtistEdgeCases:
             "members": [{"name": "No ID Member"}],
         }
 
-        result = process_artist(mock_tx, record)
+        result = await process_artist(mock_tx, record)
         assert result is True
         calls = [str(c) for c in mock_tx.run.call_args_list]
         assert not any("MEMBER_OF" in c for c in calls)
 
-    def test_group_with_id_creates_relationship(self) -> None:
+    @pytest.mark.asyncio
+    async def test_group_with_id_creates_relationship(self) -> None:
         """Test normalized group with ID creates MEMBER_OF relationship."""
         from graphinator.graphinator import process_artist
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         record = {
             "id": "artist-1",
@@ -2741,17 +2813,19 @@ class TestProcessArtistEdgeCases:
             "groups": [{"id": "string-group-id"}],
         }
 
-        result = process_artist(mock_tx, record)
+        result = await process_artist(mock_tx, record)
         assert result is True
         calls = [str(c) for c in mock_tx.run.call_args_list]
         assert any("MEMBER_OF" in c for c in calls)
 
-    def test_group_without_id_skipped(self) -> None:
+    @pytest.mark.asyncio
+    async def test_group_without_id_skipped(self) -> None:
         """Test normalized group without ID is silently skipped."""
         from graphinator.graphinator import process_artist
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         record = {
             "id": "artist-1",
@@ -2760,17 +2834,19 @@ class TestProcessArtistEdgeCases:
             "groups": [{"name": "No ID Group"}],
         }
 
-        result = process_artist(mock_tx, record)
+        result = await process_artist(mock_tx, record)
         assert result is True
         calls = [str(c) for c in mock_tx.run.call_args_list]
         assert not any("MEMBER_OF" in c for c in calls)
 
-    def test_alias_with_id_creates_relationship(self) -> None:
+    @pytest.mark.asyncio
+    async def test_alias_with_id_creates_relationship(self) -> None:
         """Test normalized alias with ID creates ALIAS_OF relationship."""
         from graphinator.graphinator import process_artist
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         record = {
             "id": "artist-1",
@@ -2779,17 +2855,19 @@ class TestProcessArtistEdgeCases:
             "aliases": [{"id": "string-alias-id"}],
         }
 
-        result = process_artist(mock_tx, record)
+        result = await process_artist(mock_tx, record)
         assert result is True
         calls = [str(c) for c in mock_tx.run.call_args_list]
         assert any("ALIAS_OF" in c for c in calls)
 
-    def test_alias_without_id_skipped(self) -> None:
+    @pytest.mark.asyncio
+    async def test_alias_without_id_skipped(self) -> None:
         """Test normalized alias without ID is silently skipped."""
         from graphinator.graphinator import process_artist
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         record = {
             "id": "artist-1",
@@ -2798,7 +2876,7 @@ class TestProcessArtistEdgeCases:
             "aliases": [{"name": "No ID Alias"}],
         }
 
-        result = process_artist(mock_tx, record)
+        result = await process_artist(mock_tx, record)
         assert result is True
         calls = [str(c) for c in mock_tx.run.call_args_list]
         assert not any("ALIAS_OF" in c for c in calls)
@@ -2807,12 +2885,14 @@ class TestProcessArtistEdgeCases:
 class TestProcessLabelEdgeCases:
     """Test process_label edge cases with normalized data."""
 
-    def test_sublabel_without_id_skipped(self) -> None:
+    @pytest.mark.asyncio
+    async def test_sublabel_without_id_skipped(self) -> None:
         """Test normalized sublabel without ID is silently skipped."""
         from graphinator.graphinator import process_label
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         record = {
             "id": "label-1",
@@ -2821,17 +2901,19 @@ class TestProcessLabelEdgeCases:
             "sublabels": [{"name": "No ID Sublabel"}],
         }
 
-        result = process_label(mock_tx, record)
+        result = await process_label(mock_tx, record)
         assert result is True
         calls = [str(c) for c in mock_tx.run.call_args_list]
         assert not any("SUBLABEL_OF" in c for c in calls)
 
-    def test_parent_label_without_id_skipped(self) -> None:
+    @pytest.mark.asyncio
+    async def test_parent_label_without_id_skipped(self) -> None:
         """Test normalized parent label without ID is silently skipped."""
         from graphinator.graphinator import process_label
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         record = {
             "id": "label-1",
@@ -2840,7 +2922,7 @@ class TestProcessLabelEdgeCases:
             "parentLabel": {"name": "No ID Parent"},
         }
 
-        result = process_label(mock_tx, record)
+        result = await process_label(mock_tx, record)
         assert result is True
         calls = [str(c) for c in mock_tx.run.call_args_list]
         assert not any("SUBLABEL_OF" in c for c in calls)
@@ -2849,12 +2931,14 @@ class TestProcessLabelEdgeCases:
 class TestProcessMasterEdgeCases:
     """Test process_master edge cases with normalized data."""
 
-    def test_artist_without_id_skipped(self) -> None:
+    @pytest.mark.asyncio
+    async def test_artist_without_id_skipped(self) -> None:
         """Test normalized artist without ID is silently skipped."""
         from graphinator.graphinator import process_master
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         record = {
             "id": "master-1",
@@ -2864,7 +2948,7 @@ class TestProcessMasterEdgeCases:
             "artists": [{"name": "Unknown Artist"}],
         }
 
-        result = process_master(mock_tx, record)
+        result = await process_master(mock_tx, record)
         assert result is True
         calls = [str(c) for c in mock_tx.run.call_args_list]
         assert not any("BY" in c and "artist" in c for c in calls)
@@ -2873,12 +2957,14 @@ class TestProcessMasterEdgeCases:
 class TestProcessLabelSublabelsString:
     """Test process_label with normalized sublabels."""
 
-    def test_sublabels_list_creates_relationship(self) -> None:
+    @pytest.mark.asyncio
+    async def test_sublabels_list_creates_relationship(self) -> None:
         """Test normalized sublabels list creates SUBLABEL_OF relationship."""
         from graphinator.graphinator import process_label
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         record = {
             "id": "label-str-1",
@@ -2887,7 +2973,7 @@ class TestProcessLabelSublabelsString:
             "sublabels": [{"id": "SubLabel As String"}],
         }
 
-        result = process_label(mock_tx, record)
+        result = await process_label(mock_tx, record)
         assert result is True
         calls = [str(c) for c in mock_tx.run.call_args_list]
         assert any("SUBLABEL_OF" in c for c in calls)
@@ -2896,12 +2982,14 @@ class TestProcessLabelSublabelsString:
 class TestProcessReleaseArtistNoId:
     """Test process_release with normalized artist missing ID."""
 
-    def test_artist_without_id_skipped(self) -> None:
+    @pytest.mark.asyncio
+    async def test_artist_without_id_skipped(self) -> None:
         """Test normalized artist without ID is silently skipped."""
         from graphinator.graphinator import process_release
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         record = {
             "id": "release-no-artist-id",
@@ -2912,7 +3000,7 @@ class TestProcessReleaseArtistNoId:
             ],
         }
 
-        result = process_release(mock_tx, record)
+        result = await process_release(mock_tx, record)
         assert result is True
         calls = [str(c) for c in mock_tx.run.call_args_list]
         assert not any("BY" in c and "artist" in c for c in calls)
@@ -2921,12 +3009,14 @@ class TestProcessReleaseArtistNoId:
 class TestProcessReleaseLabelNoId:
     """Test process_release with normalized label missing ID."""
 
-    def test_label_without_id_skipped(self) -> None:
+    @pytest.mark.asyncio
+    async def test_label_without_id_skipped(self) -> None:
         """Test normalized label without ID is silently skipped."""
         from graphinator.graphinator import process_release
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         record = {
             "id": "release-no-label-id",
@@ -2937,7 +3027,7 @@ class TestProcessReleaseLabelNoId:
             ],
         }
 
-        result = process_release(mock_tx, record)
+        result = await process_release(mock_tx, record)
         assert result is True
         calls = [str(c) for c in mock_tx.run.call_args_list]
         assert not any(")-[:ON]->" in c for c in calls)
@@ -2946,12 +3036,14 @@ class TestProcessReleaseLabelNoId:
 class TestProcessReleaseMasterNoId:
     """Test process_release with no master_id."""
 
-    def test_no_master_id_skips_relationship(self) -> None:
+    @pytest.mark.asyncio
+    async def test_no_master_id_skips_relationship(self) -> None:
         """Test that missing master_id skips DERIVED_FROM relationship."""
         from graphinator.graphinator import process_release
 
         mock_tx = MagicMock()
-        mock_tx.run.return_value.single.return_value = None
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value=None)
 
         record = {
             "id": "release-no-master-text",
@@ -2959,7 +3051,7 @@ class TestProcessReleaseMasterNoId:
             "title": "Test Release",
         }
 
-        result = process_release(mock_tx, record)
+        result = await process_release(mock_tx, record)
         assert result is True
         calls = [str(c) for c in mock_tx.run.call_args_list]
         assert not any("DERIVED_FROM" in c for c in calls)

--- a/tests/graphinator/test_graphinator.py
+++ b/tests/graphinator/test_graphinator.py
@@ -4254,3 +4254,51 @@ class TestRecoverConsumersAllTypes:
         g.active_connection = None
         g.active_channel = None
         g.queues = {}
+
+
+class TestRecoverConsumersClearsTags:
+    """Regression (cu2.54): recovery errors after ≥1 consumer registered must
+    clear consumer_tags so the stuck-state detector can re-fire."""
+
+    @pytest.mark.asyncio
+    async def test_error_after_partial_registration_clears_consumer_tags(self) -> None:
+        import graphinator.graphinator as g
+
+        g.active_connection = None
+        g.active_channel = None
+        g.consumer_tags = {}
+        g.completed_files = set()
+        g.queues = {}
+        g.last_message_time = dict.fromkeys(["artists", "labels", "masters", "releases"], 0.0)
+
+        def declare_queue(**kwargs: Any) -> Any:
+            name = kwargs.get("name", "")
+            if kwargs.get("passive"):
+                q = MagicMock()
+                q.declaration_result.message_count = 100
+                return q
+            q = AsyncMock()
+            q.bind = AsyncMock()
+            if name.endswith("-labels"):
+                q.consume = AsyncMock(side_effect=RuntimeError("channel closed mid-recovery"))
+            else:
+                q.consume = AsyncMock(return_value=f"tag-{name}")
+            return q
+
+        mock_channel = AsyncMock()
+        mock_channel.declare_queue = AsyncMock(side_effect=declare_queue)
+        mock_channel.declare_exchange = AsyncMock(return_value=AsyncMock())
+        mock_channel.set_qos = AsyncMock()
+        mock_connection = AsyncMock()
+        mock_connection.channel = AsyncMock(return_value=mock_channel)
+        mock_rmq = AsyncMock()
+        mock_rmq.connect = AsyncMock(return_value=mock_connection)
+
+        with patch.object(g, "rabbitmq_manager", mock_rmq), patch.object(g, "logger"):
+            await g._recover_consumers()
+
+        assert g.consumer_tags == {}, "stale consumer tags must be cleared"
+        assert g.active_connection is None
+
+        g.consumer_tags = {}
+        g.queues = {}

--- a/tests/graphinator/test_graphinator.py
+++ b/tests/graphinator/test_graphinator.py
@@ -4356,3 +4356,31 @@ class TestStubCleanupBatchAndOrdering:
         for label in ("Artist", "Label", "Master", "Release"):
             assert label in joined, f"cleanup must cover {label} stubs"
 
+    @pytest.mark.asyncio
+    async def test_cleanup_uses_batched_transactions(self) -> None:
+        """cu2.68: the delete is batched via CALL {} IN TRANSACTIONS, not one big tx."""
+        import graphinator.graphinator as g
+
+        graph_mock, run_calls = self._make_graph_mock()
+        with patch.object(g, "graph", graph_mock):
+            ok = await g.cleanup_stub_nodes("artists")
+
+        assert ok is True
+        assert len(run_calls) == 1
+        cypher = run_calls[0]
+        assert "IN TRANSACTIONS" in cypher, "delete must be batched to survive scale"
+        assert "DETACH DELETE" in cypher
+        assert "Artist" in cypher
+        assert "n.sha256 IS NULL" in cypher
+
+    @pytest.mark.asyncio
+    async def test_cleanup_failure_returns_false_for_retry(self) -> None:
+        """cu2.68: a failed delete must return False so the caller nacks/retries."""
+        import graphinator.graphinator as g
+
+        graph_mock, _ = self._make_graph_mock(fail=True)
+        with patch.object(g, "graph", graph_mock), patch.object(g, "logger"):
+            ok = await g.cleanup_stub_nodes("artists")
+
+        assert ok is False
+

--- a/tests/graphinator/test_graphinator.py
+++ b/tests/graphinator/test_graphinator.py
@@ -953,7 +953,12 @@ class TestCheckFileCompletion:
 
     @pytest.mark.asyncio
     async def test_extraction_complete_triggers_stub_cleanup(self) -> None:
-        """Test extraction_complete triggers stub node cleanup."""
+        """Test extraction_complete triggers stub cleanup once ALL types complete.
+
+        Cleanup is deferred until every data type has signalled
+        extraction_complete (cu2.49 / cu2.67), then runs across every entity
+        label. Seed the other three signals and send the final one.
+        """
         mock_message = AsyncMock(spec=AbstractIncomingMessage)
         completion_data = {
             "type": "extraction_complete",
@@ -961,33 +966,44 @@ class TestCheckFileCompletion:
         }
 
         mock_driver = AsyncMock()
-        mock_session_ctx = AsyncMock()
         mock_session = AsyncMock()
-        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
-        mock_driver.session = MagicMock(return_value=mock_session_ctx)
 
+        def _session(*_args: Any, **_kwargs: Any) -> AsyncMock:
+            ctx = AsyncMock()
+            ctx.__aenter__ = AsyncMock(return_value=mock_session)
+            ctx.__aexit__ = AsyncMock(return_value=False)
+            return ctx
+
+        mock_driver.session = MagicMock(side_effect=_session)
+
+        mock_summary = MagicMock()
+        mock_summary.counters.nodes_deleted = 5
         mock_result = AsyncMock()
-        mock_record = {"deleted": 5}
-        mock_result.single = AsyncMock(return_value=mock_record)
+        mock_result.consume = AsyncMock(return_value=mock_summary)
         mock_session.run = AsyncMock(return_value=mock_result)
 
         import graphinator.graphinator
 
         graphinator.graphinator.batch_processor = None
         graphinator.graphinator.graph = mock_driver
+        # All other types already signalled; this releases signal is the last.
+        graphinator.graphinator.extraction_complete_signals = {"artists", "labels", "masters"}
 
         from graphinator.graphinator import check_file_completion
 
-        result = await check_file_completion(completion_data, "artists", mock_message)
+        with patch("graphinator.graphinator.compute_genre_style_stats", AsyncMock(return_value=True)):
+            result = await check_file_completion(completion_data, "releases", mock_message)
 
         assert result is True
-        # Verify cleanup query was run for Artist nodes
-        mock_session.run.assert_called_once()
-        call_args = mock_session.run.call_args[0][0]
-        assert "Artist" in call_args
-        assert "sha256 IS NULL" in call_args
-        assert "DETACH DELETE" in call_args
+        # Cleanup runs for EVERY entity label, not just the triggering type.
+        cleanup_cyphers = [call.args[0] for call in mock_session.run.call_args_list]
+        joined = "\n".join(cleanup_cyphers)
+        for label in ("Artist", "Label", "Master", "Release"):
+            assert label in joined
+        assert "sha256 IS NULL" in joined
+        assert "DETACH DELETE" in joined
+        assert "IN TRANSACTIONS" in joined
+        mock_message.ack.assert_called_once()
 
         # Reset
         graphinator.graphinator.graph = None
@@ -1247,13 +1263,16 @@ class TestCheckFileCompletionComputeGenreStyleStats:
         graphinator.graphinator.batch_processor = None
         mock_driver = AsyncMock()
         graphinator.graphinator.graph = mock_driver
+        # releases is the final signal — the other three already arrived.
+        graphinator.graphinator.extraction_complete_signals = {"artists", "labels", "masters"}
 
         from graphinator.graphinator import check_file_completion
 
         result = await check_file_completion(completion_data, "releases", mock_message)
 
         assert result is True
-        mock_cleanup.assert_called_once_with("releases")
+        # Cleanup now runs for every entity label; stats compute exactly once.
+        assert {c.args[0] for c in mock_cleanup.call_args_list} == {"artists", "labels", "masters", "releases"}
         mock_compute.assert_called_once()
 
         # Reset
@@ -1262,8 +1281,8 @@ class TestCheckFileCompletionComputeGenreStyleStats:
     @pytest.mark.asyncio
     @patch("graphinator.graphinator.compute_genre_style_stats", new_callable=AsyncMock)
     @patch("graphinator.graphinator.cleanup_stub_nodes", new_callable=AsyncMock)
-    async def test_does_not_call_compute_genre_style_stats_for_artists(self, mock_cleanup: AsyncMock, mock_compute: AsyncMock) -> None:
-        """Test compute_genre_style_stats is NOT called for non-release data types."""
+    async def test_defers_maintenance_until_all_types_complete(self, mock_cleanup: AsyncMock, mock_compute: AsyncMock) -> None:
+        """cu2.49 / cu2.67: a single type's signal must NOT trigger any maintenance."""
         mock_message = AsyncMock(spec=AbstractIncomingMessage)
         completion_data = {
             "type": "extraction_complete",
@@ -1275,14 +1294,20 @@ class TestCheckFileCompletionComputeGenreStyleStats:
         graphinator.graphinator.batch_processor = None
         mock_driver = AsyncMock()
         graphinator.graphinator.graph = mock_driver
+        # Fresh run: only this artists signal has arrived so far.
+        graphinator.graphinator.extraction_complete_signals = set()
 
         from graphinator.graphinator import check_file_completion
 
         result = await check_file_completion(completion_data, "artists", mock_message)
 
         assert result is True
-        mock_cleanup.assert_called_once_with("artists")
+        # Neither cleanup nor stats may run while release batches could still
+        # be MERGEing cross-type stubs.
+        mock_cleanup.assert_not_called()
         mock_compute.assert_not_called()
+        mock_message.ack.assert_called_once()
+        mock_message.nack.assert_not_called()
 
         # Reset
         graphinator.graphinator.graph = None
@@ -1309,6 +1334,7 @@ class TestCheckFileCompletionMaintenanceFailure:
 
         graphinator.graphinator.batch_processor = None
         graphinator.graphinator.graph = AsyncMock()
+        graphinator.graphinator.extraction_complete_signals = {"artists", "labels", "masters"}
 
         from graphinator.graphinator import check_file_completion
 
@@ -1333,6 +1359,7 @@ class TestCheckFileCompletionMaintenanceFailure:
 
         graphinator.graphinator.batch_processor = None
         graphinator.graphinator.graph = AsyncMock()
+        graphinator.graphinator.extraction_complete_signals = {"artists", "labels", "masters"}
 
         from graphinator.graphinator import check_file_completion
 
@@ -1357,10 +1384,11 @@ class TestCheckFileCompletionMaintenanceFailure:
 
         graphinator.graphinator.batch_processor = None
         graphinator.graphinator.graph = AsyncMock()
+        # artists is the final signal — cleanup runs for all labels and fails.
+        graphinator.graphinator.extraction_complete_signals = {"labels", "masters", "releases"}
 
         from graphinator.graphinator import check_file_completion
 
-        # Use a non-releases type so only cleanup runs (compute is releases-only)
         result = await check_file_completion(completion_data, "artists", mock_message)
 
         assert result is True
@@ -4384,3 +4412,79 @@ class TestStubCleanupBatchAndOrdering:
 
         assert ok is False
 
+    @pytest.mark.asyncio
+    async def test_cleanup_deferred_until_all_types_complete(self) -> None:
+        """cu2.49 / cu2.67: no cleanup until every type signals extraction_complete."""
+        import graphinator.graphinator as g
+
+        g.extraction_complete_signals = set()
+        graph_mock, _ = self._make_graph_mock()
+        called: list[str] = []
+
+        async def fake_cleanup_all() -> bool:
+            called.append("cleanup")
+            return True
+
+        async def fake_stats() -> bool:
+            called.append("stats")
+            return True
+
+        with (
+            patch.object(g, "graph", graph_mock),
+            patch.object(g, "cleanup_all_stub_nodes", fake_cleanup_all),
+            patch.object(g, "compute_genre_style_stats", fake_stats),
+            patch.object(g, "logger"),
+        ):
+            # First three signals must NOT trigger cleanup — release batches may
+            # still be MERGEing stubs.
+            for data_type in ("artists", "labels", "masters"):
+                message = AsyncMock(spec=AbstractIncomingMessage)
+                data = {"type": "extraction_complete", "version": "v1"}
+                handled = await g.check_file_completion(data, data_type, message)
+                assert handled is True
+                message.ack.assert_called_once()
+                message.nack.assert_not_called()
+            assert called == [], "cleanup must be deferred until all types complete"
+
+            # The final signal (releases, drains last) triggers the single pass.
+            message = AsyncMock(spec=AbstractIncomingMessage)
+            data = {"type": "extraction_complete", "version": "v1"}
+            handled = await g.check_file_completion(data, "releases", message)
+            assert handled is True
+            message.ack.assert_called_once()
+            message.nack.assert_not_called()
+            assert called == ["cleanup", "stats"]
+
+        g.extraction_complete_signals = set()
+
+    @pytest.mark.asyncio
+    async def test_final_signal_nacks_when_maintenance_fails(self) -> None:
+        """cu2.67: failed maintenance nacks for retry and keeps the signal latch."""
+        import graphinator.graphinator as g
+
+        g.extraction_complete_signals = {"artists", "labels", "masters"}
+        graph_mock, _ = self._make_graph_mock()
+
+        async def failing_cleanup_all() -> bool:
+            return False
+
+        async def fake_stats() -> bool:
+            return True
+
+        with (
+            patch.object(g, "graph", graph_mock),
+            patch.object(g, "cleanup_all_stub_nodes", failing_cleanup_all),
+            patch.object(g, "compute_genre_style_stats", fake_stats),
+            patch.object(g, "logger"),
+        ):
+            message = AsyncMock(spec=AbstractIncomingMessage)
+            data = {"type": "extraction_complete", "version": "v1"}
+            handled = await g.check_file_completion(data, "releases", message)
+
+        assert handled is True
+        message.nack.assert_called_once_with(requeue=True)
+        message.ack.assert_not_called()
+        # Idempotent latch retained so the requeued message retries cleanly.
+        assert "releases" in g.extraction_complete_signals
+
+        g.extraction_complete_signals = set()

--- a/tests/graphinator/test_graphinator.py
+++ b/tests/graphinator/test_graphinator.py
@@ -1032,6 +1032,62 @@ class TestComputeGenreStyleStats:
         graphinator.graphinator.graph = None
 
     @pytest.mark.asyncio
+    async def test_driving_match_is_outside_transactional_subquery(self) -> None:
+        """Regression (cu2.17): the driving MATCH must sit OUTSIDE ``CALL {} IN
+        TRANSACTIONS`` so the update batches one node per inner transaction.
+
+        If the MATCH is the first statement *inside* the transactional subquery
+        (``CALL { MATCH (g:Genre) ... } IN TRANSACTIONS``) then nothing precedes
+        the CALL, exactly one implicit input row drives it, and the entire update
+        runs in a single transaction — defeating the batching and hitting the
+        120s transaction timeout at production scale.
+        """
+        mock_driver = AsyncMock()
+        mock_session_ctx = AsyncMock()
+        mock_session = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_driver.session = MagicMock(return_value=mock_session_ctx)
+
+        result = AsyncMock()
+        result.consume = AsyncMock(return_value=MagicMock(counters="properties_set=0"))
+        mock_session.run = AsyncMock(return_value=result)
+
+        import graphinator.graphinator
+
+        graphinator.graphinator.graph = mock_driver
+
+        from graphinator.graphinator import compute_genre_style_stats
+
+        await compute_genre_style_stats()
+
+        # (query string, driving-match snippet) for each of the three queries
+        cases = [
+            (mock_session.run.call_args_list[0][0][0], "MATCH (g:Genre)"),
+            (mock_session.run.call_args_list[1][0][0], "MATCH (s:Style)"),
+            (mock_session.run.call_args_list[2][0][0], "MATCH (l:Label)"),
+        ]
+        for query, driving_match in cases:
+            match_idx = query.index(driving_match)
+            call_idx = query.index("CALL {")
+            # Driving MATCH must appear before the transactional CALL block.
+            assert match_idx < call_idx, (
+                f"driving MATCH {driving_match!r} must precede 'CALL {{' — "
+                "otherwise the whole update runs in one transaction"
+            )
+            # The transactional subquery must import the node with WITH, not
+            # re-MATCH the full label set inside the CALL.
+            after_call = query[call_idx + len("CALL {") :]
+            first_stmt = after_call.strip().split("\n", 1)[0].strip()
+            assert first_stmt.startswith("WITH "), (
+                f"first statement inside 'CALL {{' should be a WITH import, got {first_stmt!r}"
+            )
+            assert "IN TRANSACTIONS" in query
+
+        # Reset
+        graphinator.graphinator.graph = None
+
+    @pytest.mark.asyncio
     async def test_skips_when_no_driver(self) -> None:
         """Test does nothing when graph driver is None."""
         import graphinator.graphinator

--- a/tests/graphinator/test_graphinator.py
+++ b/tests/graphinator/test_graphinator.py
@@ -175,8 +175,9 @@ class TestOnArtistMessage:
 
         captured: dict[str, Any] = {}
 
-        async def fake_add(data_type: str, record: dict[str, Any], ack_cb: Any, nack_cb: Any) -> bool:
-            captured["nack"] = nack_cb
+        async def fake_add(*args: Any) -> bool:
+            # add_message(data_type, record, ack_callback, nack_callback)
+            captured["nack"] = args[3]
             return True
 
         proc = MagicMock()
@@ -4208,3 +4209,48 @@ class TestCoverageGaps:
 
             # UTC timestamps end with +00:00
             assert result["timestamp"].endswith("+00:00")
+
+
+class TestRecoverConsumersAllTypes:
+    """Regression (cu2.53): _recover_consumers must start consumers for ALL data
+    types, not just those with a backlog at the passive-declare instant."""
+
+    @pytest.mark.asyncio
+    async def test_recovers_all_types_not_just_backlogged(self) -> None:
+        import graphinator.graphinator as g
+
+        g.active_connection = None
+        g.active_channel = None
+        g.consumer_tags = {}
+        g.completed_files = set()
+        g.queues = {}
+        g.last_message_time = dict.fromkeys(["artists", "labels", "masters", "releases"], 0.0)
+
+        def declare_queue(**kwargs: Any) -> Any:
+            if kwargs.get("passive"):
+                q = MagicMock()
+                q.declaration_result.message_count = 100 if kwargs["name"].endswith("-artists") else 0
+                return q
+            q = AsyncMock()
+            q.consume = AsyncMock(return_value=f"tag-{kwargs.get('name')}")
+            q.bind = AsyncMock()
+            return q
+
+        mock_channel = AsyncMock()
+        mock_channel.declare_queue = AsyncMock(side_effect=declare_queue)
+        mock_channel.declare_exchange = AsyncMock(return_value=AsyncMock())
+        mock_channel.set_qos = AsyncMock()
+        mock_connection = AsyncMock()
+        mock_connection.channel = AsyncMock(return_value=mock_channel)
+        mock_rmq = AsyncMock()
+        mock_rmq.connect = AsyncMock(return_value=mock_connection)
+
+        with patch.object(g, "rabbitmq_manager", mock_rmq), patch.object(g, "logger"):
+            await g._recover_consumers()
+
+        assert set(g.consumer_tags.keys()) == {"artists", "labels", "masters", "releases"}
+
+        g.consumer_tags = {}
+        g.active_connection = None
+        g.active_channel = None
+        g.queues = {}

--- a/tests/graphinator/test_graphinator.py
+++ b/tests/graphinator/test_graphinator.py
@@ -163,6 +163,34 @@ class TestOnArtistMessage:
 
     @pytest.mark.asyncio
     @patch("graphinator.graphinator.shutdown_requested", False)
+    async def test_batch_mode_nack_callback_uses_requeue_false(self) -> None:
+        """Regression (cu2.52): the batch-mode add_message nack callback must use
+        requeue=False so permanently-invalid input goes straight to the DLQ
+        instead of cycling x-delivery-limit (20) futile redeliveries.
+        """
+        import graphinator.graphinator as g
+
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        mock_message.body = json.dumps({"id": "1", "sha256": "h", "name": "x"}).encode()
+
+        captured: dict[str, Any] = {}
+
+        async def fake_add(data_type: str, record: dict[str, Any], ack_cb: Any, nack_cb: Any) -> bool:
+            captured["nack"] = nack_cb
+            return True
+
+        proc = MagicMock()
+        proc.add_message = AsyncMock(side_effect=fake_add)
+
+        with patch.object(g, "BATCH_MODE", True), patch.object(g, "batch_processor", proc):
+            await on_artist_message(mock_message)
+
+        # Simulate add_message rejecting a permanently-invalid message.
+        await captured["nack"]()
+        mock_message.nack.assert_called_once_with(requeue=False)
+
+    @pytest.mark.asyncio
+    @patch("graphinator.graphinator.shutdown_requested", False)
     async def test_handle_processing_error(self, sample_artist_data: dict[str, Any]) -> None:
         """Test error handling during processing."""
         mock_message = AsyncMock(spec=AbstractIncomingMessage)

--- a/tests/graphinator/test_graphinator.py
+++ b/tests/graphinator/test_graphinator.py
@@ -1259,6 +1259,87 @@ class TestCheckFileCompletionComputeGenreStyleStats:
         graphinator.graphinator.graph = None
 
 
+class TestCheckFileCompletionMaintenanceFailure:
+    """Regression (cu2.50): extraction_complete must NOT be acked when post-import
+    maintenance (cleanup_stub_nodes / compute_genre_style_stats) fails — it must
+    nack(requeue=True) so the idempotent maintenance is retried, since the
+    extraction_complete signal is emitted exactly once per run.
+    """
+
+    @pytest.mark.asyncio
+    @patch("graphinator.graphinator.compute_genre_style_stats", new_callable=AsyncMock)
+    @patch("graphinator.graphinator.cleanup_stub_nodes", new_callable=AsyncMock)
+    async def test_acks_when_maintenance_succeeds(self, mock_cleanup: AsyncMock, mock_compute: AsyncMock) -> None:
+        """Both maintenance steps succeed → ack, no nack."""
+        mock_cleanup.return_value = True
+        mock_compute.return_value = True
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        completion_data = {"type": "extraction_complete", "version": "20260101"}
+
+        import graphinator.graphinator
+
+        graphinator.graphinator.batch_processor = None
+        graphinator.graphinator.graph = AsyncMock()
+
+        from graphinator.graphinator import check_file_completion
+
+        result = await check_file_completion(completion_data, "releases", mock_message)
+
+        assert result is True
+        mock_message.ack.assert_called_once()
+        mock_message.nack.assert_not_called()
+        graphinator.graphinator.graph = None
+
+    @pytest.mark.asyncio
+    @patch("graphinator.graphinator.compute_genre_style_stats", new_callable=AsyncMock)
+    @patch("graphinator.graphinator.cleanup_stub_nodes", new_callable=AsyncMock)
+    async def test_nacks_when_compute_stats_fails(self, mock_cleanup: AsyncMock, mock_compute: AsyncMock) -> None:
+        """compute_genre_style_stats fails → nack(requeue=True), never ack."""
+        mock_cleanup.return_value = True
+        mock_compute.return_value = False  # stats computation failed at scale
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        completion_data = {"type": "extraction_complete", "version": "20260101"}
+
+        import graphinator.graphinator
+
+        graphinator.graphinator.batch_processor = None
+        graphinator.graphinator.graph = AsyncMock()
+
+        from graphinator.graphinator import check_file_completion
+
+        result = await check_file_completion(completion_data, "releases", mock_message)
+
+        assert result is True
+        mock_message.nack.assert_called_once_with(requeue=True)
+        mock_message.ack.assert_not_called()
+        graphinator.graphinator.graph = None
+
+    @pytest.mark.asyncio
+    @patch("graphinator.graphinator.compute_genre_style_stats", new_callable=AsyncMock)
+    @patch("graphinator.graphinator.cleanup_stub_nodes", new_callable=AsyncMock)
+    async def test_nacks_when_cleanup_fails(self, mock_cleanup: AsyncMock, mock_compute: AsyncMock) -> None:
+        """cleanup_stub_nodes fails → nack(requeue=True), never ack."""
+        mock_cleanup.return_value = False  # DETACH DELETE failed
+        mock_compute.return_value = True
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        completion_data = {"type": "extraction_complete", "version": "20260101"}
+
+        import graphinator.graphinator
+
+        graphinator.graphinator.batch_processor = None
+        graphinator.graphinator.graph = AsyncMock()
+
+        from graphinator.graphinator import check_file_completion
+
+        # Use a non-releases type so only cleanup runs (compute is releases-only)
+        result = await check_file_completion(completion_data, "artists", mock_message)
+
+        assert result is True
+        mock_message.nack.assert_called_once_with(requeue=True)
+        mock_message.ack.assert_not_called()
+        graphinator.graphinator.graph = None
+
+
 class TestScheduleConsumerCancellation:
     """Test schedule_consumer_cancellation function."""
 

--- a/tests/insights/test_insights.py
+++ b/tests/insights/test_insights.py
@@ -467,6 +467,60 @@ class TestLifespan:
             mock_pool.close.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_lifespan_missing_internal_secret_warns_and_omits_header(self) -> None:
+        """When INSIGHTS_INTERNAL_SECRET is unset, startup logs a warning and the HTTP
+        client is built WITHOUT the X-Internal-Secret header (the API will reject calls)."""
+        from fastapi import FastAPI
+
+        import insights.insights as _module
+
+        mock_pool = AsyncMock()
+        mock_pool.initialize = AsyncMock()
+        mock_pool.close = AsyncMock()
+
+        mock_http_client = AsyncMock()
+        mock_http_client.aclose = AsyncMock()
+
+        mock_health_srv = MagicMock()
+        mock_health_srv.start_background = MagicMock()
+        mock_health_srv.stop = MagicMock()
+
+        mock_config = MagicMock()
+        mock_config.postgres_host = "localhost:5432"
+        mock_config.postgres_database = "test"
+        mock_config.postgres_username = "user"
+        mock_config.postgres_password = "pass"
+        mock_config.api_base_url = "http://localhost:8004"
+        mock_config.redis_host = "redis://localhost"
+        mock_config.schedule_hours = 24
+        mock_config.milestone_years = [25, 50]
+        mock_config.internal_secret = None  # secret unset → else branch
+
+        async def fake_scheduler(*_args: object, **_kwargs: object) -> None:
+            await asyncio.sleep(100)
+
+        fake_app = FastAPI()
+
+        with (
+            patch.object(_module, "setup_logging"),
+            patch.object(_module.InsightsConfig, "from_env", return_value=mock_config),
+            patch.object(_module, "HealthServer", return_value=mock_health_srv),
+            patch.object(_module, "AsyncPostgreSQLPool", return_value=mock_pool),
+            patch("httpx.AsyncClient", return_value=mock_http_client) as mock_client_cls,
+            patch("redis.asyncio.from_url", new_callable=AsyncMock, return_value=MagicMock()),
+            patch.object(_module, "InsightsCache", return_value=MagicMock()),
+            patch.object(_module, "_scheduler_loop", side_effect=fake_scheduler),
+            patch.object(_module.logger, "warning") as mock_warning,
+        ):
+            async with _module.lifespan(fake_app):
+                # HTTP client built without the internal-secret header.
+                headers = mock_client_cls.call_args.kwargs["headers"]
+                assert "X-Internal-Secret" not in headers
+
+            # The missing-secret warning was emitted.
+            assert any("INSIGHTS_INTERNAL_SECRET is not set" in str(c.args[0]) for c in mock_warning.call_args_list)
+
+    @pytest.mark.asyncio
     async def test_lifespan_redis_unavailable_fallback(self) -> None:
         """When Redis is unavailable, caching should be disabled gracefully."""
         from fastapi import FastAPI

--- a/tests/mcp-server/test_server.py
+++ b/tests/mcp-server/test_server.py
@@ -337,6 +337,37 @@ class TestFindPath:
         assert "error" in result
         assert "not found" in result["error"]
 
+    @pytest.mark.asyncio
+    async def test_max_depth_above_api_ceiling_is_clamped_to_10(self, mock_context, app_ctx):
+        """discogsography-cu2.51: the tool used to clamp to 15 while the API's
+        _MAX_PATH_DEPTH is 10 (Query(..., le=10)), so max_depth=11-15 always got
+        forwarded and always 422'd. It must now be clamped to the API's real ceiling.
+        """
+        from mcp_server.server import find_path
+
+        fake_response = {"found": True, "length": 1, "path": []}
+        app_ctx.client.get = AsyncMock(return_value=_mock_response(fake_response))
+
+        await find_path(from_name="Kraftwerk", from_type="artist", to_name="Afrika Bambaataa", to_type="artist", max_depth=12, ctx=mock_context)
+
+        _, call_kwargs = app_ctx.client.get.call_args
+        assert call_kwargs["params"]["max_depth"] == 10
+
+    @pytest.mark.asyncio
+    async def test_max_depth_non_digit_falls_back_to_documented_default(self, mock_context, app_ctx):
+        """discogsography-cu2.51: the non-digit fallback used to be 3, contradicting the
+        documented/signature default of 10.
+        """
+        from mcp_server.server import find_path
+
+        fake_response = {"found": True, "length": 1, "path": []}
+        app_ctx.client.get = AsyncMock(return_value=_mock_response(fake_response))
+
+        await find_path(from_name="A", from_type="artist", to_name="B", to_type="artist", max_depth="not-a-number", ctx=mock_context)
+
+        _, call_kwargs = app_ctx.client.get.call_args
+        assert call_kwargs["params"]["max_depth"] == 10
+
 
 # ---------------------------------------------------------------------------
 # Tool: get_trends

--- a/tests/tableinator/test_batch_processor.py
+++ b/tests/tableinator/test_batch_processor.py
@@ -478,6 +478,63 @@ class TestPostgreSQLBatchProcessor:
         assert len(processor.queues["artists"]) == 1
 
     @pytest.mark.asyncio
+    async def test_poison_batch_nacked_to_dlq_not_wedged(self) -> None:
+        """Regression (cu2.19): a deterministic (non-transient) batch error must
+        not be retried forever.
+
+        Before the fix, the generic except path re-enqueued the batch and backed
+        off without ever nacking, so a poison record retried indefinitely; once
+        its unacked deliveries filled the prefetch window the consumer wedged
+        permanently. After the fix, bounded consecutive failures trigger a nack
+        so the poison (and its batch) is routed to the DLQ and the queue drains.
+        """
+        config = BatchConfig(
+            batch_size=5,
+            max_poison_retries=3,
+            backoff_initial=0.0,
+            min_batch_size=1,
+        )
+        processor = PostgreSQLBatchProcessor(MagicMock(), config=config)
+
+        # Deterministic non-transient failure on every batch (e.g. a DataError
+        # on a value PostgreSQL's jsonb rejects).
+        processor._process_batch = AsyncMock(  # type: ignore[method-assign]
+            side_effect=ValueError("invalid jsonb")
+        )
+
+        acks: list[int] = []
+        nacks: list[int] = []
+
+        async def ack() -> None:
+            acks.append(1)
+
+        async def nack() -> None:
+            nacks.append(1)
+
+        for i in range(2):
+            processor.queues["artists"].append(
+                PendingMessage(
+                    data_type="artists",
+                    data_id=str(i),
+                    data={"id": str(i)},
+                    sha256="h",
+                    ack_callback=ack,
+                    nack_callback=nack,
+                )
+            )
+
+        # Drive flushes; without the fix this loop never drains the queue.
+        for _ in range(50):
+            if not processor.queues["artists"]:
+                break
+            processor._backoff_until["artists"] = 0.0  # skip backoff sleeps in test
+            await processor._flush_queue("artists")
+
+        assert not processor.queues["artists"], "poison batch permanently wedged the queue"
+        assert len(nacks) == 2, "both poison messages must be nacked to the DLQ"
+        assert acks == [], "poison messages must never be acked"
+
+    @pytest.mark.asyncio
     async def test_flush_queue_ack_callback_error(self) -> None:
         """Test handling errors in ack callback."""
         mock_connection = MagicMock()

--- a/tests/tableinator/test_batch_processor.py
+++ b/tests/tableinator/test_batch_processor.py
@@ -535,6 +535,51 @@ class TestPostgreSQLBatchProcessor:
         assert acks == [], "poison messages must never be acked"
 
     @pytest.mark.asyncio
+    async def test_poison_batch_nack_failure_is_logged_and_swallowed(self) -> None:
+        """A failing nack_callback on the poison path must be caught and logged (not
+        raised), so a broken channel while routing poison to the DLQ does not crash
+        the flush loop or leave per-data-type state un-reset.
+        """
+        config = BatchConfig(
+            batch_size=5,
+            max_poison_retries=1,
+            backoff_initial=0.0,
+            min_batch_size=1,
+        )
+        processor = PostgreSQLBatchProcessor(MagicMock(), config=config)
+
+        processor._process_batch = AsyncMock(  # type: ignore[method-assign]
+            side_effect=ValueError("invalid jsonb")
+        )
+
+        async def failing_nack() -> None:
+            raise RuntimeError("channel closed")
+
+        processor.queues["artists"].append(
+            PendingMessage(
+                data_type="artists",
+                data_id="0",
+                data={"id": "0"},
+                sha256="h",
+                ack_callback=AsyncMock(),
+                nack_callback=failing_nack,
+            )
+        )
+
+        with patch("tableinator.batch_processor.logger") as mock_logger:
+            for _ in range(10):
+                if not processor.queues["artists"]:
+                    break
+                processor._backoff_until["artists"] = 0.0
+                await processor._flush_queue("artists")
+
+        # The nack failure was logged as a warning, not propagated.
+        assert any("Failed to nack message" in str(c.args[0]) for c in mock_logger.warning.call_args_list)
+        # State was still reset and the queue drained despite the nack failure.
+        assert not processor.queues["artists"]
+        assert processor._consecutive_failures["artists"] == 0
+
+    @pytest.mark.asyncio
     async def test_flush_queue_ack_callback_error(self) -> None:
         """Test handling errors in ack callback."""
         mock_connection = MagicMock()

--- a/tests/tableinator/test_batch_processor.py
+++ b/tests/tableinator/test_batch_processor.py
@@ -794,6 +794,172 @@ class TestPostgreSQLBatchProcessor:
         processor.flush_queue.assert_has_calls(expected_calls, any_order=True)
 
     @pytest.mark.asyncio
+    async def test_flush_queue_zero_effective_batch_size_pops_nothing(self) -> None:
+        """Defensive path: a non-empty queue with an effective batch size of 0 collects
+        no messages and returns early without touching the pool."""
+        mock_connection_pool = MagicMock()
+        processor = PostgreSQLBatchProcessor(mock_connection_pool)
+
+        processor.queues["artists"].append(PendingMessage("artists", "0", {"id": "0"}, "h", AsyncMock(), AsyncMock()))
+        processor._effective_batch_size["artists"] = 0
+
+        await processor._flush_queue("artists")
+
+        # No batch was built, so the connection pool was never accessed and the
+        # message stays queued.
+        mock_connection_pool.connection.assert_not_called()
+        assert len(processor.queues["artists"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_public_flush_queue_drains_until_empty(self) -> None:
+        """The public flush_queue loops _flush_queue until the queue is empty."""
+        processor = PostgreSQLBatchProcessor(MagicMock())
+
+        # Each _flush_queue call pops one message off the front.
+        async def drain_one(data_type: str) -> None:
+            if processor.queues[data_type]:
+                processor.queues[data_type].popleft()
+
+        processor._flush_queue = AsyncMock(side_effect=drain_one)  # type: ignore[method-assign]
+
+        for i in range(3):
+            processor.queues["artists"].append(PendingMessage("artists", str(i), {"id": str(i)}, "h", AsyncMock(), AsyncMock()))
+
+        await processor.flush_queue("artists")
+
+        assert not processor.queues["artists"]
+        assert processor._flush_queue.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_public_flush_queue_retry_limit_nacks_remaining(self) -> None:
+        """When _flush_queue makes no progress (queue never shrinks), the drain loop
+        hits max_flush_retries and nacks every remaining message rather than spinning
+        forever."""
+        processor = PostgreSQLBatchProcessor(MagicMock(), BatchConfig(max_flush_retries=3, backoff_initial=0.0))
+
+        # _flush_queue never drains the queue → no progress on every attempt.
+        processor._flush_queue = AsyncMock()  # type: ignore[method-assign]
+
+        nacks: list[int] = []
+
+        async def nack() -> None:
+            nacks.append(1)
+
+        for i in range(2):
+            processor.queues["artists"].append(PendingMessage("artists", str(i), {"id": str(i)}, "h", AsyncMock(), nack))
+
+        with patch("tableinator.batch_processor.logger") as mock_logger:
+            await processor.flush_queue("artists")
+
+        assert not processor.queues["artists"], "remaining messages must be drained via nack"
+        assert len(nacks) == 2
+        assert any("Flush retry limit reached" in str(c.args[0]) for c in mock_logger.error.call_args_list)
+
+    @pytest.mark.asyncio
+    async def test_public_flush_queue_backoff_retry_limit_nacks_remaining(self) -> None:
+        """The backoff branch (wait > 0) also enforces the retry limit and nacks the
+        remaining messages when no progress is made."""
+        processor = PostgreSQLBatchProcessor(MagicMock(), BatchConfig(max_flush_retries=2, backoff_initial=0.0))
+
+        # Force the wait > 0 backoff branch on every iteration.
+        processor._backoff_until["artists"] = time.time() + 3600
+        processor._flush_queue = AsyncMock()  # type: ignore[method-assign]
+
+        nacks: list[int] = []
+
+        async def nack() -> None:
+            nacks.append(1)
+
+        processor.queues["artists"].append(PendingMessage("artists", "0", {"id": "0"}, "h", AsyncMock(), nack))
+
+        with patch("tableinator.batch_processor.asyncio.sleep", new_callable=AsyncMock), patch("tableinator.batch_processor.logger") as mock_logger:
+            await processor.flush_queue("artists")
+
+        assert not processor.queues["artists"]
+        assert len(nacks) == 1
+        assert any("Flush retry limit reached" in str(c.args[0]) for c in mock_logger.error.call_args_list)
+
+    @pytest.mark.asyncio
+    async def test_public_flush_queue_backoff_nack_failure_is_logged(self) -> None:
+        """A failing nack while draining the backoff-branch retry-limit remainder is
+        caught and logged, not raised."""
+        processor = PostgreSQLBatchProcessor(MagicMock(), BatchConfig(max_flush_retries=1, backoff_initial=0.0))
+
+        processor._backoff_until["artists"] = time.time() + 3600
+        processor._flush_queue = AsyncMock()  # type: ignore[method-assign]
+
+        async def failing_nack() -> None:
+            raise RuntimeError("channel closed")
+
+        processor.queues["artists"].append(PendingMessage("artists", "0", {"id": "0"}, "h", AsyncMock(), failing_nack))
+
+        with patch("tableinator.batch_processor.asyncio.sleep", new_callable=AsyncMock), patch("tableinator.batch_processor.logger") as mock_logger:
+            await processor.flush_queue("artists")
+
+        assert not processor.queues["artists"]
+        assert any("Failed to nack message" in str(c.args[0]) for c in mock_logger.warning.call_args_list)
+
+    @pytest.mark.asyncio
+    async def test_public_flush_queue_nack_failure_is_logged(self) -> None:
+        """A failing nack while draining the no-backoff retry-limit remainder is caught
+        and logged, not raised."""
+        processor = PostgreSQLBatchProcessor(MagicMock(), BatchConfig(max_flush_retries=1, backoff_initial=0.0))
+
+        processor._flush_queue = AsyncMock()  # type: ignore[method-assign]
+
+        async def failing_nack() -> None:
+            raise RuntimeError("channel closed")
+
+        processor.queues["artists"].append(PendingMessage("artists", "0", {"id": "0"}, "h", AsyncMock(), failing_nack))
+
+        with patch("tableinator.batch_processor.logger") as mock_logger:
+            await processor.flush_queue("artists")
+
+        assert not processor.queues["artists"]
+        assert any("Failed to nack message" in str(c.args[0]) for c in mock_logger.warning.call_args_list)
+
+    @pytest.mark.asyncio
+    async def test_public_flush_queue_backoff_progress_resets_retries(self) -> None:
+        """In the backoff branch, when _flush_queue does make progress the retry
+        counter resets and the loop continues draining (covers the progress path)."""
+        processor = PostgreSQLBatchProcessor(MagicMock(), BatchConfig(max_flush_retries=5, backoff_initial=0.0))
+
+        processor._backoff_until["artists"] = time.time() + 3600
+
+        async def drain_one(data_type: str) -> None:
+            if processor.queues[data_type]:
+                processor.queues[data_type].popleft()
+
+        processor._flush_queue = AsyncMock(side_effect=drain_one)  # type: ignore[method-assign]
+
+        for i in range(2):
+            processor.queues["artists"].append(PendingMessage("artists", str(i), {"id": str(i)}, "h", AsyncMock(), AsyncMock()))
+
+        with patch("tableinator.batch_processor.asyncio.sleep", new_callable=AsyncMock):
+            await processor.flush_queue("artists")
+
+        assert not processor.queues["artists"]
+        assert processor._flush_queue.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_flush_queue_cancellation_reenqueues_messages(self) -> None:
+        """_flush_queue re-enqueues the in-flight batch and re-raises on CancelledError
+        (e.g. graceful shutdown), so no message is lost."""
+        processor = PostgreSQLBatchProcessor(MagicMock())
+
+        processor._process_batch = AsyncMock(side_effect=asyncio.CancelledError())  # type: ignore[method-assign]
+
+        for i in range(2):
+            processor.queues["artists"].append(PendingMessage("artists", str(i), {"id": str(i)}, "h", AsyncMock(), AsyncMock()))
+
+        with pytest.raises(asyncio.CancelledError):
+            await processor._flush_queue("artists")
+
+        # Both messages restored to the queue in original order.
+        assert len(processor.queues["artists"]) == 2
+        assert [m.data_id for m in processor.queues["artists"]] == ["0", "1"]
+
+    @pytest.mark.asyncio
     async def test_periodic_flush(self) -> None:
         """Test periodic flush background task."""
         mock_connection_pool = MagicMock()

--- a/tests/tableinator/test_tableinator.py
+++ b/tests/tableinator/test_tableinator.py
@@ -2973,3 +2973,120 @@ class TestCoverageGaps:
 
         # Should delegate to batch processor without error
         mock_batch.add_message.assert_called_once()
+
+
+class TestMainFullRun:
+    """Drive main() all the way through RabbitMQ connect, queue/exchange
+    declaration, consumer start, the run loop, and the finally teardown.
+
+    The existing TestMain.test_main_execution trips shutdown_requested on the
+    STARTUP_DELAY sleep, which short-circuits before the connect loop. Here
+    STARTUP_DELAY=0 skips that sleep so the full body executes, and shutdown is
+    tripped on the run-loop's own sleep instead.
+    """
+
+    @pytest.mark.asyncio
+    async def test_main_full_run_batch_mode(self) -> None:
+        import tableinator.tableinator as mod
+
+        # Reset the module-level shutdown flag (earlier tests may have left it True).
+        original_shutdown = mod.shutdown_requested
+        mod.shutdown_requested = False
+
+        # Resilient RabbitMQ manager whose connect() returns an async-context connection.
+        mock_amqp_connection = AsyncMock()
+        mock_channel = AsyncMock()
+        mock_amqp_connection.channel = AsyncMock(return_value=mock_channel)
+        mock_channel.set_qos = AsyncMock()
+        mock_exchange = AsyncMock()
+        mock_channel.declare_exchange = AsyncMock(return_value=mock_exchange)
+        mock_queue = AsyncMock()
+        mock_queue.bind = AsyncMock()
+        mock_queue.consume = AsyncMock(return_value="ctag")
+        mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
+
+        mock_rabbitmq_instance = AsyncMock()
+        mock_rabbitmq_instance.connect = AsyncMock(return_value=mock_amqp_connection)
+
+        mock_pool = MagicMock()
+        mock_pool.initialize = AsyncMock()
+        mock_pool.close = AsyncMock()
+
+        # Trip shutdown on the run-loop sleep so the loop exits after one iteration.
+        real_sleep = asyncio.sleep
+
+        async def sleep_trips_shutdown(delay: float) -> None:
+            if delay == 1.0:
+                mod.shutdown_requested = True
+            await real_sleep(0)
+
+        try:
+            with (
+                patch.dict("os.environ", {"STARTUP_DELAY": "0"}),
+                patch("tableinator.tableinator.setup_logging"),
+                patch("tableinator.tableinator.HealthServer") as mock_hs,
+                patch("tableinator.tableinator.AsyncPostgreSQLPool", return_value=mock_pool),
+                patch("tableinator.tableinator.AsyncResilientRabbitMQ", return_value=mock_rabbitmq_instance),
+                patch("tableinator.tableinator.BATCH_MODE", True),
+                patch("tableinator.tableinator.progress_reporter", new=AsyncMock()),
+                patch("tableinator.tableinator.periodic_queue_checker", new=AsyncMock()),
+                patch("tableinator.tableinator.close_rabbitmq_connection", new=AsyncMock()),
+                patch.object(mod.PostgreSQLBatchProcessor, "periodic_flush", new=AsyncMock()),
+                patch.object(mod.PostgreSQLBatchProcessor, "flush_all", new=AsyncMock()),
+                patch("tableinator.tableinator.asyncio.sleep", side_effect=sleep_trips_shutdown),
+                patch("tableinator.tableinator.signal.signal"),
+            ):
+                mock_hs.return_value = MagicMock()
+                await main()
+
+            # Connect + channel + QoS were configured.
+            mock_rabbitmq_instance.connect.assert_awaited()
+            mock_channel.set_qos.assert_awaited_once()
+            # Exchanges/queues declared and consumers started for every data type.
+            assert mock_channel.declare_exchange.await_count >= len(mod.DATA_TYPES)
+            assert mock_queue.consume.await_count == len(mod.DATA_TYPES)
+            # Pool was closed during teardown.
+            mock_pool.close.assert_awaited()
+        finally:
+            mod.shutdown_requested = original_shutdown
+
+    @pytest.mark.asyncio
+    async def test_main_full_run_no_amqp_connection(self) -> None:
+        """When every startup connect attempt fails, main() logs and returns without
+        entering the consume block."""
+        import tableinator.tableinator as mod
+
+        original_shutdown = mod.shutdown_requested
+        mod.shutdown_requested = False
+
+        mock_rabbitmq_instance = AsyncMock()
+        mock_rabbitmq_instance.connect = AsyncMock(side_effect=Exception("broker down"))
+
+        mock_pool = MagicMock()
+        mock_pool.initialize = AsyncMock()
+        mock_pool.close = AsyncMock()
+
+        real_sleep = asyncio.sleep
+
+        async def fast_sleep(_delay: float) -> None:
+            await real_sleep(0)
+
+        try:
+            with (
+                patch.dict("os.environ", {"STARTUP_DELAY": "0"}),
+                patch("tableinator.tableinator.setup_logging"),
+                patch("tableinator.tableinator.HealthServer") as mock_hs,
+                patch("tableinator.tableinator.AsyncPostgreSQLPool", return_value=mock_pool),
+                patch("tableinator.tableinator.AsyncResilientRabbitMQ", return_value=mock_rabbitmq_instance),
+                patch("tableinator.tableinator.asyncio.sleep", side_effect=fast_sleep),
+                patch("tableinator.tableinator.signal.signal"),
+            ):
+                mock_hs.return_value = MagicMock()
+                await main()
+
+            # All startup retries were attempted, then main returned at the
+            # "No AMQP connection available" guard (never opening the channel).
+            assert mock_rabbitmq_instance.connect.await_count >= 1
+            mock_rabbitmq_instance.channel.assert_not_called()
+        finally:
+            mod.shutdown_requested = original_shutdown

--- a/tests/tableinator/test_tableinator.py
+++ b/tests/tableinator/test_tableinator.py
@@ -188,6 +188,39 @@ class TestOnDataMessage:
         # Should nack without requeue for bad messages
         mock_message.nack.assert_called_once_with(requeue=False)
 
+    @pytest.mark.asyncio
+    @patch("tableinator.tableinator.shutdown_requested", False)
+    async def test_batch_mode_nack_callback_uses_requeue_false(self) -> None:
+        """Regression (cu2.52): the batch-mode add_message nack callback must use
+        requeue=False.
+
+        add_message invokes nack_callback only for permanently-invalid input
+        (unknown data_type, missing 'id', normalize failure). requeue=True sent
+        such a poison record around x-delivery-limit (20) futile redeliveries
+        before the DLQ; requeue=False routes it to the DLQ in one hop, matching
+        the non-batch validation path and the mirrored graphinator fix.
+        """
+        import tableinator.tableinator as t
+
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        mock_message.body = json.dumps({"id": "1", "sha256": "h"}).encode()
+
+        captured: dict[str, Any] = {}
+
+        async def fake_add(*, data_type: str, data: dict[str, Any], ack_callback: Any, nack_callback: Any) -> bool:
+            captured["nack"] = nack_callback
+            return True
+
+        proc = MagicMock()
+        proc.add_message = AsyncMock(side_effect=fake_add)
+
+        with patch.object(t, "BATCH_MODE", True), patch.object(t, "batch_processor", proc):
+            await on_data_message(mock_message, "artists")
+
+        # Simulate add_message rejecting a permanently-invalid message.
+        await captured["nack"]()
+        mock_message.nack.assert_called_once_with(requeue=False)
+
 
 def _make_purge_connection(total_count: int, stale_count: int) -> tuple[MagicMock, AsyncMock]:
     """Build a mock connection wired for purge_stale_rows.

--- a/tests/tableinator/test_tableinator.py
+++ b/tests/tableinator/test_tableinator.py
@@ -20,6 +20,7 @@ from tableinator.tableinator import (
     main,
     make_data_handler,
     on_data_message,
+    purge_stale_rows,
     schedule_consumer_cancellation,
     signal_handler,
 )
@@ -186,6 +187,134 @@ class TestOnDataMessage:
 
         # Should nack without requeue for bad messages
         mock_message.nack.assert_called_once_with(requeue=False)
+
+
+def _make_purge_connection(total_count: int, stale_count: int) -> tuple[MagicMock, AsyncMock]:
+    """Build a mock connection wired for purge_stale_rows.
+
+    fetchone yields the total-row count then the would-be-deleted count; fetchall
+    (only reached if the purge is not vetoed) returns stale_count data_id rows.
+    """
+    mock_cursor = AsyncMock()
+    mock_cursor.execute = AsyncMock()
+    mock_cursor.fetchone = AsyncMock(side_effect=[(total_count,), (stale_count,)])
+    mock_cursor.fetchall = AsyncMock(return_value=[(f"id-{i}",) for i in range(stale_count)])
+
+    cursor_cm = AsyncMock()
+    cursor_cm.__aenter__ = AsyncMock(return_value=mock_cursor)
+    cursor_cm.__aexit__ = AsyncMock(return_value=None)
+
+    tx_cm = AsyncMock()
+    tx_cm.__aenter__ = AsyncMock(return_value=None)
+    tx_cm.__aexit__ = AsyncMock(return_value=None)
+
+    mock_conn = MagicMock()
+    mock_conn.set_autocommit = AsyncMock()
+    mock_conn.transaction = MagicMock(return_value=tx_cm)
+    mock_conn.cursor = MagicMock(return_value=cursor_cm)
+    return mock_conn, mock_cursor
+
+
+class TestPurgeStaleRowsGuards:
+    """Regression tests for discogsography-cu2.2 — resumed-extraction mass data loss.
+
+    On a resumed extraction the extractor skips files completed in an earlier session,
+    so a data type can receive an extraction_complete signal while zero records were
+    streamed this run. Purging blindly then deletes every row written before the
+    restart. purge_stale_rows must refuse those wipes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_purges_partial_stale_rows(self, mock_async_pool: Any) -> None:
+        """Normal case: a small stale fraction is deleted (dump genuinely shrank)."""
+        mock_conn, mock_cursor = _make_purge_connection(total_count=100, stale_count=5)
+        pool = mock_async_pool(mock_conn)
+
+        with patch("tableinator.tableinator.connection_pool", pool):
+            await purge_stale_rows("artists", "2026-07-20T00:00:00+00:00", record_count=95)
+
+        # 2 count queries + 1 DELETE = 3 executes; the DELETE actually ran.
+        assert mock_cursor.execute.call_count == 3
+        mock_cursor.fetchall.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_vetoes_full_table_wipe(self, mock_async_pool: Any) -> None:
+        """The all-files-complete-before-crash variant: every row is 'stale'.
+
+        record_counts are non-zero here, so the count-based guard alone would miss it —
+        the fraction cap is what prevents the wipe.
+        """
+        mock_conn, mock_cursor = _make_purge_connection(total_count=9_000_000, stale_count=9_000_000)
+        pool = mock_async_pool(mock_conn)
+
+        with patch("tableinator.tableinator.connection_pool", pool):
+            await purge_stale_rows("artists", "2026-07-20T00:00:00+00:00", record_count=9_000_000)
+
+        # Only the two count queries ran — the DELETE was vetoed.
+        assert mock_cursor.execute.call_count == 2
+        mock_cursor.fetchall.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_vetoes_at_fraction_boundary(self, mock_async_pool: Any) -> None:
+        """The cap is inclusive: exactly 90% of the table is refused."""
+        mock_conn, mock_cursor = _make_purge_connection(total_count=100, stale_count=90)
+        pool = mock_async_pool(mock_conn)
+
+        with patch("tableinator.tableinator.connection_pool", pool):
+            await purge_stale_rows("artists", "2026-07-20T00:00:00+00:00", record_count=10)
+
+        assert mock_cursor.execute.call_count == 2
+        mock_cursor.fetchall.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_purges_just_below_boundary(self, mock_async_pool: Any) -> None:
+        """Just under the cap (89%) still purges."""
+        mock_conn, mock_cursor = _make_purge_connection(total_count=100, stale_count=89)
+        pool = mock_async_pool(mock_conn)
+
+        with patch("tableinator.tableinator.connection_pool", pool):
+            await purge_stale_rows("artists", "2026-07-20T00:00:00+00:00", record_count=11)
+
+        assert mock_cursor.execute.call_count == 3
+        mock_cursor.fetchall.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_zero_records_this_session(self, mock_async_pool: Any) -> None:
+        """record_count == 0 (resumed run re-sent nothing) short-circuits before any query."""
+        mock_conn, mock_cursor = _make_purge_connection(total_count=100, stale_count=100)
+        pool = mock_async_pool(mock_conn)
+
+        with patch("tableinator.tableinator.connection_pool", pool):
+            await purge_stale_rows("artists", "2026-07-20T00:00:00+00:00", record_count=0)
+
+        # No connection acquired, no query executed.
+        pool.connection.assert_not_called()
+        mock_cursor.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skips_empty_started_at(self, mock_async_pool: Any) -> None:
+        """Missing started_at short-circuits before touching the database."""
+        mock_conn, mock_cursor = _make_purge_connection(total_count=100, stale_count=5)
+        pool = mock_async_pool(mock_conn)
+
+        with patch("tableinator.tableinator.connection_pool", pool):
+            await purge_stale_rows("artists", "", record_count=95)
+
+        pool.connection.assert_not_called()
+        mock_cursor.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_empty_table_no_delete(self, mock_async_pool: Any) -> None:
+        """An empty table performs no DELETE."""
+        mock_conn, mock_cursor = _make_purge_connection(total_count=0, stale_count=0)
+        pool = mock_async_pool(mock_conn)
+
+        with patch("tableinator.tableinator.connection_pool", pool):
+            await purge_stale_rows("artists", "2026-07-20T00:00:00+00:00", record_count=50)
+
+        # Only the total-count query ran; short-circuited before counting stale rows.
+        assert mock_cursor.execute.call_count == 1
+        mock_cursor.fetchall.assert_not_awaited()
 
 
 class TestMain:
@@ -621,7 +750,8 @@ class TestOnDataMessageExtended:
         ):
             await on_data_message(mock_message, "artists")
 
-        mock_purge.assert_called_once_with("artists", "2026-01-01T00:00:00Z")
+        # No record_counts in the message → third positional arg is None.
+        mock_purge.assert_called_once_with("artists", "2026-01-01T00:00:00Z", None)
         mock_message.ack.assert_called_once()
 
     @pytest.mark.asyncio
@@ -1700,8 +1830,11 @@ class TestPurgeStaleRows:
 
     @pytest.mark.asyncio
     async def test_purges_stale_rows(self) -> None:
-        """Test deletes rows older than started_at."""
+        """Test deletes rows older than started_at (small stale fraction → real shrink)."""
         mock_cursor = AsyncMock()
+        # fetchone answers the total-count then the stale-count queries; 2 of 100 rows
+        # are stale (2% ≪ safety cap), so the DELETE proceeds and returns those 2 rows.
+        mock_cursor.fetchone = AsyncMock(side_effect=[(100,), (2,)])
         mock_cursor.fetchall = AsyncMock(return_value=[("old_id_1",), ("old_id_2",)])
 
         mock_cursor_cm = MagicMock()
@@ -1725,12 +1858,13 @@ class TestPurgeStaleRows:
 
         from tableinator.tableinator import purge_stale_rows
 
-        await purge_stale_rows("artists", "2026-01-01T00:00:00Z")
+        await purge_stale_rows("artists", "2026-01-01T00:00:00Z", record_count=98)
 
         # Verify autocommit was disabled before transaction
         mock_conn.set_autocommit.assert_called_once_with(False)
 
-        mock_cursor.execute.assert_called_once()
+        # 2 count queries + 1 DELETE; the DELETE (last call) carries the parsed timestamp.
+        assert mock_cursor.execute.call_count == 3
         call_args = mock_cursor.execute.call_args
         param = call_args[0][1]
         # After fix, started_at is parsed to a datetime with UTC timezone
@@ -1774,7 +1908,9 @@ class TestPurgeStaleRows:
     async def test_purge_with_naive_datetime_adds_utc(self) -> None:
         """Test purge_stale_rows with a timezone-naive timestamp adds UTC."""
         mock_cursor = AsyncMock()
-        mock_cursor.fetchall = AsyncMock(return_value=[])
+        # 3 of 100 rows stale → DELETE proceeds; fetchall returns the deleted rows.
+        mock_cursor.fetchone = AsyncMock(side_effect=[(100,), (3,)])
+        mock_cursor.fetchall = AsyncMock(return_value=[("a",), ("b",), ("c",)])
 
         mock_cursor_cm = MagicMock()
         mock_cursor_cm.__aenter__ = AsyncMock(return_value=mock_cursor)
@@ -1798,9 +1934,10 @@ class TestPurgeStaleRows:
         from tableinator.tableinator import purge_stale_rows
 
         # Pass a timezone-naive timestamp (no trailing Z or +00:00)
-        await purge_stale_rows("artists", "2026-01-01T00:00:00")
+        await purge_stale_rows("artists", "2026-01-01T00:00:00", record_count=97)
 
-        mock_cursor.execute.assert_called_once()
+        # The DELETE (last execute) receives the UTC-normalized timestamp.
+        assert mock_cursor.execute.call_count == 3
         call_args = mock_cursor.execute.call_args
         param = call_args[0][1]
         if isinstance(param, tuple):
@@ -1810,6 +1947,8 @@ class TestPurgeStaleRows:
         # Should have been converted to UTC-aware datetime
         assert param == datetime(2026, 1, 1, tzinfo=UTC)
         assert param.tzinfo is not None
+
+        tableinator.tableinator.connection_pool = None
 
         tableinator.tableinator.connection_pool = None
 

--- a/tests/tableinator/test_tableinator.py
+++ b/tests/tableinator/test_tableinator.py
@@ -3090,3 +3090,76 @@ class TestMainFullRun:
             mock_rabbitmq_instance.channel.assert_not_called()
         finally:
             mod.shutdown_requested = original_shutdown
+
+    @pytest.mark.asyncio
+    async def test_main_full_run_teardown_error_paths(self) -> None:
+        """Exercise the defensive teardown error-handlers: a KeyboardInterrupt in the
+        run loop, an exception while flushing the batch processor, a pending
+        consumer-cancellation task, and an exception while closing the pool. None may
+        escape main()."""
+        import tableinator.tableinator as mod
+
+        original_shutdown = mod.shutdown_requested
+        original_cancel_tasks = dict(mod.consumer_cancel_tasks)
+        mod.shutdown_requested = False
+
+        mock_channel = AsyncMock()
+        mock_channel.set_qos = AsyncMock()
+        mock_channel.declare_exchange = AsyncMock(return_value=AsyncMock())
+        mock_queue = AsyncMock()
+        mock_queue.bind = AsyncMock()
+        mock_queue.consume = AsyncMock(return_value="ctag")
+        mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
+        mock_amqp_connection = AsyncMock()
+        mock_amqp_connection.channel = AsyncMock(return_value=mock_channel)
+
+        mock_rabbitmq_instance = AsyncMock()
+        mock_rabbitmq_instance.connect = AsyncMock(return_value=mock_amqp_connection)
+
+        mock_pool = MagicMock()
+        mock_pool.initialize = AsyncMock()
+        # Pool close raises → covers the "Error closing connection pool" handler.
+        mock_pool.close = AsyncMock(side_effect=RuntimeError("pool close failed"))
+
+        real_sleep = asyncio.sleep
+
+        async def sleep_raises_keyboard_interrupt(delay: float) -> None:
+            if delay == 1.0:
+                raise KeyboardInterrupt
+            await real_sleep(0)
+
+        # Seed a pending consumer-cancellation task so the cancel loop body runs.
+        pending_task = MagicMock()
+
+        try:
+            with (
+                patch.dict("os.environ", {"STARTUP_DELAY": "0"}),
+                patch("tableinator.tableinator.setup_logging"),
+                patch("tableinator.tableinator.HealthServer") as mock_hs,
+                patch("tableinator.tableinator.AsyncPostgreSQLPool", return_value=mock_pool),
+                patch("tableinator.tableinator.AsyncResilientRabbitMQ", return_value=mock_rabbitmq_instance),
+                patch("tableinator.tableinator.BATCH_MODE", True),
+                patch("tableinator.tableinator.progress_reporter", new=AsyncMock()),
+                patch("tableinator.tableinator.periodic_queue_checker", new=AsyncMock()),
+                patch("tableinator.tableinator.close_rabbitmq_connection", new=AsyncMock()),
+                patch.object(mod.PostgreSQLBatchProcessor, "periodic_flush", new=AsyncMock()),
+                # flush_all raises → covers the "Error flushing batch processor" handler.
+                patch.object(mod.PostgreSQLBatchProcessor, "flush_all", new=AsyncMock(side_effect=RuntimeError("flush failed"))),
+                patch.object(mod.PostgreSQLBatchProcessor, "shutdown", new=MagicMock()),
+                patch("tableinator.tableinator.asyncio.sleep", side_effect=sleep_raises_keyboard_interrupt),
+                patch("tableinator.tableinator.signal.signal"),
+            ):
+                mock_hs.return_value = MagicMock()
+                mod.consumer_cancel_tasks.clear()
+                mod.consumer_cancel_tasks["artists"] = pending_task
+                # Must not raise despite KeyboardInterrupt + two teardown exceptions.
+                await main()
+
+            # The pending consumer-cancellation task was cancelled during teardown.
+            pending_task.cancel.assert_called_once()
+            # The pool close was attempted (and its failure swallowed).
+            mock_pool.close.assert_awaited()
+        finally:
+            mod.shutdown_requested = original_shutdown
+            mod.consumer_cancel_tasks.clear()
+            mod.consumer_cancel_tasks.update(original_cancel_tasks)

--- a/tests/tableinator/test_tableinator.py
+++ b/tests/tableinator/test_tableinator.py
@@ -207,8 +207,8 @@ class TestOnDataMessage:
 
         captured: dict[str, Any] = {}
 
-        async def fake_add(*, data_type: str, data: dict[str, Any], ack_callback: Any, nack_callback: Any) -> bool:
-            captured["nack"] = nack_callback
+        async def fake_add(**kwargs: Any) -> bool:
+            captured["nack"] = kwargs["nack_callback"]
             return True
 
         proc = MagicMock()
@@ -2283,6 +2283,56 @@ class TestRecoverConsumersTableinator:
         # Temp channel and connection should be closed since no messages
         mock_temp_channel.close.assert_called_once()
         mock_temp_connection.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_recovers_all_types_not_just_backlogged(self) -> None:
+        """Regression (cu2.53): recovery must start consumers for ALL data types,
+        not only those with a backlog at the passive-declare instant.
+
+        With a partial backlog (only 'artists' has messages), the old loop over
+        queues_with_messages started a consumer for 'artists' only, then set
+        active_connection — permanently gating off both periodic recovery routes,
+        so labels/masters/releases published later were never consumed.
+        """
+        import tableinator.tableinator as t
+
+        t.active_connection = None
+        t.active_channel = None
+        t.consumer_tags = {}
+        t.completed_files = set()
+        t.queues = {}
+        t.last_message_time = dict.fromkeys(["artists", "labels", "masters", "releases"], 0.0)
+
+        def declare_queue(**kwargs: Any) -> Any:
+            if kwargs.get("passive"):
+                q = MagicMock()
+                # Only 'artists' has a backlog at the check instant.
+                q.declaration_result.message_count = 100 if kwargs["name"].endswith("-artists") else 0
+                return q
+            q = AsyncMock()
+            q.consume = AsyncMock(return_value=f"tag-{kwargs.get('name')}")
+            q.bind = AsyncMock()
+            return q
+
+        mock_channel = AsyncMock()
+        mock_channel.declare_queue = AsyncMock(side_effect=declare_queue)
+        mock_channel.declare_exchange = AsyncMock(return_value=AsyncMock())
+        mock_channel.set_qos = AsyncMock()
+        mock_connection = AsyncMock()
+        mock_connection.channel = AsyncMock(return_value=mock_channel)
+        mock_rmq = AsyncMock()
+        mock_rmq.connect = AsyncMock(return_value=mock_connection)
+
+        with patch.object(t, "rabbitmq_manager", mock_rmq), patch.object(t, "logger"):
+            await t._recover_consumers()
+
+        assert set(t.consumer_tags.keys()) == {"artists", "labels", "masters", "releases"}
+
+        # Reset shared module state
+        t.consumer_tags = {}
+        t.active_connection = None
+        t.active_channel = None
+        t.queues = {}
 
     @pytest.mark.asyncio
     async def test_exception_during_recovery_closes_temp_connection(self) -> None:

--- a/tests/tableinator/test_tableinator.py
+++ b/tests/tableinator/test_tableinator.py
@@ -349,6 +349,19 @@ class TestPurgeStaleRowsGuards:
         assert mock_cursor.execute.call_count == 1
         mock_cursor.fetchall.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_no_stale_rows_no_delete(self, mock_async_pool: Any) -> None:
+        """A populated table with zero stale rows performs no DELETE and returns early."""
+        mock_conn, mock_cursor = _make_purge_connection(total_count=100, stale_count=0)
+        pool = mock_async_pool(mock_conn)
+
+        with patch("tableinator.tableinator.connection_pool", pool):
+            await purge_stale_rows("artists", "2026-07-20T00:00:00+00:00", record_count=100)
+
+        # Both count queries ran, but the stale count was 0 so no DELETE followed.
+        assert mock_cursor.execute.call_count == 2
+        mock_cursor.fetchall.assert_not_awaited()
+
 
 class TestMain:
     """Test main function."""

--- a/tests/tableinator/test_tableinator.py
+++ b/tests/tableinator/test_tableinator.py
@@ -2335,6 +2335,58 @@ class TestRecoverConsumersTableinator:
         t.queues = {}
 
     @pytest.mark.asyncio
+    async def test_error_after_partial_registration_clears_consumer_tags(self) -> None:
+        """Regression (cu2.54): if recovery errors after ≥1 consumer registered,
+        the except block must clear consumer_tags.
+
+        The consumers registered before the error died with the now-closed
+        connection; leaving their tags behind keeps len(consumer_tags) > 0
+        forever, permanently gating off both recovery routes (the stuck-check
+        requires 0 tags) while health still reports healthy.
+        """
+        import tableinator.tableinator as t
+
+        t.active_connection = None
+        t.active_channel = None
+        t.consumer_tags = {}
+        t.completed_files = set()
+        t.queues = {}
+        t.last_message_time = dict.fromkeys(["artists", "labels", "masters", "releases"], 0.0)
+
+        def declare_queue(**kwargs: Any) -> Any:
+            name = kwargs.get("name", "")
+            if kwargs.get("passive"):
+                q = MagicMock()
+                q.declaration_result.message_count = 100  # all have a backlog
+                return q
+            q = AsyncMock()
+            q.bind = AsyncMock()
+            # artists registers fine; labels raises mid-loop (broker flap).
+            if name.endswith("-labels"):
+                q.consume = AsyncMock(side_effect=RuntimeError("channel closed mid-recovery"))
+            else:
+                q.consume = AsyncMock(return_value=f"tag-{name}")
+            return q
+
+        mock_channel = AsyncMock()
+        mock_channel.declare_queue = AsyncMock(side_effect=declare_queue)
+        mock_channel.declare_exchange = AsyncMock(return_value=AsyncMock())
+        mock_channel.set_qos = AsyncMock()
+        mock_connection = AsyncMock()
+        mock_connection.channel = AsyncMock(return_value=mock_channel)
+        mock_rmq = AsyncMock()
+        mock_rmq.connect = AsyncMock(return_value=mock_connection)
+
+        with patch.object(t, "rabbitmq_manager", mock_rmq), patch.object(t, "logger"):
+            await t._recover_consumers()
+
+        assert t.consumer_tags == {}, "stale consumer tags must be cleared so recovery can re-fire"
+        assert t.active_connection is None
+
+        t.consumer_tags = {}
+        t.queues = {}
+
+    @pytest.mark.asyncio
     async def test_exception_during_recovery_closes_temp_connection(self) -> None:
         """Test that exception during recovery closes temp connection (lines 457-464)."""
         import tableinator.tableinator

--- a/tests/utilities/__init__.py
+++ b/tests/utilities/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the monitoring utilities in utilities/."""

--- a/tests/utilities/test_check_errors.py
+++ b/tests/utilities/test_check_errors.py
@@ -1,0 +1,119 @@
+"""Tests for utilities/check_errors.py — the service-log error scanner.
+
+Also pins two CLAUDE.md contracts:
+- ``subprocess.run`` is always called with ``timeout=`` and ``TimeoutExpired``
+  is caught.
+- The scanned service list uses the split extractor service names
+  (``extractor-discogs`` / ``extractor-musicbrainz``), never a bare
+  ``extractor``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from utilities import check_errors
+
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _completed(stdout: str) -> MagicMock:
+    result = MagicMock()
+    result.stdout = stdout
+    return result
+
+
+def test_check_service_errors_matches_patterns() -> None:
+    logs = "\n".join(
+        [
+            "2026-01-01 graphinator ERROR Failed to process message 'id'",
+            "2026-01-01 graphinator INFO everything fine",
+            "2026-01-01 graphinator Traceback (most recent call last):",
+        ]
+    )
+    with patch.object(check_errors.subprocess, "run", return_value=_completed(logs)) as run:
+        errors = check_errors.check_service_errors("graphinator", 30)
+
+    assert any("Failed to process message" in e for e in errors)
+    assert any("Traceback" in e for e in errors)
+    assert "everything fine" not in " ".join(errors)
+    # Contract: timeout is always supplied and the window is passed through.
+    kwargs = run.call_args.kwargs
+    assert kwargs["timeout"] == 60
+    assert "--since=30m" in run.call_args.args[0]
+
+
+def test_check_service_errors_no_matches() -> None:
+    with patch.object(check_errors.subprocess, "run", return_value=_completed("INFO all good\nDEBUG noop")):
+        assert check_errors.check_service_errors("graphinator") == []
+
+
+def test_check_service_errors_handles_called_process_error() -> None:
+    exc = subprocess.CalledProcessError(1, ["docker"])
+    with patch.object(check_errors.subprocess, "run", side_effect=exc):
+        errors = check_errors.check_service_errors("graphinator")
+    assert len(errors) == 1
+    assert "Error getting logs" in errors[0]
+
+
+def test_check_service_errors_handles_timeout() -> None:
+    exc = subprocess.TimeoutExpired(["docker"], 60)
+    with patch.object(check_errors.subprocess, "run", side_effect=exc):
+        errors = check_errors.check_service_errors("graphinator")
+    assert "Error getting logs" in errors[0]
+
+
+def test_main_reports_grouped_errors(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(check_errors.sys, "argv", ["check_errors.py", "15"])
+
+    def fake(service: str, _window: int) -> list[str]:
+        if service == "graphinator":
+            return [
+                "ERROR Failed to process message 'id'",
+                "ERROR Failed to process message 'id'",
+                "2026 - svc - ERROR - some other failure",
+                "ERROR bare error line without a hyphen group",
+                "a plain line without markers",
+            ]
+        return []
+
+    with patch.object(check_errors, "check_service_errors", side_effect=fake):
+        check_errors.main()
+
+    out = capsys.readouterr().out
+    assert "last 15 minutes" in out
+    assert "Failed to process message: 'id' (x2)" in out
+    assert "No errors found" in out  # services with no errors
+    assert "Total errors found:" in out
+    assert "💡 Tip:" in out
+
+
+def test_main_default_window_and_no_errors(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(check_errors.sys, "argv", ["check_errors.py"])
+    with patch.object(check_errors, "check_service_errors", return_value=[]):
+        check_errors.main()
+    out = capsys.readouterr().out
+    assert "last 60 minutes" in out
+    assert "Total errors found: 0" in out
+    assert "💡 Tip:" not in out  # no tip when nothing to show
+
+
+def test_main_scans_split_extractor_services(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLAUDE.md contract: no bare 'extractor' service; both split names present."""
+    monkeypatch.setattr(check_errors.sys, "argv", ["check_errors.py"])
+    seen: list[str] = []
+
+    def record(service: str, _window: int) -> list[str]:
+        seen.append(service)
+        return []
+
+    with patch.object(check_errors, "check_service_errors", side_effect=record):
+        check_errors.main()
+
+    assert "extractor-discogs" in seen
+    assert "extractor-musicbrainz" in seen
+    assert "extractor" not in seen

--- a/tests/utilities/test_check_queues.py
+++ b/tests/utilities/test_check_queues.py
@@ -1,0 +1,81 @@
+"""Tests for utilities/check_queues.py — the RabbitMQ consumer-queue reporter."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from utilities import check_queues
+
+
+def _response(payload: list[dict]) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = payload
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_renders_consumer_queues(capsys) -> None:
+    payload = [
+        {
+            "name": "discogsography-discogs-graphinator-artists",
+            "messages": 10,
+            "messages_ready": 7,
+            "messages_unacknowledged": 3,
+            "consumers": 1,
+            "state": "running",
+            "message_stats": {"ack_details": {"rate": 1.5}, "publish_details": {"rate": 2.25}},
+            "consumer_details": [{"consumer_tag": "ctag-1", "channel_details": {"connection_name": "conn-1"}}],
+        },
+        {"name": "unrelated-queue", "messages": 5},
+    ]
+    with patch.object(check_queues.requests, "get", return_value=_response(payload)) as get:
+        check_queues.check_rabbitmq_queues()
+
+    out = capsys.readouterr().out
+    assert "discogsography-discogs-graphinator-artists" in out
+    assert "unrelated-queue" not in out  # filtered out
+    assert "Ack Rate: 1.50 msg/s" in out
+    assert "Publish Rate: 2.25 msg/s" in out
+    assert "ctag-1" in out
+    assert "conn-1" in out
+    assert get.call_args.kwargs["timeout"] == 10
+
+
+def test_no_consumer_queues(capsys) -> None:
+    with patch.object(check_queues.requests, "get", return_value=_response([{"name": "other"}])):
+        check_queues.check_rabbitmq_queues()
+    assert "No consumer queues found!" in capsys.readouterr().out
+
+
+def test_queue_without_stats_or_consumers(capsys) -> None:
+    payload = [{"name": "discogsography-discogs-tableinator-artists", "messages": 0, "consumers": 0}]
+    with patch.object(check_queues.requests, "get", return_value=_response(payload)):
+        check_queues.check_rabbitmq_queues()
+    out = capsys.readouterr().out
+    assert "tableinator" in out
+    assert "Ack Rate" not in out  # no message_stats
+    assert "Consumer Details" not in out  # no consumers
+
+
+def test_connection_error(capsys) -> None:
+    with patch.object(check_queues.requests, "get", side_effect=requests.ConnectionError()):
+        check_queues.check_rabbitmq_queues()
+    out = capsys.readouterr().out
+    assert "Could not connect to RabbitMQ" in out
+    assert "Management plugin is enabled" in out
+
+
+def test_http_error(capsys) -> None:
+    err = requests.HTTPError()
+    err.response = MagicMock(status_code=503)
+    with patch.object(check_queues.requests, "get", side_effect=err):
+        check_queues.check_rabbitmq_queues()
+    assert "HTTP 503" in capsys.readouterr().out
+
+
+def test_unexpected_error(capsys) -> None:
+    with patch.object(check_queues.requests, "get", side_effect=ValueError("boom")):
+        check_queues.check_rabbitmq_queues()
+    assert "Unexpected error: boom" in capsys.readouterr().out

--- a/tests/utilities/test_debug_message.py
+++ b/tests/utilities/test_debug_message.py
@@ -1,0 +1,165 @@
+"""Tests for utilities/debug_message.py — the queue message peeker/analyzer."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from utilities import debug_message
+
+
+def _fake_connection(body: bytes | None) -> MagicMock:
+    """Build a pika BlockingConnection mock; ``body=None`` means empty queue."""
+    connection = MagicMock()
+    connection.is_closed = False
+    channel = MagicMock()
+    connection.channel.return_value = channel
+    if body is None:
+        channel.basic_get.return_value = (None, None, None)
+    else:
+        method = MagicMock()
+        method.delivery_tag = 42
+        channel.basic_get.return_value = (method, MagicMock(), body)
+    return connection
+
+
+# --------------------------------------------------------------------------- #
+# get_message_from_queue
+# --------------------------------------------------------------------------- #
+def test_get_message_returns_and_requeues() -> None:
+    conn = _fake_connection(json.dumps({"id": "1", "title": "x"}).encode())
+    with patch.object(debug_message.pika, "BlockingConnection", return_value=conn):
+        msg = debug_message.get_message_from_queue("q", username="u", password="p")  # noqa: S106
+
+    assert msg == {"id": "1", "title": "x"}
+    channel = conn.channel.return_value
+    channel.basic_nack.assert_called_once_with(delivery_tag=42, requeue=True)
+    conn.close.assert_called_once()
+
+
+def test_get_message_empty_queue() -> None:
+    conn = _fake_connection(None)
+    with patch.object(debug_message.pika, "BlockingConnection", return_value=conn):
+        assert debug_message.get_message_from_queue("q") is None
+    conn.close.assert_called_once()
+
+
+def test_get_message_handles_exception(capsys) -> None:
+    with patch.object(debug_message.pika, "BlockingConnection", side_effect=RuntimeError("nope")):
+        assert debug_message.get_message_from_queue("q") is None
+    assert "Error: nope" in capsys.readouterr().out
+
+
+def test_get_message_skips_close_when_already_closed() -> None:
+    conn = _fake_connection(json.dumps({"id": "1"}).encode())
+    conn.is_closed = True
+    with patch.object(debug_message.pika, "BlockingConnection", return_value=conn):
+        debug_message.get_message_from_queue("q")
+    conn.close.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# analyze_message
+# --------------------------------------------------------------------------- #
+def test_analyze_message_none(capsys) -> None:
+    debug_message.analyze_message(None, "masters")
+    assert "No message available in queue" in capsys.readouterr().out
+
+
+def test_analyze_masters_complete(capsys) -> None:
+    message = {
+        "id": "123",
+        "title": "A Record",
+        "sha256": "abcdef0123456789abcdef",
+        "genres": ["rock"],
+        "artists": {"name": "artist"},
+        "year": 1999,
+    }
+    debug_message.analyze_message(message, "masters")
+    out = capsys.readouterr().out
+    assert "Message ID: 123" in out
+    assert "✓ title" in out
+    assert "✓ genres" in out  # list optional field
+    assert "✓ artists" in out  # dict optional field
+    assert "- members: not present" not in out  # members not an optional for masters
+    assert "No obvious issues detected" in out
+
+
+def test_analyze_masters_missing_required(capsys) -> None:
+    debug_message.analyze_message({"title": "no id here"}, "masters")
+    out = capsys.readouterr().out
+    assert "✗ id: MISSING" in out
+    assert "Missing required fields: id, sha256" in out
+
+
+def test_analyze_masters_nested_artist_issues(capsys) -> None:
+    message = {
+        "id": "1",
+        "title": "t",
+        "sha256": "s",
+        "artists": {"artist": [{"id": "a"}, {"name": "no-id"}]},
+    }
+    debug_message.analyze_message(message, "masters")
+    assert "Artist 1 missing 'id' field" in capsys.readouterr().out
+
+
+def test_analyze_masters_single_artist_missing_id(capsys) -> None:
+    message = {"id": "1", "title": "t", "sha256": "s", "artists": {"artist": {"name": "solo"}}}
+    debug_message.analyze_message(message, "masters")
+    assert "Single artist missing 'id' field" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("mtype", ["artists", "labels", "releases", "unknown"])
+def test_analyze_other_types(mtype: str, capsys) -> None:
+    message = {"id": "1", "name": "n", "title": "t", "sha256": "s"}
+    debug_message.analyze_message(message, mtype)
+    assert "Message Analysis" in capsys.readouterr().out
+
+
+def test_analyze_truncates_large_message(capsys) -> None:
+    message = {"id": "1", "sha256": "s", "blob": "x" * 5000}
+    debug_message.analyze_message(message, "unknown")
+    assert "..." in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# main
+# --------------------------------------------------------------------------- #
+def test_main_no_args_exits(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(debug_message.sys, "argv", ["debug_message.py"])
+    with pytest.raises(SystemExit) as exc:
+        debug_message.main()
+    assert exc.value.code == 1
+    assert "Usage:" in capsys.readouterr().out
+
+
+def test_main_invalid_queue_type(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(debug_message.sys, "argv", ["debug_message.py", "bogus"])
+    with pytest.raises(SystemExit) as exc:
+        debug_message.main()
+    assert exc.value.code == 1
+    assert "Invalid queue type" in capsys.readouterr().out
+
+
+def test_main_invalid_consumer(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(debug_message.sys, "argv", ["debug_message.py", "artists", "bogus"])
+    with pytest.raises(SystemExit) as exc:
+        debug_message.main()
+    assert exc.value.code == 1
+    assert "Invalid consumer" in capsys.readouterr().out
+
+
+def test_main_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(debug_message.sys, "argv", ["debug_message.py", "artists", "tableinator"])
+    with (
+        patch.object(debug_message, "get_message_from_queue", return_value={"id": "1"}) as getter,
+        patch.object(debug_message, "analyze_message") as analyzer,
+    ):
+        debug_message.main()
+
+    getter.assert_called_once()
+    # Queue name is composed from the tableinator prefix + type.
+    assert getter.call_args.args[0].endswith("-artists")
+    analyzer.assert_called_once_with({"id": "1"}, "artists")

--- a/tests/utilities/test_healthcheck.py
+++ b/tests/utilities/test_healthcheck.py
@@ -1,0 +1,60 @@
+"""Tests for utilities/healthcheck.py — the container process healthcheck."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import psutil
+import pytest
+
+from utilities import healthcheck
+
+
+def _proc(cmdline: list[str] | None) -> MagicMock:
+    proc = MagicMock()
+    proc.info = {"pid": 1, "name": "python", "cmdline": cmdline}
+    return proc
+
+
+def test_check_process_found() -> None:
+    with patch.object(healthcheck.psutil, "process_iter", return_value=[_proc(["python", "graphinator/main.py"])]):
+        assert healthcheck.check_process("graphinator") is True
+
+
+def test_check_process_not_found() -> None:
+    with patch.object(healthcheck.psutil, "process_iter", return_value=[_proc(["python", "other.py"])]):
+        assert healthcheck.check_process("graphinator") is False
+
+
+def test_check_process_empty_cmdline_skipped() -> None:
+    with patch.object(healthcheck.psutil, "process_iter", return_value=[_proc(None), _proc([])]):
+        assert healthcheck.check_process("graphinator") is False
+
+
+def test_check_process_swallows_psutil_errors() -> None:
+    bad = MagicMock()
+    type(bad).info = property(lambda _self: (_ for _ in ()).throw(psutil.NoSuchProcess(1)))
+    with patch.object(healthcheck.psutil, "process_iter", return_value=[bad]):
+        assert healthcheck.check_process("graphinator") is False
+
+
+def test_main_no_args_exits_1(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(healthcheck.sys, "argv", ["healthcheck.py"])
+    with pytest.raises(SystemExit) as exc:
+        healthcheck.main()
+    assert exc.value.code == 1
+    assert "Usage:" in capsys.readouterr().out
+
+
+def test_main_process_running_exits_0(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(healthcheck.sys, "argv", ["healthcheck.py", "graphinator"])
+    with patch.object(healthcheck, "check_process", return_value=True), pytest.raises(SystemExit) as exc:
+        healthcheck.main()
+    assert exc.value.code == 0
+
+
+def test_main_process_missing_exits_1(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(healthcheck.sys, "argv", ["healthcheck.py", "graphinator"])
+    with patch.object(healthcheck, "check_process", return_value=False), pytest.raises(SystemExit) as exc:
+        healthcheck.main()
+    assert exc.value.code == 1

--- a/tests/utilities/test_monitor_queues.py
+++ b/tests/utilities/test_monitor_queues.py
@@ -1,0 +1,66 @@
+"""Tests for utilities/monitor_queues.py — the real-time queue monitor."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from utilities import monitor_queues
+
+
+def _response(payload: list[dict]) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = payload
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_get_queue_stats_success() -> None:
+    payload = [{"name": "discogsography-discogs-graphinator-artists"}]
+    with patch.object(monitor_queues.requests, "get", return_value=_response(payload)) as get:
+        result = monitor_queues.get_queue_stats(base_url="http://rmq", username="u", password="p")  # noqa: S106
+    assert result == payload
+    get.assert_called_once()
+    assert get.call_args.kwargs["timeout"] == 10
+    assert get.call_args.args[0] == "http://rmq/api/queues"
+
+
+def test_get_queue_stats_request_error(capsys) -> None:
+    with patch.object(monitor_queues.requests, "get", side_effect=requests.RequestException("down")):
+        assert monitor_queues.get_queue_stats() is None
+    assert "Error connecting to RabbitMQ" in capsys.readouterr().out
+
+
+def test_monitor_queues_renders_then_stops(capsys) -> None:
+    payload = [
+        {"name": "discogsography-discogs-graphinator-artists", "messages_ready": 4, "messages_unacknowledged": 2, "messages": 6},
+        {"name": "discogsography-musicbrainz-tableinator-releases", "messages_ready": 1, "messages_unacknowledged": 0, "messages": 1},
+        {"name": "ignored-queue", "messages_ready": 9, "messages_unacknowledged": 9, "messages": 9},
+    ]
+    with (
+        patch.object(monitor_queues, "get_queue_stats", return_value=payload),
+        patch.object(monitor_queues.time, "sleep", side_effect=KeyboardInterrupt),
+        patch.object(monitor_queues.time, "strftime", return_value="2026-01-01 00:00:00"),
+    ):
+        monitor_queues.monitor_queues(interval=1)
+
+    out = capsys.readouterr().out
+    assert "graphinator-artists" in out
+    assert "tableinator-releases" in out
+    assert "ignored-queue" not in out
+    assert "Total messages across all queues: 7" in out
+    assert "Monitoring stopped." in out
+
+
+def test_monitor_queues_handles_empty_fetch(capsys) -> None:
+    # First loop: no data -> "Failed to fetch" -> sleep -> continue; second loop
+    # interrupts. Sleep is a no-op so the ``continue`` branch is exercised.
+    with (
+        patch.object(monitor_queues, "get_queue_stats", side_effect=[None, KeyboardInterrupt]),
+        patch.object(monitor_queues.time, "sleep", return_value=None),
+    ):
+        monitor_queues.monitor_queues(interval=1)
+    out = capsys.readouterr().out
+    assert "Failed to fetch queue data" in out
+    assert "Monitoring stopped." in out

--- a/tests/utilities/test_system_monitor.py
+++ b/tests/utilities/test_system_monitor.py
@@ -1,0 +1,185 @@
+"""Tests for utilities/system_monitor.py — the whole-system status dashboard.
+
+Pins the CLAUDE.md subprocess-timeout contract (every ``subprocess.run`` passes
+``timeout=`` and both ``CalledProcessError`` and ``TimeoutExpired`` are caught)
+and the split extractor service names used when scanning logs.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from utilities import system_monitor
+
+
+def _completed(stdout: str) -> MagicMock:
+    result = MagicMock()
+    result.stdout = stdout
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# get_docker_stats
+# --------------------------------------------------------------------------- #
+def test_get_docker_stats_json_array() -> None:
+    payload = '[{"Name": "a"}, {"Name": "b"}]'
+    with patch.object(system_monitor.subprocess, "run", return_value=_completed(payload)) as run:
+        result = system_monitor.get_docker_stats()
+    assert result == [{"Name": "a"}, {"Name": "b"}]
+    assert run.call_args.kwargs["timeout"] == 60
+
+
+def test_get_docker_stats_json_lines() -> None:
+    payload = '{"Name": "a"}\n{"Name": "b"}\n'
+    with patch.object(system_monitor.subprocess, "run", return_value=_completed(payload)):
+        result = system_monitor.get_docker_stats()
+    assert result == [{"Name": "a"}, {"Name": "b"}]
+
+
+def test_get_docker_stats_called_process_error() -> None:
+    with patch.object(system_monitor.subprocess, "run", side_effect=subprocess.CalledProcessError(1, ["docker"])):
+        assert system_monitor.get_docker_stats() == []
+
+
+def test_get_docker_stats_timeout() -> None:
+    with patch.object(system_monitor.subprocess, "run", side_effect=subprocess.TimeoutExpired(["docker"], 60)):
+        assert system_monitor.get_docker_stats() == []
+
+
+# --------------------------------------------------------------------------- #
+# get_queue_stats
+# --------------------------------------------------------------------------- #
+def test_get_queue_stats_success() -> None:
+    resp = MagicMock()
+    resp.json.return_value = [{"name": "q"}]
+    resp.raise_for_status.return_value = None
+    with patch.object(system_monitor.requests, "get", return_value=resp) as get:
+        result = system_monitor.get_queue_stats(base_url="http://rmq", username="u", password="p")  # noqa: S106
+    assert result == [{"name": "q"}]
+    assert get.call_args.kwargs["timeout"] == 10
+
+
+def test_get_queue_stats_error() -> None:
+    with patch.object(system_monitor.requests, "get", side_effect=requests.RequestException()):
+        assert system_monitor.get_queue_stats() is None
+
+
+# --------------------------------------------------------------------------- #
+# get_service_logs
+# --------------------------------------------------------------------------- #
+def test_get_service_logs_success() -> None:
+    with patch.object(system_monitor.subprocess, "run", return_value=_completed("log line")) as run:
+        assert system_monitor.get_service_logs("graphinator", 5) == "log line"
+    assert run.call_args.kwargs["timeout"] == 60
+    assert "--tail=5" in run.call_args.args[0]
+
+
+def test_get_service_logs_error() -> None:
+    with patch.object(system_monitor.subprocess, "run", side_effect=subprocess.TimeoutExpired(["docker"], 60)):
+        assert system_monitor.get_service_logs("graphinator") == ""
+
+
+# --------------------------------------------------------------------------- #
+# check_neo4j_status / check_postgres_status
+# --------------------------------------------------------------------------- #
+def test_check_neo4j_status_success() -> None:
+    with patch.object(system_monitor.subprocess, "run", return_value=_completed("label | count")) as run:
+        assert system_monitor.check_neo4j_status() == "label | count"
+    assert run.call_args.kwargs["timeout"] == 60
+
+
+def test_check_neo4j_status_error_with_stderr() -> None:
+    exc = subprocess.CalledProcessError(1, ["docker"], stderr="boom")
+    with patch.object(system_monitor.subprocess, "run", side_effect=exc):
+        assert system_monitor.check_neo4j_status() == "Error: boom"
+
+
+def test_check_neo4j_status_error_without_stderr() -> None:
+    exc = subprocess.TimeoutExpired(["docker"], 60)
+    with patch.object(system_monitor.subprocess, "run", side_effect=exc):
+        assert system_monitor.check_neo4j_status().startswith("Error:")
+
+
+def test_check_postgres_status_success() -> None:
+    with patch.object(system_monitor.subprocess, "run", return_value=_completed("relname | size")):
+        assert system_monitor.check_postgres_status() == "relname | size"
+
+
+def test_check_postgres_status_error_with_stderr() -> None:
+    exc = subprocess.CalledProcessError(1, ["docker"], stderr="db down")
+    with patch.object(system_monitor.subprocess, "run", side_effect=exc):
+        assert system_monitor.check_postgres_status() == "Error: db down"
+
+
+def test_check_postgres_status_error_without_stderr() -> None:
+    with patch.object(system_monitor.subprocess, "run", side_effect=subprocess.TimeoutExpired(["docker"], 60)):
+        assert system_monitor.check_postgres_status().startswith("Error:")
+
+
+# --------------------------------------------------------------------------- #
+# monitor_system (integration over the mocked collectors)
+# --------------------------------------------------------------------------- #
+def test_monitor_system_all_healthy(capsys) -> None:
+    containers = [{"Name": "discogsography-graphinator", "State": "running", "Health": "healthy"}]
+    queues = [{"name": "discogsography-discogs-artists", "messages_ready": 2, "messages_unacknowledged": 1, "messages": 3}]
+    with (
+        patch.object(system_monitor, "get_docker_stats", return_value=containers),
+        patch.object(system_monitor, "get_queue_stats", return_value=queues),
+        patch.object(system_monitor, "check_neo4j_status", return_value="neo4j ok"),
+        patch.object(system_monitor, "check_postgres_status", return_value="pg ok"),
+        patch.object(system_monitor, "get_service_logs", return_value="INFO all good"),
+    ):
+        system_monitor.monitor_system()
+
+    out = capsys.readouterr().out
+    assert "discogsography-graphinator" in out
+    assert "Total messages: 3" in out
+    assert "neo4j ok" in out
+    assert "pg ok" in out
+    assert "No recent errors found" in out
+
+
+def test_monitor_system_all_unavailable(capsys) -> None:
+    def fake_logs(service: str, _lines: int = 20) -> str:
+        return "ERROR something Failed badly" if service == "graphinator" else ""
+
+    with (
+        patch.object(system_monitor, "get_docker_stats", return_value=[]),
+        patch.object(system_monitor, "get_queue_stats", return_value=None),
+        patch.object(system_monitor, "check_neo4j_status", return_value="Error: no neo4j"),
+        patch.object(system_monitor, "check_postgres_status", return_value="Error: no pg"),
+        patch.object(system_monitor, "get_service_logs", side_effect=fake_logs),
+    ):
+        system_monitor.monitor_system()
+
+    out = capsys.readouterr().out
+    assert "Unable to fetch container status" in out
+    assert "Unable to fetch queue data" in out
+    assert "Unable to connect to Neo4j" in out
+    assert "Unable to connect to PostgreSQL" in out
+    assert "graphinator:" in out  # error section rendered
+
+
+def test_monitor_system_scans_split_extractor_services() -> None:
+    """CLAUDE.md contract: the error scan uses both split extractor services."""
+    seen: list[str] = []
+
+    def record(service: str, _lines: int = 20) -> str:
+        seen.append(service)
+        return ""
+
+    with (
+        patch.object(system_monitor, "get_docker_stats", return_value=[]),
+        patch.object(system_monitor, "get_queue_stats", return_value=None),
+        patch.object(system_monitor, "check_neo4j_status", return_value="Error:"),
+        patch.object(system_monitor, "check_postgres_status", return_value="Error:"),
+        patch.object(system_monitor, "get_service_logs", side_effect=record),
+    ):
+        system_monitor.monitor_system()
+
+    assert "extractor-discogs" in seen
+    assert "extractor-musicbrainz" in seen
+    assert "extractor" not in seen


### PR DESCRIPTION
## Summary

Lands the complete P0/P1/P2 scope of the 2026-07-19 deep bug-hunt epic (`discogsography-cu2`): **73 verified defects fixed** (2 P0, 19 P1, 47 P2, 5 P3) across 13 serialized `--no-ff` merge bubbles, each independently reviewed and tested. The remaining 37 P3 beads stay in the backlog.

### Headline fixes
- **P0 `cu2.2` — mass data loss:** a resumed extraction no longer wipes entire PostgreSQL tables; the extractor propagates the original extraction start time from the state marker, and tableinator's purge gained zero-records-skip and ≥90%-veto guards.
- **P0 `cu2.1` — complete 2FA bypass:** 2FA challenge JWTs are rejected on every access-token validation path (allowlist: access tokens carry no `type` claim).
- **Enrichment no-op (`cu2.10`):** brainzgraphinator matched integer ids against string node properties — the entire MusicBrainz enrichment silently did nothing.
- **Consumer wedging (`cu2.19/18/17` + siblings):** poison batches now nack to the DLQ after bounded retries; non-batch graphinator awaits the async Neo4j driver; genre/style stats and stub cleanup batch per-node/10k-row transactions.
- **Security (`cu2.8/3` + 2FA family):** internal insights router fails closed behind a constant-time shared secret; Lucene injection escaped; atomic TOTP lockout/recovery-code consumption; verify-then-consume challenge ordering.
- **Pool resilience (`cu2.21/11` + siblings):** no capacity leaks on task cancellation; replenisher respects `max_connections`; sync pool no longer busy-spins.
- **Extractor correctness:** JSONL read errors fail loudly instead of busy-looping; MB dumps publish atomically via tmp+rename; SIGTERM honored mid-run; normalization + sha256 hashing always on (change detection worked only with rules enabled before); DLQ purge, SSE streaming, health-server threading, and ~40 more.

### Validation
- Assembled container: **3390 Python + 1222 Rust + 1070 JS (Vitest) tests pass**, lint/clippy/format clean.
- Each of the 13 units was additionally validated from a clean checkout at merge time.
- Per-bead regression tests included throughout (~2000 net new test lines).

### Structure
One `--no-ff` bubble per unit, per-bead conventional commits preserved inside (bisectable): `cu2.1`, `cu2.2`, then batches `extractor-misc`, `pg-pool`, `brainz-direction`, `api-queries`, `auth-2fa`, `extractor-resume`, `consumer-wedge`, `frontend`, `misc-infra`, `extractor-hardening`, `api-p2`, `extractor-signals`, `graphinator-stubs`.

Closes 73 `discogsography-cu2.*` beads (tracked in beads, label `bughunt-2026-07-19`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NU9WVG462qpDXFFV1Ys1h8