### PR TITLE
fix: security hardening — 7 bug-hunt findings (batch:security-hardening)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -58,10 +58,17 @@ class UserResponse(BaseModel):
 
 
 class SnapshotNode(BaseModel):
-    """A single node in a graph snapshot."""
+    """A single node in a graph snapshot.
 
-    id: str
-    type: str
+    ``id``/``type`` are bounded so a caller can't inflate the serialized
+    snapshot payload with megabyte-sized strings per node — the node-count
+    cap (`SnapshotStore.max_nodes`, enforced at save time) only bounds the
+    number of nodes, not their size (discogsography-cu2.110). Real Discogs/
+    MusicBrainz entity ids and type names are far shorter than these caps.
+    """
+
+    id: str = Field(max_length=128)
+    type: str = Field(max_length=32)
 
 
 class SnapshotRequest(BaseModel):

--- a/api/nlq/tools.py
+++ b/api/nlq/tools.py
@@ -102,7 +102,12 @@ def get_public_tool_schemas() -> list[dict[str, Any]]:
                         "enum": ["artist", "genre", "label", "style"],
                         "description": "Type of the target entity",
                     },
-                    "max_depth": {"type": "integer", "description": "Maximum path length (default: 6)"},
+                    "max_depth": {
+                        "type": "integer",
+                        "description": "Maximum path length (default: 6, min: 1, max: 10)",
+                        "minimum": 1,
+                        "maximum": 10,
+                    },
                 },
                 "required": ["from_id", "to_id"],
             },
@@ -647,13 +652,26 @@ class NLQToolRunner:
             result: dict[str, Any] | None = await handler(driver, name)
             return result
 
+        # Clamp the model-supplied max_depth to the same bound the HTTP
+        # /api/path route enforces (FastAPI Query(ge=1, le=MAX_PATH_DEPTH)).
+        # find_shortest_path also clamps internally as a backstop, but the
+        # NLQ engine calls it in-process (bypassing that HTTP validation
+        # layer entirely), so a user-steerable value must not reach it
+        # unbounded — an unclamped max_depth produces an exhaustive
+        # shortestPath BFS that runs up to the query timeout.
+        try:
+            raw_max_depth = int(params.get("max_depth", neo4j_queries.DEFAULT_PATH_DEPTH))
+        except (TypeError, ValueError):
+            raw_max_depth = neo4j_queries.DEFAULT_PATH_DEPTH
+        max_depth = max(neo4j_queries.MIN_PATH_DEPTH, min(raw_max_depth, neo4j_queries.MAX_PATH_DEPTH))
+
         return await agent_tools.find_path(
             driver=self._driver,
             from_name=params.get("from_id", ""),
             from_type=params.get("from_type", ""),
             to_name=params.get("to_id", ""),
             to_type=params.get("to_type", ""),
-            max_depth=params.get("max_depth", 6),
+            max_depth=max_depth,
             resolve_name=resolve_name,
             find_shortest_path_fn=neo4j_queries.find_shortest_path,
         )

--- a/api/queries/neo4j_queries.py
+++ b/api/queries/neo4j_queries.py
@@ -52,12 +52,23 @@ _LABEL_MAP: dict[str, str] = {
 # prevents traversal of internal Neo4j edges (fulltext indexes, etc.).
 _PATH_REL_TYPES = "BY|ON|IS|ALIAS_OF|MEMBER_OF|DERIVED_FROM"
 
+# shortestPath depth bounds. ``max_depth`` is interpolated as a Cypher integer
+# literal (see below) so it must be clamped server-side, not merely
+# int()-coerced — an unbounded value (e.g. from a model-steered NLQ tool
+# call) produces an exhaustive bidirectional BFS over the whole edge set that
+# runs up to the query timeout. Single source of truth for every caller
+# (HTTP /api/path route, NLQ find_path tool); the HTTP route additionally
+# enforces the same bound at the FastAPI layer for a clean 422.
+MIN_PATH_DEPTH = 1
+MAX_PATH_DEPTH = 10
+DEFAULT_PATH_DEPTH = 6
+
 
 async def find_shortest_path(
     driver: AsyncResilientNeo4jDriver,
     from_id: str,
     to_id: str,
-    max_depth: int = 6,
+    max_depth: int = DEFAULT_PATH_DEPTH,
     from_type: str = "",
     to_type: str = "",
 ) -> dict[str, Any] | None:
@@ -68,14 +79,18 @@ async def find_shortest_path(
     Each node dict has: id, name, labels.
 
     ``max_depth`` is interpolated as an integer literal in Cypher (it cannot
-    be a query parameter). The caller is responsible for validating the range.
+    be a query parameter), so it is clamped here to
+    ``[MIN_PATH_DEPTH, MAX_PATH_DEPTH]`` as a backstop regardless of what
+    the caller passes — callers should still validate/clamp their own input
+    (e.g. for a clean 422 at an HTTP boundary) rather than relying solely on
+    this internal clamp.
 
     ``from_type`` and ``to_type`` (e.g. "artist", "label") allow the query
     to use label-specific indexes instead of AllNodesScan.  When a type uses
     ``name`` as its identifier (Genre, Style), ``$from_id`` / ``$to_id`` are
     matched against the ``name`` property instead of ``id``.
     """
-    depth = int(max_depth)
+    depth = max(MIN_PATH_DEPTH, min(int(max_depth), MAX_PATH_DEPTH))
     from_label = _LABEL_MAP.get(from_type, "")
     to_label = _LABEL_MAP.get(to_type, "")
 

--- a/api/routers/app_tokens.py
+++ b/api/routers/app_tokens.py
@@ -9,6 +9,7 @@ and is never recoverable thereafter — only its SHA-256 hex hash is persisted.
 """
 
 from typing import Annotated, Any
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.responses import JSONResponse
@@ -113,10 +114,19 @@ async def revoke_app_token(
     token_id: str,
     current_user: Annotated[dict[str, Any], Depends(require_user)],
 ) -> Response:
-    """Revoke (tombstone) the named token. 404 if not owned by the caller."""
+    """Revoke (tombstone) the named token. 404 if not owned by the caller (or malformed id)."""
     user_id: str = current_user.get("sub", "")
     if not user_id:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    # token_id is an arbitrary caller-supplied path string — validate its format
+    # before it reaches the `::uuid` cast in revoke_token's SQL. A malformed id is
+    # indistinguishable from an unknown one, so both surface as the same 404
+    # rather than a 500 (or leaking format-vs-existence information).
+    try:
+        UUID(token_id)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Token not found") from None
 
     success = await _revoke_token(token_id=token_id, user_id=user_id)
     if not success:

--- a/api/routers/explore.py
+++ b/api/routers/explore.py
@@ -17,9 +17,11 @@ from api.queries import collaborator_queries, genre_tree_queries
 from api.queries.neo4j_queries import (
     AUTOCOMPLETE_DISPATCH,
     COUNT_DISPATCH,
+    DEFAULT_PATH_DEPTH as _DEFAULT_PATH_DEPTH,
     DETAILS_DISPATCH,
     EXPAND_DISPATCH,
     EXPLORE_DISPATCH,
+    MAX_PATH_DEPTH as _MAX_PATH_DEPTH,
     TRENDS_DISPATCH,
     find_shortest_path,
     get_genre_emergence,
@@ -345,8 +347,9 @@ async def get_trends(
 
 
 _VALID_PATH_TYPES = frozenset(EXPLORE_DISPATCH.keys())
-_MAX_PATH_DEPTH = 10
-_DEFAULT_PATH_DEPTH = 6
+# _MAX_PATH_DEPTH / _DEFAULT_PATH_DEPTH are re-exported (aliased on import,
+# above) from neo4j_queries — the single source of truth for shortestPath
+# depth bounds, also used by the NLQ find_path tool handler.
 
 
 def _node_label_to_type(labels: list[str]) -> str:

--- a/api/routers/extraction_analysis.py
+++ b/api/routers/extraction_analysis.py
@@ -1,5 +1,6 @@
 """Extraction Analysis router — versions, summary, violations, and parsing errors for flagged records."""
 
+import asyncio
 import json
 import math
 from pathlib import Path
@@ -134,12 +135,28 @@ def _find_version_root(version: str) -> tuple[Path, str] | None:
     return None
 
 
+# Aggregate caps on the JSONL scan (across every entity's violations.jsonl /
+# skipped.jsonl for a single version). A bad extraction can flag millions of
+# records — a multi-hundred-MB violations.jsonl loaded whole into memory (and
+# then classified with an O(N) per-violation filesystem scan) can OOM the
+# process and pin the event loop. These bound the *aggregate* read the same
+# way _MAX_RECORD_FILE_BYTES already bounds a single record's raw XML/JSON.
+_MAX_JSONL_TOTAL_BYTES = 64 * 1024 * 1024  # 64 MiB aggregate per version
+_MAX_JSONL_RECORDS = 200_000  # hard record-count backstop independent of byte size
+
+
 def _read_violations(flagged_version_dir: Path) -> list[dict[str, Any]]:
     """Read all violations.jsonl files under *flagged_version_dir*, injecting entity_type from the directory name.
 
-    Corrupt lines are logged and skipped.
+    Streams each file line-by-line (never loads a whole file into memory) and
+    stops once the aggregate byte or record cap is hit, logging a warning so
+    the truncation is visible rather than silent. Corrupt lines are logged
+    and skipped. Synchronous/blocking — callers on the event loop should run
+    this via `_get_violations` (which offloads to a worker thread and caches
+    the result), not call it directly.
     """
     violations: list[dict[str, Any]] = []
+    bytes_read = 0
     for entity_dir in sorted(flagged_version_dir.iterdir()):
         if not entity_dir.is_dir():
             continue
@@ -147,23 +164,38 @@ def _read_violations(flagged_version_dir: Path) -> list[dict[str, Any]]:
         if not jsonl_file.is_file():
             continue
         entity_type = entity_dir.name
-        for lineno, raw_line in enumerate(jsonl_file.read_text(encoding="utf-8").splitlines(), start=1):
-            line = raw_line.strip()
-            if not line:
-                continue
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                logger.warning("⚠️ Skipping corrupt JSONL line", file=str(jsonl_file), lineno=lineno)
-                continue
-            record["entity_type"] = entity_type
-            violations.append(record)
+        with jsonl_file.open(encoding="utf-8") as fh:
+            for lineno, raw_line in enumerate(fh, start=1):
+                bytes_read += len(raw_line.encode("utf-8"))
+                if bytes_read > _MAX_JSONL_TOTAL_BYTES or len(violations) >= _MAX_JSONL_RECORDS:
+                    logger.warning(
+                        "⚠️ Violations read capped — results are truncated",
+                        dir=str(flagged_version_dir),
+                        records_read=len(violations),
+                        bytes_read=bytes_read,
+                    )
+                    return violations
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning("⚠️ Skipping corrupt JSONL line", file=str(jsonl_file), lineno=lineno)
+                    continue
+                record["entity_type"] = entity_type
+                violations.append(record)
     return violations
 
 
 def _read_skipped(flagged_version_dir: Path) -> list[dict[str, Any]]:
-    """Read all skipped.jsonl files under *flagged_version_dir*, injecting entity_type from the directory name."""
+    """Read all skipped.jsonl files under *flagged_version_dir*, injecting entity_type from the directory name.
+
+    Same streaming + aggregate-cap behavior as `_read_violations`. Synchronous
+    — callers on the event loop should use `_get_skipped`.
+    """
     skipped: list[dict[str, Any]] = []
+    bytes_read = 0
     for entity_dir in sorted(flagged_version_dir.iterdir()):
         if not entity_dir.is_dir():
             continue
@@ -171,17 +203,65 @@ def _read_skipped(flagged_version_dir: Path) -> list[dict[str, Any]]:
         if not jsonl_file.is_file():
             continue
         entity_type = entity_dir.name
-        for lineno, raw_line in enumerate(jsonl_file.read_text(encoding="utf-8").splitlines(), start=1):
-            line = raw_line.strip()
-            if not line:
-                continue
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                logger.warning("⚠️ Skipping corrupt skipped JSONL line", file=str(jsonl_file), lineno=lineno)
-                continue
-            record["entity_type"] = entity_type
-            skipped.append(record)
+        with jsonl_file.open(encoding="utf-8") as fh:
+            for lineno, raw_line in enumerate(fh, start=1):
+                bytes_read += len(raw_line.encode("utf-8"))
+                if bytes_read > _MAX_JSONL_TOTAL_BYTES or len(skipped) >= _MAX_JSONL_RECORDS:
+                    logger.warning(
+                        "⚠️ Skipped-records read capped — results are truncated",
+                        dir=str(flagged_version_dir),
+                        records_read=len(skipped),
+                        bytes_read=bytes_read,
+                    )
+                    return skipped
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning("⚠️ Skipping corrupt skipped JSONL line", file=str(jsonl_file), lineno=lineno)
+                    continue
+                record["entity_type"] = entity_type
+                skipped.append(record)
+    return skipped
+
+
+# version-dir path → (expiry_timestamp, cached result). Shared by every endpoint
+# that needs a version's full violation/skipped set, so the aggregate JSONL scan
+# runs at most once per version per TTL window instead of once per request.
+_violations_cache: dict[str, tuple[float, list[dict[str, Any]]]] = {}
+_skipped_cache: dict[str, tuple[float, list[dict[str, Any]]]] = {}
+_JSONL_CACHE_TTL: float = 300.0  # 5 minutes — matches _PARSING_ERROR_CACHE_TTL
+
+
+async def _get_violations(flagged_version_dir: Path) -> list[dict[str, Any]]:
+    """Cached, off-event-loop accessor for a version's full violation set.
+
+    Every endpoint handler should call this instead of `_read_violations`
+    directly: it runs the blocking filesystem scan via `asyncio.to_thread` so
+    it can't pin the event loop, and reuses the result across endpoints/
+    requests for the cache TTL instead of re-scanning the corpus each time.
+    """
+    cache_key = str(flagged_version_dir)
+    now = time.monotonic()
+    cached = _violations_cache.get(cache_key)
+    if cached is not None and now < cached[0]:
+        return cached[1]
+    violations = await asyncio.to_thread(_read_violations, flagged_version_dir)
+    _violations_cache[cache_key] = (now + _JSONL_CACHE_TTL, violations)
+    return violations
+
+
+async def _get_skipped(flagged_version_dir: Path) -> list[dict[str, Any]]:
+    """Cached, off-event-loop accessor for a version's full skipped-record set. See `_get_violations`."""
+    cache_key = str(flagged_version_dir)
+    now = time.monotonic()
+    cached = _skipped_cache.get(cache_key)
+    if cached is not None and now < cached[0]:
+        return cached[1]
+    skipped = await asyncio.to_thread(_read_skipped, flagged_version_dir)
+    _skipped_cache[cache_key] = (now + _JSONL_CACHE_TTL, skipped)
     return skipped
 
 
@@ -348,11 +428,11 @@ async def get_summary(
     data_root, source = location
     flagged_version_dir = data_root / "flagged" / version
 
-    violations = _read_violations(flagged_version_dir)
+    violations = await _get_violations(flagged_version_dir)
     raw_state = _load_state_marker(data_root, version, source)
     summary = _build_violation_summary(violations)
 
-    skipped = _read_skipped(flagged_version_dir)
+    skipped = await _get_skipped(flagged_version_dir)
     skipped_summary = _build_skipped_summary(skipped)
 
     # Extract phase statuses from the state marker for the frontend.
@@ -393,7 +473,7 @@ async def list_skipped(
     data_root, _source = location
     flagged_version_dir = data_root / "flagged" / version
 
-    skipped = _read_skipped(flagged_version_dir)
+    skipped = await _get_skipped(flagged_version_dir)
 
     if entity_type:
         skipped = [s for s in skipped if s.get("entity_type") == entity_type]
@@ -432,7 +512,7 @@ async def list_violations(
     data_root, _source = location
     flagged_version_dir = data_root / "flagged" / version
 
-    violations = _read_violations(flagged_version_dir)
+    violations = await _get_violations(flagged_version_dir)
 
     # Apply filters
     if entity_type is not None:
@@ -478,7 +558,7 @@ async def get_violation_detail(
     data_root, _source = location
     flagged_version_dir = data_root / "flagged" / version
 
-    all_violations = _read_violations(flagged_version_dir)
+    all_violations = await _get_violations(flagged_version_dir)
     record_violations = [v for v in all_violations if v.get("record_id") == record_id]
 
     if not record_violations:
@@ -486,7 +566,7 @@ async def get_violation_detail(
 
     # Determine the entity type (use the first match)
     found_entity_type: str = record_violations[0].get("entity_type", "unknown")
-    raw_xml, parsed_json, truncated = _load_record_files(flagged_version_dir, found_entity_type, record_id)
+    raw_xml, parsed_json, truncated = await asyncio.to_thread(_load_record_files, flagged_version_dir, found_entity_type, record_id)
 
     return JSONResponse(
         content={
@@ -581,6 +661,33 @@ def _classify_violation(
     }
 
 
+def _classify_all_violations(
+    violations: list[dict[str, Any]], flagged_version_dir: Path
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Classify every violation, doing up to two stat + two file reads each.
+
+    Synchronous/blocking (O(N) filesystem I/O) — run via `asyncio.to_thread`
+    from an async handler rather than calling directly, so an oversized
+    corpus can't pin the event loop for the whole scan.
+    """
+    parsing_errors: list[dict[str, Any]] = []
+    source_issues: list[dict[str, Any]] = []
+    indeterminate: list[dict[str, Any]] = []
+
+    for v in violations:
+        entity_type: str = v.get("entity_type", "unknown")
+        entry = _classify_violation(v, flagged_version_dir, entity_type)
+        cls = entry["classification"]
+        if cls == "parsing_error":
+            parsing_errors.append(entry)
+        elif cls == "source_issue":
+            source_issues.append(entry)
+        else:
+            indeterminate.append(entry)
+
+    return parsing_errors, source_issues, indeterminate
+
+
 # ---------------------------------------------------------------------------
 # Task 5 — endpoint
 # ---------------------------------------------------------------------------
@@ -611,22 +718,8 @@ async def get_parsing_errors(
     data_root, _source = location
     flagged_version_dir = data_root / "flagged" / version
 
-    violations = _read_violations(flagged_version_dir)
-
-    parsing_errors: list[dict[str, Any]] = []
-    source_issues: list[dict[str, Any]] = []
-    indeterminate: list[dict[str, Any]] = []
-
-    for v in violations:
-        entity_type: str = v.get("entity_type", "unknown")
-        entry = _classify_violation(v, flagged_version_dir, entity_type)
-        cls = entry["classification"]
-        if cls == "parsing_error":
-            parsing_errors.append(entry)
-        elif cls == "source_issue":
-            source_issues.append(entry)
-        else:
-            indeterminate.append(entry)
+    violations = await _get_violations(flagged_version_dir)
+    parsing_errors, source_issues, indeterminate = await asyncio.to_thread(_classify_all_violations, violations, flagged_version_dir)
 
     result: dict[str, Any] = {
         "parsing_errors": parsing_errors,
@@ -666,19 +759,19 @@ async def compare_versions(
     if loc_b is None:
         raise HTTPException(status_code=404, detail=f"Version not found: {other_version!r}")
 
-    def _count_violations(data_root: Path, ver: str) -> dict[tuple[str, str, str], int]:
+    async def _count_violations(data_root: Path, ver: str) -> dict[tuple[str, str, str], int]:
         flagged_version_dir = data_root / "flagged" / ver
         counts: dict[tuple[str, str, str], int] = {}
-        for v in _read_violations(flagged_version_dir):
+        for v in await _get_violations(flagged_version_dir):
             key = (v.get("rule", "unknown"), v.get("severity", "unknown"), v.get("entity_type", "unknown"))
             counts[key] = counts.get(key, 0) + 1
         return counts
 
-    counts_a = _count_violations(loc_a[0], version)
-    counts_b = _count_violations(loc_b[0], other_version)
+    counts_a = await _count_violations(loc_a[0], version)
+    counts_b = await _count_violations(loc_b[0], other_version)
 
-    skipped_a = _read_skipped(loc_a[0] / "flagged" / version)
-    skipped_b = _read_skipped(loc_b[0] / "flagged" / other_version)
+    skipped_a = await _get_skipped(loc_a[0] / "flagged" / version)
+    skipped_b = await _get_skipped(loc_b[0] / "flagged" / other_version)
 
     def _count_by_entity(skipped: list[dict[str, Any]]) -> dict[str, int]:
         counts: dict[str, int] = {}
@@ -752,27 +845,17 @@ async def compare_versions(
     )
 
 
-@router.post("/api/admin/extraction-analysis/{version}/prompt-context")
-async def get_prompt_context(
-    version: str,
-    body: PromptContextRequest,
-    _admin: Annotated[dict[str, Any], Depends(require_admin)],
-) -> JSONResponse:
-    """Assemble structured context for AI prompts — violations and sample records grouped by rule+entity_type."""
-    _validate_version(version)
+_MAX_PROMPT_CONTEXT_SAMPLES = 5
 
-    location = _find_version_root(version)
-    if location is None:
-        raise HTTPException(status_code=404, detail=f"Version not found: {version!r}")
 
-    data_root, _source = location
-    flagged_version_dir = data_root / "flagged" / version
+def _build_prompt_contexts(all_violations: list[dict[str, Any]], flagged_version_dir: Path, rules: list[_RuleSelection]) -> list[dict[str, Any]]:
+    """Build per-rule sample-record contexts, reading each sample's raw XML/JSON.
 
-    all_violations = _read_violations(flagged_version_dir)
-
-    max_samples = 5
+    Synchronous/blocking (bounded to `_MAX_PROMPT_CONTEXT_SAMPLES` file reads per
+    rule, but still real filesystem I/O) — run via `asyncio.to_thread`.
+    """
     contexts: list[dict[str, Any]] = []
-    for sel in body.rules:
+    for sel in rules:
         matching = [v for v in all_violations if v.get("rule") == sel.rule and v.get("entity_type") == sel.entity_type]
         severity = matching[0].get("severity", "unknown") if matching else "unknown"
 
@@ -793,7 +876,7 @@ async def get_prompt_context(
                     "parsed_json": parsed_json,
                 }
             )
-            if len(sample_records) >= max_samples:
+            if len(sample_records) >= _MAX_PROMPT_CONTEXT_SAMPLES:
                 break
 
         contexts.append(
@@ -805,6 +888,27 @@ async def get_prompt_context(
                 "sample_records": sample_records,
             }
         )
+    return contexts
+
+
+@router.post("/api/admin/extraction-analysis/{version}/prompt-context")
+async def get_prompt_context(
+    version: str,
+    body: PromptContextRequest,
+    _admin: Annotated[dict[str, Any], Depends(require_admin)],
+) -> JSONResponse:
+    """Assemble structured context for AI prompts — violations and sample records grouped by rule+entity_type."""
+    _validate_version(version)
+
+    location = _find_version_root(version)
+    if location is None:
+        raise HTTPException(status_code=404, detail=f"Version not found: {version!r}")
+
+    data_root, _source = location
+    flagged_version_dir = data_root / "flagged" / version
+
+    all_violations = await _get_violations(flagged_version_dir)
+    contexts = await asyncio.to_thread(_build_prompt_contexts, all_violations, flagged_version_dir, body.rules)
 
     return JSONResponse(content={"contexts": contexts})
 
@@ -818,28 +922,14 @@ _MAX_JSON_CHARS_PER_RECORD = 1500
 _MAX_SAMPLES_FOR_AI = 3
 
 
-@router.post("/api/admin/extraction-analysis/{version}/generate-ai-prompt")
-async def generate_ai_prompt(
-    version: str,
-    body: PromptContextRequest,
-    _admin: Annotated[dict[str, Any], Depends(require_admin)],
-) -> JSONResponse:
-    """Use Claude to analyze violations and produce a targeted debugging prompt."""
-    if _anthropic_client is None:
-        raise HTTPException(status_code=503, detail="AI prompt generation unavailable — NLQ_API_KEY not configured")
+def _build_rule_sections(all_violations: list[dict[str, Any]], flagged_version_dir: Path, rules: list[_RuleSelection]) -> list[str]:
+    """Build the per-rule markdown sections for the AI prompt, reading each sample's raw XML/JSON.
 
-    _validate_version(version)
-    location = _find_version_root(version)
-    if location is None:
-        raise HTTPException(status_code=404, detail=f"Version not found: {version!r}")
-
-    data_root, source = location
-    flagged_version_dir = data_root / "flagged" / version
-    all_violations = _read_violations(flagged_version_dir)
-
-    # Build a compact context payload for Claude
+    Synchronous/blocking (bounded to `_MAX_SAMPLES_FOR_AI` file reads per rule,
+    but still real filesystem I/O) — run via `asyncio.to_thread`.
+    """
     rule_sections: list[str] = []
-    for sel in body.rules:
+    for sel in rules:
         matching = [v for v in all_violations if v.get("rule") == sel.rule and v.get("entity_type") == sel.entity_type]
         if not matching:
             continue
@@ -899,6 +989,28 @@ async def generate_ai_prompt(
                 break
 
         rule_sections.append("\n".join(section_lines))
+    return rule_sections
+
+
+@router.post("/api/admin/extraction-analysis/{version}/generate-ai-prompt")
+async def generate_ai_prompt(
+    version: str,
+    body: PromptContextRequest,
+    _admin: Annotated[dict[str, Any], Depends(require_admin)],
+) -> JSONResponse:
+    """Use Claude to analyze violations and produce a targeted debugging prompt."""
+    if _anthropic_client is None:
+        raise HTTPException(status_code=503, detail="AI prompt generation unavailable — NLQ_API_KEY not configured")
+
+    _validate_version(version)
+    location = _find_version_root(version)
+    if location is None:
+        raise HTTPException(status_code=404, detail=f"Version not found: {version!r}")
+
+    data_root, source = location
+    flagged_version_dir = data_root / "flagged" / version
+    all_violations = await _get_violations(flagged_version_dir)
+    rule_sections = await asyncio.to_thread(_build_rule_sections, all_violations, flagged_version_dir, body.rules)
 
     user_content = f"# Extraction Analysis — Version {version} (source: {source})\n\n" + "\n\n---\n\n".join(rule_sections)
 

--- a/api/routers/extraction_analysis.py
+++ b/api/routers/extraction_analysis.py
@@ -74,16 +74,25 @@ def configure(
 # ---------------------------------------------------------------------------
 
 
+# Reserved dot-segments. Both _SAFE_VERSION and _SAFE_RECORD_ID allow dots
+# (to support version strings like "20240101.0"), but a segment consisting
+# solely of dots is a reserved path-traversal token: "." is a no-op segment
+# and ".." climbs to the parent directory when joined onto a Path. Neither
+# regex excludes them on its own, so reject them explicitly after the
+# character-class match — the allowlist alone doesn't stop traversal.
+_RESERVED_DOT_SEGMENTS = frozenset({".", ".."})
+
+
 def _validate_version(version: str) -> str:
     """Validate that *version* contains only safe characters. Raises HTTP 400 on failure."""
-    if not _SAFE_VERSION.match(version):
+    if not _SAFE_VERSION.match(version) or version in _RESERVED_DOT_SEGMENTS:
         raise HTTPException(status_code=400, detail=f"Invalid version identifier: {version!r}")
     return version
 
 
 def _validate_record_id(record_id: str) -> str:
     """Validate that *record_id* contains only safe characters. Raises HTTP 400 on failure."""
-    if not _SAFE_RECORD_ID.match(record_id):
+    if not _SAFE_RECORD_ID.match(record_id) or record_id in _RESERVED_DOT_SEGMENTS:
         raise HTTPException(status_code=400, detail=f"Invalid record_id: {record_id!r}")
     return record_id
 

--- a/api/routers/snapshot.py
+++ b/api/routers/snapshot.py
@@ -2,14 +2,15 @@
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 import redis.asyncio as aioredis
 
 from api.auth import decode_token
+from api.limiter import bearer_token_key_func, limiter
 from api.models import SnapshotRequest, SnapshotResponse, SnapshotRestoreResponse
-from api.snapshot_store import SnapshotStore
+from api.snapshot_store import SnapshotQuotaExceededError, SnapshotStore, SnapshotTooLargeError
 
 
 router = APIRouter()
@@ -81,7 +82,9 @@ async def _get_current_user(
 
 
 @router.post("/api/snapshot", status_code=201)
+@limiter.limit("20/minute", key_func=bearer_token_key_func)
 async def save_snapshot(
+    request: Request,  # noqa: ARG001 — required by slowapi rate limiter
     body: SnapshotRequest,
     _current_user: Annotated[dict[str, Any], Depends(_get_current_user)],
 ) -> JSONResponse:
@@ -91,16 +94,24 @@ async def save_snapshot(
         return JSONResponse(content={"error": f"Too many nodes: maximum is {_snapshot_store.max_nodes}"}, status_code=422)
     nodes = [n.model_dump() for n in body.nodes]
     center = body.center.model_dump()
+    user_id = _current_user.get("sub")
     try:
-        token, expires_at = await _snapshot_store.save(nodes, center)
+        token, expires_at = await _snapshot_store.save(nodes, center, user_id=user_id)
+    except SnapshotTooLargeError as exc:
+        return JSONResponse(content={"error": str(exc)}, status_code=413)
+    except SnapshotQuotaExceededError as exc:
+        return JSONResponse(content={"error": str(exc)}, status_code=429)
     except ValueError as exc:
+        # Defense-in-depth: SnapshotStore.save's own max_nodes guard, for any
+        # direct caller that bypasses this router's pre-check above.
         return JSONResponse(content={"error": str(exc)}, status_code=422)
     response = SnapshotResponse(token=token, url=f"/snapshot/{token}", expires_at=expires_at.isoformat())
     return JSONResponse(content=response.model_dump(), status_code=201)
 
 
 @router.get("/api/snapshot/{token}")
-async def restore_snapshot(token: str) -> JSONResponse:
+@limiter.limit("30/minute")
+async def restore_snapshot(request: Request, token: str) -> JSONResponse:  # noqa: ARG001 — request required by slowapi rate limiter
     if _snapshot_store is None:
         return JSONResponse(content={"error": "Snapshot service not ready"}, status_code=503)
     entry = await _snapshot_store.load(token)

--- a/api/snapshot_store.py
+++ b/api/snapshot_store.py
@@ -9,20 +9,41 @@ import orjson
 import redis.asyncio as aioredis
 
 
+class SnapshotTooLargeError(ValueError):
+    """Raised when a snapshot's serialized payload exceeds the size cap."""
+
+
+class SnapshotQuotaExceededError(ValueError):
+    """Raised when a user already has too many active (non-expired) snapshots."""
+
+
 class SnapshotStore:
     """Redis-backed store for graph snapshots with native TTL eviction."""
 
     _KEY_PREFIX = "snapshot:"
+    _USER_COUNT_KEY_PREFIX = "snapshot:usercount:"
 
     def __init__(
         self,
         redis_client: aioredis.Redis,
         ttl_days: int | None = None,
         max_nodes: int | None = None,
+        max_payload_bytes: int | None = None,
+        max_per_user: int | None = None,
     ) -> None:
         self._redis = redis_client
         self._ttl_days: int = ttl_days if ttl_days is not None else int(os.environ.get("SNAPSHOT_TTL_DAYS", "28"))
         self._max_nodes: int = max_nodes if max_nodes is not None else int(os.environ.get("SNAPSHOT_MAX_NODES", "100"))
+        # Node-count alone doesn't bound per-node string size (SnapshotNode.id/type
+        # are now Field(max_length=...) too, but this is a second, independent
+        # backstop on the whole serialized payload — discogsography-cu2.110).
+        self._max_payload_bytes: int = (
+            max_payload_bytes if max_payload_bytes is not None else int(os.environ.get("SNAPSHOT_MAX_PAYLOAD_BYTES", str(64 * 1024)))
+        )
+        # Caps the number of live (non-expired) snapshots a single user can
+        # accumulate, so looping POST /api/snapshot can't mint unbounded
+        # 28-day-TTL Redis keys even with small, valid payloads.
+        self._max_per_user: int = max_per_user if max_per_user is not None else int(os.environ.get("SNAPSHOT_MAX_PER_USER", "50"))
         self._ttl_seconds: int = self._ttl_days * 86400
 
     @property
@@ -33,7 +54,15 @@ class SnapshotStore:
     def max_nodes(self) -> int:
         return self._max_nodes
 
-    async def save(self, nodes: list[dict[str, Any]], center: dict[str, Any]) -> tuple[str, datetime]:
+    @property
+    def max_payload_bytes(self) -> int:
+        return self._max_payload_bytes
+
+    @property
+    def max_per_user(self) -> int:
+        return self._max_per_user
+
+    async def save(self, nodes: list[dict[str, Any]], center: dict[str, Any], user_id: str | None = None) -> tuple[str, datetime]:
         """Save a snapshot and return (token, expires_at).
 
         Raises:
@@ -41,6 +70,10 @@ class SnapshotStore:
                 pre-checks this (for a friendlier error message), but this guard
                 protects any direct caller of SnapshotStore that bypasses the
                 router — e.g. scripts or future reuse.
+            SnapshotTooLargeError: if the serialized payload exceeds
+                ``max_payload_bytes``.
+            SnapshotQuotaExceededError: if *user_id* has already reached
+                ``max_per_user`` live snapshots.
         """
         if len(nodes) > self._max_nodes:
             raise ValueError(f"Too many nodes: {len(nodes)} exceeds maximum of {self._max_nodes}")
@@ -54,6 +87,21 @@ class SnapshotStore:
                 "created_at": now.isoformat(),
             }
         )
+        if len(payload) > self._max_payload_bytes:
+            raise SnapshotTooLargeError(f"Snapshot payload is {len(payload)} bytes, maximum is {self._max_payload_bytes}")
+
+        if user_id:
+            count_key = f"{self._USER_COUNT_KEY_PREFIX}{user_id}"
+            count = await self._redis.incr(count_key)
+            if count == 1:
+                # First snapshot in this window starts the count's own TTL so
+                # it decays alongside the snapshots it's counting (approximate
+                # sliding window — bounded exactly by max_per_user regardless).
+                await self._redis.expire(count_key, self._ttl_seconds)
+            if count > self._max_per_user:
+                await self._redis.decr(count_key)
+                raise SnapshotQuotaExceededError(f"User already has {count - 1} snapshots, maximum is {self._max_per_user}")
+
         await self._redis.set(f"{self._KEY_PREFIX}{token}", payload, ex=self._ttl_seconds)
         return token, expires_at
 

--- a/dashboard/admin_proxy.py
+++ b/dashboard/admin_proxy.py
@@ -38,7 +38,18 @@ def configure(api_host: str, api_port: int) -> None:
 
 
 def _validate_path_segment(value: str) -> bool:
-    """Return True when *value* is safe to embed in a URL path."""
+    """Return True when *value* is safe to embed in a URL path.
+
+    The alphanumeric-plus-dot allowlist intentionally permits dots for
+    version strings like "20240101.0", but a segment of pure dots (``.``
+    or ``..``) also matches that pattern and is a reserved dot-segment:
+    httpx/RFC 3986 URL normalization collapses it during `base_url` merge,
+    silently retargeting the request to a sibling endpoint. Reject those
+    explicitly so the allowlist actually prevents path-traversal, as the
+    module docstring claims.
+    """
+    if value in {".", ".."}:
+        return False
     return bool(_SAFE_PATH_SEGMENT.match(value))
 
 

--- a/tests/api/nlq/test_tools.py
+++ b/tests/api/nlq/test_tools.py
@@ -188,6 +188,52 @@ async def test_execute_find_path_no_path(runner: NLQToolRunner) -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_find_path_clamps_oversized_max_depth(runner: NLQToolRunner) -> None:
+    """Regression for discogsography-cu2.93: a model-steered max_depth far beyond
+    the HTTP route's bound must be clamped before it reaches find_shortest_path's
+    shortestPath depth literal, not forwarded unbounded."""
+    from api.queries import neo4j_queries
+
+    mock_find = AsyncMock(return_value={"nodes": [], "rels": []})
+    with patch("api.queries.neo4j_queries.find_shortest_path", new=mock_find):
+        await runner.execute("find_path", {"from_id": "a1", "to_id": "l1", "max_depth": 1000})
+    assert mock_find.await_args.kwargs["max_depth"] == neo4j_queries.MAX_PATH_DEPTH
+
+
+@pytest.mark.asyncio
+async def test_execute_find_path_clamps_non_positive_max_depth(runner: NLQToolRunner) -> None:
+    """A non-positive (or otherwise below-minimum) max_depth is clamped up, not
+    passed through as-is or allowed to disable the traversal bound."""
+    from api.queries import neo4j_queries
+
+    mock_find = AsyncMock(return_value={"nodes": [], "rels": []})
+    with patch("api.queries.neo4j_queries.find_shortest_path", new=mock_find):
+        await runner.execute("find_path", {"from_id": "a1", "to_id": "l1", "max_depth": -5})
+    assert mock_find.await_args.kwargs["max_depth"] == neo4j_queries.MIN_PATH_DEPTH
+
+
+@pytest.mark.asyncio
+async def test_execute_find_path_within_bound_passes_through_unchanged(runner: NLQToolRunner) -> None:
+    """A max_depth already inside the valid range is forwarded as-is (not floored
+    or ceilinged to a bound endpoint)."""
+    mock_find = AsyncMock(return_value={"nodes": [], "rels": []})
+    with patch("api.queries.neo4j_queries.find_shortest_path", new=mock_find):
+        await runner.execute("find_path", {"from_id": "a1", "to_id": "l1", "max_depth": 3})
+    assert mock_find.await_args.kwargs["max_depth"] == 3
+
+
+@pytest.mark.asyncio
+async def test_execute_find_path_missing_max_depth_uses_default(runner: NLQToolRunner) -> None:
+    """No max_depth supplied falls back to the shared default, not an unbounded value."""
+    from api.queries import neo4j_queries
+
+    mock_find = AsyncMock(return_value={"nodes": [], "rels": []})
+    with patch("api.queries.neo4j_queries.find_shortest_path", new=mock_find):
+        await runner.execute("find_path", {"from_id": "a1", "to_id": "l1"})
+    assert mock_find.await_args.kwargs["max_depth"] == neo4j_queries.DEFAULT_PATH_DEPTH
+
+
+@pytest.mark.asyncio
 async def test_execute_find_path_name_resolution_both(runner: NLQToolRunner) -> None:
     """Find path resolves both from_id and to_id names via EXPLORE_DISPATCH when types are provided."""
     fake_path: dict[str, Any] = {

--- a/tests/api/test_app_tokens_router.py
+++ b/tests/api/test_app_tokens_router.py
@@ -251,6 +251,21 @@ class TestRevokeAppToken:
         )
         assert resp.status_code == 404
 
+    def test_returns_404_not_500_for_malformed_token_id(self, test_client: TestClient, mock_pool: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Regression for discogsography-cu2.70: a non-UUID path segment must not reach
+        the `::uuid` SQL cast (which raises an unhandled psycopg DataError -> 500).
+        It must be rejected up front and surfaced as the same 404 as an unknown id."""
+        _patch_module_pool(mock_pool)
+
+        async def _revoke(token_id: str, user_id: str) -> bool:  # noqa: ARG001
+            raise AssertionError("revoke_token must not be called with a malformed token_id")
+
+        monkeypatch.setattr("api.routers.app_tokens._revoke_token", _revoke)
+
+        resp = test_client.delete("/api/user/app-tokens/abc", headers=_AUTH_HEADER)
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Token not found"
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Defensive 401 — JWT with empty sub claim slips past require_user

--- a/tests/api/test_dependencies.py
+++ b/tests/api/test_dependencies.py
@@ -594,6 +594,19 @@ class TestChallengeTokenRejection:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_get_optional_user_rejects_admin_token(self) -> None:
+        """Regression for discogsography-cu2.71: an admin JWT presented to an
+        optional-auth endpoint must resolve to None (anonymous), not to a user
+        session keyed by the admin's own sub — matching the admin/user token
+        isolation require_user, _get_current_user, and the sync/snapshot
+        routers all enforce."""
+        configure(TEST_SECRET)
+        token = _make_token_with_claims({"type": "admin", "jti": "admin-1"})
+        creds = _make_credentials(token)
+        result = await get_optional_user(creds)
+        assert result is None
+
+    @pytest.mark.asyncio
     async def test_require_user_rejects_unknown_token_type(self) -> None:
         """Allowlist: any typed token (present but not an access token) is rejected."""
         configure(TEST_SECRET)

--- a/tests/api/test_extraction_analysis.py
+++ b/tests/api/test_extraction_analysis.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -10,8 +12,6 @@ import pytest
 
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from fastapi.testclient import TestClient
 
 from tests.api.test_admin_endpoints import _admin_auth_headers
@@ -1121,6 +1121,135 @@ class TestReadViolationsEdgeCases:
         assert resp.status_code == 200
         # Empty lines must be skipped; only 2 real records
         assert resp.json()["total"] == 2
+
+
+class TestViolationsReadBoundedAndOffloaded:
+    """Regression for discogsography-cu2.98: the aggregate violations.jsonl scan
+    must be capped, streamed (never `.read_text().splitlines()` a whole file into
+    memory), cached per version, and run off the event loop."""
+
+    def setup_method(self) -> None:
+        import api.routers.extraction_analysis as ea
+
+        # Caches are module-level and would otherwise leak state between tests
+        # (including the pre-existing parsing-error cache, which every test in
+        # this class's module reuses version "20260101" against).
+        ea._violations_cache.clear()
+        ea._skipped_cache.clear()
+        ea._parsing_error_cache.clear()
+
+    def test_read_violations_caps_at_max_records(self, tmp_path: Path) -> None:
+        """A corpus larger than _MAX_JSONL_RECORDS is truncated, not loaded whole."""
+        import api.routers.extraction_analysis as ea
+
+        entity_dir = tmp_path / "flagged" / "20260101" / "artists"
+        entity_dir.mkdir(parents=True)
+        # Small cap for the test so we don't have to write hundreds of thousands of lines.
+        line = json.dumps({"record_id": "r", "rule": "x", "severity": "warning"})
+        with patch.object(ea, "_MAX_JSONL_RECORDS", 10), patch.object(ea, "_MAX_JSONL_TOTAL_BYTES", 10 * 1024 * 1024):
+            (entity_dir / "violations.jsonl").write_text("\n".join([line] * 50) + "\n")
+            violations = ea._read_violations(entity_dir.parent)
+
+        assert len(violations) == 10
+
+    def test_read_violations_caps_at_max_bytes(self, tmp_path: Path) -> None:
+        """A corpus whose aggregate size exceeds _MAX_JSONL_TOTAL_BYTES is truncated."""
+        import api.routers.extraction_analysis as ea
+
+        entity_dir = tmp_path / "flagged" / "20260101" / "artists"
+        entity_dir.mkdir(parents=True)
+        line = json.dumps({"record_id": "r", "rule": "x", "severity": "warning", "field_value": "y" * 200})
+        with patch.object(ea, "_MAX_JSONL_RECORDS", 1_000_000), patch.object(ea, "_MAX_JSONL_TOTAL_BYTES", 1024):
+            (entity_dir / "violations.jsonl").write_text("\n".join([line] * 50) + "\n")
+            violations = ea._read_violations(entity_dir.parent)
+
+        assert 0 < len(violations) < 50
+
+    def test_read_violations_streams_never_loads_whole_file_via_read_text(self, tmp_path: Path) -> None:
+        """_read_violations must not call Path.read_text() on the jsonl file — that
+        would defeat the streaming fix by loading the whole file into memory anyway."""
+        import api.routers.extraction_analysis as ea
+
+        entity_dir = tmp_path / "flagged" / "20260101" / "artists"
+        entity_dir.mkdir(parents=True)
+        (entity_dir / "violations.jsonl").write_text(json.dumps({"record_id": "1", "rule": "x", "severity": "warning"}) + "\n")
+
+        with patch.object(Path, "read_text", side_effect=AssertionError("read_text must not be used for the JSONL scan")):
+            violations = ea._read_violations(entity_dir.parent)
+
+        assert len(violations) == 1
+
+    @pytest.mark.asyncio
+    async def test_get_violations_caches_across_calls(self, tmp_path: Path) -> None:
+        """_get_violations must not re-scan the filesystem on a cache hit."""
+        import api.routers.extraction_analysis as ea
+
+        entity_dir = tmp_path / "flagged" / "20260101" / "artists"
+        entity_dir.mkdir(parents=True)
+        (entity_dir / "violations.jsonl").write_text(json.dumps({"record_id": "1", "rule": "x", "severity": "warning"}) + "\n")
+
+        flagged_version_dir = entity_dir.parent
+        with patch.object(ea, "_read_violations", wraps=ea._read_violations) as spy:
+            first = await ea._get_violations(flagged_version_dir)
+            second = await ea._get_violations(flagged_version_dir)
+
+        assert first == second
+        spy.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_violations_runs_off_the_event_loop(self, tmp_path: Path) -> None:
+        """_get_violations must offload the blocking scan via asyncio.to_thread, not
+        call the synchronous reader directly on the event loop."""
+        import api.routers.extraction_analysis as ea
+
+        entity_dir = tmp_path / "flagged" / "20260101" / "artists"
+        entity_dir.mkdir(parents=True)
+        (entity_dir / "violations.jsonl").write_text(json.dumps({"record_id": "1", "rule": "x", "severity": "warning"}) + "\n")
+
+        with patch("api.routers.extraction_analysis.asyncio.to_thread", wraps=asyncio.to_thread) as mock_to_thread:
+            await ea._get_violations(entity_dir.parent)
+
+        mock_to_thread.assert_called_once_with(ea._read_violations, entity_dir.parent)
+
+    def test_parsing_errors_classification_runs_off_the_event_loop(self, test_client: TestClient, tmp_path: Path) -> None:
+        """get_parsing_errors' O(N) per-violation classification loop must run via
+        asyncio.to_thread rather than blocking the event loop for the whole scan."""
+        import api.routers.extraction_analysis as ea
+
+        _make_flagged_version(tmp_path)
+
+        with (
+            patch.object(ea, "_discogs_data_root", tmp_path),
+            patch.object(ea, "_musicbrainz_data_root", None),
+            patch("api.routers.extraction_analysis.asyncio.to_thread", wraps=asyncio.to_thread) as mock_to_thread,
+        ):
+            resp = test_client.get(
+                "/api/admin/extraction-analysis/20260101/parsing-errors",
+                headers=_admin_auth_headers(),
+            )
+
+        assert resp.status_code == 200
+        classify_calls = [c for c in mock_to_thread.call_args_list if c.args and c.args[0] is ea._classify_all_violations]
+        assert len(classify_calls) == 1
+
+    def test_summary_and_violations_endpoints_share_cached_scan(self, test_client: TestClient, tmp_path: Path) -> None:
+        """Two different endpoints for the same version must not each independently
+        re-scan the full violations.jsonl corpus within the cache TTL."""
+        import api.routers.extraction_analysis as ea
+
+        _make_flagged_version(tmp_path)
+
+        with (
+            patch.object(ea, "_discogs_data_root", tmp_path),
+            patch.object(ea, "_musicbrainz_data_root", None),
+            patch.object(ea, "_read_violations", wraps=ea._read_violations) as spy,
+        ):
+            resp1 = test_client.get("/api/admin/extraction-analysis/20260101/summary", headers=_admin_auth_headers())
+            resp2 = test_client.get("/api/admin/extraction-analysis/20260101/violations", headers=_admin_auth_headers())
+
+        assert resp1.status_code == 200
+        assert resp2.status_code == 200
+        spy.assert_called_once()
 
 
 class TestLoadStateMarkerCorrupt:

--- a/tests/api/test_extraction_analysis.py
+++ b/tests/api/test_extraction_analysis.py
@@ -6,6 +6,8 @@ import json
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -971,6 +973,71 @@ class TestValidateRecordId:
             raised = True
             assert exc.status_code == 400
         assert raised, "Expected HTTPException to be raised"
+
+
+class TestDotSegmentTraversalRejected:
+    """Regression for discogsography-cu2.97: a bare '..' (or '.') segment matches
+    the alphanumeric-plus-dot allowlist regex (dots are kept to support version
+    strings like "20240101.0"), but resolves to the parent/same directory when
+    joined onto a Path — defeating the allowlist's stated traversal protection."""
+
+    def test_validate_version_rejects_pure_dotdot(self) -> None:
+        from fastapi import HTTPException
+
+        import api.routers.extraction_analysis as ea
+
+        with pytest.raises(HTTPException) as exc_info:
+            ea._validate_version("..")
+        assert exc_info.value.status_code == 400
+
+    def test_validate_version_rejects_pure_dot(self) -> None:
+        from fastapi import HTTPException
+
+        import api.routers.extraction_analysis as ea
+
+        with pytest.raises(HTTPException) as exc_info:
+            ea._validate_version(".")
+        assert exc_info.value.status_code == 400
+
+    def test_validate_record_id_rejects_pure_dotdot(self) -> None:
+        from fastapi import HTTPException
+
+        import api.routers.extraction_analysis as ea
+
+        with pytest.raises(HTTPException) as exc_info:
+            ea._validate_record_id("..")
+        assert exc_info.value.status_code == 400
+
+    def test_validate_record_id_rejects_pure_dot(self) -> None:
+        from fastapi import HTTPException
+
+        import api.routers.extraction_analysis as ea
+
+        with pytest.raises(HTTPException) as exc_info:
+            ea._validate_record_id(".")
+        assert exc_info.value.status_code == 400
+
+    def test_validate_version_still_allows_dotted_version_strings(self) -> None:
+        """The fix must not regress the documented use case dots exist for."""
+        import api.routers.extraction_analysis as ea
+
+        assert ea._validate_version("20240101.0") == "20240101.0"
+
+    def test_summary_endpoint_rejects_dotdot_version(self, test_client: TestClient, tmp_path: Path) -> None:
+        """End-to-end: GET .../%2e%2e/summary must 400, not silently scan data_root
+        itself (percent-encoding is used so the test client doesn't normalize the
+        dot-segment away before the request is sent, the same technique an
+        adversary would use against the deployed server)."""
+        import api.routers.extraction_analysis as ea
+
+        _make_flagged_version(tmp_path)
+
+        with patch.object(ea, "_discogs_data_root", tmp_path), patch.object(ea, "_musicbrainz_data_root", None):
+            resp = test_client.get(
+                "/api/admin/extraction-analysis/%2e%2e/summary",
+                headers=_admin_auth_headers(),
+            )
+        assert resp.status_code == 400
 
 
 class TestScanVersionsNonDir:

--- a/tests/api/test_neo4j_queries.py
+++ b/tests/api/test_neo4j_queries.py
@@ -1125,6 +1125,52 @@ class TestFindShortestPath:
         cypher = sent_query.text if hasattr(sent_query, "text") else sent_query
         assert "coalesce(node.id, node.name)" in cypher
 
+    @staticmethod
+    def _sent_cypher(mock_session: AsyncMock) -> str:
+        sent_query = mock_session.run.call_args[0][0]
+        return str(sent_query.text if hasattr(sent_query, "text") else sent_query)
+
+    @pytest.mark.asyncio
+    async def test_max_depth_clamped_to_upper_bound(self) -> None:
+        """Regression for discogsography-cu2.93: max_depth is interpolated as a
+        Cypher integer literal with no query-parameter escaping, so an
+        unbounded caller-supplied value (e.g. from a model-steered NLQ tool
+        call bypassing the HTTP route's Query(ge=1, le=10) validation) must be
+        clamped here as a backstop rather than reaching shortestPath as-is."""
+        from api.queries.neo4j_queries import MAX_PATH_DEPTH, find_shortest_path
+
+        mock_driver = AsyncMock()
+        mock_session = AsyncMock()
+        mock_result = AsyncMock()
+        mock_result.single = AsyncMock(return_value=None)
+        mock_session.run = AsyncMock(return_value=mock_result)
+        mock_driver.session = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock()))
+
+        await find_shortest_path(mock_driver, "1", "2", max_depth=1000)
+
+        cypher = self._sent_cypher(mock_session)
+        assert f"*..{MAX_PATH_DEPTH}]" in cypher
+        assert "*..1000]" not in cypher
+
+    @pytest.mark.asyncio
+    async def test_max_depth_clamped_to_lower_bound(self) -> None:
+        """A non-positive max_depth is clamped up to MIN_PATH_DEPTH, not
+        forwarded as-is (which would produce a malformed/empty-range Cypher
+        traversal)."""
+        from api.queries.neo4j_queries import MIN_PATH_DEPTH, find_shortest_path
+
+        mock_driver = AsyncMock()
+        mock_session = AsyncMock()
+        mock_result = AsyncMock()
+        mock_result.single = AsyncMock(return_value=None)
+        mock_session.run = AsyncMock(return_value=mock_result)
+        mock_driver.session = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock()))
+
+        await find_shortest_path(mock_driver, "1", "2", max_depth=-5)
+
+        cypher = self._sent_cypher(mock_session)
+        assert f"*..{MIN_PATH_DEPTH}]" in cypher
+
 
 # ---------------------------------------------------------------------------
 # get_year_range

--- a/tests/api/test_snapshot.py
+++ b/tests/api/test_snapshot.py
@@ -64,6 +64,120 @@ class TestSaveSnapshot:
             snap_module._snapshot_store = original
 
 
+class TestSnapshotNodeFieldLimits:
+    """Regression for discogsography-cu2.110: SnapshotNode.id/type had no
+    max_length, so 100 nodes (the node-count cap) could each carry a
+    megabyte-sized id/type string — the count cap alone didn't bound payload
+    size."""
+
+    def test_rejects_oversized_node_id(self, test_client: TestClient, auth_headers: dict[str, str]) -> None:
+        body = {
+            "nodes": [{"id": "x" * 200, "type": "artist"}],
+            "center": {"id": "1", "type": "artist"},
+        }
+        response = test_client.post("/api/snapshot", json=body, headers=auth_headers)
+        assert response.status_code == 422
+
+    def test_rejects_oversized_node_type(self, test_client: TestClient, auth_headers: dict[str, str]) -> None:
+        body = {
+            "nodes": [{"id": "1", "type": "x" * 200}],
+            "center": {"id": "1", "type": "artist"},
+        }
+        response = test_client.post("/api/snapshot", json=body, headers=auth_headers)
+        assert response.status_code == 422
+
+    def test_rejects_oversized_center_id(self, test_client: TestClient, auth_headers: dict[str, str]) -> None:
+        body = {
+            "nodes": [{"id": "1", "type": "artist"}],
+            "center": {"id": "x" * 200, "type": "artist"},
+        }
+        response = test_client.post("/api/snapshot", json=body, headers=auth_headers)
+        assert response.status_code == 422
+
+    def test_accepts_id_and_type_at_the_boundary(self, test_client: TestClient, auth_headers: dict[str, str]) -> None:
+        """max_length is inclusive — exactly at the cap must still be accepted."""
+        body = {
+            "nodes": [{"id": "1" * 128, "type": "a" * 32}],
+            "center": {"id": "1", "type": "artist"},
+        }
+        response = test_client.post("/api/snapshot", json=body, headers=auth_headers)
+        assert response.status_code == 201
+
+
+class TestSnapshotPayloadAndQuotaLimits:
+    """Regression for discogsography-cu2.110: the serialized payload size cap and
+    per-user quota, exercised end-to-end through the router."""
+
+    def test_save_snapshot_rejects_oversized_payload(self, test_client: TestClient, auth_headers: dict[str, str]) -> None:
+        import api.routers.snapshot as snap_module
+
+        original_store = snap_module._snapshot_store
+        import fakeredis.aioredis as aioredis_fake
+
+        small_payload_store = SnapshotStore(aioredis_fake.FakeRedis(), max_payload_bytes=50)
+        snap_module._snapshot_store = small_payload_store
+        try:
+            body = {
+                "nodes": [{"id": "1", "type": "artist"}],
+                "center": {"id": "1", "type": "artist"},
+            }
+            response = test_client.post("/api/snapshot", json=body, headers=auth_headers)
+        finally:
+            snap_module._snapshot_store = original_store
+        assert response.status_code == 413
+
+    def test_save_snapshot_enforces_per_user_quota(self, test_client: TestClient, auth_headers: dict[str, str]) -> None:
+        import api.routers.snapshot as snap_module
+
+        original_store = snap_module._snapshot_store
+        import fakeredis.aioredis as aioredis_fake
+
+        quota_store = SnapshotStore(aioredis_fake.FakeRedis(), max_per_user=1)
+        snap_module._snapshot_store = quota_store
+        try:
+            body = {
+                "nodes": [{"id": "1", "type": "artist"}],
+                "center": {"id": "1", "type": "artist"},
+            }
+            first = test_client.post("/api/snapshot", json=body, headers=auth_headers)
+            second = test_client.post("/api/snapshot", json=body, headers=auth_headers)
+        finally:
+            snap_module._snapshot_store = original_store
+        assert first.status_code == 201
+        assert second.status_code == 429
+
+
+class TestSnapshotRateLimits:
+    """Regression for discogsography-cu2.110: POST /api/snapshot had no
+    @limiter.limit decorator (unlike every other write endpoint), so looping
+    the endpoint had no per-minute throttle independent of the payload/quota
+    checks above."""
+
+    def test_save_snapshot_rate_limited_after_threshold(self, test_client: TestClient, auth_headers: dict[str, str]) -> None:
+        import api.routers.snapshot as snap_module
+
+        original_store = snap_module._snapshot_store
+        import fakeredis.aioredis as aioredis_fake
+
+        # Quota comfortably above the rate limit so the quota check doesn't
+        # mask the rate-limit behavior under test.
+        store = SnapshotStore(aioredis_fake.FakeRedis(), max_per_user=1000)
+        snap_module._snapshot_store = store
+        try:
+            body = {"nodes": [{"id": "1", "type": "artist"}], "center": {"id": "1", "type": "artist"}}
+            responses = [test_client.post("/api/snapshot", json=body, headers=auth_headers) for _ in range(21)]
+        finally:
+            snap_module._snapshot_store = original_store
+
+        assert responses[-1].status_code == 429
+        assert all(r.status_code == 201 for r in responses[:20])
+
+    def test_restore_snapshot_rate_limited_after_threshold(self, test_client: TestClient) -> None:
+        responses = [test_client.get("/api/snapshot/nonexistent-token") for _ in range(31)]
+        assert responses[-1].status_code == 429
+        assert all(r.status_code == 404 for r in responses[:30])
+
+
 class TestRestoreSnapshot:
     """Tests for GET /api/snapshot/{token}."""
 

--- a/tests/dashboard/test_admin_proxy.py
+++ b/tests/dashboard/test_admin_proxy.py
@@ -86,6 +86,16 @@ class TestValidatePathSegment:
     def test_rejects_spaces(self) -> None:
         assert _validate_path_segment("foo bar") is False
 
+    def test_rejects_dot_dot_dot_segment(self) -> None:
+        """Regression for discogsography-cu2.83: a pure ``..`` segment matches the
+        alphanumeric-plus-dot allowlist regex, but httpx/RFC 3986 URL normalization
+        collapses it during base_url merge — silently retargeting the request to a
+        sibling endpoint. Must be rejected explicitly."""
+        assert _validate_path_segment("..") is False
+
+    def test_rejects_single_dot_segment(self) -> None:
+        assert _validate_path_segment(".") is False
+
 
 # ---------------------------------------------------------------------------
 # POST /admin/api/login
@@ -711,3 +721,32 @@ class TestAuthHeaderForwarding:
         call_kwargs = mock_instance.get.call_args
         headers = call_kwargs.kwargs.get("headers", {})
         assert "Authorization" not in headers
+
+
+class TestExtractionAnalysisTraversalRejected:
+    """Regression for discogsography-cu2.83: a ``..`` path segment previously passed
+    `_validate_path_segment` (dots are allowlisted for version strings) and was then
+    silently collapsed by httpx/RFC 3986 URL normalization, retargeting the proxied
+    request to a sibling `/api/admin/*` endpoint. Use a percent-encoded segment so the
+    test client doesn't itself normalize the dot-segment away before the request is
+    sent — the same technique an adversary would use against the deployed server."""
+
+    @patch("dashboard.admin_proxy.httpx.AsyncClient")
+    def test_ea_summary_rejects_dot_dot_version(self, mock_cls_patch: AsyncMock, proxy_client: TestClient) -> None:
+        resp = proxy_client.get("/admin/api/extraction-analysis/%2e%2e/summary")
+        assert resp.status_code == 400
+        mock_cls_patch.assert_not_called()
+
+    @patch("dashboard.admin_proxy.httpx.AsyncClient")
+    def test_ea_compare_rejects_dot_dot_in_either_version(self, mock_cls_patch: AsyncMock, proxy_client: TestClient) -> None:
+        resp = proxy_client.get("/admin/api/extraction-analysis/%2e%2e/compare/1.0")
+        assert resp.status_code == 400
+        resp2 = proxy_client.get("/admin/api/extraction-analysis/1.0/compare/%2e%2e")
+        assert resp2.status_code == 400
+        mock_cls_patch.assert_not_called()
+
+    @patch("dashboard.admin_proxy.httpx.AsyncClient")
+    def test_ea_violation_detail_rejects_dot_dot_record_id(self, mock_cls_patch: AsyncMock, proxy_client: TestClient) -> None:
+        resp = proxy_client.get("/admin/api/extraction-analysis/1.0/violations/%2e%2e")
+        assert resp.status_code == 400
+        mock_cls_patch.assert_not_called()

--- a/tests/explore/test_snapshot.py
+++ b/tests/explore/test_snapshot.py
@@ -99,6 +99,97 @@ class TestSnapshotStore:
         assert expected - 5 <= ttl <= expected
 
 
+class TestSnapshotStoreLimits:
+    """Regression for discogsography-cu2.110: SnapshotStore had no cap on the
+    serialized payload size and no per-user quota, so a looping authenticated
+    user could mint unbounded 28-day-TTL Redis keys — even with small, valid
+    payloads under the node-count cap (`max_nodes` only bounds node count, not
+    per-node string size or the number of distinct snapshots per user)."""
+
+    @pytest.mark.asyncio
+    async def test_save_rejects_oversized_payload(self) -> None:
+        from api.snapshot_store import SnapshotTooLargeError
+
+        store = SnapshotStore(aioredis_fake.FakeRedis(), max_payload_bytes=100)
+        nodes = [{"id": "1", "type": "artist", "extra": "x" * 200}]
+        center = {"id": "1", "type": "artist"}
+        with pytest.raises(SnapshotTooLargeError):
+            await store.save(nodes, center)
+
+    @pytest.mark.asyncio
+    async def test_save_under_payload_cap_succeeds(self) -> None:
+        store = SnapshotStore(aioredis_fake.FakeRedis(), max_payload_bytes=64 * 1024)
+        nodes = [{"id": "1", "type": "artist"}]
+        center = {"id": "1", "type": "artist"}
+        token, _ = await store.save(nodes, center)
+        assert token
+
+    @pytest.mark.asyncio
+    async def test_max_payload_bytes_from_env(self) -> None:
+        with patch.dict("os.environ", {"SNAPSHOT_MAX_PAYLOAD_BYTES": "12345"}):
+            store = SnapshotStore(aioredis_fake.FakeRedis())
+            assert store.max_payload_bytes == 12345
+
+    @pytest.mark.asyncio
+    async def test_save_enforces_per_user_quota(self) -> None:
+        from api.snapshot_store import SnapshotQuotaExceededError
+
+        store = SnapshotStore(aioredis_fake.FakeRedis(), max_per_user=2)
+        nodes = [{"id": "1", "type": "artist"}]
+        center = {"id": "1", "type": "artist"}
+
+        await store.save(nodes, center, user_id="user-1")
+        await store.save(nodes, center, user_id="user-1")
+        with pytest.raises(SnapshotQuotaExceededError):
+            await store.save(nodes, center, user_id="user-1")
+
+    @pytest.mark.asyncio
+    async def test_per_user_quota_is_scoped_per_user(self) -> None:
+        """Hitting one user's quota must not affect a different user's ability to save."""
+        store = SnapshotStore(aioredis_fake.FakeRedis(), max_per_user=1)
+        nodes = [{"id": "1", "type": "artist"}]
+        center = {"id": "1", "type": "artist"}
+
+        await store.save(nodes, center, user_id="user-1")
+        # user-1 is now at quota; user-2 must still be able to save.
+        token, _ = await store.save(nodes, center, user_id="user-2")
+        assert token
+
+    @pytest.mark.asyncio
+    async def test_save_without_user_id_skips_quota_check(self) -> None:
+        """No user_id (e.g. anonymous callers, if any exist) means no quota is tracked."""
+        store = SnapshotStore(aioredis_fake.FakeRedis(), max_per_user=1)
+        nodes = [{"id": "1", "type": "artist"}]
+        center = {"id": "1", "type": "artist"}
+
+        await store.save(nodes, center)
+        token, _ = await store.save(nodes, center)
+        assert token
+
+    @pytest.mark.asyncio
+    async def test_max_per_user_from_env(self) -> None:
+        with patch.dict("os.environ", {"SNAPSHOT_MAX_PER_USER": "7"}):
+            store = SnapshotStore(aioredis_fake.FakeRedis())
+            assert store.max_per_user == 7
+
+    @pytest.mark.asyncio
+    async def test_rejected_save_does_not_consume_quota(self) -> None:
+        """A save rejected for being oversized must not still count against the
+        user's quota (roll back the increment on the size-cap failure path)."""
+        from api.snapshot_store import SnapshotTooLargeError
+
+        redis = aioredis_fake.FakeRedis()
+        store = SnapshotStore(redis, max_per_user=5, max_payload_bytes=100)
+        oversized_nodes = [{"id": "1", "type": "artist", "extra": "x" * 200}]
+        center = {"id": "1", "type": "artist"}
+
+        with pytest.raises(SnapshotTooLargeError):
+            await store.save(oversized_nodes, center, user_id="user-1")
+
+        count = await redis.get("snapshot:usercount:user-1")
+        assert count is None
+
+
 # ---------------------------------------------------------------------------
 # API endpoint tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Lands the `batch:security-hardening` work group — seven security/auth findings from the 2026-07-19 bug-hunt residue, one conventional commit per bead.

## Beads
- `discogsography-cu2.70` — app-token revoke: validate token_id as a UUID before the `::uuid` SQL cast; malformed ids now 404 (was 500), without leaking format-vs-existence
- `discogsography-cu2.71` — get_optional_user admin/user token isolation: verified already enforced on main (grep sweep across all four validation sites); pinned with an explicit regression test
- `discogsography-cu2.83` — dashboard admin_proxy: reject `.`/`..` path segments the dot-permitting allowlist previously matched (RFC 3986 normalization was silently retargeting proxied requests)
- `discogsography-cu2.93` — NLQ find_path: clamp model-supplied max_depth server-side to [1, 10]; bounds now single-sourced in neo4j_queries and shared with the HTTP route, with an internal backstop clamp in find_shortest_path
- `discogsography-cu2.97` — extraction-analysis: reject `.`/`..` in version/record_id validators (character-class allowlist alone didn't stop traversal)
- `discogsography-cu2.98` — extraction-analysis: stream violations.jsonl line-by-line with aggregate caps (64 MiB / 200k records), offloaded to a worker thread with caching — no more unbounded whole-file reads on the event loop
- `discogsography-cu2.110` — snapshots: bound SnapshotNode field sizes and add save rate limiting + per-user quota so authenticated users can't exhaust Redis

## Tests
Every fix carries regression tests (traversal attempts, clamp bounds, oversized payloads, admin-token rejection); +916/−112 across 17 files, validated in the batch worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UCBSBYhPWx9ESjDDJxsmY