### PR TITLE
fix: pipeline data-integrity & message-loss — 8 bug-hunt findings (batch:data-integrity)

### DIFF
--- a/api/metrics_collector.py
+++ b/api/metrics_collector.py
@@ -87,15 +87,21 @@ class MetricsBuffer:
         self._entries.append(_Entry(path=path, status_code=status_code, duration_ms=duration_ms))
 
     def flush(self) -> dict[str, dict[str, Any]]:
-        """Group buffered entries by path, compute stats, clear buffer, and return results."""
+        """Group buffered entries by path and compute stats, WITHOUT clearing the buffer.
+
+        Non-destructive on purpose: the caller is responsible for calling
+        :meth:`clear` only after the returned stats have been durably persisted.
+        This keeps a failed persist from silently discarding the window's
+        samples — they simply stay buffered (growth still bounded by
+        ``max_size`` via ``record()``'s eviction) and are folded into the next
+        cycle's stats until a persist finally succeeds.
+        """
         if not self._entries:
             return {}
 
-        entries, self._entries = self._entries, deque()
-
         groups: dict[str, list[float]] = {}
         error_counts: dict[str, int] = {}
-        for entry in entries:
+        for entry in self._entries:
             groups.setdefault(entry.path, []).append(entry.duration_ms)
             if entry.status_code >= 500:
                 error_counts[entry.path] = error_counts.get(entry.path, 0) + 1
@@ -112,6 +118,10 @@ class MetricsBuffer:
                 "error_count": error_counts.get(path, 0),
             }
         return result
+
+    def clear(self) -> None:
+        """Drop all buffered entries.  Call only after a successful persist of ``flush()``'s result."""
+        self._entries = deque()
 
 
 # ---------------------------------------------------------------------------
@@ -289,7 +299,8 @@ async def run_collector(
         except Exception:
             logger.error("❌ Error collecting service health")
 
-        # 3. Flush metrics buffer and attach endpoint_stats to API row
+        # 3. Flush metrics buffer (non-destructive) and attach endpoint_stats to API row
+        endpoint_stats: dict[str, dict[str, Any]] = {}
         try:
             endpoint_stats = metrics_buffer.flush()
             if endpoint_stats:
@@ -310,10 +321,14 @@ async def run_collector(
         except Exception:
             logger.error("❌ Error flushing metrics buffer")
 
-        # 4. Persist
+        # 4. Persist — only drop the buffered endpoint stats once they're durably
+        # written; on failure they stay buffered (bounded by max_size) and are
+        # retried as part of the next cycle's stats instead of being lost.
         try:
             await persist_metrics(pool, queue_rows, health_rows)
             logger.info("📊 Persisted metrics", queues=len(queue_rows), health=len(health_rows))
+            if endpoint_stats:
+                metrics_buffer.clear()
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -640,15 +640,23 @@ async def run_full_sync(
             neo4j_driver=neo4j_driver,
         )
 
-        # Invalidate user-scoped recommendation cache
+    except Exception as exc:
+        error_message = str(exc)
+        logger.error("❌ Sync failed", user_id=str(user_uuid), error=error_message)
+    finally:
+        # Invalidate the user-scoped recommendation cache whenever a sync was
+        # attempted — not only on full success. sync_collection/sync_wantlist
+        # commit each page durably (autocommit executemany + immediate Neo4j
+        # writes) as they go, so a failure partway through (e.g. Neo4j hiccups
+        # on a later page) can leave the collection/wantlist durably changed
+        # even though run_full_sync takes the exception path above. Without
+        # this, stale personalized recommendations would keep serving for up
+        # to the cache's TTL. invalidate_user() already swallows Redis errors
+        # internally, so running it unconditionally here is safe.
         if redis_client is not None:
             rec_cache = RecommendCache(redis=redis_client)
             await rec_cache.invalidate_user(str(user_uuid))
             logger.info("🔄 Recommendation cache invalidated", user_id=str(user_uuid))
-
-    except Exception as exc:
-        error_message = str(exc)
-        logger.error("❌ Sync failed", user_id=str(user_uuid), error=error_message)
 
     # Update sync_history record
     final_status = "failed" if error_message else "completed"

--- a/brainztableinator/brainztableinator.py
+++ b/brainztableinator/brainztableinator.py
@@ -3,6 +3,7 @@ import contextlib
 import os
 import signal
 import time
+import uuid
 from asyncio import run
 from datetime import UTC, datetime
 from pathlib import Path
@@ -23,7 +24,7 @@ from common import (
     setup_logging,
 )
 from orjson import loads
-from psycopg.errors import InterfaceError, OperationalError
+from psycopg.errors import DataError, InterfaceError, OperationalError
 from psycopg.types.json import Jsonb
 
 logger = structlog.get_logger(__name__)
@@ -787,6 +788,21 @@ async def on_data_message(message: AbstractIncomingMessage, data_type: str) -> N
             await message.nack(requeue=False)
             return
 
+        # Guard against a non-UUID mbid/id — e.g. the extractor's "unknown" sentinel
+        # for a JSONL line missing its id. This would otherwise pass the emptiness
+        # check above, fail the PostgreSQL UUID cast deterministically, and churn
+        # through the quorum queue's redelivery limit before dead-lettering.
+        try:
+            uuid.UUID(data_id)
+        except (ValueError, AttributeError, TypeError):
+            logger.warning(
+                "⚠️ Nacking record with non-UUID mbid/id",
+                data_type=data_type,
+                data_id=data_id,
+            )
+            await message.nack(requeue=False)
+            return
+
         # Extract record details for logging
         record_name = data.get("name", "Unknown")
         logger.debug(
@@ -839,6 +855,20 @@ async def on_data_message(message: AbstractIncomingMessage, data_type: str) -> N
     except (InterfaceError, OperationalError) as e:
         logger.warning("⚠️ Database connection issue, will retry", error=str(e))
         await message.nack(requeue=True)
+    except DataError as e:
+        # Malformed data that deterministically fails a column cast (e.g. a
+        # non-UUID mbid that slipped past validation above). Retrying would
+        # fail identically every time, so nack without requeue instead of
+        # churning through the quorum queue's redelivery limit.
+        logger.error(
+            "❌ Non-retryable data error, nacking without requeue",
+            data_type=data_type,
+            error=str(e),
+        )
+        try:
+            await message.nack(requeue=False)
+        except Exception as nack_error:  # noqa: BLE001 - the nack path itself is best-effort; the broker will redeliver
+            logger.warning("⚠️ Failed to nack message", error=str(nack_error))
     except Exception as e:  # noqa: BLE001 - per-message fault must nack rather than kill the consumer
         logger.error("❌ Failed to process message", data_type=data_type, error=str(e))
         try:

--- a/common/config.py
+++ b/common/config.py
@@ -462,6 +462,17 @@ def setup_logging(
     if level is None:
         level = getenv("LOG_LEVEL", "INFO").upper()
 
+    # Normalize and validate the level name (strip stray whitespace, e.g. from a
+    # compose file) and fall back to INFO instead of crashing on an unrecognized
+    # value ('TRACE', a typo, trailing punctuation, ...). getattr() is called
+    # with an explicit default so an invalid name can never raise AttributeError.
+    normalized_level = level.strip().upper()
+    resolved_level = getattr(logging, normalized_level, None)
+    invalid_level_value: str | None = None
+    if not isinstance(resolved_level, int):
+        invalid_level_value = level
+        resolved_level = logging.INFO
+
     # Configure structlog processors
     timestamper = structlog.processors.TimeStamper(fmt="iso", utc=True)
 
@@ -532,10 +543,16 @@ def setup_logging(
 
     # Configure root logger
     logging.basicConfig(
-        level=getattr(logging, level.upper()),
+        level=resolved_level,
         handlers=handlers,
         force=True,
     )
+
+    if invalid_level_value is not None:
+        logging.getLogger(__name__).warning(
+            "⚠️ Unrecognized LOG_LEVEL %r; falling back to INFO",
+            invalid_level_value,
+        )
 
     # Suppress verbose pika logs
     logging.getLogger("pika").setLevel(logging.WARNING)

--- a/extractor/src/discogs_downloader.rs
+++ b/extractor/src/discogs_downloader.rs
@@ -112,6 +112,29 @@ impl Downloader {
         let month = extract_month_from_filename(&latest_files[0].name);
         info!("📅 Latest available month: {}", month);
 
+        // Fetch the Discogs-published CHECKSUM file so each data file's SHA-256 can be
+        // verified against an authoritative source rather than only the self-generated
+        // hash computed from whatever bytes happened to arrive (discogsography-cu2.106).
+        // Best-effort: if the CHECKSUM file can't be fetched or parsed, log and proceed
+        // without verification rather than blocking the whole dump on a transient
+        // fetch failure — this is additive hardening, not a hard gate.
+        let published_checksums = match Self::find_checksum_entry(&available_files, &latest_files) {
+            Some(checksum_file) => match self.fetch_checksums(&checksum_file).await {
+                Ok(map) => {
+                    info!("🔐 Fetched published CHECKSUM file ({} entries)", map.len());
+                    Some(map)
+                }
+                Err(e) => {
+                    warn!("⚠️ Failed to fetch/parse published CHECKSUM file — proceeding without integrity verification: {}", e);
+                    None
+                }
+            },
+            None => {
+                warn!("⚠️ No CHECKSUM file found alongside the latest monthly dump — proceeding without integrity verification");
+                None
+            }
+        };
+
         // Start download phase tracking if state marker is available
         if let Some(ref mut marker) = self.state_marker {
             marker.start_download(latest_files.len());
@@ -123,7 +146,25 @@ impl Downloader {
         for file_info in &latest_files {
             let filename = std::path::Path::new(&file_info.name).file_name().and_then(|name| name.to_str()).unwrap_or("unknown_file");
 
-            if self.should_download(file_info).await? {
+            let mut needs_download = self.should_download(file_info).await?;
+
+            // should_download() only proves the local file hasn't changed since it was
+            // downloaded — it can't tell a genuine dump from a previously-trusted bad
+            // 200-response body (the exact hole this bead closes). Cross-check the
+            // locally-trusted checksum against the published one whenever available, and
+            // force a re-download on mismatch instead of trusting it forever.
+            if !needs_download
+                && let Some(ref published) = published_checksums
+                && let Some(expected) = published.get(filename)
+            {
+                let locally_trusted = self.metadata.get(filename).map(|info| info.checksum.as_str());
+                if locally_trusted != Some(expected.as_str()) {
+                    warn!("⚠️ Locally-trusted checksum for {} does not match the published CHECKSUM — forcing re-download", filename);
+                    needs_download = true;
+                }
+            }
+
+            if needs_download {
                 // Start tracking file download
                 if let Some(ref mut marker) = self.state_marker {
                     marker.start_file_download(filename);
@@ -132,6 +173,33 @@ impl Downloader {
 
                 match self.download_file(file_info).await {
                     Ok(downloaded_size) => {
+                        // Verify the downloaded bytes against the Discogs-published CHECKSUM
+                        // before trusting them. Without this, a 200-response whose body isn't
+                        // the real dump (CDN/interstitial error page, a proxy-truncated stream)
+                        // would be hashed by download_file, recorded as metadata truth, and
+                        // never re-downloaded until the next monthly release or a manual
+                        // file/metadata deletion.
+                        if let Some(ref published) = published_checksums
+                            && let Some(expected) = published.get(filename)
+                        {
+                            let actual = self.metadata.get(filename).map(|info| info.checksum.clone());
+                            if actual.as_deref() != Some(expected.as_str()) {
+                                error!(
+                                    "❌ Checksum mismatch for {}: expected {} from published CHECKSUM, got {:?}. Deleting corrupt download.",
+                                    filename, expected, actual
+                                );
+                                self.metadata.remove(filename);
+                                let local_path = self.output_directory.join(filename);
+                                if local_path.exists()
+                                    && let Err(e) = fs::remove_file(&local_path).await
+                                {
+                                    warn!("⚠️ Failed to remove corrupt file {}: {}", filename, e);
+                                }
+                                return Err(anyhow::anyhow!("Checksum verification failed for {} against published CHECKSUM", filename));
+                            }
+                            debug!("🔐 Verified {} against published CHECKSUM", filename);
+                        }
+
                         info!("✅ Successfully downloaded: {}", filename);
 
                         // Persist metadata immediately so a later file's failure can't
@@ -335,6 +403,58 @@ impl Downloader {
 
         warn!("No complete version found with all expected data files");
         Ok(Vec::new())
+    }
+
+    /// Locate the CHECKSUM entry sharing the same version id as `data_files`, among the
+    /// unfiltered `files` list (`get_latest_monthly_files` drops the CHECKSUM entry from
+    /// its own return value, so callers that need it look it up here instead).
+    fn find_checksum_entry(files: &[S3FileInfo], data_files: &[S3FileInfo]) -> Option<S3FileInfo> {
+        let sample = data_files.first()?;
+        let sample_basename = std::path::Path::new(&sample.name).file_name().and_then(|f| f.to_str())?;
+        let version_id = sample_basename.split('_').nth(1)?;
+
+        files
+            .iter()
+            .find(|f| {
+                let basename = std::path::Path::new(&f.name).file_name().and_then(|n| n.to_str()).unwrap_or("");
+                basename.contains("CHECKSUM") && basename.split('_').nth(1) == Some(version_id)
+            })
+            .cloned()
+    }
+
+    /// Fetch and parse the Discogs-published CHECKSUM file for a version, mapping each data
+    /// filename to its published SHA-256. Standard `sha256sum`-style lines are expected:
+    /// `<hex64>  <filename>` (optionally `*filename` for binary mode).
+    async fn fetch_checksums(&self, checksum_file: &S3FileInfo) -> Result<HashMap<String, String>> {
+        let download_url = format!("{}?download={}", self.base_url, urlencoding::encode(&checksum_file.name));
+
+        let response = self.client.get(&download_url).await.context("Failed to fetch CHECKSUM file")?;
+        if !response.status().is_success() {
+            return Err(anyhow::anyhow!("CHECKSUM file fetch returned HTTP {}", response.status()));
+        }
+        let text = response.text().await.context("Failed to read CHECKSUM file body")?;
+
+        let mut checksums = HashMap::new();
+        for line in text.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let mut parts = line.splitn(2, char::is_whitespace);
+            let hash = parts.next().unwrap_or("");
+            let name_part = parts.next().unwrap_or("").trim();
+            let name_part = name_part.strip_prefix('*').unwrap_or(name_part);
+            if hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit()) && !name_part.is_empty() {
+                let basename = std::path::Path::new(name_part).file_name().and_then(|n| n.to_str()).unwrap_or(name_part);
+                checksums.insert(basename.to_string(), hash.to_lowercase());
+            }
+        }
+
+        if checksums.is_empty() {
+            return Err(anyhow::anyhow!("No checksum entries parsed from CHECKSUM file"));
+        }
+
+        Ok(checksums)
     }
 
     pub async fn should_download(&self, file_info: &S3FileInfo) -> Result<bool> {

--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -581,7 +581,17 @@ pub async fn process_single_file(
 
     let total_count = validator_handle.unwrap_or(0);
 
-    // Mark file as completed in state marker FIRST (consistent with Python)
+    // Send the file completion message BEFORE marking the file Completed in
+    // the state marker. If this AMQP send fails, the marker stays NOT
+    // Completed, so pending_files() on the next run still includes this file
+    // and send_file_complete is retried — instead of the signal being
+    // silently and permanently dropped (the previous "marker first" ordering
+    // let an AMQP failure land in the window after the marker was already
+    // durably Completed, so a retry would skip the file and never resend).
+    mq.send_file_complete(data_type, file_name, total_count).await?;
+
+    // Now that the completion signal has been durably handed off to the
+    // broker, mark the file as completed in the state marker.
     {
         let mut marker = state_marker.lock().await;
         marker.complete_file_processing(file_name, total_count);
@@ -596,11 +606,13 @@ pub async fn process_single_file(
         s.active_connections.remove(&data_type);
     }
 
-    // THEN send file completion message (consistent with Python)
-    mq.send_file_complete(data_type, file_name, total_count).await?;
-
-    // Clean up
-    mq.close().await?;
+    // Clean up — best-effort. A cleanup failure here is purely cosmetic (the
+    // completion signal was already sent and the marker already committed
+    // above), so it must not flip an otherwise fully-successful file to
+    // Failed and trigger the failure cooldown.
+    if let Err(e) = mq.close().await {
+        warn!("⚠️ Failed to cleanly close per-file MQ connection for {}: {}", file_name, e);
+    }
 
     info!("✅ Completed processing {} with {} records", file_name, total_count);
     Ok(())
@@ -1464,6 +1476,18 @@ pub async fn process_musicbrainz_data(
             success = false;
         }
 
+        // Send file_complete BEFORE marking the file Completed in the state marker
+        // (only attempted on success, to avoid misleading consumers). A failed send
+        // must also flip file_success back off so the marker below stays NOT
+        // Completed and the file remains pending on the next run — instead of the
+        // signal being silently and permanently dropped for a file the marker
+        // already claims is done.
+        if file_success && let Err(e) = mq.send_file_complete(*data_type, file_name, total_count).await {
+            error!("❌ Failed to send file_complete for {}: {}", data_type, e);
+            file_success = false;
+            success = false;
+        }
+
         // Mark file complete only on success; on failure, save current state without marking complete
         {
             let mut sm = state_marker.lock().await;
@@ -1480,12 +1504,6 @@ pub async fn process_musicbrainz_data(
                 s.completed_files.insert(file_name.to_string());
             }
             s.active_connections.remove(data_type);
-        }
-
-        // Send file_complete message only on success to avoid misleading consumers
-        if file_success && let Err(e) = mq.send_file_complete(*data_type, file_name, total_count).await {
-            error!("❌ Failed to send file_complete for {}: {}", data_type, e);
-            success = false;
         }
 
         record_counts.insert(data_type.to_string(), total_count);

--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -1071,12 +1071,39 @@ pub(crate) const DISCOGS_POLL_INTERVAL: Duration = Duration::from_secs(3600);
 pub(crate) const DISCOGS_HEALTH_TIMEOUT: Duration = Duration::from_secs(5);
 pub(crate) const DISCOGS_MAX_UNREACHABLE_RETRIES: u32 = 10;
 
+// The "unreachable" case (connection refused, DNS failure, timeout) is a startup-ordering
+// race — extractor-musicbrainz starting before extractor-discogs is reachable — not
+// "Discogs is busy". It must use a short escalating backoff distinct from
+// DISCOGS_POLL_INTERVAL's hourly busy-wait cadence, or the race costs hours instead of
+// minutes (discogsography-i7sa: observed a 4-hour idle wait from a single unlucky
+// restart-timing race, at the old fixed 3600s-per-attempt retry).
+#[cfg(not(test))]
+pub(crate) const DISCOGS_UNREACHABLE_BASE_DELAY: Duration = Duration::from_secs(5);
+#[cfg(test)]
+pub(crate) const DISCOGS_UNREACHABLE_BASE_DELAY: Duration = Duration::from_millis(5);
+
+#[cfg(not(test))]
+pub(crate) const DISCOGS_UNREACHABLE_MAX_DELAY: Duration = Duration::from_secs(300);
+#[cfg(test)]
+pub(crate) const DISCOGS_UNREACHABLE_MAX_DELAY: Duration = Duration::from_millis(50);
+
+/// Escalating backoff for a consecutive-unreachable attempt count: doubles from
+/// `DISCOGS_UNREACHABLE_BASE_DELAY`, capped at `DISCOGS_UNREACHABLE_MAX_DELAY`. `attempt` is
+/// 1-based (the count *after* incrementing for the failure that just happened).
+pub(crate) fn discogs_unreachable_backoff(attempt: u32) -> Duration {
+    let exponent = attempt.saturating_sub(1).min(16); // guard against shl overflow
+    let multiplier = 1u32.checked_shl(exponent).unwrap_or(u32::MAX);
+    DISCOGS_UNREACHABLE_BASE_DELAY.saturating_mul(multiplier).min(DISCOGS_UNREACHABLE_MAX_DELAY)
+}
+
 /// Wait until the Discogs extractor is not actively extracting.
 pub async fn wait_for_discogs_idle(url: &str, shutdown_flag: &AtomicBool) -> Result<()> {
     wait_for_discogs_idle_with_interval(url, shutdown_flag, DISCOGS_POLL_INTERVAL).await
 }
 
-/// Internal implementation with configurable poll interval (for testing).
+/// Internal implementation with configurable poll interval (for testing). `poll_interval`
+/// governs only the "Discogs is busy" (status == "running") wait; an unreachable endpoint
+/// always uses the short escalating backoff from `discogs_unreachable_backoff`.
 pub async fn wait_for_discogs_idle_with_interval(url: &str, shutdown_flag: &AtomicBool, poll_interval: Duration) -> Result<()> {
     let client = reqwest::Client::builder().timeout(DISCOGS_HEALTH_TIMEOUT).build()?;
 
@@ -1107,6 +1134,7 @@ pub async fn wait_for_discogs_idle_with_interval(url: &str, shutdown_flag: &Atom
                         return Ok(());
                     }
                 }
+                tokio::time::sleep(poll_interval).await;
             }
             Err(_) => {
                 unreachable_count += 1;
@@ -1117,14 +1145,14 @@ pub async fn wait_for_discogs_idle_with_interval(url: &str, shutdown_flag: &Atom
                     );
                     return Ok(());
                 }
+                let backoff = discogs_unreachable_backoff(unreachable_count);
                 warn!(
                     "⚠️ Discogs health endpoint unreachable (attempt {}/{}), retrying in {:?}...",
-                    unreachable_count, DISCOGS_MAX_UNREACHABLE_RETRIES, poll_interval
+                    unreachable_count, DISCOGS_MAX_UNREACHABLE_RETRIES, backoff
                 );
+                tokio::time::sleep(backoff).await;
             }
         }
-
-        tokio::time::sleep(poll_interval).await;
     }
 }
 

--- a/extractor/src/main.rs
+++ b/extractor/src/main.rs
@@ -63,8 +63,6 @@ async fn main() -> Result<()> {
     // Display ASCII art
     print_ascii_art(args.source.as_ref());
 
-    info!("🚀 Starting Rust-based Discogs data extractor with high performance");
-
     // Load configuration from environment (drop-in replacement for extractor)
     let mut config = match ExtractorConfig::from_env() {
         Ok(c) => c,
@@ -83,6 +81,11 @@ async fn main() -> Result<()> {
     if let Some(s) = args.source {
         config.source = s;
     }
+
+    // Logged AFTER config.source is fully resolved (env var + CLI override) so the
+    // startup banner reflects the actual --source mode instead of always claiming
+    // "Discogs" — cosmetic, but misleading in the extractor-musicbrainz container's logs.
+    info!("{}", startup_banner_message(config.source));
 
     // Load and compile data quality rules if configured
     let compiled_rules = if let Some(ref rules_path) = config.data_quality_rules {
@@ -196,6 +199,15 @@ async fn apply_failure_cooldown(env_value: Option<&str>) {
     if cooldown > 0 {
         error!("😴 Sleeping {}s before exiting to avoid restart-loop flapping (override with FAILURE_COOLDOWN_SECS=0)", cooldown);
         tokio::time::sleep(std::time::Duration::from_secs(cooldown)).await;
+    }
+}
+
+/// Startup banner text reflecting the actual resolved `--source` mode, instead of a
+/// hardcoded "Discogs" claim regardless of which extractor container is running.
+fn startup_banner_message(source: Source) -> &'static str {
+    match source {
+        Source::Discogs => "🚀 Starting Rust-based Discogs data extractor with high performance",
+        Source::MusicBrainz => "🚀 Starting Rust-based MusicBrainz data extractor with high performance",
     }
 }
 

--- a/extractor/src/message_queue.rs
+++ b/extractor/src/message_queue.rs
@@ -269,12 +269,22 @@ impl MessagePublisher for MessageQueue {
     }
 
     async fn close(&self) -> Result<()> {
-        if let Some(channel) = self.channel.write().await.take() {
-            channel.close(200, "Normal shutdown".into()).await?;
+        // Best-effort on both halves: a channel-close error (typical when the
+        // broker already dropped the connection) must not skip the connection
+        // close. Every call site except one already treats close() as
+        // best-effort (`let _ = mq.close().await;`); make the implementation
+        // match that contract instead of early-returning via `?` and leaving
+        // the connection open.
+        if let Some(channel) = self.channel.write().await.take()
+            && let Err(e) = channel.close(200, "Normal shutdown".into()).await
+        {
+            warn!("⚠️ Failed to close AMQP channel cleanly: {}", e);
         }
 
-        if let Some(conn) = self.connection.write().await.take() {
-            conn.close(200, "Normal shutdown".into()).await?;
+        if let Some(conn) = self.connection.write().await.take()
+            && let Err(e) = conn.close(200, "Normal shutdown".into()).await
+        {
+            warn!("⚠️ Failed to close AMQP connection cleanly: {}", e);
         }
 
         info!("🔌 AMQP connection closed");

--- a/extractor/src/tests/downloader_tests.rs
+++ b/extractor/src/tests/downloader_tests.rs
@@ -422,6 +422,200 @@ async fn test_download_discogs_data_with_state_marker() {
     assert_eq!(marker.download_phase.status, crate::state_marker::PhaseStatus::Completed);
 }
 
+/// SHA-256 of the literal bodies the mockito download mocks below serve
+/// (`"fake {type} data"`), computed once and hardcoded so tests don't
+/// depend on `sha2` at the call site for the published-CHECKSUM fixture.
+fn fake_data_checksums_txt() -> String {
+    "2d89e4146a50731264b28056ed61c904a99de6bfe1af8c82d139bd8cbee850f6  discogs_20260101_artists.xml.gz\n\
+     246d842084dfd15b2da652a5a19da2287ae7cc2235f0d71aa7ab3ee64140a813  discogs_20260101_labels.xml.gz\n\
+     613e7e23d0ce2d0c60dd2da6216457bbd8de38c940696c11d3fc57a352cb1851  discogs_20260101_masters.xml.gz\n\
+     bd804e5e894bd322addead6469d641f07fe36650cd2ae637a5912e28f28c5ee8  discogs_20260101_releases.xml.gz\n"
+        .to_string()
+}
+
+#[tokio::test]
+async fn test_download_discogs_data_verifies_against_published_checksum() {
+    // discogsography-cu2.106 regression: a genuine download whose bytes match the
+    // Discogs-published CHECKSUM must succeed as before.
+    let temp_dir = TempDir::new().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let base_url = format!("{}/", server.url());
+
+    let main_page_html = r#"<html><body>
+        <a href="?prefix=data%2F2026%2F">2026/</a>
+    </body></html>"#;
+    let _main_mock = server.mock("GET", "/").with_status(200).with_body(main_page_html).create_async().await;
+
+    let year_page_html = r#"<html><body>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_artists.xml.gz">artists</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_labels.xml.gz">labels</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_masters.xml.gz">masters</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_releases.xml.gz">releases</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_CHECKSUM.txt">checksum</a>
+    </body></html>"#;
+    let _year_mock = server.mock("GET", "/?prefix=data%2F2026%2F").with_status(200).with_body(year_page_html).create_async().await;
+
+    let _checksum_mock = server
+        .mock("GET", "/?download=data%2F2026%2Fdiscogs_20260101_CHECKSUM.txt")
+        .with_status(200)
+        .with_body(fake_data_checksums_txt())
+        .create_async()
+        .await;
+
+    let file_types = ["artists", "labels", "masters", "releases"];
+    let mut _download_mocks = Vec::new();
+    for file_type in &file_types {
+        let download_path = format!("/?download=data%2F2026%2Fdiscogs_20260101_{}.xml.gz", file_type);
+        let mock = server
+            .mock("GET", download_path.as_str())
+            .with_status(200)
+            .with_body(format!("fake {} data", file_type))
+            .create_async()
+            .await;
+        _download_mocks.push(mock);
+    }
+
+    let mut downloader = Downloader::new_with_base_url(temp_dir.path().to_path_buf(), base_url).await.unwrap();
+
+    let result = downloader.download_discogs_data().await.unwrap();
+
+    assert_eq!(result.len(), 4);
+    for file_type in &file_types {
+        let filename = format!("discogs_20260101_{}.xml.gz", file_type);
+        assert!(downloader.metadata.contains_key(&filename), "expected metadata for {}", filename);
+    }
+}
+
+#[tokio::test]
+async fn test_download_discogs_data_checksum_mismatch_deletes_corrupt_file() {
+    // discogsography-cu2.106 regression: a 200-response whose body isn't the real dump
+    // (a bad-but-complete download) must NOT be permanently trusted. On a
+    // published-CHECKSUM mismatch, the corrupt local file and its metadata entry must be
+    // removed and the run must fail loudly instead of silently succeeding.
+    let temp_dir = TempDir::new().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let base_url = format!("{}/", server.url());
+
+    let main_page_html = r#"<html><body>
+        <a href="?prefix=data%2F2026%2F">2026/</a>
+    </body></html>"#;
+    let _main_mock = server.mock("GET", "/").with_status(200).with_body(main_page_html).create_async().await;
+
+    let year_page_html = r#"<html><body>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_artists.xml.gz">artists</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_labels.xml.gz">labels</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_masters.xml.gz">masters</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_releases.xml.gz">releases</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_CHECKSUM.txt">checksum</a>
+    </body></html>"#;
+    let _year_mock = server.mock("GET", "/?prefix=data%2F2026%2F").with_status(200).with_body(year_page_html).create_async().await;
+
+    // Published CHECKSUM disagrees with what the mocked artists download actually
+    // serves below (an interstitial error page, standing in for a bad 200 body).
+    let bogus_checksum = format!("{}  discogs_20260101_artists.xml.gz\n", "0".repeat(64));
+    let _checksum_mock = server
+        .mock("GET", "/?download=data%2F2026%2Fdiscogs_20260101_CHECKSUM.txt")
+        .with_status(200)
+        .with_body(bogus_checksum)
+        .create_async()
+        .await;
+
+    let _artists_mock = server
+        .mock("GET", "/?download=data%2F2026%2Fdiscogs_20260101_artists.xml.gz")
+        .with_status(200)
+        .with_body("<html>upstream interstitial error page</html>")
+        .create_async()
+        .await;
+
+    let mut downloader = Downloader::new_with_base_url(temp_dir.path().to_path_buf(), base_url).await.unwrap();
+
+    let result = downloader.download_discogs_data().await;
+
+    assert!(result.is_err(), "a published-CHECKSUM mismatch must fail the run, not silently succeed");
+
+    let corrupt_path = temp_dir.path().join("discogs_20260101_artists.xml.gz");
+    assert!(!corrupt_path.exists(), "the corrupt file must be deleted on checksum mismatch");
+    assert!(!downloader.metadata.contains_key("discogs_20260101_artists.xml.gz"), "the corrupt metadata entry must be removed");
+}
+
+#[tokio::test]
+async fn test_download_discogs_data_redownloads_when_locally_trusted_checksum_disagrees_with_published() {
+    // discogsography-cu2.106 regression: a file that was previously downloaded and
+    // self-checksummed (should_download() would normally skip it as "up to date") must
+    // be forced to re-download when the published CHECKSUM disagrees — closing the
+    // "permanently trusted" hole for files that were already corrupted before this fix
+    // shipped.
+    use sha2::{Digest, Sha256};
+
+    let temp_dir = TempDir::new().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let base_url = format!("{}/", server.url());
+
+    let main_page_html = r#"<html><body>
+        <a href="?prefix=data%2F2026%2F">2026/</a>
+    </body></html>"#;
+    let _main_mock = server.mock("GET", "/").with_status(200).with_body(main_page_html).create_async().await;
+
+    let year_page_html = r#"<html><body>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_artists.xml.gz">artists</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_labels.xml.gz">labels</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_masters.xml.gz">masters</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_releases.xml.gz">releases</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_CHECKSUM.txt">checksum</a>
+    </body></html>"#;
+    let _year_mock = server.mock("GET", "/?prefix=data%2F2026%2F").with_status(200).with_body(year_page_html).create_async().await;
+
+    let _checksum_mock = server
+        .mock("GET", "/?download=data%2F2026%2Fdiscogs_20260101_CHECKSUM.txt")
+        .with_status(200)
+        .with_body(fake_data_checksums_txt())
+        .create_async()
+        .await;
+
+    // Pre-create all 4 local files with a self-consistent (but WRONG, i.e. not matching
+    // the published CHECKSUM) checksum in metadata — as if a bad download was trusted
+    // under the pre-fix behavior.
+    let file_types = ["artists", "labels", "masters", "releases"];
+    let mut downloader = Downloader::new_with_base_url(temp_dir.path().to_path_buf(), base_url).await.unwrap();
+    for file_type in &file_types {
+        let filename = format!("discogs_20260101_{}.xml.gz", file_type);
+        let content = format!("previously trusted bad {} data", file_type);
+        let local_path = temp_dir.path().join(&filename);
+        fs::write(&local_path, content.as_bytes()).await.unwrap();
+
+        let mut hasher = Sha256::new();
+        hasher.update(content.as_bytes());
+        let checksum = hex::encode(hasher.finalize());
+
+        downloader.metadata.insert(
+            filename,
+            LocalFileInfo { path: local_path.to_string_lossy().to_string(), checksum, version: "202601".to_string(), size: content.len() as u64 },
+        );
+    }
+
+    // Re-download mocks serving content that DOES match the published CHECKSUM.
+    let mut _download_mocks = Vec::new();
+    for file_type in &file_types {
+        let download_path = format!("/?download=data%2F2026%2Fdiscogs_20260101_{}.xml.gz", file_type);
+        let mock = server
+            .mock("GET", download_path.as_str())
+            .with_status(200)
+            .with_body(format!("fake {} data", file_type))
+            .create_async()
+            .await;
+        _download_mocks.push(mock);
+    }
+
+    let result = downloader.download_discogs_data().await.unwrap();
+
+    assert_eq!(result.len(), 4);
+    for file_type in &file_types {
+        let filename = format!("discogs_20260101_{}.xml.gz", file_type);
+        let content = std::fs::read_to_string(temp_dir.path().join(&filename)).unwrap();
+        assert_eq!(content, format!("fake {} data", file_type), "{} must have been re-downloaded with fresh, verified content", filename);
+    }
+}
+
 #[tokio::test]
 async fn test_download_discogs_data_skips_already_downloaded() {
     use sha2::{Digest, Sha256};

--- a/extractor/src/tests/extractor_tests.rs
+++ b/extractor/src/tests/extractor_tests.rs
@@ -1383,4 +1383,51 @@ mod wait_for_discogs_idle_tests {
 
         assert!(result.is_ok());
     }
+
+    #[tokio::test]
+    async fn test_unreachable_endpoint_uses_short_backoff_not_poll_interval() {
+        // discogsography-i7sa regression: an unreachable Discogs health endpoint (a
+        // startup-ordering race, not "Discogs is busy") must retry on the short
+        // escalating backoff, NOT the hourly poll_interval — otherwise a single
+        // unlucky restart-timing race costs hours instead of minutes. Pass a
+        // deliberately huge poll_interval (as production does — DISCOGS_POLL_INTERVAL
+        // is 3600s) and prove all DISCOGS_MAX_UNREACHABLE_RETRIES attempts complete
+        // in well under one poll_interval's worth of real time.
+        let url = "http://127.0.0.1:19999/health";
+        let shutdown = AtomicBool::new(false);
+        let huge_poll_interval = Duration::from_secs(3600);
+
+        let start = tokio::time::Instant::now();
+        let result = tokio::time::timeout(Duration::from_secs(10), wait_for_discogs_idle_with_interval(url, &shutdown, huge_poll_interval)).await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_ok(), "must give up after DISCOGS_MAX_UNREACHABLE_RETRIES, not hang for poll_interval-per-attempt");
+        assert!(result.unwrap().is_ok());
+        assert!(elapsed < Duration::from_secs(5), "unreachable retries must not wait a full poll_interval per attempt: took {:?}", elapsed);
+    }
+}
+
+mod discogs_unreachable_backoff_tests {
+    use crate::extractor::{DISCOGS_UNREACHABLE_MAX_DELAY, discogs_unreachable_backoff};
+
+    #[test]
+    fn test_escalates_and_caps() {
+        // discogsography-i7sa: escalating (each attempt waits longer than the last)
+        // and bounded (never exceeds the cap, so retries stay "minutes, not hours").
+        let mut previous = discogs_unreachable_backoff(1);
+        for attempt in 2..=10u32 {
+            let backoff = discogs_unreachable_backoff(attempt);
+            assert!(backoff >= previous, "attempt {} backoff must not shrink vs attempt {}", attempt, attempt - 1);
+            assert!(backoff <= DISCOGS_UNREACHABLE_MAX_DELAY, "attempt {} backoff must never exceed the cap", attempt);
+            previous = backoff;
+        }
+    }
+
+    #[test]
+    fn test_zero_and_overflow_safe_attempts() {
+        // attempt=0 and very large attempts must not panic (shift-overflow guard).
+        let _ = discogs_unreachable_backoff(0);
+        let capped = discogs_unreachable_backoff(u32::MAX);
+        assert_eq!(capped, DISCOGS_UNREACHABLE_MAX_DELAY);
+    }
 }

--- a/extractor/src/tests/main_tests.rs
+++ b/extractor/src/tests/main_tests.rs
@@ -54,6 +54,17 @@ fn test_ascii_art_display_musicbrainz() {
 }
 
 #[test]
+fn test_startup_banner_message_reflects_source() {
+    // discogsography-i7sa regression: the startup banner must name the actual --source
+    // mode, not unconditionally claim "Discogs" regardless of which container is running.
+    assert!(startup_banner_message(Source::Discogs).contains("Discogs"));
+    assert!(!startup_banner_message(Source::Discogs).contains("MusicBrainz"));
+
+    assert!(startup_banner_message(Source::MusicBrainz).contains("MusicBrainz"));
+    assert!(!startup_banner_message(Source::MusicBrainz).contains("Discogs"));
+}
+
+#[test]
 fn test_ascii_art_display_none() {
     // Just verify the function doesn't panic with no source
     print_ascii_art(None);

--- a/extractor/src/tests/message_queue_tests.rs
+++ b/extractor/src/tests/message_queue_tests.rs
@@ -277,6 +277,27 @@ async fn test_get_channel_with_no_channel_triggers_reconnect() {
 }
 
 #[tokio::test]
+async fn test_close_with_no_channel_or_connection_is_ok() {
+    // discogsography-cu2.108 regression: close() must be a best-effort no-op
+    // (never early-return via `?`) when there's nothing to close — the
+    // happy-path baseline for the "always attempt both closes" contract.
+    let mq = MessageQueue {
+        connection: Arc::new(RwLock::new(None)),
+        channel: Arc::new(RwLock::new(None)),
+        reconnect_mutex: tokio::sync::Mutex::new(()),
+        url: String::new(),
+        max_retries: 1,
+        exchange_prefix: DEFAULT_EXCHANGE_PREFIX.to_string(),
+    };
+
+    let result = mq.close().await;
+    assert!(result.is_ok(), "close() with no channel/connection must succeed: {:?}", result.err());
+    // Both slots must remain drained (taken) after close().
+    assert!(mq.channel.read().await.is_none());
+    assert!(mq.connection.read().await.is_none());
+}
+
+#[tokio::test]
 async fn test_new_connection_failure_with_retries() {
     // Use 2 retries to exercise the retry backoff loop (lines 72-75):
     // - First attempt: try_connect fails, retry_count=1 < 2, warn + sleep(1s) + backoff doubled

--- a/extractor/tests/extractor_di_test.rs
+++ b/extractor/tests/extractor_di_test.rs
@@ -64,6 +64,85 @@ async fn test_process_single_file_mq_setup_called() {
     assert!(result.is_err());
 }
 
+/// Write a minimal valid (empty) gzip-compressed artists XML file, as parser_test.rs does,
+/// so process_single_file can run its full pipeline to a real success.
+fn write_empty_artists_gz(path: &std::path::Path) {
+    let xml_content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<artists>\n</artists>";
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(xml_content.as_bytes()).unwrap();
+    let compressed = encoder.finish().unwrap();
+    std::fs::write(path, compressed).unwrap();
+}
+
+#[tokio::test]
+async fn test_process_single_file_amqp_failure_at_send_file_complete_leaves_marker_not_completed() {
+    // discogsography-cu2.107 regression: a send_file_complete failure must leave the
+    // state marker NOT Completed for this file, so pending_files() still includes it
+    // on the next run and the signal is retried — instead of the marker already
+    // claiming the file done (the old "marker first" ordering) and the signal being
+    // silently and permanently dropped.
+    let temp_dir = TempDir::new().unwrap();
+    let file_name = "discogs_20260101_artists.xml.gz";
+    write_empty_artists_gz(&temp_dir.path().join(file_name));
+
+    let config = Arc::new(test_config(temp_dir.path()));
+    let state = Arc::new(RwLock::new(ExtractorState::default()));
+    let state_marker = Arc::new(Mutex::new(StateMarker::new("20260101".to_string())));
+    let marker_path = temp_dir.path().join("marker.json");
+
+    let mut mock_mq = MockMessagePublisher::new();
+    mock_mq.expect_setup_exchange().returning(|_| Ok(()));
+    mock_mq.expect_publish_batch().returning(|_, _| Ok(()));
+    mock_mq.expect_send_file_complete().times(1).returning(|_, _, _| Err(anyhow::anyhow!("AMQP connection dropped")));
+    mock_mq.expect_close().times(..).returning(|| Ok(()));
+
+    let mq: Arc<dyn extractor::message_queue::MessagePublisher> = Arc::new(mock_mq);
+
+    let result = process_single_file(file_name, config, state, state_marker.clone(), marker_path, mq, None).await;
+
+    assert!(result.is_err(), "a send_file_complete failure must propagate as an error");
+
+    let marker = state_marker.lock().await;
+    let file_status = marker.processing_phase.progress_by_file.get(file_name);
+    assert_ne!(
+        file_status.map(|s| s.status),
+        Some(extractor::state_marker::PhaseStatus::Completed),
+        "the file must NOT be marked Completed when send_file_complete failed — otherwise \
+         pending_files() would skip it on the next run and the signal would never be retried"
+    );
+}
+
+#[tokio::test]
+async fn test_process_single_file_close_failure_does_not_fail_the_run() {
+    // discogsography-cu2.108 regression: a cleanup (mq.close()) failure is purely
+    // cosmetic — the completion signal was already sent and the marker already
+    // committed — so it must not flip an otherwise fully-successful file to Failed.
+    let temp_dir = TempDir::new().unwrap();
+    let file_name = "discogs_20260101_artists.xml.gz";
+    write_empty_artists_gz(&temp_dir.path().join(file_name));
+
+    let config = Arc::new(test_config(temp_dir.path()));
+    let state = Arc::new(RwLock::new(ExtractorState::default()));
+    let state_marker = Arc::new(Mutex::new(StateMarker::new("20260101".to_string())));
+    let marker_path = temp_dir.path().join("marker.json");
+
+    let mut mock_mq = MockMessagePublisher::new();
+    mock_mq.expect_setup_exchange().returning(|_| Ok(()));
+    mock_mq.expect_publish_batch().returning(|_, _| Ok(()));
+    mock_mq.expect_send_file_complete().times(1).returning(|_, _, _| Ok(()));
+    mock_mq.expect_close().times(1).returning(|| Err(anyhow::anyhow!("channel already closed")));
+
+    let mq: Arc<dyn extractor::message_queue::MessagePublisher> = Arc::new(mock_mq);
+
+    let result = process_single_file(file_name, config, state, state_marker.clone(), marker_path, mq, None).await;
+
+    assert!(result.is_ok(), "a cosmetic close() failure must not fail an otherwise successful file: {:?}", result.err());
+
+    let marker = state_marker.lock().await;
+    let file_status = marker.processing_phase.progress_by_file.get(file_name);
+    assert_eq!(file_status.map(|s| s.status), Some(extractor::state_marker::PhaseStatus::Completed));
+}
+
 #[tokio::test]
 async fn test_message_publisher_increments_error_count_on_failure() {
     let state = Arc::new(RwLock::new(ExtractorState::default()));

--- a/tests/api/test_metrics_collector.py
+++ b/tests/api/test_metrics_collector.py
@@ -71,14 +71,40 @@ class TestMetricsBuffer:
         assert stats["count"] == 2
         assert stats["error_count"] == 0
 
-    def test_flush_clears_buffer(self) -> None:
+    def test_flush_is_non_destructive(self) -> None:
+        """flush() must NOT clear the buffer — only clear() does, and only after a successful persist."""
+        from api.metrics_collector import MetricsBuffer
+
+        buf = MetricsBuffer(max_size=100)
+        buf.record("/api/search", 200, 10.0)
+        first = buf.flush()
+        second = buf.flush()
+        assert first == second
+        assert second["/api/search"]["count"] == 1
+
+    def test_clear_empties_buffer(self) -> None:
         from api.metrics_collector import MetricsBuffer
 
         buf = MetricsBuffer(max_size=100)
         buf.record("/api/search", 200, 10.0)
         buf.flush()
+        buf.clear()
         result = buf.flush()
         assert result == {}
+
+    def test_flush_after_failed_persist_accumulates(self) -> None:
+        """Entries recorded between a failed flush and the retry are included next cycle."""
+        from api.metrics_collector import MetricsBuffer
+
+        buf = MetricsBuffer(max_size=100)
+        buf.record("/api/search", 200, 10.0)
+        first = buf.flush()
+        assert first["/api/search"]["count"] == 1
+
+        # Simulate more requests arriving before the buffer is ever cleared
+        buf.record("/api/search", 200, 20.0)
+        second = buf.flush()
+        assert second["/api/search"]["count"] == 2
 
     def test_max_size_drops_oldest(self) -> None:
         from api.metrics_collector import MetricsBuffer
@@ -626,6 +652,69 @@ class TestRunCollector:
             pytest.raises(asyncio.CancelledError),
         ):
             await run_collector(mock_pool, config, buf)
+
+    @pytest.mark.anyio
+    async def test_collector_persist_failure_does_not_drop_endpoint_stats(self) -> None:
+        """A failed persist must NOT discard buffered endpoint stats — they survive for the next cycle."""
+        from api.metrics_collector import MetricsBuffer, run_collector
+
+        mock_pool = MagicMock()
+        config = MagicMock()
+        config.rabbitmq_management_host = "localhost"
+        config.rabbitmq_management_port = 15672
+        config.rabbitmq_username = "guest"
+        config.rabbitmq_password = "guest"
+        config.metrics_retention_days = 30
+        config.metrics_collection_interval = 1
+
+        buf = MetricsBuffer(max_size=100)
+        buf.record("/api/search", 200, 10.0)
+
+        with (
+            patch("api.metrics_collector.collect_queue_metrics", new_callable=AsyncMock, return_value=[]),
+            patch("api.metrics_collector.collect_service_health", new_callable=AsyncMock, return_value=[]),
+            patch("api.metrics_collector.persist_metrics", new_callable=AsyncMock, side_effect=RuntimeError("db error")),
+            patch("api.metrics_collector.prune_old_metrics", new_callable=AsyncMock),
+            patch("asyncio.sleep", side_effect=asyncio.CancelledError),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await run_collector(mock_pool, config, buf)
+
+        # The sample recorded before the failed cycle must still be in the buffer.
+        result = buf.flush()
+        assert result["/api/search"]["count"] == 1
+
+    @pytest.mark.anyio
+    async def test_collector_persist_success_clears_endpoint_stats(self) -> None:
+        """A successful persist clears the buffer so the same samples aren't reported twice."""
+        from api.metrics_collector import MetricsBuffer, run_collector
+
+        mock_pool = MagicMock()
+        config = MagicMock()
+        config.rabbitmq_management_host = "localhost"
+        config.rabbitmq_management_port = 15672
+        config.rabbitmq_username = "guest"
+        config.rabbitmq_password = "guest"
+        config.metrics_retention_days = 30
+        config.metrics_collection_interval = 1
+
+        buf = MetricsBuffer(max_size=100)
+        buf.record("/api/search", 200, 10.0)
+
+        async def succeed_then_cancel(_pool: Any, _q: Any, _h: list[dict[str, Any]]) -> None:
+            return None
+
+        with (
+            patch("api.metrics_collector.collect_queue_metrics", new_callable=AsyncMock, return_value=[]),
+            patch("api.metrics_collector.collect_service_health", new_callable=AsyncMock, return_value=[]),
+            patch("api.metrics_collector.persist_metrics", side_effect=succeed_then_cancel),
+            patch("api.metrics_collector.prune_old_metrics", new_callable=AsyncMock),
+            patch("asyncio.sleep", side_effect=asyncio.CancelledError),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await run_collector(mock_pool, config, buf)
+
+        assert buf.flush() == {}
 
     @pytest.mark.anyio
     async def test_collector_handles_prune_error(self) -> None:

--- a/tests/api/test_syncer.py
+++ b/tests/api/test_syncer.py
@@ -1047,6 +1047,114 @@ class TestRunFullSync:
         assert mock_decrypt.call_count == 4
 
     @pytest.mark.asyncio
+    async def test_success_invalidates_recommendation_cache(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """A fully successful sync invalidates the user-scoped recommendation cache."""
+        mock_pg_pool._mock_cur.fetchone.return_value = {
+            "access_token": "at",
+            "access_secret": "as",
+            "provider_username": "user",
+        }
+        mock_pg_pool._mock_cur.fetchall.return_value = [
+            {"key": "discogs_consumer_key", "value": "ck"},
+            {"key": "discogs_consumer_secret", "value": "cs"},
+        ]
+
+        mock_redis = MagicMock()
+
+        with (
+            patch("api.syncer.sync_collection", new_callable=AsyncMock, return_value=10),
+            patch("api.syncer.sync_wantlist", new_callable=AsyncMock, return_value=5),
+            patch("api.syncer.decrypt_oauth_token", side_effect=lambda val, _key: val),
+            patch("api.syncer.RecommendCache") as mock_cache_cls,
+        ):
+            mock_cache = mock_cache_cls.return_value
+            mock_cache.invalidate_user = AsyncMock()
+
+            result = await run_full_sync(
+                TEST_USER_UUID,
+                "sync-cache-ok",
+                mock_pg_pool,
+                mock_neo4j,
+                TEST_USER_AGENT,
+                redis_client=mock_redis,
+            )
+
+        assert result["status"] == "completed"
+        mock_cache.invalidate_user.assert_awaited_once_with(str(TEST_USER_UUID))
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_still_invalidates_recommendation_cache(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """discogsography-cu2.99 regression: a partial failure (collection synced,
+        wantlist raises) must still invalidate the recommendation cache — the
+        collection sync already durably wrote data via autocommit executemany,
+        so skipping invalidation on the exception path would serve stale
+        personalized results for up to the cache TTL.
+        """
+        mock_pg_pool._mock_cur.fetchone.return_value = {
+            "access_token": "at",
+            "access_secret": "as",
+            "provider_username": "user",
+        }
+        mock_pg_pool._mock_cur.fetchall.return_value = [
+            {"key": "discogs_consumer_key", "value": "ck"},
+            {"key": "discogs_consumer_secret", "value": "cs"},
+        ]
+
+        mock_redis = MagicMock()
+
+        with (
+            patch("api.syncer.sync_collection", new_callable=AsyncMock, return_value=10),
+            patch("api.syncer.sync_wantlist", new_callable=AsyncMock, side_effect=RuntimeError("neo4j hiccup")),
+            patch("api.syncer.decrypt_oauth_token", side_effect=lambda val, _key: val),
+            patch("api.syncer.RecommendCache") as mock_cache_cls,
+        ):
+            mock_cache = mock_cache_cls.return_value
+            mock_cache.invalidate_user = AsyncMock()
+
+            result = await run_full_sync(
+                TEST_USER_UUID,
+                "sync-cache-partial",
+                mock_pg_pool,
+                mock_neo4j,
+                TEST_USER_AGENT,
+                redis_client=mock_redis,
+            )
+
+        assert result["status"] == "failed"
+        mock_cache.invalidate_user.assert_awaited_once_with(str(TEST_USER_UUID))
+
+    @pytest.mark.asyncio
+    async def test_no_redis_client_skips_invalidation(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """When redis_client is None, no RecommendCache is constructed."""
+        mock_pg_pool._mock_cur.fetchone.return_value = {
+            "access_token": "at",
+            "access_secret": "as",
+            "provider_username": "user",
+        }
+        mock_pg_pool._mock_cur.fetchall.return_value = [
+            {"key": "discogs_consumer_key", "value": "ck"},
+            {"key": "discogs_consumer_secret", "value": "cs"},
+        ]
+
+        with (
+            patch("api.syncer.sync_collection", new_callable=AsyncMock, return_value=10),
+            patch("api.syncer.sync_wantlist", new_callable=AsyncMock, return_value=5),
+            patch("api.syncer.decrypt_oauth_token", side_effect=lambda val, _key: val),
+            patch("api.syncer.RecommendCache") as mock_cache_cls,
+        ):
+            result = await run_full_sync(
+                TEST_USER_UUID,
+                "sync-no-redis",
+                mock_pg_pool,
+                mock_neo4j,
+                TEST_USER_AGENT,
+                redis_client=None,
+            )
+
+        assert result["status"] == "completed"
+        mock_cache_cls.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_return_dict_structure(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
         mock_pg_pool._mock_cur.fetchone.return_value = None
 

--- a/tests/brainztableinator/test_brainztableinator.py
+++ b/tests/brainztableinator/test_brainztableinator.py
@@ -534,7 +534,7 @@ class TestOnDataMessage:
     async def test_valid_data_message_calls_processor(self):
         """A valid data message with 'id' should call the appropriate processor."""
         mock_message = AsyncMock()
-        mock_message.body = b'{"id": "artist-mbid-1", "name": "Test Artist"}'
+        mock_message.body = b'{"id": "550e8400-e29b-41d4-a716-446655440000", "name": "Test Artist"}'
 
         mock_pool = MagicMock()
         mock_conn = AsyncMock()
@@ -569,14 +569,14 @@ class TestOnDataMessage:
         ):
             await on_data_message(mock_message, "artists")
 
-            mock_processor.assert_called_once_with(mock_conn, {"id": "artist-mbid-1", "name": "Test Artist"})
+            mock_processor.assert_called_once_with(mock_conn, {"id": "550e8400-e29b-41d4-a716-446655440000", "name": "Test Artist"})
             mock_message.ack.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_shutdown_requested_nacks_with_requeue(self):
         """When shutdown_requested is True, message should be nacked with requeue."""
         mock_message = AsyncMock()
-        mock_message.body = b'{"id": "artist-mbid-1", "name": "Test Artist"}'
+        mock_message.body = b'{"id": "550e8400-e29b-41d4-a716-446655440000", "name": "Test Artist"}'
 
         with patch("brainztableinator.brainztableinator.shutdown_requested", True):
             await on_data_message(mock_message, "artists")
@@ -633,10 +633,85 @@ class TestOnDataMessage:
             mock_message.ack.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_message_non_uuid_id_nacks_without_requeue(self):
+        """The extractor's 'unknown' sentinel (or any non-UUID id) should be nacked without
+        requeue instead of deterministically failing the PostgreSQL UUID cast and churning
+        through the quorum queue's redelivery limit."""
+        mock_message = AsyncMock()
+        mock_message.body = b'{"id": "unknown", "name": "Missing ID Artist"}'
+
+        with (
+            patch("brainztableinator.brainztableinator.shutdown_requested", False),
+            patch("brainztableinator.brainztableinator.completed_files", set()),
+            patch("brainztableinator.brainztableinator.connection_pool", MagicMock()),
+        ):
+            await on_data_message(mock_message, "artists")
+
+            mock_message.nack.assert_called_once_with(requeue=False)
+            mock_message.ack.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_message_truncated_id_nacks_without_requeue(self):
+        """A truncated/corrupt id string that isn't a valid UUID should also be rejected."""
+        mock_message = AsyncMock()
+        mock_message.body = b'{"id": "550e8400-e29b-41d4-a716", "name": "Truncated ID Artist"}'
+
+        with (
+            patch("brainztableinator.brainztableinator.shutdown_requested", False),
+            patch("brainztableinator.brainztableinator.completed_files", set()),
+            patch("brainztableinator.brainztableinator.connection_pool", MagicMock()),
+        ):
+            await on_data_message(mock_message, "artists")
+
+            mock_message.nack.assert_called_once_with(requeue=False)
+            mock_message.ack.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_data_error_nacks_without_requeue(self):
+        """A DataError raised during processing (e.g. a downstream cast failure) is
+        non-retryable and must nack without requeue instead of churning redeliveries."""
+        from psycopg.errors import DataError
+
+        mock_message = AsyncMock()
+        mock_message.body = b'{"id": "550e8400-e29b-41d4-a716-446655440000", "name": "Test"}'
+
+        mock_pool = MagicMock()
+        mock_conn = AsyncMock()
+        mock_conn.transaction = MagicMock(return_value=AsyncMock())
+        mock_conn_cm = AsyncMock()
+        mock_conn_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_pool.connection = MagicMock(return_value=mock_conn_cm)
+
+        mock_processor = AsyncMock(side_effect=DataError("invalid input syntax for type uuid"))
+
+        with (
+            patch("brainztableinator.brainztableinator.shutdown_requested", False),
+            patch("brainztableinator.brainztableinator.completed_files", set()),
+            patch("brainztableinator.brainztableinator.connection_pool", mock_pool),
+            patch(
+                "brainztableinator.brainztableinator.message_counts",
+                {"artists": 0, "labels": 0, "release-groups": 0, "releases": 0},
+            ),
+            patch(
+                "brainztableinator.brainztableinator.last_message_time",
+                {"artists": 0.0, "labels": 0.0, "release-groups": 0.0, "releases": 0.0},
+            ),
+            patch.dict(
+                "brainztableinator.brainztableinator.PROCESSORS",
+                {"artists": mock_processor},
+            ),
+        ):
+            await on_data_message(mock_message, "artists")
+
+            mock_message.nack.assert_called_once_with(requeue=False)
+            mock_message.ack.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_no_processor_for_data_type_nacks(self):
         """Unknown data type with no processor should nack without requeue."""
         mock_message = AsyncMock()
-        mock_message.body = b'{"id": "mbid-1", "name": "Test"}'
+        mock_message.body = b'{"id": "550e8400-e29b-41d4-a716-446655440000", "name": "Test"}'
 
         mock_pool = MagicMock()
         mock_conn = AsyncMock()
@@ -666,7 +741,7 @@ class TestOnDataMessage:
     async def test_connection_pool_none_nacks_with_requeue(self):
         """When connection_pool is None, message should be nacked with requeue."""
         mock_message = AsyncMock()
-        mock_message.body = b'{"id": "mbid-1", "name": "Test"}'
+        mock_message.body = b'{"id": "550e8400-e29b-41d4-a716-446655440000", "name": "Test"}'
 
         with (
             patch("brainztableinator.brainztableinator.shutdown_requested", False),
@@ -692,7 +767,7 @@ class TestOnDataMessage:
         from psycopg.errors import OperationalError
 
         mock_message = AsyncMock()
-        mock_message.body = b'{"id": "mbid-1", "name": "Test"}'
+        mock_message.body = b'{"id": "550e8400-e29b-41d4-a716-446655440000", "name": "Test"}'
 
         mock_pool = MagicMock()
         mock_conn = AsyncMock()
@@ -1682,7 +1757,7 @@ class TestOnDataMessageExtended:
         from psycopg.errors import InterfaceError
 
         mock_message = AsyncMock()
-        mock_message.body = json.dumps({"id": "mbid-1", "name": "Test"}).encode()
+        mock_message.body = json.dumps({"id": "550e8400-e29b-41d4-a716-446655440000", "name": "Test"}).encode()
 
         mock_pool = MagicMock()
         mock_pool.connection.side_effect = InterfaceError("Interface error")
@@ -1708,7 +1783,7 @@ class TestOnDataMessageExtended:
     async def test_handles_generic_exception_nack_with_requeue(self) -> None:
         """Test generic exception triggers nack with requeue."""
         mock_message = AsyncMock()
-        mock_message.body = json.dumps({"id": "mbid-1", "name": "Test"}).encode()
+        mock_message.body = json.dumps({"id": "550e8400-e29b-41d4-a716-446655440000", "name": "Test"}).encode()
 
         mock_pool = MagicMock()
         mock_pool.connection.side_effect = Exception("Unexpected failure")
@@ -1734,7 +1809,7 @@ class TestOnDataMessageExtended:
     async def test_handles_nack_failure(self) -> None:
         """Test handling failure during nack operation."""
         mock_message = AsyncMock()
-        mock_message.body = json.dumps({"id": "mbid-1", "name": "Test"}).encode()
+        mock_message.body = json.dumps({"id": "550e8400-e29b-41d4-a716-446655440000", "name": "Test"}).encode()
         mock_message.nack.side_effect = Exception("Nack failed")
 
         mock_pool = MagicMock()
@@ -1763,7 +1838,7 @@ class TestOnDataMessageExtended:
         """Test that progress is logged at the correct interval."""
 
         mock_message = AsyncMock()
-        mock_message.body = json.dumps({"id": "mbid-1", "name": "Test Artist"}).encode()
+        mock_message.body = json.dumps({"id": "550e8400-e29b-41d4-a716-446655440000", "name": "Test Artist"}).encode()
 
         mock_pool = MagicMock()
         mock_conn = AsyncMock()

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -298,6 +298,45 @@ class TestSetupLogging:
         logger = logging.getLogger()
         assert logger.level == logging.ERROR
 
+    def test_setup_logging_strips_trailing_whitespace(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that a trailing-whitespace LOG_LEVEL (e.g. from a compose file) does not crash."""
+        import logging
+
+        logging.root.handlers = []
+        monkeypatch.setenv("LOG_LEVEL", "INFO ")
+
+        setup_logging("test_service")
+
+        logger = logging.getLogger()
+        assert logger.level == logging.INFO
+
+    def test_setup_logging_falls_back_to_info_on_unrecognized_level(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Test that an unrecognized LOG_LEVEL (e.g. 'TRACE') falls back to INFO with a warning instead of raising."""
+        import logging
+
+        logging.root.handlers = []
+        monkeypatch.setenv("LOG_LEVEL", "TRACE")
+
+        setup_logging("test_service")
+
+        logger = logging.getLogger()
+        assert logger.level == logging.INFO
+        captured = capsys.readouterr()
+        assert "Unrecognized LOG_LEVEL" in captured.out
+
+    def test_setup_logging_falls_back_to_info_on_explicit_invalid_level(self) -> None:
+        """Test that an explicit invalid level parameter also falls back instead of raising."""
+        import logging
+
+        logging.root.handlers = []
+
+        setup_logging("test_service", level="NOTALEVEL")
+
+        logger = logging.getLogger()
+        assert logger.level == logging.INFO
+
     def test_setup_logging_warns_db_profiling(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that setup_logging warns when database profiling is enabled."""
         import logging


### PR DESCRIPTION
Lands the `batch:data-integrity` work group — eight data-integrity/message-loss fixes across the pipeline (4 Rust extractor, 4 Python), one conventional commit per bead.

## Beads
- `discogsography-cu2.79` — setup_logging: normalize LOG_LEVEL (whitespace, unknown values like TRACE) and fall back to INFO with a warning instead of crashing every service at startup
- `discogsography-cu2.72` — MetricsBuffer: keep buffered endpoint stats until the INSERT actually succeeds (bounded on repeated failure) instead of destructively flushing first
- `discogsography-cu2.78` — brainztableinator: validate mbid as UUID up front and dead-letter immediately (extractor's "unknown" sentinel was churning 20 quorum-queue redeliveries); DataError now classed non-retryable
- `discogsography-cu2.99` — sync: invalidate the recommendation cache on partially-failed syncs too — PG/Neo4j mutations no longer serve stale personalized results
- `discogsography-cu2.106` — extractor: verify Discogs downloads against the published CHECKSUM file instead of trusting a self-generated checksum of whatever bytes arrived
- `discogsography-cu2.107` — extractor: send file_complete over AMQP before marking the state marker Completed, so a broker failure in that window can't permanently drop the completion signal; cleanup-only mq.close() failure no longer flips a successful file to Failed
- `discogsography-cu2.108` — extractor: MessageQueue::close() is best-effort on both halves — a channel-close error no longer skips connection.close()
- `discogsography-i7sa` — extractor-musicbrainz: short escalating backoff (instead of a fixed 3600s sleep) when the Discogs health endpoint is unreachable at startup

## Tests
+968/−47 across 17 files, including 79 lines of new Rust integration tests for the state-marker/AMQP ordering and close semantics; Python suites extended for logging normalization, buffer retention, UUID dead-lettering, and cache invalidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UCBSBYhPWx9ESjDDJxsmY