### PR TITLE
fix: insights/Neo4j performance failures — P1 rarity timeout + 4 related (batch:insights-perf)

### DIFF
--- a/api/queries/rarity_queries.py
+++ b/api/queries/rarity_queries.py
@@ -167,217 +167,386 @@ def compute_rarity_tier(score: float) -> str:
 
 
 # ── Neo4j batch signal queries ──────────────────────────────────────
+#
+# CHUNKING CONTRACT — read before editing any query in this section.
+#
+# These signal queries used to run as eight UNBOUNDED full-graph scans
+# (`MATCH (r:Release) ...`). On the production graph that never completed:
+# Neo4j killed the transaction at exactly db.transaction.timeout (600s) with
+# Neo.ClientError.Transaction.TransactionTimedOutClientConfiguration, so
+# release_rarity failed on 33 consecutive daily cycles (2026-06-22 → 2026-07-23)
+# and the rarity data was permanently stale.
+#
+# Every signal query is now keyed off an explicit `$ids` page:
+#
+#   UNWIND $ids AS rid
+#   MATCH (r:Release {id: rid})
+#
+# `UNWIND` + a property-map match forces an index seek per id against the
+# `release_id` uniqueness constraint, so a page's working set is proportional to
+# RARITY_PAGE_SIZE rather than to the whole graph. Each query also carries an
+# explicit server-side timeout well under db.transaction.timeout, so a pathological
+# page fails fast and loudly instead of silently burning the 600s budget.
+#
+# Pages are produced by keyset pagination over `r.id` (a string — the extractor
+# parses ids as text), which is index-backed and, unlike SKIP/LIMIT, does not
+# degrade as the offset grows.
+#
+# DO NOT reintroduce a bare `MATCH (r:Release)` here.
+
+# Releases per page. Sized so a page's eight queries stay far inside the 600s
+# server-side transaction timeout while keeping the number of round trips sane.
+RARITY_PAGE_SIZE = 20_000
+
+# Per-query server-side timeout. Must stay comfortably below Neo4j's
+# db.transaction.timeout (600s in production) so a slow page surfaces as a fast,
+# attributable failure rather than a 600s stall.
+RARITY_QUERY_TIMEOUT_SECONDS = 120.0
+
+# Keyset pagination over the (uniqueness-constrained, therefore indexed) r.id.
+# Ids are strings, so "" is a valid open-ended start cursor.
+_RELEASE_ID_PAGE_QUERY = """
+MATCH (r:Release)
+WHERE r.id > $cursor
+RETURN r.id AS release_id
+ORDER BY r.id
+LIMIT $limit
+"""
+
+# Label-count store lookup — O(1) in Neo4j, not a scan.
+_RELEASE_COUNT_QUERY = """
+MATCH (r:Release)
+RETURN count(r) AS total
+"""
+
+# 1. Pressing scarcity: count siblings per master (+ display fields)
+#
+# NOTE (discogsography-cu2.75): the master lookup and the sibling lookup are
+# deliberately two separate OPTIONAL MATCHes. Combining them into one pattern
+# makes `m` contingent on a sibling existing: for a release that IS linked to a
+# master but is that master's ONLY pressing, the combined pattern (including its
+# inline WHERE sibling <> r) fails entirely and `m` comes back null too —
+# misclassifying the rarest pressing case (a unique pressing of a master) as "no
+# master link", scoring it 90.0 (standalone) instead of 100.0 (unique pressing).
+# The +1 must therefore be applied INSIDE the non-null branch, to a plain
+# sibling_count, rather than folded into the aggregate.
+_PRESSING_QUERY = """
+UNWIND $ids AS rid
+MATCH (r:Release {id: rid})
+OPTIONAL MATCH (r)-[:DERIVED_FROM]->(m:Master)
+OPTIONAL MATCH (m)<-[:DERIVED_FROM]-(sibling:Release)
+WHERE sibling <> r
+WITH r, m, count(DISTINCT sibling) AS sibling_count
+WITH r, CASE WHEN m IS NULL THEN 0 ELSE sibling_count + 1 END AS pressing_count
+OPTIONAL MATCH (r)-[:BY]->(a:Artist)
+WITH r, pressing_count, collect(DISTINCT a.name)[0] AS artist_name
+RETURN r.id AS release_id, pressing_count,
+       r.title AS title, artist_name, r.year AS year
+"""
+
+# 2. Label catalog size per release
+_LABEL_QUERY = """
+UNWIND $ids AS rid
+MATCH (r:Release {id: rid})-[:ON]->(l:Label)
+WITH r.id AS release_id, min(COALESCE(l.release_count, 0)) AS label_catalog_size
+RETURN release_id, label_catalog_size
+"""
+
+# 3. Formats per release
+_FORMAT_QUERY = """
+UNWIND $ids AS rid
+MATCH (r:Release {id: rid})
+WHERE r.formats IS NOT NULL
+RETURN r.id AS release_id, r.formats AS formats
+"""
+
+# 4. Temporal: release year + latest sibling year
+_TEMPORAL_QUERY = """
+UNWIND $ids AS rid
+MATCH (r:Release {id: rid})
+OPTIONAL MATCH (r)-[:DERIVED_FROM]->(m:Master)<-[:DERIVED_FROM]-(sibling:Release)
+WHERE sibling.year IS NOT NULL AND sibling <> r
+WITH r.id AS release_id, r.year AS year,
+     max(sibling.year) AS latest_sibling_year
+RETURN release_id, year, latest_sibling_year
+"""
+
+# 5. Graph degree per release.
+# Use COUNT {} rather than size([(r)-[]-() | 1]): the list comprehension
+# materialises a list element per relationship for every Release, which over
+# the full graph exhausts the Neo4j transaction memory pool. COUNT {} counts
+# without building the intermediate list.
+_DEGREE_QUERY = """
+UNWIND $ids AS rid
+MATCH (r:Release {id: rid})
+WITH r, COUNT { (r)--() } AS degree
+RETURN r.id AS release_id, degree
+"""
+
+# Quality signals for hidden gem scoring
+# 6. Max artist degree per release
+_ARTIST_DEGREE_QUERY = """
+UNWIND $ids AS rid
+MATCH (r:Release {id: rid})-[:BY]->(a:Artist)
+WITH r.id AS release_id, max(COUNT { (a)--() }) AS artist_max_degree
+RETURN release_id, artist_max_degree
+"""
+
+# 7. Max label catalog size per release
+_LABEL_SIZE_QUERY = """
+UNWIND $ids AS rid
+MATCH (r:Release {id: rid})-[:ON]->(l:Label)
+WITH r.id AS release_id, max(COALESCE(l.release_count, 0)) AS label_max_catalog
+RETURN release_id, label_max_catalog
+"""
+
+# 8. Max genre release count per release
+_GENRE_COUNT_QUERY = """
+UNWIND $ids AS rid
+MATCH (r:Release {id: rid})-[:IS]->(g:Genre)
+WITH r.id AS release_id, max(COALESCE(g.release_count, 0)) AS genre_max_release_count
+RETURN release_id, genre_max_release_count
+"""
 
 
-async def fetch_all_rarity_signals(driver: Any, pool: Any = None) -> list[dict[str, Any]]:
+def _percentile_rank(value: float, sorted_values: list[float]) -> float:
+    """Return percentile rank (0.0 to 1.0) of value in sorted list."""
+    if not sorted_values or value <= 0:
+        return 0.0
+    return bisect.bisect_left(sorted_values, value) / len(sorted_values)
+
+
+async def _fetch_release_id_page(driver: Any, cursor: str, limit: int) -> list[str]:
+    """Return the next page of release ids strictly after ``cursor``."""
+    rows = await run_query(
+        driver,
+        _RELEASE_ID_PAGE_QUERY,
+        database="neo4j",
+        timeout=RARITY_QUERY_TIMEOUT_SECONDS,
+        cursor=cursor,
+        limit=limit,
+    )
+    return [row["release_id"] for row in rows]
+
+
+async def _load_community_counts(pool: Any) -> dict[str, tuple[int, int]]:
+    """Load community have/want counts from PostgreSQL (neutral fallback on failure)."""
+    if pool is None:
+        return {}
+    try:
+        async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute("SELECT release_id, have_count, want_count FROM insights.community_counts")
+            community_rows = await cur.fetchall()
+        community_map = {str(r["release_id"]): (r["have_count"], r["want_count"]) for r in community_rows}
+        logger.info("📊 Community counts loaded", count=len(community_map))
+    except Exception:
+        logger.warning("⚠️ Failed to load community counts, using neutral fallback", exc_info=True)
+        return {}
+    return community_map
+
+
+async def _fetch_page_signals(driver: Any, ids: list[str]) -> dict[str, list[dict[str, Any]]]:
+    """Run the eight signal queries for one page of release ids.
+
+    Run sequentially, not via asyncio.gather: running them concurrently sums
+    their working sets against the single dbms.memory.transaction.total.max
+    pool, which tips it into a TransientError MemoryPoolOutOfMemoryError.
+    Sequential execution caps peak transaction memory at one query at a time.
+    This is a daily background computation, so the wall-clock cost is acceptable.
+    """
+
+    async def _run(cypher: str) -> list[dict[str, Any]]:
+        return await run_query(
+            driver,
+            cypher,
+            database="neo4j",
+            timeout=RARITY_QUERY_TIMEOUT_SECONDS,
+            ids=ids,
+        )
+
+    return {
+        "pressing": await _run(_PRESSING_QUERY),
+        "label": await _run(_LABEL_QUERY),
+        "format": await _run(_FORMAT_QUERY),
+        "temporal": await _run(_TEMPORAL_QUERY),
+        "degree": await _run(_DEGREE_QUERY),
+        "artist_degree": await _run(_ARTIST_DEGREE_QUERY),
+        "label_size": await _run(_LABEL_SIZE_QUERY),
+        "genre_count": await _run(_GENRE_COUNT_QUERY),
+    }
+
+
+async def fetch_all_rarity_signals(
+    driver: Any,
+    pool: Any = None,
+    *,
+    page_size: int = RARITY_PAGE_SIZE,
+) -> list[dict[str, Any]]:
     """Fetch all rarity signals from Neo4j and compute scores.
 
-    Executes 8 batch Cypher queries (5 signal queries + 3 quality queries),
-    joins by release_id, and computes composite rarity + hidden gem scores.
-    Optionally fetches community counts (have/want) from PostgreSQL when pool is provided.
+    Walks the Release set in keyset-paginated chunks of ``page_size``. For each
+    page it runs the eight signal queries (5 signal + 3 quality) scoped to that
+    page's ids, joins them by release_id, and computes the composite rarity
+    score. Community counts (have/want) are loaded once from PostgreSQL when a
+    pool is provided.
 
-    Returns a list of dicts ready for PostgreSQL insertion.
+    Hidden-gem scoring needs percentile ranks over the *global* quality-signal
+    distributions, so those are accumulated while paging and applied in a final
+    pass — no second trip to Neo4j.
+
+    Args:
+        driver: The async Neo4j driver.
+        pool: Optional PostgreSQL pool for community counts.
+        page_size: Releases per chunk. Bounds per-transaction working set.
+
+    Returns:
+        A list of dicts ready for PostgreSQL insertion.
     """
     current_year = datetime.now(UTC).year
 
-    # 1. Pressing scarcity: count siblings per master
-    # NOTE: the master lookup and the sibling lookup are deliberately two separate
-    # OPTIONAL MATCHes. Combining them into one pattern (as previously written) makes
-    # `m` contingent on a sibling existing: for a release that IS linked to a master
-    # but is that master's ONLY pressing, the combined pattern (including its inline
-    # WHERE sibling <> r) fails entirely and `m` comes back null too — misclassifying
-    # the rarest pressing case (a unique pressing of a master) as "no master link".
-    pressing_query = """
-    MATCH (r:Release)
-    OPTIONAL MATCH (r)-[:DERIVED_FROM]->(m:Master)
-    OPTIONAL MATCH (m)<-[:DERIVED_FROM]-(sibling:Release)
-    WHERE sibling <> r
-    WITH r, m, count(DISTINCT sibling) AS sibling_count
-    WITH r, CASE WHEN m IS NULL THEN 0 ELSE sibling_count + 1 END AS pressing_count
-    OPTIONAL MATCH (r)-[:BY]->(a:Artist)
-    WITH r, pressing_count, collect(DISTINCT a.name)[0] AS artist_name
-    RETURN r.id AS release_id, pressing_count,
-           r.title AS title, artist_name, r.year AS year
-    """
+    logger.info("🔍 Fetching rarity signals from Neo4j...", page_size=page_size)
 
-    # 2. Label catalog size per release
-    label_query = """
-    MATCH (r:Release)-[:ON]->(l:Label)
-    WITH r.id AS release_id, min(COALESCE(l.release_count, 0)) AS label_catalog_size
-    RETURN release_id, label_catalog_size
-    """
+    community_map = await _load_community_counts(pool)
 
-    # 3. Formats per release
-    format_query = """
-    MATCH (r:Release)
-    WHERE r.formats IS NOT NULL
-    RETURN r.id AS release_id, r.formats AS formats
-    """
-
-    # 4. Temporal: release year + latest sibling year
-    temporal_query = """
-    MATCH (r:Release)
-    OPTIONAL MATCH (r)-[:DERIVED_FROM]->(m:Master)<-[:DERIVED_FROM]-(sibling:Release)
-    WHERE sibling.year IS NOT NULL AND sibling <> r
-    WITH r.id AS release_id, r.year AS year,
-         max(sibling.year) AS latest_sibling_year
-    RETURN release_id, year, latest_sibling_year
-    """
-
-    # 5. Graph degree per release.
-    # Use COUNT {} rather than size([(r)-[]-() | 1]): the list comprehension
-    # materialises a list element per relationship for every Release, which over
-    # the full graph exhausts the Neo4j transaction memory pool. COUNT {} counts
-    # without building the intermediate list.
-    degree_query = """
-    MATCH (r:Release)
-    WITH r, COUNT { (r)--() } AS degree
-    RETURN r.id AS release_id, degree
-    """
-
-    # Quality signals for hidden gem scoring
-    # 6. Max artist degree per release
-    artist_degree_query = """
-    MATCH (r:Release)-[:BY]->(a:Artist)
-    WITH r.id AS release_id, max(COUNT { (a)--() }) AS artist_max_degree
-    RETURN release_id, artist_max_degree
-    """
-
-    # 7. Max label catalog size per release
-    label_size_query = """
-    MATCH (r:Release)-[:ON]->(l:Label)
-    WITH r.id AS release_id, max(COALESCE(l.release_count, 0)) AS label_max_catalog
-    RETURN release_id, label_max_catalog
-    """
-
-    # 8. Max genre release count per release
-    genre_count_query = """
-    MATCH (r:Release)-[:IS]->(g:Genre)
-    WITH r.id AS release_id, max(COALESCE(g.release_count, 0)) AS genre_max_release_count
-    RETURN release_id, genre_max_release_count
-    """
-
-    logger.info("🔍 Fetching rarity signals from Neo4j...")
-
-    # Run sequentially, not via asyncio.gather: each of these is a full-graph
-    # scan, and running all eight concurrently sums their working sets against
-    # the single dbms.memory.transaction.total.max pool — which tips it into a
-    # TransientError MemoryPoolOutOfMemoryError. Sequential execution caps peak
-    # transaction memory at one query at a time. This runs in a daily background
-    # computation, so the extra wall-clock time is acceptable.
-    pressing_rows = await run_query(driver, pressing_query, database="neo4j")
-    label_rows = await run_query(driver, label_query, database="neo4j")
-    format_rows = await run_query(driver, format_query, database="neo4j")
-    temporal_rows = await run_query(driver, temporal_query, database="neo4j")
-    degree_rows = await run_query(driver, degree_query, database="neo4j")
-    artist_degree_rows = await run_query(driver, artist_degree_query, database="neo4j")
-    label_size_rows = await run_query(driver, label_size_query, database="neo4j")
-    genre_count_rows = await run_query(driver, genre_count_query, database="neo4j")
-
-    logger.info(
-        "📊 Rarity signal data fetched",
-        releases=len(pressing_rows),
-        labels=len(label_rows),
-        formats=len(format_rows),
-    )
-
-    # 9. Community counts from PostgreSQL (if pool available)
-    community_map: dict[str, tuple[int, int]] = {}
-    if pool is not None:
-        try:
-            async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
-                await cur.execute("SELECT release_id, have_count, want_count FROM insights.community_counts")
-                community_rows = await cur.fetchall()
-            community_map = {str(r["release_id"]): (r["have_count"], r["want_count"]) for r in community_rows}
-            logger.info("📊 Community counts loaded", count=len(community_map))
-        except Exception:
-            logger.warning("⚠️ Failed to load community counts, using neutral fallback", exc_info=True)
-
-    # Build lookup dicts keyed by release_id
-    label_map = {r["release_id"]: r["label_catalog_size"] for r in label_rows}
-    format_map = {r["release_id"]: r["formats"] for r in format_rows}
-    temporal_map = {r["release_id"]: r for r in temporal_rows}
-    degree_map = {r["release_id"]: r["degree"] for r in degree_rows}
-    artist_deg_map = {r["release_id"]: r["artist_max_degree"] for r in artist_degree_rows}
-    label_size_map = {r["release_id"]: r["label_max_catalog"] for r in label_size_rows}
-    genre_count_map = {r["release_id"]: r["genre_max_release_count"] for r in genre_count_rows}
-
-    # Compute percentile normalization for quality signals
-    all_artist_degrees = sorted(r["artist_max_degree"] for r in artist_degree_rows if r["artist_max_degree"])
-    all_label_sizes = sorted(r["label_max_catalog"] for r in label_size_rows if r["label_max_catalog"])
-    all_genre_counts = sorted(r["genre_max_release_count"] for r in genre_count_rows if r["genre_max_release_count"])
-
-    def _percentile_rank(value: float, sorted_values: list[float]) -> float:
-        """Return percentile rank (0.0 to 1.0) of value in sorted list."""
-        if not sorted_values or value <= 0:
-            return 0.0
-        return bisect.bisect_left(sorted_values, value) / len(sorted_values)
-
-    # Score each release
     results: list[dict[str, Any]] = []
-    for row in pressing_rows:
-        rid = row["release_id"]
+    # Deferred hidden-gem inputs, positionally parallel to `results`:
+    # (unrounded rarity_score, artist_max_degree, label_max_catalog,
+    # genre_max_release_count). The UNROUNDED score is kept deliberately —
+    # hidden_gem_score has always been derived from it, not from the rounded
+    # value stored in the result dict.
+    quality_inputs: list[tuple[float, float, float, float]] = []
+    all_artist_degrees: list[float] = []
+    all_label_sizes: list[float] = []
+    all_genre_counts: list[float] = []
 
-        pressing_score = compute_pressing_scarcity_score(row["pressing_count"])
-        label_score = compute_label_catalog_score(label_map.get(rid, 0))
-        fmt_score = compute_format_rarity_score(format_map.get(rid, []))
+    cursor = ""
+    pages = 0
+    while True:
+        ids = await _fetch_release_id_page(driver, cursor, page_size)
+        if not ids:
+            break
+        cursor = ids[-1]
+        pages += 1
 
-        temporal_info = temporal_map.get(rid, {})
-        temporal_score = compute_temporal_scarcity_score(
-            temporal_info.get("year"),
-            temporal_info.get("latest_sibling_year"),
-            current_year,
-        )
+        signals = await _fetch_page_signals(driver, ids)
+        pressing_rows = signals["pressing"]
 
-        isolation_score = compute_graph_isolation_score(degree_map.get(rid, 0))
+        label_map = {r["release_id"]: r["label_catalog_size"] for r in signals["label"]}
+        format_map = {r["release_id"]: r["formats"] for r in signals["format"]}
+        temporal_map = {r["release_id"]: r for r in signals["temporal"]}
+        degree_map = {r["release_id"]: r["degree"] for r in signals["degree"]}
+        artist_deg_map = {r["release_id"]: r["artist_max_degree"] for r in signals["artist_degree"]}
+        label_size_map = {r["release_id"]: r["label_max_catalog"] for r in signals["label_size"]}
+        genre_count_map = {r["release_id"]: r["genre_max_release_count"] for r in signals["genre_count"]}
 
-        have, want = community_map.get(rid, (None, None))
-        prevalence_score = compute_collection_prevalence_score(have, want or 0) if have is not None else 50.0  # neutral fallback
+        all_artist_degrees.extend(r["artist_max_degree"] for r in signals["artist_degree"] if r["artist_max_degree"])
+        all_label_sizes.extend(r["label_max_catalog"] for r in signals["label_size"] if r["label_max_catalog"])
+        all_genre_counts.extend(r["genre_max_release_count"] for r in signals["genre_count"] if r["genre_max_release_count"])
 
-        rarity_score = (
-            SIGNAL_WEIGHTS["pressing_scarcity"] * pressing_score
-            + SIGNAL_WEIGHTS["label_catalog"] * label_score
-            + SIGNAL_WEIGHTS["format_rarity"] * fmt_score
-            + SIGNAL_WEIGHTS["temporal_scarcity"] * temporal_score
-            + SIGNAL_WEIGHTS["graph_isolation"] * isolation_score
-            + SIGNAL_WEIGHTS["collection_prevalence"] * prevalence_score
-        )
+        for row in pressing_rows:
+            rid = row["release_id"]
 
-        tier = compute_rarity_tier(rarity_score)
+            pressing_score = compute_pressing_scarcity_score(row["pressing_count"])
+            label_score = compute_label_catalog_score(label_map.get(rid, 0))
+            fmt_score = compute_format_rarity_score(format_map.get(rid, []))
 
-        # Hidden gem: quality multiplier from artist/label/genre prominence
-        artist_deg = artist_deg_map.get(rid, 0) or 0
-        label_sz = label_size_map.get(rid, 0) or 0
-        genre_ct = genre_count_map.get(rid, 0) or 0
+            temporal_info = temporal_map.get(rid, {})
+            temporal_score = compute_temporal_scarcity_score(
+                temporal_info.get("year"),
+                temporal_info.get("latest_sibling_year"),
+                current_year,
+            )
 
+            isolation_score = compute_graph_isolation_score(degree_map.get(rid, 0))
+
+            have, want = community_map.get(rid, (None, None))
+            prevalence_score = compute_collection_prevalence_score(have, want or 0) if have is not None else 50.0  # neutral fallback
+
+            rarity_score = (
+                SIGNAL_WEIGHTS["pressing_scarcity"] * pressing_score
+                + SIGNAL_WEIGHTS["label_catalog"] * label_score
+                + SIGNAL_WEIGHTS["format_rarity"] * fmt_score
+                + SIGNAL_WEIGHTS["temporal_scarcity"] * temporal_score
+                + SIGNAL_WEIGHTS["graph_isolation"] * isolation_score
+                + SIGNAL_WEIGHTS["collection_prevalence"] * prevalence_score
+            )
+
+            quality_inputs.append(
+                (
+                    rarity_score,
+                    artist_deg_map.get(rid, 0) or 0,
+                    label_size_map.get(rid, 0) or 0,
+                    genre_count_map.get(rid, 0) or 0,
+                )
+            )
+
+            results.append(
+                {
+                    "release_id": rid,
+                    "title": row.get("title") or "",
+                    "artist_name": row.get("artist_name") or "",
+                    "year": row.get("year"),
+                    "rarity_score": round(rarity_score, 1),
+                    "tier": compute_rarity_tier(rarity_score),
+                    # Filled in below, once the global distributions are known.
+                    "hidden_gem_score": 0.0,
+                    "pressing_scarcity": pressing_score,
+                    "label_catalog": label_score,
+                    "format_rarity": fmt_score,
+                    "temporal_scarcity": temporal_score,
+                    "graph_isolation": isolation_score,
+                    "collection_prevalence": prevalence_score,
+                }
+            )
+
+        logger.debug("📄 Rarity page scored", page=pages, ids=len(ids), scored=len(results))
+
+    # Percentile normalization for quality signals, over the global distributions.
+    all_artist_degrees.sort()
+    all_label_sizes.sort()
+    all_genre_counts.sort()
+
+    for entry, (rarity_score, artist_deg, label_sz, genre_ct) in zip(results, quality_inputs, strict=True):
         quality_multiplier = (
             0.4 * _percentile_rank(artist_deg, all_artist_degrees)
             + 0.3 * _percentile_rank(label_sz, all_label_sizes)
             + 0.3 * _percentile_rank(genre_ct, all_genre_counts)
         )
+        entry["hidden_gem_score"] = round(rarity_score * quality_multiplier, 1)
 
-        hidden_gem_score = round(rarity_score * quality_multiplier, 1)
+    # Coverage check. The keyset walk compares `r.id > $cursor` against a string
+    # cursor; if the graph ever held non-string Release ids the comparison would
+    # yield null and silently truncate the walk. count(r) is served from Neo4j's
+    # label count store (O(1), not a scan), so this costs nothing and turns a
+    # silent partial result into a loud one.
+    await _warn_on_incomplete_coverage(driver, scored=len(results))
 
-        results.append(
-            {
-                "release_id": rid,
-                "title": row.get("title") or "",
-                "artist_name": row.get("artist_name") or "",
-                "year": row.get("year"),
-                "rarity_score": round(rarity_score, 1),
-                "tier": tier,
-                "hidden_gem_score": hidden_gem_score,
-                "pressing_scarcity": pressing_score,
-                "label_catalog": label_score,
-                "format_rarity": fmt_score,
-                "temporal_scarcity": temporal_score,
-                "graph_isolation": isolation_score,
-                "collection_prevalence": prevalence_score,
-            }
-        )
-
-    logger.info("✅ Rarity scores computed", total=len(results))
+    logger.info("✅ Rarity scores computed", total=len(results), pages=pages)
     return results
+
+
+async def _warn_on_incomplete_coverage(driver: Any, scored: int) -> None:
+    """Log a warning when the paginated walk scored fewer releases than exist."""
+    try:
+        count_rows = await run_query(
+            driver,
+            _RELEASE_COUNT_QUERY,
+            database="neo4j",
+            timeout=RARITY_QUERY_TIMEOUT_SECONDS,
+        )
+    except Exception:
+        logger.debug("⚠️ Release count check skipped", exc_info=True)
+        return
+    if not count_rows:
+        return
+    total = count_rows[0].get("total")
+    if isinstance(total, int) and scored < total:
+        logger.warning(
+            "⚠️ Rarity pagination covered fewer releases than the graph holds",
+            scored=scored,
+            total=total,
+            missing=total - scored,
+        )
 
 
 # ── PostgreSQL lookup functions ─────────────────────────────────────

--- a/api/routers/admin.py
+++ b/api/routers/admin.py
@@ -36,6 +36,7 @@ from api.queries.admin_queries import (
     get_user_stats,
 )
 from api.queries.metrics_queries import get_health_history, get_queue_history
+from common import describe_exception
 from common.config import (
     AMQP_QUEUE_PREFIX_BRAINZGRAPHINATOR,
     AMQP_QUEUE_PREFIX_BRAINZTABLEINATOR,
@@ -416,7 +417,7 @@ async def _track_extraction(extraction_id: str) -> None:
                         "⚠️ Extraction tracking iteration failed",
                         extraction_id=extraction_id,
                         attempt=consecutive_failures,
-                        error=str(exc),
+                        error=describe_exception(exc),
                     )
 
                 if consecutive_failures >= max_failures:

--- a/api/routers/insights_compute.py
+++ b/api/routers/insights_compute.py
@@ -73,6 +73,20 @@ router = APIRouter(
 _ENRICHMENT_DELAY_SECONDS = 1.0  # 1 req/sec to stay under 60 req/min
 _STALENESS_DAYS = 7
 
+# Hard cap on releases enriched per invocation.
+#
+# The enrichment loop is rate-limited to one Discogs request per second, so its
+# wall-clock cost is unbounded in the number of stale releases — a backlog of
+# 10k releases would take ~3 hours and blow ANY client read timeout. That is why
+# community_enrichment failed four times in production with an (empty-stringing)
+# ReadTimeout: the endpoint simply never returned.
+#
+# Bounding the batch makes the endpoint's worst case predictable
+# (~1500 * 1.5s ≈ 2250s, comfortably inside the insights client's 3600s read
+# budget) and costs nothing in completeness: the daily scheduler drains the
+# remaining backlog on subsequent cycles.
+MAX_ENRICHMENT_RELEASES = 1500
+
 # Cache TTL for data-completeness (6 hours — full table scans are very expensive)
 _COMPLETENESS_CACHE_TTL = 21600
 
@@ -210,11 +224,23 @@ async def _enrich_community_counts(
             (_STALENESS_DAYS,),
         )
         rows = await cur.fetchall()
-        release_ids = [r["release_id"] for r in rows]
+        all_release_ids = [r["release_id"] for r in rows]
 
-    if not release_ids:
+    if not all_release_ids:
         logger.info("📊 No releases need community enrichment")
-        return {"enriched": 0, "skipped": 0, "errors": 0}
+        return {"enriched": 0, "skipped": 0, "errors": 0, "remaining": 0}
+
+    # Bound the batch so this endpoint always returns inside the caller's read
+    # timeout — the leftover backlog is picked up by the next scheduled cycle.
+    release_ids = all_release_ids[:MAX_ENRICHMENT_RELEASES]
+    remaining = len(all_release_ids) - len(release_ids)
+    if remaining:
+        logger.info(
+            "📊 Community enrichment backlog capped for this cycle",
+            batch_size=len(release_ids),
+            backlog=len(all_release_ids),
+            remaining=remaining,
+        )
 
     logger.info("📊 Releases needing community enrichment", count=len(release_ids))
 
@@ -232,7 +258,7 @@ async def _enrich_community_counts(
 
         if not token:
             logger.warning("⚠️ No Discogs OAuth credentials for community enrichment")
-            return {"enriched": 0, "skipped": len(release_ids), "errors": 0, "error": "no_credentials"}
+            return {"enriched": 0, "skipped": len(release_ids), "errors": 0, "remaining": remaining, "error": "no_credentials"}
 
         access_token = decrypt_oauth_token(token["access_token"], encryption_key)
         access_secret = decrypt_oauth_token(token["access_secret"], encryption_key)
@@ -242,7 +268,7 @@ async def _enrich_community_counts(
         app_config = {r["key"]: r["value"] for r in config_rows}
         if "discogs_consumer_key" not in app_config or "discogs_consumer_secret" not in app_config:
             logger.warning("⚠️ Discogs app credentials not configured")
-            return {"enriched": 0, "skipped": len(release_ids), "errors": 0, "error": "no_credentials"}
+            return {"enriched": 0, "skipped": len(release_ids), "errors": 0, "remaining": remaining, "error": "no_credentials"}
         consumer_key = decrypt_oauth_token(app_config["discogs_consumer_key"], encryption_key)
         consumer_secret = decrypt_oauth_token(app_config["discogs_consumer_secret"], encryption_key)
 
@@ -358,8 +384,13 @@ async def _enrich_community_counts(
         except Exception as e:
             logger.error("❌ Failed to update Neo4j community counts", error=str(e))
 
-    logger.info("✅ Community enrichment complete", enriched=enriched, errors=errors)
-    return {"enriched": enriched, "skipped": len(release_ids) - enriched - errors, "errors": errors}
+    logger.info("✅ Community enrichment complete", enriched=enriched, errors=errors, remaining=remaining)
+    return {
+        "enriched": enriched,
+        "skipped": len(release_ids) - enriched - errors,
+        "errors": errors,
+        "remaining": remaining,
+    }
 
 
 @router.get("/community-enrichment")

--- a/api/routers/insights_compute.py
+++ b/api/routers/insights_compute.py
@@ -27,6 +27,7 @@ from api.queries.insights_neo4j_queries import (
 from api.queries.insights_pg_queries import query_data_completeness
 from api.queries.rarity_queries import fetch_all_rarity_signals
 from api.syncer import DISCOGS_API_BASE, MAX_RATE_LIMIT_RETRIES, _auth_header
+from common import describe_exception
 
 
 logger = structlog.get_logger(__name__)
@@ -281,7 +282,7 @@ async def _enrich_community_counts(
                 try:
                     response = await client.get(url, headers=headers)
                 except httpx.HTTPError as exc:
-                    logger.warning("⚠️ Discogs API request failed for release", release_id=release_id, error=str(exc))
+                    logger.warning("⚠️ Discogs API request failed for release", release_id=release_id, error=describe_exception(exc))
                     fetch_failed = True
                     break
 

--- a/api/routers/insights_compute.py
+++ b/api/routers/insights_compute.py
@@ -12,7 +12,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 import httpx
-from neo4j.exceptions import TransientError
+from neo4j.exceptions import ClientError, Neo4jError, TransientError
 from psycopg.rows import dict_row
 import structlog
 
@@ -181,6 +181,44 @@ async def data_completeness(request: Request) -> JSONResponse:  # noqa: ARG001
     return JSONResponse(content=response)
 
 
+# Neo4j error codes that mean "the database gave up on this transaction", not
+# "the server has a bug". Both are retryable and must surface as 503, never 500.
+#
+# TransactionTimedOutClientConfiguration is a *ClientError*, not a TransientError,
+# which is exactly why the previous handler missed it: rarity-scores blew
+# db.transaction.timeout (600s) on every production run and the ClientError
+# escaped as an unhandled 500.
+TRANSACTION_TIMEOUT_CODES = frozenset(
+    {
+        "Neo.ClientError.Transaction.TransactionTimedOut",
+        "Neo.ClientError.Transaction.TransactionTimedOutClientConfiguration",
+    }
+)
+
+
+def _find_retryable_neo4j_error(exc: BaseException) -> Neo4jError | None:
+    """Return the first retryable Neo4j error in ``exc``, or ``None``.
+
+    Unwraps ``BaseExceptionGroup`` (the driver's internals can surface a
+    transaction failure wrapped in one) and ``__cause__`` chains, so a retryable
+    error is recognised no matter how it was re-raised.
+    """
+    if isinstance(exc, BaseExceptionGroup):
+        for inner in exc.exceptions:
+            found = _find_retryable_neo4j_error(inner)
+            if found is not None:
+                return found
+        return None
+    if isinstance(exc, TransientError):
+        return exc
+    if isinstance(exc, ClientError) and exc.code in TRANSACTION_TIMEOUT_CODES:
+        return exc
+    cause = exc.__cause__
+    if cause is not None and cause is not exc:
+        return _find_retryable_neo4j_error(cause)
+    return None
+
+
 @router.get("/rarity-scores")
 @limiter.limit("5/minute")
 async def rarity_scores(request: Request) -> JSONResponse:  # noqa: ARG001
@@ -189,13 +227,21 @@ async def rarity_scores(request: Request) -> JSONResponse:  # noqa: ARG001
         return JSONResponse(content={"error": "Service not ready"}, status_code=503)
     try:
         results = await fetch_all_rarity_signals(_neo4j, _pool)
-    except TransientError:
-        # e.g. MemoryPoolOutOfMemoryError under DB pressure — transient, not a
-        # server bug. Return 503 so the caller logs a meaningful, retryable
-        # failure instead of a bare 500.
-        logger.warning("⚠️ Rarity computation hit a transient Neo4j error", exc_info=True)
+    except (TransientError, ClientError, BaseExceptionGroup) as exc:
+        # TransientError: e.g. MemoryPoolOutOfMemoryError under DB pressure.
+        # ClientError: a transaction timeout (see TRANSACTION_TIMEOUT_CODES).
+        # Neither is a server bug — return 503 so the caller logs a meaningful,
+        # retryable failure instead of a bare 500.
+        retryable = _find_retryable_neo4j_error(exc)
+        if retryable is None:
+            raise
+        logger.warning(
+            "⚠️ Rarity computation hit a retryable Neo4j error",
+            code=retryable.code,
+            exc_info=True,
+        )
         return JSONResponse(
-            content={"error": "Neo4j temporarily unavailable (transient error)"},
+            content={"error": "Neo4j temporarily unavailable (retryable error)", "code": retryable.code},
             status_code=503,
         )
     return JSONResponse(content={"items": results})

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -39,6 +39,7 @@ from common.db_resilience import (
     async_resilient_connection,
     resilient_connection,
 )
+from common.errors import describe_exception
 from common.health_server import HealthServer
 from common.neo4j_resilient import (
     AsyncResilientNeo4jDriver,
@@ -121,6 +122,7 @@ __all__ = [
     "_hmac_sha1_signature",
     "_oauth_escape",
     "async_resilient_connection",
+    "describe_exception",
     "execute_sql",
     "get_config",
     "is_db_profiling",

--- a/common/errors.py
+++ b/common/errors.py
@@ -1,0 +1,38 @@
+"""Exception-description helpers for diagnosable error logging.
+
+Several exception types raised by the networking and database stacks carry an
+**empty** ``str()`` — most notably ``httpx.ReadTimeout`` / ``httpx.ConnectTimeout``
+/ ``httpx.ConnectError``, which are constructed with no message when the failure
+comes from the transport layer. Logging ``error=str(exc)`` for those produces a
+literal ``error=""`` line, which makes the failure unrecoverable from production
+logs (observed for four ``community_enrichment`` failures, 2026-06-26 → 2026-07-19).
+
+:func:`describe_exception` is the single helper every error log site should use
+instead of ``str(exc)``: it always names the exception type, so the failure mode
+is identifiable even when the message is empty.
+"""
+
+__all__ = ["describe_exception"]
+
+
+def describe_exception(exc: BaseException) -> str:
+    """Return a non-empty, diagnosable description of ``exc``.
+
+    Always prefixes the exception's class name so a message-less exception (e.g.
+    ``httpx.ReadTimeout``) still yields an identifiable log value.
+
+    Args:
+        exc: The exception to describe.
+
+    Returns:
+        ``"TypeName: message"`` when the exception stringifies non-empty,
+        otherwise just ``"TypeName"``.
+
+    Examples:
+        >>> describe_exception(ValueError("bad input"))
+        'ValueError: bad input'
+        >>> describe_exception(TimeoutError())
+        'TimeoutError'
+    """
+    detail = str(exc)
+    return f"{type(exc).__name__}: {detail}" if detail else type(exc).__name__

--- a/dashboard/admin_proxy.py
+++ b/dashboard/admin_proxy.py
@@ -16,6 +16,8 @@ import httpx
 from starlette.responses import JSONResponse
 import structlog
 
+from common import describe_exception
+
 
 logger = structlog.get_logger(__name__)
 
@@ -105,7 +107,7 @@ async def proxy_login(request: Request) -> Response:
             else:
                 resp = await client.post(url, headers=headers)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -119,7 +121,7 @@ async def proxy_logout(request: Request) -> Response:
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(url, headers=headers)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -133,7 +135,7 @@ async def proxy_list_extractions(request: Request) -> Response:
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(url, headers=headers)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -149,7 +151,7 @@ async def proxy_get_extraction(extraction_id: str, request: Request) -> Response
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(url, headers=headers)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -171,7 +173,7 @@ async def proxy_trigger(request: Request) -> Response:
             else:
                 resp = await client.post(url, headers=headers)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -199,7 +201,7 @@ async def proxy_trigger_musicbrainz(request: Request) -> Response:
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(url, headers=headers, content=payload)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -218,7 +220,7 @@ async def proxy_user_stats(request: Request) -> Response:
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(url, headers=headers)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -232,7 +234,7 @@ async def proxy_sync_activity(request: Request) -> Response:
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(url, headers=headers)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -246,7 +248,7 @@ async def proxy_storage(request: Request) -> Response:
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(url, headers=headers)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -262,7 +264,7 @@ async def proxy_dlq_purge(queue: str, request: Request) -> Response:
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(url, headers=headers)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -290,7 +292,7 @@ async def proxy_queue_history(
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(url, headers=headers, params=params)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -313,7 +315,7 @@ async def proxy_health_history(
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(url, headers=headers, params=params)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -347,7 +349,7 @@ async def proxy_audit_log(
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(url, headers=headers, params=params)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -366,7 +368,7 @@ async def proxy_ea_versions(request: Request) -> Response:
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(url, headers=headers)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -382,7 +384,7 @@ async def proxy_ea_summary(version: str, request: Request) -> Response:
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(url, headers=headers)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -400,7 +402,7 @@ async def proxy_ea_violation_detail(version: str, record_id: str, request: Reque
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(url, headers=headers)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -429,7 +431,7 @@ async def proxy_ea_skipped(
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(url, headers=headers, params=params)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -464,7 +466,7 @@ async def proxy_ea_violations(
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(url, headers=headers, params=params)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -480,7 +482,7 @@ async def proxy_ea_parsing_errors(version: str, request: Request) -> Response:
         async with httpx.AsyncClient(timeout=60.0) as client:
             resp = await client.get(url, headers=headers)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -498,7 +500,7 @@ async def proxy_ea_compare(version: str, other_version: str, request: Request) -
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(url, headers=headers)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -522,7 +524,7 @@ async def proxy_ea_prompt_context(version: str, request: Request) -> Response:
             else:
                 resp = await client.post(url, headers=headers)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)
 
@@ -546,6 +548,6 @@ async def proxy_ea_generate_ai_prompt(version: str, request: Request) -> Respons
             else:
                 resp = await client.post(url, headers=headers)
     except (httpx.ConnectError, httpx.RequestError) as exc:
-        logger.error("❌ API service unreachable", url=url, error=str(exc))
+        logger.error("❌ API service unreachable", url=url, error=describe_exception(exc))
         return _unavailable_response()
     return _ok_response(resp)

--- a/explore/explore.py
+++ b/explore/explore.py
@@ -18,6 +18,7 @@ import uvicorn
 
 from common import (
     HealthServer,
+    describe_exception,
     setup_logging,
 )
 
@@ -146,7 +147,7 @@ async def proxy_api(path: str, request: Request) -> Response:
         logger.warning("⚠️ Proxy request timed out", path=path)
         return JSONResponse(content={"error": "Request timed out"}, status_code=504)
     except httpx.HTTPError as exc:
-        logger.error("❌ Proxy request failed", path=path, error=str(exc))
+        logger.error("❌ Proxy request failed", path=path, error=describe_exception(exc))
         return JSONResponse(content={"error": "Upstream service error"}, status_code=502)
 
     skip_response_headers = {"content-encoding", "transfer-encoding", "content-length"}
@@ -160,7 +161,7 @@ async def proxy_api(path: str, request: Request) -> Response:
                 async for chunk in proxied.aiter_raw():
                     yield chunk
             except httpx.HTTPError as exc:
-                logger.warning("⚠️ Proxy stream interrupted", path=path, error=str(exc))
+                logger.warning("⚠️ Proxy stream interrupted", path=path, error=describe_exception(exc))
             finally:
                 await proxied.aclose()
 
@@ -174,7 +175,7 @@ async def proxy_api(path: str, request: Request) -> Response:
         return JSONResponse(content={"error": "Request timed out"}, status_code=504)
     except httpx.HTTPError as exc:
         await proxied.aclose()
-        logger.error("❌ Proxy request failed", path=path, error=str(exc))
+        logger.error("❌ Proxy request failed", path=path, error=describe_exception(exc))
         return JSONResponse(content={"error": "Upstream service error"}, status_code=502)
     await proxied.aclose()
 

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -24,7 +24,7 @@ from common import (
     setup_logging,
 )
 from common.credit_roles import categorize_role
-from neo4j.exceptions import ServiceUnavailable, SessionExpired
+from neo4j.exceptions import ServiceUnavailable, SessionExpired, TransientError
 from orjson import loads
 
 from graphinator.batch_processor import BatchConfig, Neo4jBatchProcessor
@@ -700,31 +700,31 @@ async def compute_genre_style_stats() -> bool:
     } IN TRANSACTIONS OF 100 ROWS
     """
 
+    # These share the transaction-memory pool with stub cleanup and the insights
+    # background scans, so they get the same retry-under-pressure treatment and
+    # are staggered rather than run back to back.
+    stats_queries = [
+        ("Genre", genre_cypher),
+        ("Style", style_cypher),
+        ("Label", label_cypher),
+    ]
+
     try:
-        logger.info("📊 Computing aggregate stats on Genre nodes...")
-        async with graph.session(database="neo4j") as session:
-            result = await session.run(genre_cypher)
-            summary = await result.consume()
-            logger.info(
-                "✅ Genre stats computed",
-                counters=str(summary.counters),
+        for index, (node_label, cypher) in enumerate(stats_queries):
+            if index:
+                await asyncio.sleep(MAINTENANCE_SETTLE_SECONDS)
+            logger.info(f"📊 Computing aggregate stats on {node_label} nodes...")
+            summary = await _run_maintenance_query(
+                lambda _batch_size, _cypher=cypher: _cypher,
+                f"{node_label} stats computation",
+                node_label=node_label,
             )
-
-        logger.info("📊 Computing aggregate stats on Style nodes...")
-        async with graph.session(database="neo4j") as session:
-            result = await session.run(style_cypher)
-            summary = await result.consume()
+            if summary is None:
+                # Retries exhausted — already logged. Fail so the caller nacks
+                # and the whole maintenance step is retried on the next cycle.
+                return False
             logger.info(
-                "✅ Style stats computed",
-                counters=str(summary.counters),
-            )
-
-        logger.info("📊 Computing aggregate stats on Label nodes...")
-        async with graph.session(database="neo4j") as session:
-            result = await session.run(label_cypher)
-            summary = await result.consume()
-            logger.info(
-                "✅ Label stats computed",
+                f"✅ {node_label} stats computed",
                 counters=str(summary.counters),
             )
     except Exception as e:  # noqa: BLE001 - aggregate stats are advisory; failure must not stop ingestion
@@ -735,6 +735,96 @@ async def compute_genre_style_stats() -> bool:
         return False
 
     return True
+
+
+# ── Post-import maintenance under transaction-memory pressure ──────────────
+#
+# Post-import maintenance shares Neo4j's single transaction-memory pool
+# (dbms.memory.transaction.total.max, 16 GiB in production) with ingestion and
+# the insights background scans. Jul 5-9 that pool was exhausted repeatedly
+# (Neo.TransientError.General.MemoryPoolOutOfMemoryError), which killed
+# stub-Master cleanup twice — silently skipping the maintenance — and broke
+# seven dashboard health checks.
+#
+# Two defences, applied to EVERY batched maintenance query in this module:
+#
+#  1. Bound the working set. Smaller `IN TRANSACTIONS OF n ROWS` chunks keep a
+#     single inner transaction cheap even when the chunk contains high-degree
+#     nodes whose DETACH DELETE touches many relationships.
+#  2. Retry with backoff AND a halved chunk size. Pool exhaustion is transient
+#     and contention-driven, so waiting and then asking for less is the correct
+#     response. Every query here is idempotent and `IN TRANSACTIONS` commits per
+#     chunk, so a retry resumes from where the failed attempt stopped instead of
+#     redoing its work.
+#
+# Reduced from 10000: a chunk of 10000 DETACH DELETEs over high-degree stubs was
+# still large enough to contend for the shared pool.
+STUB_CLEANUP_BATCH_SIZE = 1000
+
+# Floor for the halving backoff — below this the round-trip overhead dominates.
+MAINTENANCE_MIN_BATCH_SIZE = 50
+
+MAINTENANCE_MAX_ATTEMPTS = 4
+MAINTENANCE_RETRY_BASE_DELAY_SECONDS = 30.0
+
+# Pause between consecutive heavy maintenance queries so the transaction pool
+# can drain before the next one claims it, rather than running them back to back.
+MAINTENANCE_SETTLE_SECONDS = 5.0
+
+
+async def _run_maintenance_query(
+    build_cypher: Any,
+    description: str,
+    batch_size: int | None = None,
+    **log_fields: Any,
+) -> Any | None:
+    """Run a batched maintenance query, retrying on transaction-memory exhaustion.
+
+    Args:
+        build_cypher: Callable taking the current batch size and returning the
+            Cypher to run. Called again with a smaller size on each retry.
+        description: Human-readable name used in log messages.
+        batch_size: Starting `IN TRANSACTIONS OF n ROWS` size, or ``None`` for
+            queries that are not batch-size parameterised.
+        **log_fields: Extra structured log fields.
+
+    Returns:
+        The query summary on success, or ``None`` if every attempt failed.
+    """
+    if graph is None:
+        return None
+
+    current_batch = batch_size
+    for attempt in range(1, MAINTENANCE_MAX_ATTEMPTS + 1):
+        try:
+            async with graph.session(database="neo4j") as session:
+                result = await session.run(build_cypher(current_batch))
+                return await result.consume()
+        except TransientError as e:
+            # Pool exhaustion / contention — retryable. Anything else is a real
+            # error and propagates to the caller's handler.
+            if attempt == MAINTENANCE_MAX_ATTEMPTS:
+                logger.error(
+                    f"❌ {description} exhausted retries under transaction-memory pressure",
+                    attempts=attempt,
+                    batch_size=current_batch,
+                    error=str(e),
+                    **log_fields,
+                )
+                return None
+            delay = MAINTENANCE_RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1))
+            if current_batch is not None:
+                current_batch = max(MAINTENANCE_MIN_BATCH_SIZE, current_batch // 2)
+            logger.warning(
+                f"⚠️ {description} hit transaction-memory pressure — retrying with a smaller batch",
+                attempt=attempt,
+                next_batch_size=current_batch,
+                retry_in_seconds=delay,
+                error=str(e),
+                **log_fields,
+            )
+            await asyncio.sleep(delay)
+    return None
 
 
 async def cleanup_all_stub_nodes() -> bool:
@@ -750,7 +840,11 @@ async def cleanup_all_stub_nodes() -> bool:
         caller can nack and retry (each cleanup is idempotent).
     """
     ok = True
-    for data_type in DATA_TYPES:
+    for index, data_type in enumerate(DATA_TYPES):
+        if index:
+            # Stagger: let the shared transaction pool drain between labels
+            # instead of firing four DETACH DELETE sweeps back to back.
+            await asyncio.sleep(MAINTENANCE_SETTLE_SECONDS)
         if not await cleanup_stub_nodes(data_type):
             ok = False
     return ok
@@ -792,32 +886,46 @@ async def cleanup_stub_nodes(data_type: str) -> bool:
     # forever. Mirrors the compute_genre_style_stats batching in this file: the
     # driving MATCH sits OUTSIDE the transactional subquery and the node is
     # re-imported via WITH, so each inner transaction deletes at most one chunk.
-    cleanup_cypher = f"""
+    #
+    # The chunk size is a parameter of the retry loop, not a constant in the
+    # query: under transaction-memory pressure _run_maintenance_query re-runs
+    # this with progressively smaller chunks. IN TRANSACTIONS commits per chunk,
+    # so a retry only has to delete what the failed attempt did not.
+    def _build_cleanup_cypher(batch_size: int | None) -> str:
+        return f"""
     MATCH (n:{label})
     WHERE n.sha256 IS NULL
     CALL {{
         WITH n
         DETACH DELETE n
-    }} IN TRANSACTIONS OF 10000 ROWS
+    }} IN TRANSACTIONS OF {batch_size} ROWS
     """
 
     try:
-        async with graph.session(database="neo4j") as session:
-            result = await session.run(cleanup_cypher)
-            summary = await result.consume()
-            deleted = summary.counters.nodes_deleted
+        summary = await _run_maintenance_query(
+            _build_cleanup_cypher,
+            f"Stub {label} cleanup",
+            batch_size=STUB_CLEANUP_BATCH_SIZE,
+            data_type=data_type,
+        )
+        if summary is None:
+            # Retries exhausted — already logged. Report failure so the caller
+            # nacks and the cleanup is retried on the next cycle rather than
+            # being silently skipped.
+            return False
 
-            if deleted > 0:
-                logger.info(
-                    f"🧹 Cleaned up {deleted} stub {label} nodes (no sha256 property)",
-                    data_type=data_type,
-                    deleted=deleted,
-                )
-            else:
-                logger.info(
-                    f"✅ No stub {label} nodes to clean up",
-                    data_type=data_type,
-                )
+        deleted = summary.counters.nodes_deleted
+        if deleted > 0:
+            logger.info(
+                f"🧹 Cleaned up {deleted} stub {label} nodes (no sha256 property)",
+                data_type=data_type,
+                deleted=deleted,
+            )
+        else:
+            logger.info(
+                f"✅ No stub {label} nodes to clean up",
+                data_type=data_type,
+            )
     except Exception as e:  # noqa: BLE001 - stub cleanup is advisory; failure must not stop ingestion
         logger.error(
             f"❌ Failed to clean up stub {label} nodes",

--- a/insights/cache.py
+++ b/insights/cache.py
@@ -1,8 +1,34 @@
 """Redis cache for precomputed insight results.
 
-Uses cache-aside (lazy loading) pattern with configurable TTL.
-All operations are safe — Redis failures fall through silently
-so the service can always fall back to PostgreSQL.
+Uses cache-aside (lazy loading) with a **generation-versioned key namespace**.
+All operations are safe — Redis failures fall through silently so the service
+can always fall back to PostgreSQL.
+
+Why a generation, not a plain DELETE
+------------------------------------
+Cache-aside is a read-then-populate pair with an unbounded gap between the two
+(the endpoint reads Postgres, exits the connection context — a real cooperative
+scheduling yield — then serialises and writes to Redis). The scheduler
+concurrently does DELETE+INSERT in a transaction and then invalidates.
+
+With a plain SCAN+DELETE invalidation the two can interleave as:
+
+1. endpoint reads the OLD rows from Postgres,
+2. scheduler commits the NEW rows and invalidates the cache,
+3. endpoint's ``set`` lands — writing the stale result *after* the invalidation.
+
+That stale entry then survives with TTL = ``schedule_hours`` (24h by default)
+and is served to every subsequent request until the *next* cycle's
+invalidation, masking freshly computed data for a full day.
+
+Versioning the namespace removes the race instead of narrowing it. Every key is
+written as ``insights:g{generation}:...``, and the scheduler bumps the
+generation on invalidation. A request captures the generation *before* its
+database read, so a request that straddles a recompute writes into the OLD
+generation's namespace — which nobody reads any more — while readers arriving
+after the bump miss cleanly and repopulate from the new data. There is no
+ordering requirement between the endpoint's ``set`` and the scheduler's
+invalidation at all.
 """
 
 import json
@@ -13,18 +39,58 @@ import structlog
 
 logger = structlog.get_logger(__name__)
 
+# The monotonically increasing cache generation.
+#
+# Deliberately OUTSIDE the "insights:*" namespace: invalidate_all scans and
+# deletes that namespace, and deleting the generation counter would roll the
+# namespace back to g0 and resurrect keys from an earlier generation.
+GENERATION_KEY = "insights-generation"
+
+# Only generation-scoped keys belong to this cache. Scanning "insights:*" would
+# also sweep the API service's own "insights:data-completeness" entry (a 6h
+# cache) when both services share a Redis.
+_VERSIONED_KEY_PATTERN = "insights:g*"
+
 
 class InsightsCache:
-    """Redis cache for precomputed insight results."""
+    """Redis cache for precomputed insight results, keyed by generation."""
 
     def __init__(self, redis: Any, ttl_seconds: int) -> None:
         self._redis = redis
         self._ttl = ttl_seconds
 
-    async def get(self, key: str) -> dict[str, Any] | None:
-        """Get cached value. Returns None on miss or Redis error."""
+    @staticmethod
+    def versioned_key(key: str, generation: int) -> str:
+        """Return ``key`` rewritten into ``generation``'s namespace.
+
+        Accepts keys with or without the legacy ``insights:`` prefix so call
+        sites can keep using their existing cache-key strings.
+        """
+        suffix = key.removeprefix("insights:")
+        return f"insights:g{generation}:{suffix}"
+
+    async def generation(self) -> int:
+        """Return the current cache generation.
+
+        Callers MUST read this *before* their database read, and pass the same
+        value to both :meth:`get` and :meth:`set`, so a request that straddles a
+        recompute writes to the generation it actually read from.
+
+        Returns ``0`` when the counter is unset or Redis is unavailable.
+        """
         try:
-            raw = await self._redis.get(key)
+            raw = await self._redis.get(GENERATION_KEY)
+            if raw is None:
+                return 0
+            return int(raw)
+        except Exception:
+            logger.debug("⚠️ Cache generation read failed, using generation 0")
+            return 0
+
+    async def get(self, key: str, generation: int) -> dict[str, Any] | None:
+        """Get a cached value from ``generation``. Returns None on miss or Redis error."""
+        try:
+            raw = await self._redis.get(self.versioned_key(key, generation))
             if raw is None:
                 return None
             result: dict[str, Any] = json.loads(raw)
@@ -33,26 +99,58 @@ class InsightsCache:
             logger.debug("⚠️ Cache get failed, falling through to database", key=key)
             return None
 
-    async def set(self, key: str, value: dict[str, Any]) -> None:
-        """Cache a value with TTL. Silently fails if Redis is down."""
+    async def set(self, key: str, value: dict[str, Any], generation: int) -> None:
+        """Cache a value in ``generation`` with TTL. Silently fails if Redis is down.
+
+        Writing into a superseded generation is harmless by construction: those
+        keys are unreachable and expire on their own.
+        """
         try:
-            await self._redis.set(key, json.dumps(value, default=str), ex=self._ttl)
+            await self._redis.set(
+                self.versioned_key(key, generation),
+                json.dumps(value, default=str),
+                ex=self._ttl,
+            )
         except Exception:
             logger.debug("⚠️ Cache set failed", key=key)
 
     async def invalidate_all(self) -> None:
-        """Delete all insights:* keys using SCAN + DELETE (never KEYS *)."""
+        """Retire the current generation and reclaim its keys.
+
+        Bumping the generation is what actually invalidates: it happens
+        atomically (INCR) and takes effect for every subsequent reader
+        immediately. The SCAN+DELETE that follows is only housekeeping to free
+        memory sooner than the TTL would; keys belonging to the new generation
+        are deliberately skipped, since a request may already have populated
+        them from freshly committed data.
+        """
+        try:
+            generation = int(await self._redis.incr(GENERATION_KEY))
+        except Exception:
+            logger.warning("⚠️ Cache generation bump failed — cache may serve stale data until TTL")
+            return
+
+        logger.info("🔄 Cache generation advanced", generation=generation)
+
+        current_prefix = f"insights:g{generation}:"
         try:
             cursor: str | int = "0"
             deleted = 0
             while True:
-                cursor, keys = await self._redis.scan(cursor=int(cursor), match="insights:*", count=100)
-                if keys:
-                    await self._redis.delete(*keys)
-                    deleted += len(keys)
+                cursor, keys = await self._redis.scan(cursor=int(cursor), match=_VERSIONED_KEY_PATTERN, count=100)
+                stale = [k for k in keys if not _as_str(k).startswith(current_prefix)]
+                if stale:
+                    await self._redis.delete(*stale)
+                    deleted += len(stale)
                 if int(cursor) == 0:
                     break
             if deleted:
-                logger.info("🔄 Cache invalidated", keys_deleted=deleted)
+                logger.info("🔄 Cache invalidated", keys_deleted=deleted, generation=generation)
         except Exception:
-            logger.debug("⚠️ Cache invalidation failed")
+            # Non-fatal: the generation bump already invalidated the cache.
+            logger.debug("⚠️ Cache key reclamation failed")
+
+
+def _as_str(key: Any) -> str:
+    """Normalise a Redis key to str (clients may return bytes)."""
+    return key.decode() if isinstance(key, bytes) else str(key)

--- a/insights/computations.py
+++ b/insights/computations.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, Any, cast
 import httpx
 import structlog
 
+from common import describe_exception
+
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
@@ -63,18 +65,6 @@ async def _fetch_from_api(
     return items
 
 
-def _describe_error(exc: Exception) -> str:
-    """Return a non-empty, diagnosable description of *exc*.
-
-    ``str(exc)`` is empty for several exceptions raised here — notably
-    ``httpx.ReadTimeout`` — which previously produced blank ``error=""`` log
-    lines that were impossible to triage. Always prefix the exception type so
-    the failure mode is identifiable even when the message is empty.
-    """
-    detail = str(exc)
-    return f"{type(exc).__name__}: {detail}" if detail else type(exc).__name__
-
-
 async def compute_and_store_artist_centrality(client: httpx.AsyncClient, pool: Any, limit: int = 100) -> int:
     """Compute artist centrality and store results."""
     started_at = datetime.now(UTC)
@@ -109,11 +99,11 @@ async def compute_and_store_artist_centrality(client: httpx.AsyncClient, pool: A
         await _log_computation(pool, "artist_centrality", "completed", started_at, len(results))
         return len(results)
     except Exception as e:
-        logger.error("❌ Artist centrality computation failed", error=str(e))
+        logger.error("❌ Artist centrality computation failed", error=describe_exception(e))
         try:
-            await _log_computation(pool, "artist_centrality", "failed", started_at, error_message=str(e))
+            await _log_computation(pool, "artist_centrality", "failed", started_at, error_message=describe_exception(e))
         except Exception as log_err:
-            logger.warning("⚠️ Failed to log computation error", error=str(log_err))
+            logger.warning("⚠️ Failed to log computation error", error=describe_exception(log_err))
         raise
 
 
@@ -143,11 +133,11 @@ async def compute_and_store_genre_trends(client: httpx.AsyncClient, pool: Any) -
         await _log_computation(pool, "genre_trends", "completed", started_at, len(results))
         return len(results)
     except Exception as e:
-        logger.error("❌ Genre trends computation failed", error=str(e))
+        logger.error("❌ Genre trends computation failed", error=describe_exception(e))
         try:
-            await _log_computation(pool, "genre_trends", "failed", started_at, error_message=str(e))
+            await _log_computation(pool, "genre_trends", "failed", started_at, error_message=describe_exception(e))
         except Exception as log_err:
-            logger.warning("⚠️ Failed to log computation error", error=str(log_err))
+            logger.warning("⚠️ Failed to log computation error", error=describe_exception(log_err))
         raise
 
 
@@ -191,11 +181,11 @@ async def compute_and_store_label_longevity(client: httpx.AsyncClient, pool: Any
         await _log_computation(pool, "label_longevity", "completed", started_at, len(results))
         return len(results)
     except Exception as e:
-        logger.error("❌ Label longevity computation failed", error=str(e))
+        logger.error("❌ Label longevity computation failed", error=describe_exception(e))
         try:
-            await _log_computation(pool, "label_longevity", "failed", started_at, error_message=str(e))
+            await _log_computation(pool, "label_longevity", "failed", started_at, error_message=describe_exception(e))
         except Exception as log_err:
-            logger.warning("⚠️ Failed to log computation error", error=str(log_err))
+            logger.warning("⚠️ Failed to log computation error", error=describe_exception(log_err))
         raise
 
 
@@ -260,11 +250,11 @@ async def compute_and_store_anniversaries(
         await _log_computation(pool, "anniversaries", "completed", started_at, rows_written)
         return rows_written
     except Exception as e:
-        logger.error("❌ Anniversaries computation failed", error=str(e))
+        logger.error("❌ Anniversaries computation failed", error=describe_exception(e))
         try:
-            await _log_computation(pool, "anniversaries", "failed", started_at, error_message=str(e))
+            await _log_computation(pool, "anniversaries", "failed", started_at, error_message=describe_exception(e))
         except Exception as log_err:
-            logger.warning("⚠️ Failed to log computation error", error=str(log_err))
+            logger.warning("⚠️ Failed to log computation error", error=describe_exception(log_err))
         raise
 
 
@@ -308,11 +298,11 @@ async def compute_and_store_data_completeness(client: httpx.AsyncClient, pool: A
         await _log_computation(pool, "data_completeness", "completed", started_at, len(results))
         return len(results)
     except Exception as e:
-        logger.error("❌ Data completeness computation failed", error=_describe_error(e))
+        logger.error("❌ Data completeness computation failed", error=describe_exception(e))
         try:
-            await _log_computation(pool, "data_completeness", "failed", started_at, error_message=_describe_error(e))
+            await _log_computation(pool, "data_completeness", "failed", started_at, error_message=describe_exception(e))
         except Exception as log_err:
-            logger.warning("⚠️ Failed to log computation error", error=_describe_error(log_err))
+            logger.warning("⚠️ Failed to log computation error", error=describe_exception(log_err))
         raise
 
 
@@ -328,11 +318,11 @@ async def compute_and_store_community_enrichment(client: httpx.AsyncClient, pool
         await _log_computation(pool, "community_enrichment", "completed", started_at, enriched)
         return enriched
     except Exception as e:
-        logger.error("❌ Community enrichment failed", error=str(e))
+        logger.error("❌ Community enrichment failed", error=describe_exception(e))
         try:
-            await _log_computation(pool, "community_enrichment", "failed", started_at, error_message=str(e))
+            await _log_computation(pool, "community_enrichment", "failed", started_at, error_message=describe_exception(e))
         except Exception as log_err:
-            logger.warning("⚠️ Failed to log computation error", error=str(log_err))
+            logger.warning("⚠️ Failed to log computation error", error=describe_exception(log_err))
         raise
 
 
@@ -383,11 +373,11 @@ async def compute_and_store_rarity(client: httpx.AsyncClient, pool: Any) -> int:
         await _log_computation(pool, "release_rarity", "completed", started_at, len(results))
         return len(results)
     except Exception as e:
-        logger.error("❌ Release rarity computation failed", error=_describe_error(e))
+        logger.error("❌ Release rarity computation failed", error=describe_exception(e))
         try:
-            await _log_computation(pool, "release_rarity", "failed", started_at, error_message=_describe_error(e))
+            await _log_computation(pool, "release_rarity", "failed", started_at, error_message=describe_exception(e))
         except Exception as log_err:
-            logger.warning("⚠️ Failed to log computation error", error=_describe_error(log_err))
+            logger.warning("⚠️ Failed to log computation error", error=describe_exception(log_err))
         raise
 
 
@@ -419,8 +409,8 @@ async def run_all_computations(
         try:
             results[name] = await factory()
         except Exception as e:
-            logger.error("❌ Computation failed — continuing with remaining computations", computation=name, error=str(e))
-            errors[name] = str(e)
+            logger.error("❌ Computation failed — continuing with remaining computations", computation=name, error=describe_exception(e))
+            errors[name] = describe_exception(e)
 
     total = sum(results.values())
     logger.info("✅ All insight computations complete", total_rows=total, breakdown=results, failed=list(errors.keys()) or None)

--- a/insights/computations.py
+++ b/insights/computations.py
@@ -23,6 +23,59 @@ if TYPE_CHECKING:
 logger = structlog.get_logger(__name__)
 
 
+# ── Per-endpoint HTTP timeouts ──────────────────────────────────────────────
+#
+# Every /api/internal/insights/* endpoint runs an uncached full-scan computation
+# on a cold cache, so a single scalar timeout for the whole client is wrong in
+# both directions: passing ``timeout=300.0`` also gives *connect* 300 seconds
+# (a dead API should fail in seconds), while 300s of *read* is far under the
+# documented worst-case latency of the heavy endpoints. Production saw
+# data_completeness fail once with ReadTimeout and community_enrichment fail
+# four times for the same reason.
+#
+# Split the budget: a short connect/write/pool timeout, and a per-endpoint read
+# timeout with generous headroom over the worst observed cold-cache latency.
+#
+#   endpoint              worst observed cold-cache cost          read budget
+#   --------------------  --------------------------------------  -----------
+#   data-completeness     ~400s releases seq scan (>600s on bad         1800s
+#                         days); API caches the result for 6h
+#   rarity-scores         chunked full-graph Neo4j scans                1800s
+#   community-enrichment  1 Discogs request/second, capped at           3600s
+#                         MAX_ENRICHMENT_RELEASES per invocation
+#   everything else       full-graph Neo4j aggregations                  900s
+_CONNECT_TIMEOUT_SECONDS = 10.0
+_WRITE_TIMEOUT_SECONDS = 30.0
+_POOL_TIMEOUT_SECONDS = 60.0
+DEFAULT_READ_TIMEOUT_SECONDS = 900.0
+
+ENDPOINT_READ_TIMEOUTS: dict[str, float] = {
+    "/api/internal/insights/data-completeness": 1800.0,
+    "/api/internal/insights/rarity-scores": 1800.0,
+    "/api/internal/insights/community-enrichment": 3600.0,
+}
+
+
+def endpoint_timeout(path: str | None = None) -> httpx.Timeout:
+    """Return the ``httpx.Timeout`` to use for an internal computation endpoint.
+
+    Args:
+        path: The API path being requested. ``None`` yields the default budget,
+            which is what the shared client is constructed with.
+
+    Returns:
+        A timeout with a short connect/write/pool budget and a read budget sized
+        for that endpoint's worst-case cold-cache latency.
+    """
+    read = ENDPOINT_READ_TIMEOUTS.get(path or "", DEFAULT_READ_TIMEOUT_SECONDS)
+    return httpx.Timeout(
+        connect=_CONNECT_TIMEOUT_SECONDS,
+        read=read,
+        write=_WRITE_TIMEOUT_SECONDS,
+        pool=_POOL_TIMEOUT_SECONDS,
+    )
+
+
 async def _log_computation(
     pool: Any,
     insight_type: str,
@@ -50,14 +103,17 @@ async def _fetch_from_api(
     client: httpx.AsyncClient,
     path: str,
     params: dict[str, Any] | None = None,
-    timeout: float | None = None,
+    timeout: httpx.Timeout | float | None = None,
 ) -> list[dict[str, Any]]:
-    """Fetch computation data from the API service."""
+    """Fetch computation data from the API service.
+
+    Unless ``timeout`` is given explicitly, the per-endpoint budget from
+    :func:`endpoint_timeout` is applied — never the client's scalar default.
+    """
     kwargs: dict[str, Any] = {}
     if params:
         kwargs["params"] = params
-    if timeout is not None:
-        kwargs["timeout"] = timeout
+    kwargs["timeout"] = endpoint_timeout(path) if timeout is None else timeout
     response = await client.get(path, **kwargs)
     response.raise_for_status()
     data: dict[str, Any] = response.json()
@@ -262,11 +318,10 @@ async def compute_and_store_data_completeness(client: httpx.AsyncClient, pool: A
     """Compute data completeness and store results."""
     started_at = datetime.now(UTC)
     try:
-        # Data completeness does full sequential scans whose duration varies widely
-        # (observed ~230s on a warm day, but exceeding 600s on others). The endpoint
-        # caches results in Redis for 6h, so only the cold path is slow; give the
-        # cold path generous headroom to avoid spurious ReadTimeouts.
-        results = await _fetch_from_api(client, "/api/internal/insights/data-completeness", timeout=1200.0)
+        # Full sequential scans whose duration varies widely (~230s warm, over
+        # 600s on bad days). The endpoint caches in Redis for 6h, so only the
+        # cold path is slow — see ENDPOINT_READ_TIMEOUTS for the budget.
+        results = await _fetch_from_api(client, "/api/internal/insights/data-completeness")
         if not results:
             await _log_computation(pool, "data_completeness", "completed", started_at, 0)
             return 0
@@ -310,7 +365,8 @@ async def compute_and_store_community_enrichment(client: httpx.AsyncClient, pool
     """Trigger community enrichment via the API internal endpoint."""
     started_at = datetime.now(UTC)
     try:
-        response = await client.get("/api/internal/insights/community-enrichment", timeout=3600.0)
+        path = "/api/internal/insights/community-enrichment"
+        response = await client.get(path, timeout=endpoint_timeout(path))
         response.raise_for_status()
         data: dict[str, Any] = response.json()
         enriched = int(data.get("enriched", 0))
@@ -330,9 +386,9 @@ async def compute_and_store_rarity(client: httpx.AsyncClient, pool: Any) -> int:
     """Compute release rarity scores and store results."""
     started_at = datetime.now(UTC)
     try:
-        # The API runs eight full-graph Neo4j scans sequentially (to cap transaction
-        # memory), so allow generous headroom over the client default.
-        results = await _fetch_from_api(client, "/api/internal/insights/rarity-scores", timeout=1200.0)
+        # The API runs the rarity signal scans chunked and sequentially (to cap
+        # transaction memory) — see ENDPOINT_READ_TIMEOUTS for the budget.
+        results = await _fetch_from_api(client, "/api/internal/insights/rarity-scores")
         if not results:
             logger.info("📊 No rarity score results to store")
             await _log_computation(pool, "release_rarity", "completed", started_at, 0)

--- a/insights/insights.py
+++ b/insights/insights.py
@@ -209,8 +209,13 @@ async def top_artists(
         return JSONResponse(content={"error": "Service not ready"}, status_code=503)
 
     cache_key = f"insights:top-artists:{limit}"
+    # Capture the cache generation BEFORE reading Postgres. A request that
+    # straddles a recompute then writes back into the generation it actually
+    # read from, which the scheduler has already retired — so it can never
+    # re-cache pre-update data over fresh results.
+    generation = await _cache.generation() if _cache else 0
     if _cache:
-        cached = await _cache.get(cache_key)
+        cached = await _cache.get(cache_key, generation)
         if cached is not None:
             return JSONResponse(content=cached)
 
@@ -225,7 +230,7 @@ async def top_artists(
     items = [ArtistCentralityItem(rank=r[0], artist_id=r[1], artist_name=r[2], edge_count=r[3]).model_dump() for r in rows]
     result = {"metric": "centrality", "items": items, "count": len(items)}
     if _cache:
-        await _cache.set(cache_key, result)
+        await _cache.set(cache_key, result, generation)
     return JSONResponse(content=result)
 
 
@@ -236,8 +241,10 @@ async def genre_trends(genre: str = Query(...)) -> JSONResponse:
         return JSONResponse(content={"error": "Service not ready"}, status_code=503)
 
     cache_key = f"insights:genre-trends:{genre.replace(':', '_')}"
+    # Read the generation BEFORE the DB read — see insights/cache.py.
+    generation = await _cache.generation() if _cache else 0
     if _cache:
-        cached = await _cache.get(cache_key)
+        cached = await _cache.get(cache_key, generation)
         if cached is not None:
             return JSONResponse(content=cached)
 
@@ -254,7 +261,7 @@ async def genre_trends(genre: str = Query(...)) -> JSONResponse:
     resp = GenreTrendsResponse(genre=genre, trends=[GenreTrendItem(**t) for t in trends], peak_decade=peak)
     result = resp.model_dump()
     if _cache:
-        await _cache.set(cache_key, result)
+        await _cache.set(cache_key, result, generation)
     return JSONResponse(content=result)
 
 
@@ -265,8 +272,10 @@ async def label_longevity(limit: int = Query(50, ge=1, le=200)) -> JSONResponse:
         return JSONResponse(content={"error": "Service not ready"}, status_code=503)
 
     cache_key = f"insights:label-longevity:{limit}"
+    # Read the generation BEFORE the DB read — see insights/cache.py.
+    generation = await _cache.generation() if _cache else 0
     if _cache:
-        cached = await _cache.get(cache_key)
+        cached = await _cache.get(cache_key, generation)
         if cached is not None:
             return JSONResponse(content=cached)
 
@@ -296,7 +305,7 @@ async def label_longevity(limit: int = Query(50, ge=1, le=200)) -> JSONResponse:
     ]
     result = {"items": items, "count": len(items)}
     if _cache:
-        await _cache.set(cache_key, result)
+        await _cache.set(cache_key, result, generation)
     return JSONResponse(content=result)
 
 
@@ -307,8 +316,10 @@ async def release_rarity(limit: int = Query(50, ge=1, le=500)) -> JSONResponse:
         return JSONResponse(content={"error": "Service not ready"}, status_code=503)
 
     cache_key = f"insights:release-rarity:{limit}"
+    # Read the generation BEFORE the DB read — see insights/cache.py.
+    generation = await _cache.generation() if _cache else 0
     if _cache:
-        cached = await _cache.get(cache_key)
+        cached = await _cache.get(cache_key, generation)
         if cached is not None:
             return JSONResponse(content=cached)
 
@@ -344,7 +355,7 @@ async def release_rarity(limit: int = Query(50, ge=1, le=500)) -> JSONResponse:
     ]
     result = {"items": items, "count": len(items)}
     if _cache:
-        await _cache.set(cache_key, result)
+        await _cache.set(cache_key, result, generation)
     return JSONResponse(content=result)
 
 
@@ -356,8 +367,10 @@ async def this_month() -> JSONResponse:
 
     now = datetime.now(UTC)
     cache_key = f"insights:this-month:{now.year}-{now.month}"
+    # Read the generation BEFORE the DB read — see insights/cache.py.
+    generation = await _cache.generation() if _cache else 0
     if _cache:
-        cached = await _cache.get(cache_key)
+        cached = await _cache.get(cache_key, generation)
         if cached is not None:
             return JSONResponse(content=cached)
 
@@ -386,7 +399,7 @@ async def this_month() -> JSONResponse:
     if _cache and items:
         # Only cache non-empty results to avoid caching stale empty data
         # on the 1st of a new month before the scheduler has run
-        await _cache.set(cache_key, result)
+        await _cache.set(cache_key, result, generation)
     return JSONResponse(content=result)
 
 
@@ -397,8 +410,10 @@ async def data_completeness() -> JSONResponse:
         return JSONResponse(content={"error": "Service not ready"}, status_code=503)
 
     cache_key = "insights:data-completeness"
+    # Read the generation BEFORE the DB read — see insights/cache.py.
+    generation = await _cache.generation() if _cache else 0
     if _cache:
-        cached = await _cache.get(cache_key)
+        cached = await _cache.get(cache_key, generation)
         if cached is not None:
             return JSONResponse(content=cached)
 
@@ -425,7 +440,7 @@ async def data_completeness() -> JSONResponse:
     ]
     result = {"items": items, "count": len(items)}
     if _cache:
-        await _cache.set(cache_key, result)
+        await _cache.set(cache_key, result, generation)
     return JSONResponse(content=result)
 
 

--- a/insights/insights.py
+++ b/insights/insights.py
@@ -25,7 +25,7 @@ import uvicorn
 from common import AsyncPostgreSQLPool, HealthServer, parse_postgres_host_port, setup_logging
 from common.config import InsightsConfig
 from insights.cache import InsightsCache
-from insights.computations import run_all_computations
+from insights.computations import endpoint_timeout, run_all_computations
 from insights.models import (
     AnniversaryItem,
     ArtistCentralityItem,
@@ -134,7 +134,12 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
         _client_headers["X-Internal-Secret"] = _config.internal_secret
     else:
         logger.warning("⚠️ INSIGHTS_INTERNAL_SECRET is not set — internal API calls will be rejected by the API")
-    _http_client = httpx.AsyncClient(base_url=_config.api_base_url, timeout=300.0, headers=_client_headers)
+    # A scalar timeout would also apply to *connect* (a dead API must fail in
+    # seconds, not minutes) and is far too tight for the heavy computation
+    # endpoints. Every request overrides this with its per-endpoint budget from
+    # computations.endpoint_timeout(); this is only the fallback for anything
+    # that does not.
+    _http_client = httpx.AsyncClient(base_url=_config.api_base_url, timeout=endpoint_timeout(), headers=_client_headers)
     logger.info("🔧 API HTTP client initialized", base_url=_config.api_base_url)
 
     # Initialize Redis cache

--- a/mcp-server/mcp_server/server.py
+++ b/mcp-server/mcp_server/server.py
@@ -100,7 +100,7 @@ async def _api_get(app: AppContext, path: str, params: dict[str, Any] | None = N
         logger.error("API HTTP error", url=url, status=exc.response.status_code)
         return {"error": f"API returned HTTP {exc.response.status_code}", "url": url}
     except Exception as exc:
-        logger.error("API request failed", url=url, error=str(exc))
+        logger.error("API request failed", url=url, error=repr(exc))
         return {"error": f"API request failed: {exc}", "url": url}
 
 
@@ -115,7 +115,7 @@ async def _api_post(app: AppContext, path: str, json_data: dict[str, Any] | None
         logger.error("API HTTP error", url=url, status=exc.response.status_code)
         return {"error": f"API returned HTTP {exc.response.status_code}", "url": url}
     except Exception as exc:
-        logger.error("API request failed", url=url, error=str(exc))
+        logger.error("API request failed", url=url, error=repr(exc))
         return {"error": f"API request failed: {exc}", "url": url}
 
 

--- a/tests/api/test_community_enrichment.py
+++ b/tests/api/test_community_enrichment.py
@@ -431,3 +431,96 @@ class TestCommunityEnrichmentEndpoint:
             assert "error" in body
         finally:
             insights_compute_module._pool = original_pool
+
+
+class TestEnrichmentBatchCap:
+    """Regression for the unbounded enrichment loop (discogsography-1cxi).
+
+    The loop is rate-limited to one Discogs request per second, so an unbounded
+    backlog makes the endpoint's wall-clock cost unbounded too — which is how
+    community_enrichment collected four ReadTimeout failures in production.
+    """
+
+    @pytest.mark.asyncio
+    async def test_backlog_is_capped_and_remaining_is_reported(self) -> None:
+        from api.routers.insights_compute import MAX_ENRICHMENT_RELEASES, _enrich_community_counts
+
+        backlog = MAX_ENRICHMENT_RELEASES + 250
+        mock_pool = MagicMock()
+        mock_cur = AsyncMock()
+        call_count = 0
+
+        async def mock_fetchall():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [{"release_id": i} for i in range(backlog)]
+            return []
+
+        mock_cur.fetchall = mock_fetchall
+        # No OAuth token -> returns immediately, before the rate-limited loop,
+        # so the assertion isolates the batching decision.
+        mock_cur.fetchone = AsyncMock(return_value=None)
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+
+        result = await _enrich_community_counts(mock_pool, None, None)
+
+        # Only MAX_ENRICHMENT_RELEASES were taken into this cycle...
+        assert result["skipped"] == MAX_ENRICHMENT_RELEASES
+        # ...and the leftover backlog is reported for the next cycle.
+        assert result["remaining"] == 250
+
+    @pytest.mark.asyncio
+    async def test_backlog_under_the_cap_leaves_nothing_remaining(self) -> None:
+        from api.routers.insights_compute import _enrich_community_counts
+
+        mock_pool = MagicMock()
+        mock_cur = AsyncMock()
+        call_count = 0
+
+        async def mock_fetchall():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [{"release_id": 1}, {"release_id": 2}]
+            return []
+
+        mock_cur.fetchall = mock_fetchall
+        mock_cur.fetchone = AsyncMock(return_value=None)
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+
+        result = await _enrich_community_counts(mock_pool, None, None)
+
+        assert result["remaining"] == 0
+        assert result["skipped"] == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_backlog_reports_zero_remaining(self) -> None:
+        from api.routers.insights_compute import _enrich_community_counts
+
+        mock_pool = MagicMock()
+        mock_cur = AsyncMock()
+        mock_cur.fetchall = AsyncMock(return_value=[])
+        mock_cur.__aenter__ = AsyncMock(return_value=mock_cur)
+        mock_cur.__aexit__ = AsyncMock(return_value=False)
+        mock_conn = AsyncMock()
+        mock_conn.cursor = MagicMock(return_value=mock_cur)
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pool.connection = MagicMock(return_value=mock_conn)
+
+        result = await _enrich_community_counts(mock_pool, None, None)
+
+        assert result["remaining"] == 0

--- a/tests/api/test_insights_compute.py
+++ b/tests/api/test_insights_compute.py
@@ -4,6 +4,17 @@ import json
 from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
+from neo4j.exceptions import Neo4jError
+
+
+def _neo4j_error(code: str, message: str = "boom") -> Neo4jError:
+    """Build a real Neo4jError with a server code.
+
+    ``Neo4jError.code`` is a read-only property, so the driver's own hydration
+    factory is the only way to construct one faithfully — and it dispatches to
+    the right subclass (ClientError / TransientError) from the code itself.
+    """
+    return Neo4jError._hydrate_neo4j(code=code, message=message)
 
 
 class TestArtistCentralityEndpoint:
@@ -257,6 +268,48 @@ class TestRarityScoresEndpoint:
             response = test_client.get("/api/internal/insights/rarity-scores")
         assert response.status_code == 503
         assert "error" in response.json()
+
+    def test_503_on_transaction_timeout_client_error(self, test_client: TestClient) -> None:
+        """discogsography-lx1n: the 600s transaction timeout is a ClientError.
+
+        The previous handler only caught TransientError, so this escaped as an
+        unhandled 500 on every production run.
+        """
+        err = _neo4j_error("Neo.ClientError.Transaction.TransactionTimedOutClientConfiguration", "transaction timed out")
+        with patch(
+            "api.routers.insights_compute.fetch_all_rarity_signals",
+            new=AsyncMock(side_effect=err),
+        ):
+            response = test_client.get("/api/internal/insights/rarity-scores")
+        assert response.status_code == 503
+        body = response.json()
+        assert body["code"] == "Neo.ClientError.Transaction.TransactionTimedOutClientConfiguration"
+
+    def test_503_when_the_timeout_arrives_inside_an_exception_group(self, test_client: TestClient) -> None:
+        """The driver can surface the failure wrapped in an ExceptionGroup."""
+        err = _neo4j_error("Neo.ClientError.Transaction.TransactionTimedOut", "transaction timed out")
+        group = ExceptionGroup("unhandled errors in a TaskGroup", [err])
+        with patch(
+            "api.routers.insights_compute.fetch_all_rarity_signals",
+            new=AsyncMock(side_effect=group),
+        ):
+            response = test_client.get("/api/internal/insights/rarity-scores")
+        assert response.status_code == 503
+
+    def test_non_retryable_client_error_is_not_masked_as_503(self, test_client: TestClient) -> None:
+        """A genuine query bug must still surface as a server error, not a 503."""
+        from neo4j.exceptions import ClientError
+
+        err = _neo4j_error("Neo.ClientError.Statement.SyntaxError", "invalid syntax")
+        assert isinstance(err, ClientError)  # same class, non-retryable code
+        with patch(
+            "api.routers.insights_compute.fetch_all_rarity_signals",
+            new=AsyncMock(side_effect=err),
+        ):
+            # The fixture's TestClient uses raise_server_exceptions=False, so an
+            # unhandled exception surfaces as a 500 rather than propagating.
+            response = test_client.get("/api/internal/insights/rarity-scores")
+        assert response.status_code == 500
 
 
 class TestAnniversariesValidation:

--- a/tests/api/test_rarity_queries.py
+++ b/tests/api/test_rarity_queries.py
@@ -615,6 +615,59 @@ class TestGetRarityByLabel:
 # ── Neo4j batch query tests ──────────────────────────────────────────
 
 
+def _fake_run_query(
+    *,
+    pressing: list | None = None,
+    label: list | None = None,
+    formats: list | None = None,
+    temporal: list | None = None,
+    degree: list | None = None,
+    artist_degree: list | None = None,
+    label_size: list | None = None,
+    genre_count: list | None = None,
+    page_size: int = 20_000,
+):
+    """Build a run_query stub that dispatches on the cypher, not on call order.
+
+    fetch_all_rarity_signals is paginated, so the call sequence is
+    (page query, 8 signal queries)* + a final empty page + a count query.
+    Dispatching on the query text keeps these tests independent of that
+    interleaving.
+    """
+    pressing = pressing or []
+    signal_rows = {
+        "label_catalog_size": label or [],
+        "r.formats AS formats": formats or [],
+        "latest_sibling_year": temporal or [],
+        "AS degree": degree or [],
+        "artist_max_degree": artist_degree or [],
+        "label_max_catalog": label_size or [],
+        "genre_max_release_count": genre_count or [],
+    }
+    # Every release the pressing query knows about, paged out by the keyset walk.
+    all_ids = [row["release_id"] for row in pressing]
+    served: list[str] = []
+
+    async def _run(_driver, cypher, **kwargs):
+        if "ORDER BY r.id" in cypher:  # keyset page query
+            cursor = kwargs["cursor"]
+            remaining = [i for i in all_ids if i > cursor]
+            page = remaining[:page_size]
+            served.extend(page)
+            return [{"release_id": i} for i in page]
+        if "count(r) AS total" in cypher:  # coverage check
+            return [{"total": len(all_ids)}]
+        ids = set(kwargs["ids"])
+        if "pressing_count," in cypher:
+            return [r for r in pressing if r["release_id"] in ids]
+        for marker, rows in signal_rows.items():
+            if marker in cypher:
+                return [r for r in rows if r["release_id"] in ids]
+        raise AssertionError(f"unrecognised cypher:\n{cypher}")
+
+    return _run
+
+
 class TestFetchAllRaritySignals:
     @pytest.mark.asyncio
     async def test_computes_scores_for_releases(self) -> None:
@@ -646,17 +699,17 @@ class TestFetchAllRaritySignals:
         mock_pool = MagicMock()
         mock_pool.connection = MagicMock(return_value=mock_conn)
 
-        with patch("api.queries.rarity_queries.run_query") as mock_run:
-            mock_run.side_effect = [
-                pressing_data,
-                label_data,
-                format_data,
-                temporal_data,
-                degree_data,
-                artist_degree_data,
-                label_size_data,
-                genre_count_data,
-            ]
+        run_query = _fake_run_query(
+            pressing=pressing_data,
+            label=label_data,
+            formats=format_data,
+            temporal=temporal_data,
+            degree=degree_data,
+            artist_degree=artist_degree_data,
+            label_size=label_size_data,
+            genre_count=genre_count_data,
+        )
+        with patch("api.queries.rarity_queries.run_query", side_effect=run_query):
             results = await fetch_all_rarity_signals(mock_driver, mock_pool)
 
         assert len(results) == 1
@@ -695,17 +748,17 @@ class TestFetchAllRaritySignals:
         mock_pool = MagicMock()
         mock_pool.connection = MagicMock(return_value=mock_conn)
 
-        with patch("api.queries.rarity_queries.run_query") as mock_run:
-            mock_run.side_effect = [
-                pressing_data,
-                label_data,
-                format_data,
-                temporal_data,
-                degree_data,
-                artist_degree_data,
-                label_size_data,
-                genre_count_data,
-            ]
+        run_query = _fake_run_query(
+            pressing=pressing_data,
+            label=label_data,
+            formats=format_data,
+            temporal=temporal_data,
+            degree=degree_data,
+            artist_degree=artist_degree_data,
+            label_size=label_size_data,
+            genre_count=genre_count_data,
+        )
+        with patch("api.queries.rarity_queries.run_query", side_effect=run_query):
             results = await fetch_all_rarity_signals(mock_driver, mock_pool)
 
         assert len(results) == 1
@@ -730,17 +783,17 @@ class TestFetchAllRaritySignals:
         mock_pool = MagicMock()
         mock_pool.connection = MagicMock(side_effect=RuntimeError("db connection failed"))
 
-        with patch("api.queries.rarity_queries.run_query") as mock_run:
-            mock_run.side_effect = [
-                pressing_data,
-                label_data,
-                format_data,
-                temporal_data,
-                degree_data,
-                artist_degree_data,
-                label_size_data,
-                genre_count_data,
-            ]
+        run_query = _fake_run_query(
+            pressing=pressing_data,
+            label=label_data,
+            formats=format_data,
+            temporal=temporal_data,
+            degree=degree_data,
+            artist_degree=artist_degree_data,
+            label_size=label_size_data,
+            genre_count=genre_count_data,
+        )
+        with patch("api.queries.rarity_queries.run_query", side_effect=run_query):
             results = await fetch_all_rarity_signals(mock_driver, mock_pool)
 
         assert len(results) == 1
@@ -760,17 +813,17 @@ class TestFetchAllRaritySignals:
         label_size_data = [{"release_id": "1", "label_max_catalog": 2000}]
         genre_count_data = [{"release_id": "1", "genre_max_release_count": 50000}]
 
-        with patch("api.queries.rarity_queries.run_query") as mock_run:
-            mock_run.side_effect = [
-                pressing_data,
-                label_data,
-                format_data,
-                temporal_data,
-                degree_data,
-                artist_degree_data,
-                label_size_data,
-                genre_count_data,
-            ]
+        run_query = _fake_run_query(
+            pressing=pressing_data,
+            label=label_data,
+            formats=format_data,
+            temporal=temporal_data,
+            degree=degree_data,
+            artist_degree=artist_degree_data,
+            label_size=label_size_data,
+            genre_count=genre_count_data,
+        )
+        with patch("api.queries.rarity_queries.run_query", side_effect=run_query):
             results = await fetch_all_rarity_signals(mock_driver, None)
 
         assert len(results) == 1
@@ -782,19 +835,40 @@ class TestFetchAllRaritySignals:
         separate OPTIONAL MATCHes. A single combined pattern makes `m` (and therefore
         pressing_count) null whenever the release is its master's ONLY pressing —
         misclassifying the rarest pressing case as "no master link".
+
+        Asserted against the query actually handed to the driver, so the property
+        survives the chunked (page-scoped) rewrite of fetch_all_rarity_signals.
         """
         mock_driver = MagicMock()
+        pressing_data = [{"release_id": "1", "pressing_count": 1, "title": "R1", "artist_name": "A1", "year": 1970}]
+        run_query = _fake_run_query(pressing=pressing_data)
+        sent: list[str] = []
 
-        with patch("api.queries.rarity_queries.run_query") as mock_run:
-            mock_run.side_effect = [[], [], [], [], [], [], [], []]
+        async def _recording(driver, cypher, **kwargs):
+            sent.append(cypher)
+            return await run_query(driver, cypher, **kwargs)
+
+        with patch("api.queries.rarity_queries.run_query", side_effect=_recording):
             await fetch_all_rarity_signals(mock_driver, None)
 
-        pressing_cypher = mock_run.call_args_list[0].args[1]
+        pressing_cypher = next(c for c in sent if "pressing_count," in c)
         # Two independent OPTIONAL MATCH clauses, not one combined pattern that
         # conditions `m` on a sibling existing.
         assert "OPTIONAL MATCH (r)-[:DERIVED_FROM]->(m:Master)\n" in pressing_cypher
         assert "OPTIONAL MATCH (m)<-[:DERIVED_FROM]-(sibling:Release)" in pressing_cypher
         assert "OPTIONAL MATCH (r)-[:DERIVED_FROM]->(m:Master)<-[:DERIVED_FROM]-(sibling:Release)" not in pressing_cypher
+        # The +1 must live inside the non-null branch, not in the aggregate —
+        # otherwise the combined-pattern bug returns by another route.
+        assert "count(DISTINCT sibling) AS sibling_count" in pressing_cypher
+        assert "CASE WHEN m IS NULL THEN 0 ELSE sibling_count + 1 END" in pressing_cypher
+
+    def test_pressing_query_constant_keeps_the_split_lookup(self) -> None:
+        """The chunked constant is the single source of truth — pin it directly."""
+        from api.queries.rarity_queries import _PRESSING_QUERY
+
+        assert "OPTIONAL MATCH (r)-[:DERIVED_FROM]->(m:Master)\n" in _PRESSING_QUERY
+        assert "OPTIONAL MATCH (m)<-[:DERIVED_FROM]-(sibling:Release)" in _PRESSING_QUERY
+        assert "OPTIONAL MATCH (r)-[:DERIVED_FROM]->(m:Master)<-[:DERIVED_FROM]-(sibling:Release)" not in _PRESSING_QUERY
 
     @pytest.mark.asyncio
     async def test_sole_pressing_of_master_scores_as_unique_not_standalone(self) -> None:
@@ -814,17 +888,17 @@ class TestFetchAllRaritySignals:
         label_size_data = [{"release_id": "1", "label_max_catalog": 2000}]
         genre_count_data = [{"release_id": "1", "genre_max_release_count": 50000}]
 
-        with patch("api.queries.rarity_queries.run_query") as mock_run:
-            mock_run.side_effect = [
-                pressing_data,
-                label_data,
-                format_data,
-                temporal_data,
-                degree_data,
-                artist_degree_data,
-                label_size_data,
-                genre_count_data,
-            ]
+        run_query = _fake_run_query(
+            pressing=pressing_data,
+            label=label_data,
+            formats=format_data,
+            temporal=temporal_data,
+            degree=degree_data,
+            artist_degree=artist_degree_data,
+            label_size=label_size_data,
+            genre_count=genre_count_data,
+        )
+        with patch("api.queries.rarity_queries.run_query", side_effect=run_query):
             results = await fetch_all_rarity_signals(mock_driver, None)
 
         assert results[0]["pressing_scarcity"] == 100.0
@@ -894,3 +968,177 @@ class TestRarityPaginationTiebreaker:
         ):
             await get_rarity_by_label(MagicMock(), mock_pool, "456")
         assert "ORDER BY rarity_score DESC, release_id" in self._first_order_by_sql(mock_cur)
+
+
+class TestRarityChunking:
+    """discogsography-lx1n: the rarity signal scans must never run unbounded.
+
+    Eight full-graph `MATCH (r:Release)` scans blew Neo4j's 600s
+    db.transaction.timeout on every production run, failing release_rarity 33
+    cycles in a row.
+    """
+
+    def test_no_signal_query_scans_the_whole_release_set(self) -> None:
+        """Every signal query must be scoped to an explicit $ids page."""
+        from api.queries import rarity_queries
+
+        signal_queries = {
+            name: value
+            for name, value in vars(rarity_queries).items()
+            if name.endswith("_QUERY") and name not in {"_RELEASE_ID_PAGE_QUERY", "_RELEASE_COUNT_QUERY"}
+        }
+        assert signal_queries, "no signal queries discovered — did they get renamed?"
+
+        for name, cypher in signal_queries.items():
+            assert "UNWIND $ids AS rid" in cypher, f"{name} is not page-scoped"
+            assert "MATCH (r:Release {id: rid})" in cypher, f"{name} does not seek by indexed id"
+            # The unbounded scan that caused the outage.
+            assert "MATCH (r:Release)\n" not in cypher, f"{name} reintroduced a full-graph scan"
+
+    def test_query_timeout_stays_under_the_server_transaction_timeout(self) -> None:
+        """Must fail fast rather than burn the full 600s db.transaction.timeout."""
+        from api.queries.rarity_queries import RARITY_QUERY_TIMEOUT_SECONDS
+
+        assert RARITY_QUERY_TIMEOUT_SECONDS < 600.0
+
+    @pytest.mark.asyncio
+    async def test_every_neo4j_query_carries_an_explicit_timeout(self) -> None:
+        mock_driver = MagicMock()
+        pressing_data = [{"release_id": "1", "pressing_count": 1, "title": "R1", "artist_name": "A1", "year": 1970}]
+        run_query = _fake_run_query(pressing=pressing_data)
+        seen: list[float | None] = []
+
+        async def _recording(driver, cypher, **kwargs):
+            seen.append(kwargs.get("timeout"))
+            return await run_query(driver, cypher, **kwargs)
+
+        with patch("api.queries.rarity_queries.run_query", side_effect=_recording):
+            await fetch_all_rarity_signals(mock_driver, None)
+
+        from api.queries.rarity_queries import RARITY_QUERY_TIMEOUT_SECONDS
+
+        assert seen, "no queries were run"
+        assert all(t == RARITY_QUERY_TIMEOUT_SECONDS for t in seen), seen
+
+    @pytest.mark.asyncio
+    async def test_pages_the_release_set_and_scores_every_release(self) -> None:
+        """A release set larger than one page is fully covered across pages."""
+        mock_driver = MagicMock()
+        # Ids are strings and the walk is a lexicographic keyset scan, so use
+        # zero-padded ids to keep string order == numeric order.
+        ids = [f"{i:04d}" for i in range(25)]
+        pressing_data = [{"release_id": rid, "pressing_count": 1, "title": f"R{rid}", "artist_name": "A", "year": 1970} for rid in ids]
+        degree_data = [{"release_id": rid, "degree": 3} for rid in ids]
+
+        page_size = 10
+        run_query = _fake_run_query(pressing=pressing_data, degree=degree_data, page_size=page_size)
+        pages: list[int] = []
+
+        async def _recording(driver, cypher, **kwargs):
+            rows = await run_query(driver, cypher, **kwargs)
+            if "ORDER BY r.id" in cypher and rows:
+                pages.append(len(rows))
+            return rows
+
+        with patch("api.queries.rarity_queries.run_query", side_effect=_recording):
+            results = await fetch_all_rarity_signals(mock_driver, None, page_size=page_size)
+
+        # 25 releases at 10/page -> 10, 10, 5
+        assert pages == [10, 10, 5]
+        assert [r["release_id"] for r in results] == ids
+
+    @pytest.mark.asyncio
+    async def test_no_page_query_requests_more_than_page_size(self) -> None:
+        mock_driver = MagicMock()
+        ids = [f"{i:04d}" for i in range(12)]
+        pressing_data = [{"release_id": rid, "pressing_count": 1, "title": "R", "artist_name": "A", "year": 1970} for rid in ids]
+        run_query = _fake_run_query(pressing=pressing_data, page_size=5)
+        limits: list[int] = []
+
+        async def _recording(driver, cypher, **kwargs):
+            if "ORDER BY r.id" in cypher:
+                limits.append(kwargs["limit"])
+            return await run_query(driver, cypher, **kwargs)
+
+        with patch("api.queries.rarity_queries.run_query", side_effect=_recording):
+            await fetch_all_rarity_signals(mock_driver, None, page_size=5)
+
+        assert limits and all(limit == 5 for limit in limits)
+
+    @pytest.mark.asyncio
+    async def test_signal_queries_only_receive_ids_from_the_current_page(self) -> None:
+        mock_driver = MagicMock()
+        ids = [f"{i:04d}" for i in range(6)]
+        pressing_data = [{"release_id": rid, "pressing_count": 1, "title": "R", "artist_name": "A", "year": 1970} for rid in ids]
+        run_query = _fake_run_query(pressing=pressing_data, page_size=2)
+        id_batches: list[list[str]] = []
+
+        async def _recording(driver, cypher, **kwargs):
+            if "UNWIND $ids AS rid" in cypher:
+                id_batches.append(list(kwargs["ids"]))
+            return await run_query(driver, cypher, **kwargs)
+
+        with patch("api.queries.rarity_queries.run_query", side_effect=_recording):
+            await fetch_all_rarity_signals(mock_driver, None, page_size=2)
+
+        assert id_batches
+        assert all(len(batch) <= 2 for batch in id_batches)
+        # 3 pages x 8 signal queries
+        assert len(id_batches) == 24
+
+    @pytest.mark.asyncio
+    async def test_hidden_gem_percentiles_span_pages(self) -> None:
+        """Percentile ranks are global, not per-page — a paged walk must not change them."""
+        mock_driver = MagicMock()
+        ids = [f"{i:04d}" for i in range(6)]
+        pressing_data = [{"release_id": rid, "pressing_count": 1, "title": "R", "artist_name": "A", "year": 1970} for rid in ids]
+        artist_degree_data = [{"release_id": rid, "artist_max_degree": (i + 1) * 10} for i, rid in enumerate(ids)]
+
+        def _score(page_size: int) -> list[float]:
+            return [r["hidden_gem_score"] for r in scored[page_size]]
+
+        scored = {}
+        for page_size in (6, 2, 1):
+            run_query = _fake_run_query(
+                pressing=pressing_data,
+                artist_degree=artist_degree_data,
+                page_size=page_size,
+            )
+            with patch("api.queries.rarity_queries.run_query", side_effect=run_query):
+                scored[page_size] = await fetch_all_rarity_signals(mock_driver, None, page_size=page_size)
+
+        # Identical results regardless of how the walk was chunked.
+        assert _score(6) == _score(2) == _score(1)
+        # And the percentiles are actually doing something.
+        assert len(set(_score(6))) > 1
+
+    @pytest.mark.asyncio
+    async def test_warns_when_pagination_covers_fewer_releases_than_the_graph(self) -> None:
+        """A truncated keyset walk must be loud, not silent."""
+        mock_driver = MagicMock()
+        pressing_data = [{"release_id": "1", "pressing_count": 1, "title": "R", "artist_name": "A", "year": 1970}]
+        run_query = _fake_run_query(pressing=pressing_data)
+
+        async def _undercounting(driver, cypher, **kwargs):
+            if "count(r) AS total" in cypher:
+                return [{"total": 999}]
+            return await run_query(driver, cypher, **kwargs)
+
+        with (
+            patch("api.queries.rarity_queries.run_query", side_effect=_undercounting),
+            patch("api.queries.rarity_queries.logger.warning") as mock_warning,
+        ):
+            await fetch_all_rarity_signals(mock_driver, None)
+
+        assert mock_warning.called
+        assert mock_warning.call_args.kwargs["missing"] == 998
+
+    @pytest.mark.asyncio
+    async def test_empty_graph_returns_no_results(self) -> None:
+        mock_driver = MagicMock()
+        run_query = _fake_run_query()
+
+        with patch("api.queries.rarity_queries.run_query", side_effect=run_query):
+            results = await fetch_all_rarity_signals(mock_driver, None)
+
+        assert results == []

--- a/tests/common/test_errors.py
+++ b/tests/common/test_errors.py
@@ -1,0 +1,48 @@
+"""Tests for common.errors.describe_exception."""
+
+import httpx
+import pytest
+
+from common import describe_exception
+from common.errors import describe_exception as direct_describe_exception
+
+
+class TestDescribeException:
+    """describe_exception must never return an empty string."""
+
+    def test_exception_with_message_includes_type_and_message(self) -> None:
+        assert describe_exception(ValueError("bad input")) == "ValueError: bad input"
+
+    def test_exception_without_message_falls_back_to_type_name(self) -> None:
+        assert describe_exception(TimeoutError()) == "TimeoutError"
+
+    def test_read_timeout_names_the_type(self) -> None:
+        """The regression that motivated this helper: httpx.ReadTimeout str() is empty."""
+        exc = httpx.ReadTimeout("")
+        assert str(exc) == ""  # guards the premise of the bug
+        assert describe_exception(exc) == "ReadTimeout"
+        assert "ReadTimeout" in describe_exception(exc)
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            httpx.ReadTimeout(""),
+            httpx.ConnectTimeout(""),
+            httpx.ConnectError(""),
+            httpx.PoolTimeout(""),
+            httpx.WriteTimeout(""),
+        ],
+    )
+    def test_message_less_httpx_transport_errors_are_diagnosable(self, exc: Exception) -> None:
+        described = describe_exception(exc)
+        assert described != ""
+        assert described == type(exc).__name__
+
+    def test_never_returns_empty_for_a_bare_exception(self) -> None:
+        assert describe_exception(Exception()) == "Exception"
+
+    def test_accepts_base_exception(self) -> None:
+        assert describe_exception(KeyboardInterrupt()) == "KeyboardInterrupt"
+
+    def test_reexported_from_common_package(self) -> None:
+        assert describe_exception is direct_describe_exception

--- a/tests/graphinator/conftest.py
+++ b/tests/graphinator/conftest.py
@@ -31,3 +31,19 @@ def reset_extraction_complete_signals():
     g.extraction_complete_signals = set()
     yield
     g.extraction_complete_signals = saved
+
+
+@pytest.fixture(autouse=True)
+def instant_maintenance_delays():
+    """Collapse post-import maintenance wall-clock delays to zero.
+
+    Maintenance staggers heavy queries (MAINTENANCE_SETTLE_SECONDS) and backs
+    off on Neo4j transaction-memory pressure (MAINTENANCE_RETRY_BASE_DELAY_SECONDS).
+    Those are production pacing values; tests assert the control flow, not the
+    clock, so waiting on them would only make the suite slow.
+    """
+    with (
+        patch("graphinator.graphinator.MAINTENANCE_SETTLE_SECONDS", 0.0),
+        patch("graphinator.graphinator.MAINTENANCE_RETRY_BASE_DELAY_SECONDS", 0.0),
+    ):
+        yield

--- a/tests/graphinator/test_graphinator.py
+++ b/tests/graphinator/test_graphinator.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextlib
 import json
+import re
 import signal
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -4488,3 +4489,182 @@ class TestStubCleanupBatchAndOrdering:
         assert "releases" in g.extraction_complete_signals
 
         g.extraction_complete_signals = set()
+
+
+class TestMaintenanceUnderMemoryPressure:
+    """discogsography-79p9: Neo4j transaction-memory exhaustion (16 GiB pool).
+
+    Jul 5-9 production hit Neo.TransientError.General.MemoryPoolOutOfMemoryError
+    repeatedly. Stub-Master cleanup failed twice and was silently skipped with no
+    retry, and dashboard health checks failed 7 times.
+    """
+
+    @staticmethod
+    def _pressure_graph(fail_times: int) -> tuple[MagicMock, list[str]]:
+        """Graph mock whose first ``fail_times`` runs raise MemoryPoolOutOfMemoryError."""
+        from neo4j.exceptions import Neo4jError
+
+        run_calls: list[str] = []
+        attempts = {"n": 0}
+
+        class _Result:
+            async def consume(self) -> MagicMock:
+                summary = MagicMock()
+                summary.counters.nodes_deleted = 7
+                return summary
+
+        class _Session:
+            async def __aenter__(self) -> "_Session":
+                return self
+
+            async def __aexit__(self, *args: Any) -> None:
+                return None
+
+            async def run(self, cypher: str, *_args: Any, **_kwargs: Any) -> "_Result":
+                run_calls.append(cypher)
+                attempts["n"] += 1
+                if attempts["n"] <= fail_times:
+                    raise Neo4jError._hydrate_neo4j(
+                        code="Neo.TransientError.General.MemoryPoolOutOfMemoryError",
+                        message="using 16.0 GiB of 16.0 GiB dbms.memory.transaction.total.max",
+                    )
+                return _Result()
+
+        graph_mock = MagicMock()
+        graph_mock.session = MagicMock(return_value=_Session())
+        return graph_mock, run_calls
+
+    def test_cleanup_batch_size_is_bounded(self) -> None:
+        """Reduced from 10000 — a chunk that large still contended for the pool."""
+        import graphinator.graphinator as g
+
+        assert g.STUB_CLEANUP_BATCH_SIZE <= 1000
+        assert g.MAINTENANCE_MIN_BATCH_SIZE <= g.STUB_CLEANUP_BATCH_SIZE
+
+    @pytest.mark.asyncio
+    async def test_cleanup_retries_on_transaction_memory_exhaustion(self) -> None:
+        """The maintenance is retried, not silently skipped."""
+        import graphinator.graphinator as g
+
+        graph_mock, run_calls = self._pressure_graph(fail_times=2)
+        with patch.object(g, "graph", graph_mock):
+            ok = await g.cleanup_stub_nodes("masters")
+
+        assert ok is True, "cleanup must recover once the pool frees up"
+        assert len(run_calls) == 3, "two failures then a success"
+        assert all("Master" in c for c in run_calls)
+
+    @pytest.mark.asyncio
+    async def test_each_retry_halves_the_batch_size(self) -> None:
+        """Under memory pressure, ask the database for less work, not the same."""
+        import graphinator.graphinator as g
+
+        graph_mock, run_calls = self._pressure_graph(fail_times=2)
+        with patch.object(g, "graph", graph_mock):
+            await g.cleanup_stub_nodes("masters")
+
+        sizes = [int(re.search(r"IN TRANSACTIONS OF (\d+) ROWS", c).group(1)) for c in run_calls]
+        assert sizes == [
+            g.STUB_CLEANUP_BATCH_SIZE,
+            g.STUB_CLEANUP_BATCH_SIZE // 2,
+            g.STUB_CLEANUP_BATCH_SIZE // 4,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_batch_size_never_falls_below_the_floor(self) -> None:
+        import graphinator.graphinator as g
+
+        graph_mock, run_calls = self._pressure_graph(fail_times=3)
+        with (
+            patch.object(g, "graph", graph_mock),
+            patch.object(g, "STUB_CLEANUP_BATCH_SIZE", g.MAINTENANCE_MIN_BATCH_SIZE),
+        ):
+            await g.cleanup_stub_nodes("masters")
+
+        sizes = [int(re.search(r"IN TRANSACTIONS OF (\d+) ROWS", c).group(1)) for c in run_calls]
+        assert all(size >= g.MAINTENANCE_MIN_BATCH_SIZE for size in sizes)
+
+    @pytest.mark.asyncio
+    async def test_exhausted_retries_report_failure_for_the_next_cycle(self) -> None:
+        """Never silently skip — return False so the caller nacks and retries."""
+        import graphinator.graphinator as g
+
+        graph_mock, run_calls = self._pressure_graph(fail_times=99)
+        with patch.object(g, "graph", graph_mock):
+            ok = await g.cleanup_stub_nodes("masters")
+
+        assert ok is False
+        assert len(run_calls) == g.MAINTENANCE_MAX_ATTEMPTS
+
+    @pytest.mark.asyncio
+    async def test_non_transient_errors_are_not_retried(self) -> None:
+        """A real bug must fail fast, not burn four attempts and a backoff."""
+        import graphinator.graphinator as g
+
+        run_calls: list[str] = []
+
+        class _Session:
+            async def __aenter__(self) -> "_Session":
+                return self
+
+            async def __aexit__(self, *args: Any) -> None:
+                return None
+
+            async def run(self, cypher: str, *_args: Any, **_kwargs: Any) -> Any:
+                run_calls.append(cypher)
+                raise RuntimeError("syntax error")
+
+        graph_mock = MagicMock()
+        graph_mock.session = MagicMock(return_value=_Session())
+
+        with patch.object(g, "graph", graph_mock), patch.object(g, "logger"):
+            ok = await g.cleanup_stub_nodes("masters")
+
+        assert ok is False
+        assert len(run_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_stats_computation_retries_under_pressure(self) -> None:
+        """Fix-one-fix-all: the sibling maintenance query shares the same pool."""
+        import graphinator.graphinator as g
+
+        graph_mock, run_calls = self._pressure_graph(fail_times=1)
+        with patch.object(g, "graph", graph_mock):
+            ok = await g.compute_genre_style_stats()
+
+        assert ok is True
+        # 1 failed Genre attempt + Genre retry + Style + Label
+        assert len(run_calls) == 4
+
+    @pytest.mark.asyncio
+    async def test_stats_computation_reports_failure_when_retries_exhaust(self) -> None:
+        import graphinator.graphinator as g
+
+        graph_mock, _ = self._pressure_graph(fail_times=99)
+        with patch.object(g, "graph", graph_mock):
+            ok = await g.compute_genre_style_stats()
+
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_cleanup_sweeps_are_staggered(self) -> None:
+        """Four DETACH DELETE sweeps must not fire back to back at the pool."""
+        import graphinator.graphinator as g
+
+        graph_mock, run_calls = self._pressure_graph(fail_times=0)
+        sleeps: list[float] = []
+
+        async def _record_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        with (
+            patch.object(g, "graph", graph_mock),
+            patch.object(g, "MAINTENANCE_SETTLE_SECONDS", 7.5),
+            patch.object(g.asyncio, "sleep", _record_sleep),
+        ):
+            ok = await g.cleanup_all_stub_nodes()
+
+        assert ok is True
+        assert len(run_calls) == 4
+        # One settle between each pair of labels — not before the first.
+        assert sleeps == [7.5, 7.5, 7.5]

--- a/tests/insights/conftest.py
+++ b/tests/insights/conftest.py
@@ -7,6 +7,10 @@ import httpx
 import pytest
 
 
+# Arbitrary non-zero generation — proves endpoints use the value they read.
+TEST_CACHE_GENERATION = 4
+
+
 @pytest.fixture
 def mock_http_client() -> AsyncMock:
     """Mock httpx.AsyncClient for API calls."""
@@ -56,6 +60,9 @@ def test_client(mock_http_client: AsyncMock, mock_pg_pool: AsyncMock) -> TestCli
 def mock_cache() -> AsyncMock:
     """Mock InsightsCache."""
     cache = AsyncMock()
+    # A real int, not an AsyncMock sentinel: endpoints must thread this exact
+    # value from generation() through get() and set() (discogsography-cu2.109).
+    cache.generation = AsyncMock(return_value=TEST_CACHE_GENERATION)
     cache.get = AsyncMock(return_value=None)
     cache.set = AsyncMock()
     cache.invalidate_all = AsyncMock()

--- a/tests/insights/test_cache.py
+++ b/tests/insights/test_cache.py
@@ -1,18 +1,21 @@
 """Tests for insights cache module."""
 
+from typing import Any
 from unittest.mock import AsyncMock
 
+import fakeredis.aioredis as aioredis_fake
 import pytest
 
-from insights.cache import InsightsCache
+from insights.cache import GENERATION_KEY, InsightsCache
 
 
 @pytest.fixture
 def mock_redis() -> AsyncMock:
-    """Create a mock Redis client."""
+    """Create a mock Redis client (for error-path tests)."""
     redis = AsyncMock()
     redis.get = AsyncMock(return_value=None)
     redis.set = AsyncMock()
+    redis.incr = AsyncMock(return_value=1)
     redis.scan = AsyncMock(return_value=(0, []))
     redis.delete = AsyncMock()
     return redis
@@ -24,47 +27,162 @@ def cache(mock_redis: AsyncMock) -> InsightsCache:
     return InsightsCache(mock_redis, ttl_seconds=3600)
 
 
+@pytest.fixture
+def real_redis() -> Any:
+    """A real (in-memory) Redis, so generation semantics are exercised for real."""
+    return aioredis_fake.FakeRedis(decode_responses=True)
+
+
+@pytest.fixture
+def real_cache(real_redis: Any) -> InsightsCache:
+    return InsightsCache(real_redis, ttl_seconds=3600)
+
+
+class TestVersionedKey:
+    def test_namespaces_by_generation(self) -> None:
+        assert InsightsCache.versioned_key("insights:top-artists:10", 3) == "insights:g3:top-artists:10"
+
+    def test_accepts_keys_without_the_legacy_prefix(self) -> None:
+        assert InsightsCache.versioned_key("top-artists:10", 3) == "insights:g3:top-artists:10"
+
+    def test_generation_key_is_outside_the_scanned_namespace(self) -> None:
+        """invalidate_all deletes insights:g* — the counter must not be swept with it."""
+        assert not GENERATION_KEY.startswith("insights:g")
+
+
 class TestCacheGet:
     @pytest.mark.asyncio
     async def test_returns_none_on_miss(self, cache: InsightsCache) -> None:
-        result = await cache.get("insights:top-artists:10")
-        assert result is None
+        assert await cache.get("insights:top-artists:10", 0) is None
 
     @pytest.mark.asyncio
     async def test_returns_cached_value_on_hit(self, cache: InsightsCache, mock_redis: AsyncMock) -> None:
         mock_redis.get.return_value = '{"items": [1, 2, 3], "count": 3}'
-        result = await cache.get("insights:top-artists:10")
-        assert result == {"items": [1, 2, 3], "count": 3}
+        assert await cache.get("insights:top-artists:10", 0) == {"items": [1, 2, 3], "count": 3}
+
+    @pytest.mark.asyncio
+    async def test_reads_from_the_requested_generation(self, cache: InsightsCache, mock_redis: AsyncMock) -> None:
+        await cache.get("insights:top-artists:10", 7)
+        mock_redis.get.assert_awaited_once_with("insights:g7:top-artists:10")
 
     @pytest.mark.asyncio
     async def test_returns_none_on_redis_error(self, cache: InsightsCache, mock_redis: AsyncMock) -> None:
         mock_redis.get.side_effect = ConnectionError("Redis down")
-        result = await cache.get("insights:top-artists:10")
-        assert result is None
+        assert await cache.get("insights:top-artists:10", 0) is None
 
 
 class TestCacheSet:
     @pytest.mark.asyncio
-    async def test_stores_value_with_ttl(self, cache: InsightsCache, mock_redis: AsyncMock) -> None:
-        await cache.set("insights:top-artists:10", {"items": [], "count": 0})
+    async def test_stores_value_with_ttl_in_the_generation_namespace(self, cache: InsightsCache, mock_redis: AsyncMock) -> None:
+        await cache.set("insights:top-artists:10", {"items": [], "count": 0}, 2)
         mock_redis.set.assert_called_once()
         call_args = mock_redis.set.call_args
-        assert call_args[0][0] == "insights:top-artists:10"
+        assert call_args[0][0] == "insights:g2:top-artists:10"
         assert call_args[1]["ex"] == 3600
 
     @pytest.mark.asyncio
     async def test_silently_fails_on_redis_error(self, cache: InsightsCache, mock_redis: AsyncMock) -> None:
         mock_redis.set.side_effect = ConnectionError("Redis down")
-        # Should not raise
-        await cache.set("insights:top-artists:10", {"items": []})
+        await cache.set("insights:top-artists:10", {"items": []}, 0)  # must not raise
+
+
+class TestCacheGeneration:
+    @pytest.mark.asyncio
+    async def test_starts_at_zero(self, real_cache: InsightsCache) -> None:
+        assert await real_cache.generation() == 0
+
+    @pytest.mark.asyncio
+    async def test_advances_on_invalidation(self, real_cache: InsightsCache) -> None:
+        await real_cache.invalidate_all()
+        assert await real_cache.generation() == 1
+        await real_cache.invalidate_all()
+        assert await real_cache.generation() == 2
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_zero_on_redis_error(self, cache: InsightsCache, mock_redis: AsyncMock) -> None:
+        mock_redis.get.side_effect = ConnectionError("Redis down")
+        assert await cache.generation() == 0
+
+
+class TestCacheAsideRace:
+    """discogsography-cu2.109: a request straddling a recompute must not re-cache stale data.
+
+    Interleaving that used to poison the cache for a full schedule interval:
+      1. endpoint reads OLD rows from Postgres,
+      2. scheduler commits NEW rows and invalidates,
+      3. endpoint's set() lands — writing the stale result AFTER the invalidation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_set_after_invalidation_is_not_served(self, real_cache: InsightsCache) -> None:
+        # 1. The request captures the generation before its database read.
+        generation = await real_cache.generation()
+        stale = {"items": ["yesterday's rankings"], "count": 1}
+
+        # 2. The scheduler finishes its cycle and invalidates.
+        await real_cache.invalidate_all()
+
+        # 3. The in-flight request's set finally lands — into the retired generation.
+        await real_cache.set("insights:top-artists:100", stale, generation)
+
+        # A subsequent request reads the CURRENT generation and must miss,
+        # falling through to the freshly computed Postgres rows.
+        current = await real_cache.generation()
+        assert current != generation
+        assert await real_cache.get("insights:top-artists:100", current) is None
+
+    @pytest.mark.asyncio
+    async def test_normal_cache_aside_still_hits(self, real_cache: InsightsCache) -> None:
+        """The fix must not break the non-racing path."""
+        generation = await real_cache.generation()
+        payload = {"items": [1, 2, 3], "count": 3}
+        await real_cache.set("insights:top-artists:100", payload, generation)
+        assert await real_cache.get("insights:top-artists:100", await real_cache.generation()) == payload
+
+    @pytest.mark.asyncio
+    async def test_entries_written_after_the_bump_are_preserved(self, real_cache: InsightsCache) -> None:
+        """Housekeeping must not delete keys from the generation now being served."""
+        await real_cache.invalidate_all()
+        generation = await real_cache.generation()
+        payload = {"items": ["fresh"], "count": 1}
+        await real_cache.set("insights:top-artists:100", payload, generation)
+        assert await real_cache.get("insights:top-artists:100", generation) == payload
+
+    @pytest.mark.asyncio
+    async def test_every_generation_is_distinct(self, real_cache: InsightsCache) -> None:
+        seen = set()
+        for _ in range(3):
+            seen.add(await real_cache.generation())
+            await real_cache.invalidate_all()
+        assert len(seen) == 3
 
 
 class TestCacheInvalidateAll:
     @pytest.mark.asyncio
-    async def test_deletes_matching_keys(self, cache: InsightsCache, mock_redis: AsyncMock) -> None:
-        mock_redis.scan.return_value = (0, ["insights:top-artists:10", "insights:genre-trends:Rock"])
-        await cache.invalidate_all()
-        mock_redis.delete.assert_called_once_with("insights:top-artists:10", "insights:genre-trends:Rock")
+    async def test_reclaims_superseded_generation_keys(self, real_cache: InsightsCache, real_redis: Any) -> None:
+        generation = await real_cache.generation()
+        await real_cache.set("insights:top-artists:10", {"a": 1}, generation)
+        await real_cache.set("insights:genre-trends:Rock", {"b": 2}, generation)
+
+        await real_cache.invalidate_all()
+
+        assert await real_redis.get(f"insights:g{generation}:top-artists:10") is None
+        assert await real_redis.get(f"insights:g{generation}:genre-trends:Rock") is None
+
+    @pytest.mark.asyncio
+    async def test_does_not_touch_unversioned_insights_keys(self, real_cache: InsightsCache, real_redis: Any) -> None:
+        """The API service caches insights:data-completeness on a possibly-shared Redis."""
+        await real_redis.set("insights:data-completeness", "api-owned")
+
+        await real_cache.invalidate_all()
+
+        assert await real_redis.get("insights:data-completeness") == "api-owned"
+
+    @pytest.mark.asyncio
+    async def test_preserves_the_generation_counter(self, real_cache: InsightsCache, real_redis: Any) -> None:
+        await real_cache.invalidate_all()
+        await real_cache.invalidate_all()
+        assert await real_redis.get(GENERATION_KEY) == "2"
 
     @pytest.mark.asyncio
     async def test_handles_no_keys(self, cache: InsightsCache, mock_redis: AsyncMock) -> None:
@@ -74,16 +192,27 @@ class TestCacheInvalidateAll:
 
     @pytest.mark.asyncio
     async def test_handles_multiple_scan_pages(self, cache: InsightsCache, mock_redis: AsyncMock) -> None:
-        # First scan returns cursor=42 (not done), second returns cursor=0 (done)
+        # incr returns 1, so "insights:g1:" is the live generation and is skipped.
         mock_redis.scan.side_effect = [
-            ("42", ["insights:key1"]),
-            ("0", ["insights:key2"]),
+            ("42", ["insights:g0:key1"]),
+            ("0", ["insights:g0:key2"]),
         ]
         await cache.invalidate_all()
         assert mock_redis.delete.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_silently_fails_on_redis_error(self, cache: InsightsCache, mock_redis: AsyncMock) -> None:
-        mock_redis.scan.side_effect = ConnectionError("Redis down")
-        # Should not raise
+    async def test_handles_bytes_keys_from_the_client(self, cache: InsightsCache, mock_redis: AsyncMock) -> None:
+        mock_redis.scan.side_effect = [(0, [b"insights:g0:key1"])]
         await cache.invalidate_all()
+        mock_redis.delete.assert_called_once_with(b"insights:g0:key1")
+
+    @pytest.mark.asyncio
+    async def test_scan_failure_does_not_raise(self, cache: InsightsCache, mock_redis: AsyncMock) -> None:
+        mock_redis.scan.side_effect = ConnectionError("Redis down")
+        await cache.invalidate_all()  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_incr_failure_does_not_raise(self, cache: InsightsCache, mock_redis: AsyncMock) -> None:
+        mock_redis.incr.side_effect = ConnectionError("Redis down")
+        await cache.invalidate_all()  # must not raise
+        mock_redis.delete.assert_not_called()

--- a/tests/insights/test_computations.py
+++ b/tests/insights/test_computations.py
@@ -48,7 +48,7 @@ def _make_mock_pool() -> AsyncMock:
 class TestFetchFromApi:
     @pytest.mark.asyncio
     async def test_basic_call_without_params_or_timeout(self) -> None:
-        from insights.computations import _fetch_from_api
+        from insights.computations import _fetch_from_api, endpoint_timeout
 
         mock_response = MagicMock()
         mock_response.json.return_value = {"items": [{"id": 1}]}
@@ -58,12 +58,13 @@ class TestFetchFromApi:
 
         result = await _fetch_from_api(mock_client, "/api/test")
 
-        mock_client.get.assert_called_once_with("/api/test")
+        # An unmapped path still gets the split default budget, never a scalar.
+        mock_client.get.assert_called_once_with("/api/test", timeout=endpoint_timeout("/api/test"))
         assert result == [{"id": 1}]
 
     @pytest.mark.asyncio
     async def test_passes_params_when_provided(self) -> None:
-        from insights.computations import _fetch_from_api
+        from insights.computations import _fetch_from_api, endpoint_timeout
 
         mock_response = MagicMock()
         mock_response.json.return_value = {"items": []}
@@ -73,7 +74,7 @@ class TestFetchFromApi:
 
         await _fetch_from_api(mock_client, "/api/test", params={"limit": 10})
 
-        mock_client.get.assert_called_once_with("/api/test", params={"limit": 10})
+        mock_client.get.assert_called_once_with("/api/test", params={"limit": 10}, timeout=endpoint_timeout("/api/test"))
 
     @pytest.mark.asyncio
     async def test_passes_timeout_when_provided(self) -> None:
@@ -719,3 +720,52 @@ class TestRunAllComputations:
             await run_all_computations(mock_client, mock_pool, milestone_years=custom_milestones)
 
         mock_anniv.assert_called_once_with(mock_client, mock_pool, milestone_years=custom_milestones)
+
+
+class TestEndpointTimeouts:
+    """Regression for ReadTimeout failures on the heavy endpoints (discogsography-1cxi)."""
+
+    def test_connect_budget_is_short_so_a_dead_api_fails_fast(self) -> None:
+        from insights.computations import endpoint_timeout
+
+        timeout = endpoint_timeout("/api/internal/insights/data-completeness")
+        assert timeout.connect is not None
+        assert timeout.connect <= 30.0
+
+    def test_default_read_budget_applies_to_unmapped_paths(self) -> None:
+        from insights.computations import DEFAULT_READ_TIMEOUT_SECONDS, endpoint_timeout
+
+        assert endpoint_timeout("/api/internal/insights/genre-trends").read == DEFAULT_READ_TIMEOUT_SECONDS
+        assert endpoint_timeout().read == DEFAULT_READ_TIMEOUT_SECONDS
+
+    def test_data_completeness_read_budget_clears_the_documented_worst_case(self) -> None:
+        """The API documents a ~400s releases seq scan, exceeding 600s on bad days."""
+        from insights.computations import endpoint_timeout
+
+        read = endpoint_timeout("/api/internal/insights/data-completeness").read
+        assert read is not None
+        assert read >= 1200.0
+
+    def test_community_enrichment_budget_covers_the_capped_batch(self) -> None:
+        """1 Discogs req/s * MAX_ENRICHMENT_RELEASES must fit inside the read budget."""
+        from api.routers.insights_compute import _ENRICHMENT_DELAY_SECONDS, MAX_ENRICHMENT_RELEASES
+        from insights.computations import endpoint_timeout
+
+        read = endpoint_timeout("/api/internal/insights/community-enrichment").read
+        assert read is not None
+        worst_case = MAX_ENRICHMENT_RELEASES * _ENRICHMENT_DELAY_SECONDS
+        assert read > worst_case, f"read budget {read}s does not cover worst case {worst_case}s"
+
+    def test_rarity_read_budget_clears_the_neo4j_transaction_timeout(self) -> None:
+        """Must outlast the server-side db.transaction.timeout (600s) plus overhead."""
+        from insights.computations import endpoint_timeout
+
+        read = endpoint_timeout("/api/internal/insights/rarity-scores").read
+        assert read is not None
+        assert read >= 1200.0
+
+    def test_every_mapped_endpoint_exceeds_the_default(self) -> None:
+        from insights.computations import DEFAULT_READ_TIMEOUT_SECONDS, ENDPOINT_READ_TIMEOUTS
+
+        for path, read in ENDPOINT_READ_TIMEOUTS.items():
+            assert read > DEFAULT_READ_TIMEOUT_SECONDS, path

--- a/tests/insights/test_computations.py
+++ b/tests/insights/test_computations.py
@@ -120,21 +120,93 @@ class TestFetchFromApi:
 
 
 class TestDescribeError:
-    """Tests for _describe_error — guards against blank error log lines."""
+    """Guards against blank error log lines from message-less exceptions."""
 
     def test_includes_type_when_message_empty(self) -> None:
         """An exception with an empty str() (e.g. httpx.ReadTimeout) still names its type."""
         import httpx
 
-        from insights.computations import _describe_error
+        from insights.computations import describe_exception
 
         # httpx.ReadTimeout("") has an empty str(), which previously logged as error="".
-        assert _describe_error(httpx.ReadTimeout("")) == "ReadTimeout"
+        assert describe_exception(httpx.ReadTimeout("")) == "ReadTimeout"
 
     def test_includes_type_and_message_when_present(self) -> None:
-        from insights.computations import _describe_error
+        from insights.computations import describe_exception
 
-        assert _describe_error(ValueError("boom")) == "ValueError: boom"
+        assert describe_exception(ValueError("boom")) == "ValueError: boom"
+
+
+# Every compute_and_store_* entry point, with the API path it fetches. A
+# ReadTimeout on that fetch must produce a log line + computation_log row that
+# names "ReadTimeout" rather than the historical blank error="".
+_COMPUTATION_ENTRY_POINTS = [
+    ("compute_and_store_artist_centrality", "artist_centrality"),
+    ("compute_and_store_genre_trends", "genre_trends"),
+    ("compute_and_store_label_longevity", "label_longevity"),
+    ("compute_and_store_anniversaries", "anniversaries"),
+    ("compute_and_store_data_completeness", "data_completeness"),
+    ("compute_and_store_community_enrichment", "community_enrichment"),
+    ("compute_and_store_rarity", "release_rarity"),
+]
+
+
+class TestReadTimeoutIsDiagnosable:
+    """Regression for the blank error="" production logs (discogsography-ggz6)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("func_name", "insight_type"), _COMPUTATION_ENTRY_POINTS)
+    async def test_read_timeout_names_the_exception_type(self, func_name: str, insight_type: str) -> None:
+        import httpx
+
+        import insights.computations as computations
+
+        func = getattr(computations, func_name)
+        mock_client = AsyncMock()
+        # httpx.ReadTimeout("") stringifies to "" — the exact production case.
+        mock_client.get = AsyncMock(side_effect=httpx.ReadTimeout(""))
+        mock_pool = _make_mock_pool()
+
+        with (
+            patch.object(computations.logger, "error") as mock_log_error,
+            patch.object(computations, "_log_computation", new=AsyncMock()) as mock_log_computation,
+            pytest.raises(httpx.ReadTimeout),
+        ):
+            await func(mock_client, mock_pool)
+
+        # The structlog error call must carry a diagnosable error value.
+        assert mock_log_error.call_count == 1
+        logged_error = mock_log_error.call_args.kwargs["error"]
+        assert logged_error == "ReadTimeout", f"{func_name} logged error={logged_error!r}"
+
+        # ...and so must the persisted computation_log row.
+        failure_calls = [c for c in mock_log_computation.await_args_list if c.args[2] == "failed"]
+        assert len(failure_calls) == 1
+        assert failure_calls[0].args[1] == insight_type
+        assert failure_calls[0].kwargs["error_message"] == "ReadTimeout"
+
+    @pytest.mark.asyncio
+    async def test_run_all_computations_names_the_type_for_a_failed_member(self) -> None:
+        import httpx
+
+        import insights.computations as computations
+
+        mock_client = AsyncMock()
+        mock_pool = _make_mock_pool()
+
+        with (
+            patch.object(computations, "compute_and_store_artist_centrality", side_effect=httpx.ReadTimeout("")),
+            patch.object(computations, "compute_and_store_genre_trends", return_value=0),
+            patch.object(computations, "compute_and_store_label_longevity", return_value=0),
+            patch.object(computations, "compute_and_store_anniversaries", return_value=0),
+            patch.object(computations, "compute_and_store_data_completeness", return_value=0),
+            patch.object(computations, "compute_and_store_community_enrichment", return_value=0),
+            patch.object(computations, "compute_and_store_rarity", return_value=0),
+            patch.object(computations.logger, "error") as mock_log_error,
+        ):
+            await computations.run_all_computations(mock_client, mock_pool)
+
+        assert mock_log_error.call_args.kwargs["error"] == "ReadTimeout"
 
 
 class TestComputeAndStoreArtistCentrality:

--- a/tests/insights/test_insights.py
+++ b/tests/insights/test_insights.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi.testclient import TestClient
 import pytest
 
+from tests.insights.conftest import TEST_CACHE_GENERATION
+
 
 class TestHealthEndpoint:
     def test_health_returns_200(self, test_client: TestClient) -> None:
@@ -111,7 +113,7 @@ class TestTopArtistsCacheIntegration:
         mock_cache.get.return_value = None
         response = test_client_with_cache.get("/api/insights/top-artists?limit=10")
         assert response.status_code == 200
-        mock_cache.get.assert_called_once_with("insights:top-artists:10")
+        mock_cache.get.assert_called_once_with("insights:top-artists:10", TEST_CACHE_GENERATION)
         mock_cache.set.assert_called_once()
         key = mock_cache.set.call_args[0][0]
         assert key == "insights:top-artists:10"
@@ -138,7 +140,7 @@ class TestGenreTrendsCacheIntegration:
         mock_cache.get.return_value = None
         response = test_client_with_cache.get("/api/insights/genre-trends?genre=Rock")
         assert response.status_code == 200
-        mock_cache.get.assert_called_once_with("insights:genre-trends:Rock")
+        mock_cache.get.assert_called_once_with("insights:genre-trends:Rock", TEST_CACHE_GENERATION)
         mock_cache.set.assert_called_once()
 
     def test_cache_hit_returns_cached_data(
@@ -163,7 +165,7 @@ class TestLabelLongevityCacheIntegration:
         mock_cache.get.return_value = None
         response = test_client_with_cache.get("/api/insights/label-longevity?limit=10")
         assert response.status_code == 200
-        mock_cache.get.assert_called_once_with("insights:label-longevity:10")
+        mock_cache.get.assert_called_once_with("insights:label-longevity:10", TEST_CACHE_GENERATION)
         mock_cache.set.assert_called_once()
 
     def test_cache_hit_returns_cached_data(
@@ -216,7 +218,7 @@ class TestDataCompletenessCacheIntegration:
         mock_cache.get.return_value = None
         response = test_client_with_cache.get("/api/insights/data-completeness")
         assert response.status_code == 200
-        mock_cache.get.assert_called_once_with("insights:data-completeness")
+        mock_cache.get.assert_called_once_with("insights:data-completeness", TEST_CACHE_GENERATION)
         mock_cache.set.assert_called_once()
 
     def test_cache_hit_returns_cached_data(
@@ -300,7 +302,7 @@ class TestReleaseRarityCacheIntegration:
         data = response.json()
         assert data["count"] == 1
         assert data["items"][0]["release_id"] == 1
-        mock_cache.get.assert_called_once_with("insights:release-rarity:10")
+        mock_cache.get.assert_called_once_with("insights:release-rarity:10", TEST_CACHE_GENERATION)
         mock_cache.set.assert_called_once()
 
     def test_cache_hit_returns_cached_data(
@@ -620,3 +622,55 @@ class TestServiceNotReadyResponses:
         response = test_client_no_pool.get("/api/insights/status")
         assert response.status_code == 503
         assert "error" in response.json()
+
+
+# Every read endpoint that caches, with the cache key it uses.
+_CACHED_ENDPOINTS = [
+    ("/api/insights/top-artists?limit=10", "insights:top-artists:10"),
+    ("/api/insights/genre-trends?genre=Rock", "insights:genre-trends:Rock"),
+    ("/api/insights/label-longevity?limit=10", "insights:label-longevity:10"),
+    ("/api/insights/release-rarity?limit=10", "insights:release-rarity:10"),
+    ("/api/insights/data-completeness", "insights:data-completeness"),
+]
+
+
+class TestCacheGenerationThreading:
+    """discogsography-cu2.109: every read endpoint must write back to the
+    generation it read from, so a request straddling a recompute cannot
+    re-cache pre-update data over freshly computed results.
+    """
+
+    @pytest.mark.parametrize(("url", "cache_key"), _CACHED_ENDPOINTS)
+    def test_get_and_set_use_the_same_generation(
+        self,
+        test_client_with_cache: TestClient,
+        mock_cache: AsyncMock,
+        url: str,
+        cache_key: str,
+    ) -> None:
+        mock_cache.get.return_value = None
+
+        response = test_client_with_cache.get(url)
+
+        assert response.status_code == 200
+        assert mock_cache.get.call_args[0] == (cache_key, TEST_CACHE_GENERATION)
+        assert mock_cache.set.call_args[0][0] == cache_key
+        assert mock_cache.set.call_args[0][2] == TEST_CACHE_GENERATION, "set() must use the generation captured before the DB read, not a re-read one"
+
+    @pytest.mark.parametrize("url", [url for url, _ in _CACHED_ENDPOINTS])
+    def test_generation_is_read_before_the_cache_lookup(
+        self,
+        test_client_with_cache: TestClient,
+        mock_cache: AsyncMock,
+        url: str,
+    ) -> None:
+        """Ordering guard: generation() must precede get() (and therefore the DB read)."""
+        calls: list[str] = []
+        mock_cache.generation = AsyncMock(side_effect=lambda: calls.append("generation") or TEST_CACHE_GENERATION)
+        mock_cache.get = AsyncMock(side_effect=lambda *_a, **_k: calls.append("get"))
+        mock_cache.set = AsyncMock(side_effect=lambda *_a, **_k: calls.append("set"))
+
+        response = test_client_with_cache.get(url)
+
+        assert response.status_code == 200
+        assert calls == ["generation", "get", "set"]

--- a/tests/insights/test_rarity_computation.py
+++ b/tests/insights/test_rarity_computation.py
@@ -58,11 +58,9 @@ class TestComputeAndStoreRarity:
             rows = await compute_and_store_rarity(mock_client, mock_pool)
 
         assert rows == 1
-        mock_fetch.assert_called_once_with(
-            mock_client,
-            "/api/internal/insights/rarity-scores",
-            timeout=1200.0,
-        )
+        # The per-endpoint budget is applied inside _fetch_from_api, so the
+        # call site no longer passes a magic scalar.
+        mock_fetch.assert_called_once_with(mock_client, "/api/internal/insights/rarity-scores")
 
     @pytest.mark.asyncio
     async def test_empty_results(self) -> None:
@@ -124,7 +122,10 @@ class TestComputeAndStoreCommunityEnrichment:
             result = await compute_and_store_community_enrichment(mock_client, mock_pool)
 
         assert result == 5
-        mock_client.get.assert_called_once_with("/api/internal/insights/community-enrichment", timeout=3600.0)
+        from insights.computations import endpoint_timeout
+
+        path = "/api/internal/insights/community-enrichment"
+        mock_client.get.assert_called_once_with(path, timeout=endpoint_timeout(path))
         mock_log.assert_called_once()
         args = mock_log.call_args
         assert args[0][1] == "community_enrichment"


### PR DESCRIPTION
Lands the `batch:insights-perf` work group — the P1 rarity-computation failure plus four related insights/Neo4j reliability fixes, one conventional commit per bead.

## Beads
- `discogsography-lx1n` (**P1**) — release_rarity had never computed successfully (33 consecutive daily failures): eight unbounded full-graph scans hit Neo4j's 600s transaction timeout, surfacing as a ClientError the TransientError-only handler missed. Now: keyset pagination over `r.id` (20k/page), every signal query scoped to its page via `UNWIND $ids` index seeks, 120s per-query server-side timeouts, global hidden-gem percentiles preserved, O(1) coverage check, and the route now recognizes timeout ClientErrors as retryable 503s. Tests pin the invariants (no bare `MATCH (r:Release)` can be reintroduced; page-size-invariant scores).
- `discogsography-ggz6` — insights failure logs now name the exception type (str(exc) is empty for httpx.ReadTimeout), making timeout failures diagnosable.
- `discogsography-1cxi` — internal-API client timeouts sized for cold-cache latency (~400s PG scans no longer die at the client).
- `discogsography-79p9` — graphinator stub-Master maintenance batches its deletes to survive Neo4j transaction-memory pressure (16G pool exhaustion broke cleanup + dashboard health).
- `discogsography-cu2.109` — insights cache namespace is versioned, so a request straddling the scheduler's recompute can no longer re-cache pre-update data.

## Integration note
Rebased onto main after #433; the rewritten rarity query constants were reconciled to preserve #433's pressing-scarcity OPTIONAL MATCH split (cu2.75) and temporal-scarcity floor (cu2.94) — verified post-rebase.

## Tests
+1,913/−424 across 23 files, including chunking-contract tests, ExceptionGroup-unwrapping route tests, and cache-versioning races.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UCBSBYhPWx9ESjDDJxsmY