### PR TITLE
fix: analytics scoring correctness — 7 bug-hunt findings (batch:analytics-scoring)

### DIFF
--- a/api/queries/neo4j_queries.py
+++ b/api/queries/neo4j_queries.py
@@ -283,7 +283,7 @@ async def _expand_releases(
     MATCH {match_clause}{year_filter}
     RETURN r.id AS id, r.title AS name, 'release' AS type,
            CASE WHEN r.year > 0 THEN r.year ELSE null END AS year
-    ORDER BY year DESC
+    ORDER BY year IS NULL ASC, year DESC
     SKIP $offset
     LIMIT $limit
     """

--- a/api/queries/rarity_queries.py
+++ b/api/queries/rarity_queries.py
@@ -114,7 +114,7 @@ def compute_temporal_scarcity_score(
     if release_year is None:
         return 50.0
     age = current_year - release_year
-    base = min(100.0, age * 1.5)
+    base = max(0.0, min(100.0, age * 1.5))
     if latest_sibling_year is not None and latest_sibling_year >= current_year - 10:
         base = max(0.0, base - 40.0)
     return base

--- a/api/queries/rarity_queries.py
+++ b/api/queries/rarity_queries.py
@@ -181,12 +181,19 @@ async def fetch_all_rarity_signals(driver: Any, pool: Any = None) -> list[dict[s
     current_year = datetime.now(UTC).year
 
     # 1. Pressing scarcity: count siblings per master
+    # NOTE: the master lookup and the sibling lookup are deliberately two separate
+    # OPTIONAL MATCHes. Combining them into one pattern (as previously written) makes
+    # `m` contingent on a sibling existing: for a release that IS linked to a master
+    # but is that master's ONLY pressing, the combined pattern (including its inline
+    # WHERE sibling <> r) fails entirely and `m` comes back null too — misclassifying
+    # the rarest pressing case (a unique pressing of a master) as "no master link".
     pressing_query = """
     MATCH (r:Release)
-    OPTIONAL MATCH (r)-[:DERIVED_FROM]->(m:Master)<-[:DERIVED_FROM]-(sibling:Release)
+    OPTIONAL MATCH (r)-[:DERIVED_FROM]->(m:Master)
+    OPTIONAL MATCH (m)<-[:DERIVED_FROM]-(sibling:Release)
     WHERE sibling <> r
-    WITH r, m, count(DISTINCT sibling) + 1 AS pressing_count_with_master
-    WITH r, CASE WHEN m IS NULL THEN 0 ELSE pressing_count_with_master END AS pressing_count
+    WITH r, m, count(DISTINCT sibling) AS sibling_count
+    WITH r, CASE WHEN m IS NULL THEN 0 ELSE sibling_count + 1 END AS pressing_count
     OPTIONAL MATCH (r)-[:BY]->(a:Artist)
     WITH r, pressing_count, collect(DISTINCT a.name)[0] AS artist_name
     RETURN r.id AS release_id, pressing_count,

--- a/api/queries/recommend_queries.py
+++ b/api/queries/recommend_queries.py
@@ -338,7 +338,7 @@ async def get_collector_counts(driver: AsyncResilientNeo4jDriver, release_ids: l
     UNWIND $release_ids AS rid
     MATCH (r:Release {id: rid})
     OPTIONAL MATCH (u:User)-[:COLLECTED]->(r)
-    RETURN r.id AS id, count(u) AS collectors
+    RETURN r.id AS id, count(DISTINCT u) AS collectors
     """
     rows = await run_query(driver, cypher, release_ids=release_ids)
     return {row["id"]: row["collectors"] for row in rows}

--- a/api/queries/taste_queries.py
+++ b/api/queries/taste_queries.py
@@ -58,9 +58,10 @@ async def get_obscurity_score(
     """
     cypher = """
     MATCH (u:User {id: $user_id})-[:COLLECTED]->(r:Release)
+    WITH DISTINCT u, r
     OPTIONAL MATCH (other:User)-[:COLLECTED]->(r)
     WHERE other <> u
-    WITH r, count(other) AS collectors
+    WITH r, count(DISTINCT other) AS collectors
     RETURN collectors
     ORDER BY collectors
     """

--- a/api/routers/admin.py
+++ b/api/routers/admin.py
@@ -586,7 +586,7 @@ async def purge_dlq(
                 status_code=status.HTTP_502_BAD_GATEWAY,
                 detail=f"RabbitMQ returned {resp.status_code}",
             )
-    except httpx.ConnectError as exc:
+    except (httpx.ConnectError, httpx.RequestError) as exc:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="RabbitMQ management API unreachable",

--- a/api/routers/snapshot.py
+++ b/api/routers/snapshot.py
@@ -91,7 +91,10 @@ async def save_snapshot(
         return JSONResponse(content={"error": f"Too many nodes: maximum is {_snapshot_store.max_nodes}"}, status_code=422)
     nodes = [n.model_dump() for n in body.nodes]
     center = body.center.model_dump()
-    token, expires_at = await _snapshot_store.save(nodes, center)
+    try:
+        token, expires_at = await _snapshot_store.save(nodes, center)
+    except ValueError as exc:
+        return JSONResponse(content={"error": str(exc)}, status_code=422)
     response = SnapshotResponse(token=token, url=f"/snapshot/{token}", expires_at=expires_at.isoformat())
     return JSONResponse(content=response.model_dump(), status_code=201)
 

--- a/api/snapshot_store.py
+++ b/api/snapshot_store.py
@@ -34,7 +34,16 @@ class SnapshotStore:
         return self._max_nodes
 
     async def save(self, nodes: list[dict[str, Any]], center: dict[str, Any]) -> tuple[str, datetime]:
-        """Save a snapshot and return (token, expires_at)."""
+        """Save a snapshot and return (token, expires_at).
+
+        Raises:
+            ValueError: if ``nodes`` exceeds ``max_nodes``. The API router also
+                pre-checks this (for a friendlier error message), but this guard
+                protects any direct caller of SnapshotStore that bypasses the
+                router — e.g. scripts or future reuse.
+        """
+        if len(nodes) > self._max_nodes:
+            raise ValueError(f"Too many nodes: {len(nodes)} exceeds maximum of {self._max_nodes}")
         token = secrets.token_urlsafe(12)
         now = datetime.now(UTC)
         expires_at = now + timedelta(seconds=self._ttl_seconds)

--- a/common/credit_roles.py
+++ b/common/credit_roles.py
@@ -102,13 +102,22 @@ ROLE_CATEGORIES: dict[str, set[str]] = {
     },
 }
 
-# Build reverse lookup: lowercase role fragment → category
-# Use ROLE_CATEGORIES (ordered dict) as iteration source to ensure deterministic
-# ordering — longer fragments first within each category for specificity.
+# Build reverse lookup: lowercase role fragment → category, for the O(1) direct
+# (exact-key) match. Iteration order doesn't matter for a dict lookup.
 _ROLE_TO_CATEGORY: dict[str, str] = {}
 for _cat, _roles in ROLE_CATEGORIES.items():
-    for _role in sorted(_roles, key=len, reverse=True):
+    for _role in _roles:
         _ROLE_TO_CATEGORY[_role] = _cat
+
+# Substring-scan order: every (fragment, category) pair, sorted by fragment length
+# descending GLOBALLY across all categories (not just within one). categorize_role's
+# fallback substring scan returns the first match, so specificity must be
+# global — a short generic fragment declared in an earlier category (e.g.
+# engineering's "engineer") must never pre-empt a longer, more specific fragment
+# in a later-declared category (e.g. mastering's "mastering engineer"). A
+# per-category-only length sort (the previous approach) let category declaration
+# order silently defeat specificity for compound cross-category credits.
+_ROLE_FRAGMENTS_BY_SPECIFICITY: list[tuple[str, str]] = sorted(_ROLE_TO_CATEGORY.items(), key=lambda pair: (-len(pair[0]), pair[0]))
 
 
 def categorize_role(raw_role: str) -> str:
@@ -116,7 +125,7 @@ def categorize_role(raw_role: str) -> str:
 
     The raw role may contain multiple comma-separated roles
     (e.g. "Recorded By, Mixed By").  We check each fragment against
-    the taxonomy and return the first match.
+    the taxonomy and return the first (most specific) match.
 
     Returns:
         One of: "production", "engineering", "mastering", "session",
@@ -128,8 +137,9 @@ def categorize_role(raw_role: str) -> str:
     if lower in _ROLE_TO_CATEGORY:
         return _ROLE_TO_CATEGORY[lower]
 
-    # Check if any known role fragment is contained in the raw string
-    for role_fragment, category in _ROLE_TO_CATEGORY.items():
+    # Check if any known role fragment is contained in the raw string, longest
+    # (most specific) fragment first, regardless of which category declared it.
+    for role_fragment, category in _ROLE_FRAGMENTS_BY_SPECIFICITY:
         if role_fragment in lower:
             return category
 

--- a/tests/api/test_admin_endpoints.py
+++ b/tests/api/test_admin_endpoints.py
@@ -326,6 +326,39 @@ class TestDlqPurge:
         )
         assert resp.status_code == 502
 
+    @patch("api.routers.admin.httpx.AsyncClient")
+    def test_purge_read_timeout_returns_502(self, mock_client_cls: Any, test_client: TestClient) -> None:
+        """discogsography-cu2.77: a slow/flapping RabbitMQ management API raises
+        ReadTimeout (a TimeoutException/RequestError subclass), not ConnectError.
+        Must surface as 502, not an unhandled 500.
+        """
+        mock_client_instance = AsyncMock()
+        mock_client_instance.delete = AsyncMock(side_effect=httpx.ReadTimeout("Read timed out"))
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client_instance
+
+        resp = test_client.post(
+            "/api/admin/dlq/purge/discogsography-discogs-graphinator-artists.dlq",
+            headers=_admin_auth_headers(),
+        )
+        assert resp.status_code == 502
+
+    @patch("api.routers.admin.httpx.AsyncClient")
+    def test_purge_remote_protocol_error_returns_502(self, mock_client_cls: Any, test_client: TestClient) -> None:
+        """A flapping connection raising RemoteProtocolError must also surface as 502."""
+        mock_client_instance = AsyncMock()
+        mock_client_instance.delete = AsyncMock(side_effect=httpx.RemoteProtocolError("Server disconnected"))
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client_instance
+
+        resp = test_client.post(
+            "/api/admin/dlq/purge/discogsography-discogs-graphinator-artists.dlq",
+            headers=_admin_auth_headers(),
+        )
+        assert resp.status_code == 502
+
 
 class TestGetExtraction:
     def test_success(self, test_client: TestClient, mock_cur: AsyncMock) -> None:

--- a/tests/api/test_neo4j_queries.py
+++ b/tests/api/test_neo4j_queries.py
@@ -1237,3 +1237,71 @@ class TestGraphStatsQuery:
         driver = _make_driver(records=[])
         result = await get_graph_stats(driver)
         assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# discogsography-cu2.74: unknown-year (null) releases must sort last, not first,
+# under the default newest-first ORDER BY year DESC.
+# ---------------------------------------------------------------------------
+
+
+class TestExpandReleasesNullYearOrdering:
+    """CASE WHEN r.year > 0 THEN r.year ELSE null END maps year-0/absent to null.
+
+    In Cypher, ORDER BY ... DESC puts null FIRST unless a nulls-last tiebreaker is
+    added. Every caller of _expand_releases must carry that tiebreaker.
+    """
+
+    def _capture_driver(self) -> tuple[MagicMock, list[tuple[str, Any]]]:
+        calls: list[tuple[str, Any]] = []
+        mock_result = _MockResult(records=[])
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        async def _run_side_effect(cypher: str, params: Any, **_kwargs: Any) -> _MockResult:
+            calls.append((cypher, params))
+            return mock_result
+
+        mock_session.run = AsyncMock(side_effect=_run_side_effect)
+        driver = MagicMock()
+        driver.session = MagicMock(return_value=mock_session)
+        return driver, calls
+
+    @pytest.mark.asyncio
+    async def test_expand_artist_releases_orders_nulls_last(self) -> None:
+        from api.queries.neo4j_queries import expand_artist_releases
+
+        driver, calls = self._capture_driver()
+        await expand_artist_releases(driver, "Radiohead", limit=50, offset=0)
+        cypher, _params = calls[0]
+        assert "ORDER BY year IS NULL ASC, year DESC" in cypher
+        # Guard against regressing to the bare (null-first) form.
+        assert "ORDER BY year DESC" not in cypher.replace("ORDER BY year IS NULL ASC, year DESC", "")
+
+    @pytest.mark.asyncio
+    async def test_expand_genre_releases_orders_nulls_last(self) -> None:
+        from api.queries.neo4j_queries import expand_genre_releases
+
+        driver, calls = self._capture_driver()
+        await expand_genre_releases(driver, "Rock", limit=50, offset=0)
+        cypher, _params = calls[0]
+        assert "ORDER BY year IS NULL ASC, year DESC" in cypher
+
+    @pytest.mark.asyncio
+    async def test_expand_label_releases_orders_nulls_last(self) -> None:
+        from api.queries.neo4j_queries import expand_label_releases
+
+        driver, calls = self._capture_driver()
+        await expand_label_releases(driver, "Warp Records", limit=50, offset=0)
+        cypher, _params = calls[0]
+        assert "ORDER BY year IS NULL ASC, year DESC" in cypher
+
+    @pytest.mark.asyncio
+    async def test_expand_style_releases_orders_nulls_last(self) -> None:
+        from api.queries.neo4j_queries import expand_style_releases
+
+        driver, calls = self._capture_driver()
+        await expand_style_releases(driver, "Art Rock", limit=50, offset=0)
+        cypher, _params = calls[0]
+        assert "ORDER BY year IS NULL ASC, year DESC" in cypher

--- a/tests/api/test_rarity_queries.py
+++ b/tests/api/test_rarity_queries.py
@@ -759,6 +759,59 @@ class TestFetchAllRaritySignals:
         assert len(results) == 1
         assert results[0]["collection_prevalence"] == 50.0
 
+    @pytest.mark.asyncio
+    async def test_pressing_query_uses_two_optional_matches(self) -> None:
+        """discogsography-cu2.75: the master lookup and sibling lookup must be two
+        separate OPTIONAL MATCHes. A single combined pattern makes `m` (and therefore
+        pressing_count) null whenever the release is its master's ONLY pressing —
+        misclassifying the rarest pressing case as "no master link".
+        """
+        mock_driver = MagicMock()
+
+        with patch("api.queries.rarity_queries.run_query") as mock_run:
+            mock_run.side_effect = [[], [], [], [], [], [], [], []]
+            await fetch_all_rarity_signals(mock_driver, None)
+
+        pressing_cypher = mock_run.call_args_list[0].args[1]
+        # Two independent OPTIONAL MATCH clauses, not one combined pattern that
+        # conditions `m` on a sibling existing.
+        assert "OPTIONAL MATCH (r)-[:DERIVED_FROM]->(m:Master)\n" in pressing_cypher
+        assert "OPTIONAL MATCH (m)<-[:DERIVED_FROM]-(sibling:Release)" in pressing_cypher
+        assert "OPTIONAL MATCH (r)-[:DERIVED_FROM]->(m:Master)<-[:DERIVED_FROM]-(sibling:Release)" not in pressing_cypher
+
+    @pytest.mark.asyncio
+    async def test_sole_pressing_of_master_scores_as_unique_not_standalone(self) -> None:
+        """discogsography-cu2.75: a release that IS linked to a master but has no
+        sibling pressings must score pressing_count=1 (-> 100.0, unique pressing),
+        not pressing_count=0 (-> 90.0, standalone/no-master-link).
+        """
+        mock_driver = MagicMock()
+
+        # Post-fix pressing_query semantics for a sole-pressing-with-master release.
+        pressing_data = [{"release_id": "1", "pressing_count": 1, "title": "R1", "artist_name": "A1", "year": 1970}]
+        label_data = [{"release_id": "1", "label_catalog_size": 20}]
+        format_data = [{"release_id": "1", "formats": ["LP"]}]
+        temporal_data = [{"release_id": "1", "year": 1970, "latest_sibling_year": None}]
+        degree_data = [{"release_id": "1", "degree": 3}]
+        artist_degree_data = [{"release_id": "1", "artist_max_degree": 500}]
+        label_size_data = [{"release_id": "1", "label_max_catalog": 2000}]
+        genre_count_data = [{"release_id": "1", "genre_max_release_count": 50000}]
+
+        with patch("api.queries.rarity_queries.run_query") as mock_run:
+            mock_run.side_effect = [
+                pressing_data,
+                label_data,
+                format_data,
+                temporal_data,
+                degree_data,
+                artist_degree_data,
+                label_size_data,
+                genre_count_data,
+            ]
+            results = await fetch_all_rarity_signals(mock_driver, None)
+
+        assert results[0]["pressing_scarcity"] == 100.0
+
 
 class TestRarityPaginationTiebreaker:
     """discogsography-cu2.55: rarity_score / hidden_gem_score are heavily

--- a/tests/api/test_rarity_queries.py
+++ b/tests/api/test_rarity_queries.py
@@ -113,6 +113,23 @@ class TestTemporalScarcityScore:
         score = compute_temporal_scarcity_score(None, None, current_year)
         assert score == 50.0
 
+    def test_future_dated_release_floors_at_zero(self) -> None:
+        """discogsography-cu2.94: a typo'd/erroneous future year (e.g. 2050) must not
+        drive the score negative — the age-based base is floored at 0.0, matching the
+        existing upper-bound cap at 100.0.
+        """
+        current_year = datetime.now(UTC).year
+        score = compute_temporal_scarcity_score(current_year + 24, None, current_year)
+        assert score == 0.0
+        assert score >= 0.0
+
+    def test_next_year_release_floors_at_zero(self) -> None:
+        """A legitimate upcoming/pre-order release dated next year also must not
+        yield a negative signal, even though the magnitude is small (age=-1)."""
+        current_year = datetime.now(UTC).year
+        score = compute_temporal_scarcity_score(current_year + 1, None, current_year)
+        assert score == 0.0
+
 
 class TestGraphIsolationScore:
     def test_very_isolated(self) -> None:

--- a/tests/api/test_recommend_queries.py
+++ b/tests/api/test_recommend_queries.py
@@ -613,6 +613,34 @@ class TestGetCollectorCounts:
         result = await get_collector_counts(driver, [])
         assert result == {}
 
+    @pytest.mark.asyncio
+    async def test_counts_distinct_users_not_relationships(self) -> None:
+        """discogsography-cu2.76: a collector who owns multiple copies of a release
+        (one COLLECTED relationship per instance_id) must be counted once, not once
+        per copy — count(DISTINCT u), not count(u).
+        """
+        from api.queries.recommend_queries import get_collector_counts
+
+        calls: list[tuple[Any, ...]] = []
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        async def _run_side(*args: Any, **_kwargs: Any) -> _MockResult:
+            calls.append(args)
+            return _MockResult(records=[])
+
+        mock_session.run = AsyncMock(side_effect=_run_side)
+        driver = MagicMock()
+        driver.session = MagicMock(return_value=mock_session)
+
+        await get_collector_counts(driver, ["r1"])
+
+        cypher = calls[0][0]
+        assert "count(DISTINCT u)" in cypher
+        assert "count(u)" not in cypher.replace("count(DISTINCT u)", "")
+
 
 # ---------------------------------------------------------------------------
 # get_label_affinity_candidates

--- a/tests/api/test_snapshot_store.py
+++ b/tests/api/test_snapshot_store.py
@@ -1,0 +1,52 @@
+"""Unit tests for api/snapshot_store.py — SnapshotStore.save's own max_nodes guard.
+
+discogsography-c3w: SnapshotStore.save previously never checked len(nodes)
+against self._max_nodes; only the API router (api/routers/snapshot.py)
+enforced the cap. Any direct caller of SnapshotStore bypassing the router
+(scripts, future reuse) could persist arbitrarily large payloads to Redis.
+"""
+
+import fakeredis.aioredis as aioredis_fake
+import pytest
+
+from api.snapshot_store import SnapshotStore
+
+
+class TestSnapshotStoreMaxNodes:
+    @pytest.mark.asyncio
+    async def test_save_within_limit_succeeds(self) -> None:
+        store = SnapshotStore(aioredis_fake.FakeRedis(), max_nodes=2)
+        token, expires_at = await store.save(
+            [{"id": "1", "type": "artist"}, {"id": "2", "type": "artist"}],
+            {"id": "1", "type": "artist"},
+        )
+        assert token
+        assert expires_at is not None
+
+    @pytest.mark.asyncio
+    async def test_save_over_limit_raises_value_error(self) -> None:
+        """Direct SnapshotStore.save() call must enforce max_nodes itself,
+        independent of any caller-side pre-check."""
+        store = SnapshotStore(aioredis_fake.FakeRedis(), max_nodes=2)
+        nodes = [{"id": str(i), "type": "artist"} for i in range(3)]
+        with pytest.raises(ValueError, match="Too many nodes"):
+            await store.save(nodes, {"id": "0", "type": "artist"})
+
+    @pytest.mark.asyncio
+    async def test_save_over_limit_does_not_persist_to_redis(self) -> None:
+        """The rejected snapshot must not be written to Redis at all."""
+        redis_client = aioredis_fake.FakeRedis()
+        store = SnapshotStore(redis_client, max_nodes=2)
+        nodes = [{"id": str(i), "type": "artist"} for i in range(3)]
+        with pytest.raises(ValueError):
+            await store.save(nodes, {"id": "0", "type": "artist"})
+        keys = await redis_client.keys(f"{store._KEY_PREFIX}*")
+        assert keys == []
+
+    @pytest.mark.asyncio
+    async def test_save_exactly_at_limit_succeeds(self) -> None:
+        """The boundary case: exactly max_nodes is allowed, not just under it."""
+        store = SnapshotStore(aioredis_fake.FakeRedis(), max_nodes=3)
+        nodes = [{"id": str(i), "type": "artist"} for i in range(3)]
+        token, _ = await store.save(nodes, {"id": "0", "type": "artist"})
+        assert token

--- a/tests/api/test_taste_queries.py
+++ b/tests/api/test_taste_queries.py
@@ -215,6 +215,42 @@ class TestGetObscurityScore:
         assert result["score"] == 0.7
         assert result["median_collectors"] == 3.0
 
+    @pytest.mark.asyncio
+    async def test_counts_distinct_collectors_not_relationships(self) -> None:
+        """discogsography-cu2.76: the syncer creates one COLLECTED relationship per
+        instance_id, so a user owning multiple copies of a release must not multiply
+        the collector count. The query must count(DISTINCT other) over a
+        DISTINCT (u, r) base, not count(other).
+        """
+        from api.queries.taste_queries import get_obscurity_score
+
+        calls: list[Any] = []
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        async def _run_side(query: Any, *_a: Any, **_kw: Any) -> _MockResult:
+            text = getattr(query, "text", query)
+            calls.append(text)
+            if "collectors" in text:
+                return _MockResult(records=[])
+            return _MockResult(single={"total": 0})
+
+        mock_session.run = AsyncMock(side_effect=_run_side)
+        driver = MagicMock()
+        driver.session = MagicMock(return_value=mock_session)
+
+        await get_obscurity_score(driver, "user-1")
+
+        collectors_cypher = next(c for c in calls if "collectors" in c)
+        assert "count(DISTINCT other)" in collectors_cypher
+        assert "count(other)" not in collectors_cypher
+        # The user's own duplicate-copy rows must be neutralised before the
+        # OPTIONAL MATCH cross-join, or `other` is still counted once per copy
+        # the user owns of the same release.
+        assert "WITH DISTINCT u, r" in collectors_cypher
+
 
 # ---------------------------------------------------------------------------
 # get_taste_drift

--- a/tests/common/test_credit_roles.py
+++ b/tests/common/test_credit_roles.py
@@ -64,6 +64,28 @@ class TestCategorizeRole:
     def test_remix(self) -> None:
         assert categorize_role("Remix") == "engineering"
 
+    # ── discogsography-cu2.80: cross-category specificity ──────────────────
+    # Compound comma-joined credits that contain the generic "engineer"
+    # fragment (declared in the "engineering" category) but are actually a
+    # more specific mastering credit must resolve to "mastering", not
+    # "engineering". The substring scan must be globally length-ordered
+    # across every category, not just within a category.
+
+    def test_compound_lacquer_cut_mastering_engineer(self) -> None:
+        assert categorize_role("Lacquer Cut By, Mastering Engineer") == "mastering"
+
+    def test_compound_remastered_mastering_engineer(self) -> None:
+        assert categorize_role("Remastered By, Mastering Engineer") == "mastering"
+
+    def test_compound_mastered_by_mastering_engineer(self) -> None:
+        assert categorize_role("Mastered By, Mastering Engineer") == "mastering"
+
+    def test_plain_engineer_still_engineering(self) -> None:
+        """A bare, non-compound 'engineer' fragment must still resolve to
+        engineering — only the longer, more specific fragments should win."""
+        assert categorize_role("Assistant Engineer") == "engineering"
+        assert categorize_role("Recording Engineer") == "engineering"
+
 
 class TestAllCategories:
     """Test the ALL_CATEGORIES constant."""


### PR DESCRIPTION
Lands the `batch:analytics-scoring` work group — seven analytics/scoring correctness fixes from the 2026-07-19 bug-hunt residue, one conventional commit per bead.

## Beads
- `discogsography-cu2.74` — expand-releases: sort unknown-year releases last (`ORDER BY year IS NULL ASC, year DESC`)
- `discogsography-cu2.75` — pressing-scarcity: split master/sibling lookup into two OPTIONAL MATCHes so sole-pressing masters aren't misclassified as unlinked
- `discogsography-cu2.76` — obscurity score: count DISTINCT collectors, not COLLECTED relationships (multi-copy ownership no longer skews the score)
- `discogsography-cu2.77` — purge_dlq: broaden httpx handler to RequestError so management-API timeouts return 502, not 500
- `discogsography-cu2.80` — categorize_role: globally specificity-first substring matching (compound credits like "Lacquer Cut By, Mastering Engineer" now categorize correctly)
- `discogsography-cu2.94` — temporal rarity: floor the age-based base at 0 for future-dated releases
- `discogsography-c3w` — SnapshotStore.save now enforces max_nodes itself (router pre-check no longer the only guard)

## Tests
All seven fixes carry regression tests (+309 test lines across api/ and common/ suites); `just lint-python` and the api/common test targets ran green in the batch worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UCBSBYhPWx9ESjDDJxsmY