### PR TITLE
chore: repo config hygiene — AGF scaffolding, ignore-file cleanup, 215MB Docker context fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,11 +21,21 @@ env/
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
+.hypothesis/
+.tox/
+.nox/
 htmlcov/
 .coverage
 .coverage.*
 coverage.xml
+coverage.json
 *.cover
+test-results/
+
+# Rust — the extractor's build dir can reach multiple GB and every service
+# builds with `context: .`, so it must never enter the build context
+target/
+.bin/
 
 # IDEs
 .vscode/
@@ -33,15 +43,20 @@ coverage.xml
 *.swp
 *.swo
 *~
+\#*#
+.#*
 .DS_Store
 
 # Project specific
 *.log
 /discogs-data/
 /logs/
+data/
+backups/
 tests/
 docs/
 utilities/
+design/
 
 # Environment files
 .env
@@ -60,6 +75,7 @@ utilities/
 *.key
 *.crt
 *.cer
+secrets/
 
 # Build artifacts
 build/
@@ -71,27 +87,39 @@ docker-compose*.yml
 Dockerfile*
 .dockerignore
 
+# Agent tooling and local indexes — large, machine-local, never needed at build time
+.beads/
+.dolt/
+.beads-credential-key
+.bv/
+.repowise/
+.claude/
+.mcp.json
+.worktrees/
+.playwright-mcp/
+
 # Development files
 .pre-commit-config.yaml
 pyrightconfig.json
 CLAUDE.md
-# Note: README.md is needed by Dockerfiles for uv sync
-# Exclude all markdown files except README.md
+AGENTS.md
+# Exclude all markdown files except README.md, which Dockerfiles need for uv sync.
+# The `**/` prefix on the negation matters: a bare `!README.md` would re-include
+# only the root README, and seven service pyproject.toml files declare
+# `readme = "README.md"` relative to their own package directory.
 **/*.md
-!README.md
+!**/README.md
 
 # Temporary files
 *.tmp
 *.temp
+temp/
 .cache/
 
-# Additional IDEs
-*.swp
-*.swo
-*~
-\#*#
-.#*
-
-# Frontend (if applicable)
+# Frontend
 node_modules/
 static/build/
+explore/coverage/
+explore/coverage-e2e/
+.nyc_output/
+perftest-results/

--- a/.gitignore
+++ b/.gitignore
@@ -78,8 +78,10 @@ test-results/
 *.mo
 *.pot
 
-# Django stuff:
+# Service logs (services log to /logs/{service_name}.log)
 *.log
+
+# Django stuff:
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
@@ -96,7 +98,7 @@ docs/_build/
 
 # PyBuilder
 .pybuilder/
-target/
+# Note: target/ is covered by the Rust section below
 
 # Jupyter Notebook
 .ipynb_checkpoints
@@ -196,7 +198,7 @@ secrets/
 # Dashboard/Frontend (if applicable)
 node_modules/
 static/build/
-explore/coverage/
+# Note: explore/coverage/ is covered by the JavaScript coverage section below
 # Generated at Docker build time by the Tailwind CLI; not committed
 dashboard/static/tailwind.css
 explore/static/tailwind.css
@@ -289,9 +291,8 @@ temp/
 .AppleDouble
 .LSOverride
 
-# Icon must end with two \r
-Icon
-
+# Custom folder icon (the real filename ends in a carriage return)
+Icon?
 
 # Thumbnails
 ._*
@@ -322,12 +323,17 @@ Temporary Items
 
 # Built Visual Studio Code Extensions
 *.vsix
+
+###
+# Superpowers
+###
 .superpowers/
 
 ###
-# Istanbul / nyc coverage
+# JavaScript coverage (Vitest / Istanbul / nyc)
 ###
 .nyc_output/
+explore/coverage/
 explore/coverage-e2e/
 
 ###
@@ -335,16 +341,18 @@ explore/coverage-e2e/
 ###
 perftest-results/
 
-# Beads / Dolt files (added by bd init)
-.dolt/
-*.db
-.beads-credential-key
-.beads/proxieddb/
-
 ###
-# beads (bead corpus lives on the dolt remote: refs/dolt/data)
+# Beadhive / beads / bv
+# The bead corpus lives on the dolt remote (refs/dolt/data), so the whole
+# .beads/ tree is machine-local — that also covers proxieddb/ and the
+# issues.jsonl export that bv reads.
 ###
 .beads/
+.dolt/
+.beads-credential-key
+*.db
+# bv (beads viewer) local config and caches
+.bv/
 
 ###
 # Repowise codebase index

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+<!-- bh:agf:start (managed by `bh hive init` — edit outside these markers; `-f` refreshes) -->
+## AGF — Agentic Git Flow
+
+This repo is onboarded as a **`bh` hive** and develops via **AGF**: work is tracked in beads
+and driven through `bh`, **not** raw `git` / `bd` / `gh`.
+
+- **Is this repo set up for AGF?** → run `bh hive ready` (add `-v` for the line-item breakdown).
+- **Lifecycle, roles, conventions:** see `docs/AGF.md` and the bh plugin's role skills.
+- Drive beads with `bh work`; load the role skill for your seat (coordinator / developer / merger).
+- Batch/collapsed work lives in ONE shared `wt/batch/<group>` worktree and completes as a UNIT:
+  `bh work submit --group` then `bh work merge --group` — per-bead `submit`/`check` don't apply.
+<!-- bh:agf:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,13 +290,150 @@ All variables support `_FILE` variants for Docker Compose runtime secrets in pro
 - Token validation code exists in `api/dependencies.py`, `api/api.py`, `api/routers/sync.py`, and `api/routers/snapshot.py` — changes to one must be applied to all
 - Batch processors exist in `graphinator/batch_processor.py` and `tableinator/batch_processor.py` — changes to one should be mirrored in the other
 
-<!-- bh:agf:start (managed by `bh rig init` — edit outside these markers; `-f` refreshes) -->
+<!-- bh:agf:start (managed by `bh hive init` — edit outside these markers; `-f` refreshes) -->
 ## AGF — Agentic Git Flow
 
-This repo is onboarded as a **`bh` rig** and develops via **AGF**: work is tracked in beads
+This repo is onboarded as a **`bh` hive** and develops via **AGF**: work is tracked in beads
 and driven through `bh`, **not** raw `git` / `bd` / `gh`.
 
-- **Is this repo set up for AGF?** → run `bh rig ready` (add `-v` for the line-item breakdown).
-- **Lifecycle, roles, conventions:** see `.beads/PRIME.md` and `docs/AGF.md`.
+- **Is this repo set up for AGF?** → run `bh hive ready` (add `-v` for the line-item breakdown).
+- **Lifecycle, roles, conventions:** see `docs/AGF.md` and the bh plugin's role skills.
 - Drive beads with `bh work`; load the role skill for your seat (coordinator / developer / merger).
+- Batch/collapsed work lives in ONE shared `wt/batch/<group>` worktree and completes as a UNIT:
+  `bh work submit --group` then `bh work merge --group` — per-bead `submit`/`check` don't apply.
 <!-- bh:agf:end -->
+
+<!-- bv-agent-instructions-v3 -->
+
+---
+
+## Bead Triage with bv
+
+> **Toolchain for this hive:** reads and lifecycle both go through **`bh work`**.
+> Triage is **`bv`**. Bead authoring goes through **`bh plan file`** (molecules) or the
+> **bh MCP `bd_create`** tool (standalone beads).
+> **Do not invoke `bd` directly** — it can hit the wrong database, and the `bh bd`
+> passthrough is **disabled** in this hive (`passthrough.bd_enabled`, default off);
+> it exits non-zero rather than running.
+> **`br` (beads_rust) is NOT installed and will not be** — never invoke it.
+
+The bead corpus is **not** stored in git. `.beads/` is gitignored and the corpus lives
+on the dolt remote (`refs/dolt/data`); `.beads/issues.jsonl` is a local export that
+`bv` reads. Never hand-parse it — and never assume a filename, since `bv` auto-discovers it.
+
+### Using bv as an AI sidecar
+
+bv is a graph-aware triage engine over the bead DAG. Instead of parsing the JSONL export
+or hallucinating graph traversal, use robot flags for deterministic, dependency-aware
+output with precomputed metrics (PageRank, betweenness, critical path, cycles, HITS,
+eigenvector, k-core).
+
+**Scope boundary:** bv answers *what to work on* (triage, priority, planning) and is
+strictly read-only. Creating, modifying, and closing beads goes through `bh work` (and
+`bh plan file` / the bh MCP `bd_create` for authoring) — never through bv.
+
+**CRITICAL: Use ONLY --robot-\* flags. Bare bv launches an interactive TUI that blocks your session.**
+
+#### The Workflow: Start With Triage
+
+**`bv --robot-triage` is your single entry point.** It returns everything you need in one call:
+
+- `quick_ref`: at-a-glance counts + top 3 picks
+- `recommendations`: ranked actionable items with scores, reasons, unblock info
+- `quick_wins`: low-effort high-impact items
+- `blockers_to_clear`: items that unblock the most downstream work
+- `project_health`: status/type/priority distributions, graph metrics
+- `commands`: copy-paste shell commands for next steps
+
+```bash
+bv --robot-triage        # THE MEGA-COMMAND: start here
+bv --robot-next          # Minimal: just the single top pick
+
+# Token-optimized output (TOON) for lower LLM context usage:
+bv --robot-triage --format toon
+```
+
+Before acting on a pick, verify current state with `bh work issue <id>` (bead fields) —
+note `bh work show <id>` is different: it renders the bead *branch's* commit history.
+`recommendations` can include graph-important blocked or assigned work; only
+`quick_ref.top_picks` represents claimable work. Ignore any `claim_command` bv emits —
+claiming in this hive is `bh work claim` / `bh work assign`, not a raw tracker mutation.
+
+#### Other bv Commands
+
+| Command | Returns |
+|---------|---------|
+| `--robot-plan` | Parallel execution tracks with unblocks lists |
+| `--robot-priority` | Priority misalignment detection with confidence |
+| `--robot-insights` | Full metrics: PageRank, betweenness, HITS, eigenvector, critical path, cycles, k-core |
+| `--robot-alerts` | Stale issues, blocking cascades, priority mismatches |
+| `--robot-suggest` | Hygiene: duplicates, missing deps, label suggestions, cycle breaks |
+| `--robot-diff --diff-since <ref>` | Changes since ref: new/closed/modified issues |
+| `--robot-graph [--graph-format=json\|dot\|mermaid]` | Dependency graph export |
+
+#### Scoping & Filtering
+
+```bash
+bv --robot-plan --label backend              # Scope to label's subgraph
+bv --robot-insights --as-of HEAD~30          # Historical point-in-time
+bv --recipe actionable --robot-plan          # Pre-filter: ready to work (no blockers)
+bv --recipe high-impact --robot-triage       # Pre-filter: top PageRank scores
+```
+
+If `bv` is not on PATH (`command -v bv`), fall back to `bh work ready` and
+`bh work schedule <epic>`.
+
+### Bead Management Commands
+
+Read-only surfaces:
+
+```bash
+bh work ready --json                  # Beads with no unmet blockers, dependency-ordered
+bh work list --status open --json     # Filter by state
+bh work issue <id> --json             # One bead's fields (labels, model:/harness:)
+bh work brief <id>                    # Requirements/goals + the validation command
+bh work schedule <epic>               # Dispatch plan for a molecule
+```
+
+Lifecycle verbs — the only way to move a bead's state. Some are seat-restricted:
+`assign` is orchestrator-only, `merge`/`finish` are merge-owner-only.
+
+```bash
+bh work claim <id>                    # Worker ack: provision worktree -> in_progress
+bh work assign <id> --to <name>       # Orchestrator: stamp assignee + provision
+bh work check <id>                    # Run the hive's validation command
+bh work submit <id>                   # Handoff: review gate + review:pending
+bh work resume <id>                   # Re-attach after changes-requested
+bh work abandon <id> [--rm]           # Release the claim
+```
+
+**Work happens in the bead worktree, never in the main clone** — `claim` prints its path.
+The durable artifact is the `wt/bead/<type>/<id>` branch, not the directory.
+
+Authoring new beads (there is no `bd create` path here):
+
+```bash
+bh plan file                          # Molecule: epic + children + dep DAG
+# standalone bead: bh MCP tool `bd_create` (batch-creates from structured items)
+```
+
+### Key Concepts
+
+- **Dependencies**: beads can block other beads. `bh work ready --json` shows only unblocked work.
+- **Priority**: P0=critical, P1=high, P2=medium, P3=low, P4=backlog (use numbers 0-4, not words)
+- **Types**: task, bug, feature, epic, chore, docs, question
+- **Molecule**: an epic plus its children and their dependency DAG — the unit a dispatcher delivers
+
+### Git Policy
+
+`bv` never commits or pushes, and `bh work` owns every git operation around the
+lifecycle — raw `git` is for the change *inside* the worktree only. This repo's own git
+rules govern: work happens in bh-managed worktrees, every change gets a bead first, every
+change lands via a PR, and nothing is committed or pushed unless explicitly asked. Those
+rules override any generic workflow advice from tooling output.
+
+One caveat worth knowing: `bh hive init` with `--claude`/`--agents` implies `--furnish`,
+whose final step **commits** the scaffolding to whatever branch you are standing on,
+without prompting. Run it from a branch you intend to commit to.
+
+<!-- end-bv-agent-instructions -->

--- a/graphinator/.dockerignore
+++ b/graphinator/.dockerignore
@@ -1,1 +1,0 @@
-Dockerfile

--- a/justfile
+++ b/justfile
@@ -154,6 +154,11 @@ lint-python:
     uv run ruff check .
     uv run mypy .
 
+# Type-check Python with mypy (AGF validation gate; `just lint` also runs mypy via pre-commit)
+[group('quality')]
+typecheck:
+    uv run mypy .
+
 # Format all Python code with ruff
 [group('quality')]
 format:

--- a/tableinator/.dockerignore
+++ b/tableinator/.dockerignore
@@ -1,1 +1,0 @@
-Dockerfile


### PR DESCRIPTION
Bead: `discogsography-4634` · review gate `discogsography-mb5k`

Repo configuration hygiene found while verifying the beadhive and repowise setups. Three commits, no application code touched.

## `chore(agf)` — AGF scaffolding + bead-tooling guidance

Runs `bh hive init --claude --agents -f`, clearing the one failing `bh hive ready` required check (`claude settings`). Adds `AGENTS.md` and refreshes the managed `bh:agf` block in `CLAUDE.md`: `bh rig` → `bh hive`, drops the pointer to the now-deprecated `.beads/PRIME.md`, adds batch/group worktree guidance.

Also rewrites the bead-tooling section of `CLAUDE.md`, in place between the bv marker comments so bv does not re-prompt at startup. The generated stanza referenced **`br` (beads_rust) 18 times** — `br` is not installed and will not be, so every one of those commands would have failed for the next agent. Three further inaccuracies corrected:

- It claimed beads are "stored in `.beads/` and tracked in git". Nothing under `.beads/` is tracked — the corpus lives on the dolt remote (`refs/dolt/data`).
- It told agents to claim work via a raw tracker mutation; here that is `bh work claim`.
- `bd` is not reachable: the `bh bd` passthrough is disabled by default (`passthrough.bd_enabled`). Reads go through `bh work ready|issue|list`; authoring through `bh plan file` or the bh MCP `bd_create`.

## `chore(ignore)` — 215MB → 9MB Docker build context

`.dockerignore` excluded neither `.beads/` (152MB) nor `.repowise/` (63MB), and every service builds with `context: .`, so both were shipped to the daemon on all 11 builds. Measured with a `FROM scratch` probe:

```
before: transferring context: 214.85MB
after:  transferring context:   8.88MB
```

Also excludes `target/` (Rust build dir — absent right now but multi-GB after `just extractor-build`), `.bin/`, `.dolt/`, `.bv/`, `.claude/`, `.mcp.json`, `.worktrees/`, `.playwright-mcp/`, `data/`, `backups/`, `design/`, `secrets/`, and missing test/coverage artifacts.

**Latent bug fixed in the same file:** `!README.md` re-included only the *root* README, while seven service `pyproject.toml` files declare `readme = "README.md"` relative to their own package directory (the root one is commented out with *"to avoid Docker build issues"* — the same bite). Now `!**/README.md`, verified in a container:

```
RUN ls /ctx/common/README.md /ctx/graphinator/README.md
→ NESTED_READMES_PRESENT
```

Strictly additive to the context, so it cannot break a build; no Dockerfile `COPY`s any newly excluded path.

**Deletes `graphinator/.dockerignore` and `tableinator/.dockerignore`.** Each held one line, `Dockerfile`. Every build path uses context `.` (compose ×11, `build.yml`, `docker-validate.yml`), so Docker never read them — that would require `<service>/Dockerfile.dockerignore` — and root `.dockerignore` already covers `Dockerfile*`. They were also the only 2 of 11 services to have one.

`.gitignore`: dedupes `target/` and `explore/coverage/`; drops `.beads/proxieddb/` as redundant; merges the two split beads sections and folds in `.bv/` under a proper header; fixes `Icon` → `Icon?` (bare `Icon` ignored any file or directory of that name); un-misfiles `.superpowers/`; splits `*.log` out of the Django block. Verified `git ls-files | git check-ignore --stdin` returns nothing.

## `chore(just)` — `typecheck` recipe

The hive's `work.validate_cmd` is `sh -c "just lint && just typecheck"`, but no `typecheck` recipe existed, so `bh work check`/`submit` failed after `just lint` passed. Adds the recipe rather than carving out a per-repo `validate_cmd` override.

## Validation

`just lint` (all pre-commit hooks: ruff, mypy, bandit, hadolint, shellcheck, yamllint, cargo fmt/clippy) and `just typecheck` both pass from a clean checkout — `Success: no issues found in 116 source files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cznaoyTiDXWPdkvxqkgjG