### PR TITLE
fix: dashboard display nits — rate truncation + non-UTF-8 400 (batch:dashboard-nits)

### DIFF
--- a/api/queries/metrics_queries.py
+++ b/api/queries/metrics_queries.py
@@ -51,6 +51,18 @@ def _round_or_int(value: Any, *, is_raw: bool) -> int | float:
     return round(float(value), 2)
 
 
+def _round_rate(value: Any) -> float:
+    """Return a rounded float rate regardless of raw/aggregated range.
+
+    Rate columns (publish_rate, deliver_rate) are always floats collected from
+    RabbitMQ management stats — unlike the integer count gauges, they must never
+    be truncated with int(), or sub-1 msg/s rates render as a misleading 0.
+    """
+    if value is None:
+        return 0.0
+    return round(float(value), 2)
+
+
 async def get_queue_history(pool: Any, range_value: str) -> dict[str, Any]:
     """Fetch queue metrics history for the given time range.
 
@@ -108,8 +120,8 @@ async def get_queue_history(pool: Any, range_value: str) -> dict[str, Any]:
             "ready": _round_or_int(row["ready"], is_raw=is_raw),
             "unacked": _round_or_int(row["unacked"], is_raw=is_raw),
             "total": _round_or_int(row.get("ready", 0), is_raw=is_raw) + _round_or_int(row.get("unacked", 0), is_raw=is_raw),
-            "publish_rate": _round_or_int(row["publish_rate"], is_raw=is_raw),
-            "deliver_rate": _round_or_int(row["deliver_rate"], is_raw=is_raw),
+            "publish_rate": _round_rate(row["publish_rate"]),
+            "deliver_rate": _round_rate(row["deliver_rate"]),
         }
 
         target = dlq_summary if name.endswith(".dlq") else queues

--- a/dashboard/admin_proxy.py
+++ b/dashboard/admin_proxy.py
@@ -74,11 +74,21 @@ async def _validated_json_body(request: Request) -> bytes | None:
     Re-serialising through ``json.loads`` / ``json.dumps`` sanitises the
     payload so that no raw user bytes are forwarded verbatim.  Returns
     ``None`` when the body is empty.
+
+    Raises ``json.JSONDecodeError`` for both malformed JSON and non-UTF-8
+    bodies, so every caller's single ``except json.JSONDecodeError`` clause
+    handles both cases uniformly instead of only the former (a raw
+    ``UnicodeDecodeError`` is a ``ValueError`` sibling, not a subclass, of
+    ``json.JSONDecodeError``, and would otherwise escape as an unhandled 500).
     """
     raw = await request.body()
     if not raw:
         return None
-    parsed = json.loads(raw)
+    try:
+        parsed = json.loads(raw)
+    except UnicodeDecodeError as exc:
+        msg = f"Request body is not valid UTF-8: {exc}"
+        raise json.JSONDecodeError(msg, "", 0) from exc
     return json.dumps(parsed, separators=(",", ":")).encode()
 
 

--- a/tests/api/test_metrics_queries.py
+++ b/tests/api/test_metrics_queries.py
@@ -10,6 +10,7 @@ from api.queries.metrics_queries import (
     GRANULARITY_MAP,
     _bucket_to_trunc_unit,
     _round_or_int,
+    _round_rate,
     get_health_history,
     get_queue_history,
 )
@@ -103,6 +104,19 @@ class TestHelpers:
         assert _round_or_int(None, is_raw=True) == 0
         assert _round_or_int(None, is_raw=False) == 0.0
 
+    def test_round_rate_sub_one_preserves_float(self):
+        """Regression: sub-1 msg/s rates must not truncate to 0 (discogsography-cu2.73)."""
+        assert _round_rate(0.8) == 0.8
+        assert isinstance(_round_rate(0.8), float)
+        assert _round_rate(0.05) == 0.05
+
+    def test_round_rate_rounds_to_two_places(self):
+        assert _round_rate(2.9) == 2.9
+        assert _round_rate(42.678) == 42.68
+
+    def test_round_rate_none(self):
+        assert _round_rate(None) == 0.0
+
 
 class TestGetQueueHistory:
     """Tests for get_queue_history query function."""
@@ -141,6 +155,34 @@ class TestGetQueueHistory:
         assert len(queue["history"]) == 2
         assert queue["current"]["ready"] == 8
         assert result["dlq_summary"] == {}
+
+    @pytest.mark.asyncio
+    async def test_raw_range_sub_one_rate_not_truncated(self):
+        """Regression: 1h/6h (raw) ranges must preserve sub-1 msg/s rates as floats,
+        not truncate them to 0 via int() (discogsography-cu2.73)."""
+        rows = [
+            {
+                "queue_name": "graphinator-artists",
+                "ts": "2026-03-25T10:00:00",
+                "ready": 10,
+                "unacked": 2,
+                "total": 12,
+                "publish_rate": 0.8,
+                "deliver_rate": 0.5,
+            },
+        ]
+        pool, execute_side_effect = _mock_pool_with_rows(rows)
+
+        with patch("api.queries.metrics_queries.execute_sql", side_effect=execute_side_effect):
+            result = await get_queue_history(pool, "1h")
+
+        point = result["queues"]["graphinator-artists"]["history"][0]
+        assert point["publish_rate"] == 0.8
+        assert point["deliver_rate"] == 0.5
+        assert isinstance(point["publish_rate"], float)
+        assert isinstance(point["deliver_rate"], float)
+        # Integer count fields are still ints on raw ranges.
+        assert isinstance(point["ready"], int)
 
     @pytest.mark.asyncio
     async def test_dlq_separation(self):

--- a/tests/dashboard/test_admin_proxy.py
+++ b/tests/dashboard/test_admin_proxy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import FastAPI
@@ -9,7 +10,7 @@ from fastapi.testclient import TestClient
 import httpx as httpx_mod
 import pytest
 
-from dashboard.admin_proxy import _validate_path_segment, configure, router
+from dashboard.admin_proxy import _validate_path_segment, _validated_json_body, configure, router
 
 
 def _mock_httpx(method: str = "post", status: int = 200, content: bytes = b"{}") -> tuple[AsyncMock, AsyncMock]:
@@ -647,6 +648,42 @@ class TestTriggerMusicBrainzProxy:
         assert resp.status_code == 502
 
 
+class TestValidatedJsonBody:
+    """Direct unit tests for _validated_json_body (discogsography-cu2.84)."""
+
+    @pytest.mark.asyncio
+    async def test_non_utf8_body_raises_json_decode_error(self) -> None:
+        """A non-UTF-8 body must raise json.JSONDecodeError, not UnicodeDecodeError,
+        so every caller's existing `except json.JSONDecodeError` clause catches it."""
+        request = MagicMock()
+        request.body = AsyncMock(return_value=b"\xff")
+
+        with pytest.raises(json.JSONDecodeError):
+            await _validated_json_body(request)
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_raises_json_decode_error(self) -> None:
+        request = MagicMock()
+        request.body = AsyncMock(return_value=b"{not valid json")
+
+        with pytest.raises(json.JSONDecodeError):
+            await _validated_json_body(request)
+
+    @pytest.mark.asyncio
+    async def test_empty_body_returns_none(self) -> None:
+        request = MagicMock()
+        request.body = AsyncMock(return_value=b"")
+
+        assert await _validated_json_body(request) is None
+
+    @pytest.mark.asyncio
+    async def test_valid_json_body_reserialised(self) -> None:
+        request = MagicMock()
+        request.body = AsyncMock(return_value=b'{"a": 1}')
+
+        assert await _validated_json_body(request) == b'{"a":1}'
+
+
 class TestMalformedJsonBody:
     def test_login_malformed_json_returns_400(self, proxy_client: TestClient) -> None:
         """POST /admin/api/login with malformed JSON body returns 400."""
@@ -687,6 +724,41 @@ class TestMalformedJsonBody:
         )
         assert resp.status_code == 400
         assert "JSON object" in resp.json()["detail"]
+
+    def test_login_non_utf8_body_returns_400(self, proxy_client: TestClient) -> None:
+        """POST /admin/api/login with a non-UTF-8 body returns 400, not an unhandled 500.
+
+        Regression for discogsography-cu2.84: json.loads(bytes) raises
+        UnicodeDecodeError (a ValueError sibling, not a subclass, of
+        json.JSONDecodeError) for invalid UTF-8 bytes such as b"\\xff".
+        """
+        resp = proxy_client.post(
+            "/admin/api/login",
+            content=b"\xff",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 400
+        assert "Malformed JSON" in resp.json()["detail"]
+
+    def test_trigger_non_utf8_body_returns_400(self, proxy_client: TestClient) -> None:
+        """POST /admin/api/extractions/trigger with a non-UTF-8 body returns 400."""
+        resp = proxy_client.post(
+            "/admin/api/extractions/trigger",
+            content=b"{\xff}",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 400
+        assert "Malformed JSON" in resp.json()["detail"]
+
+    def test_trigger_musicbrainz_non_utf8_body_returns_400(self, proxy_client: TestClient) -> None:
+        """POST /admin/api/extractions/trigger-musicbrainz with a non-UTF-8 body returns 400."""
+        resp = proxy_client.post(
+            "/admin/api/extractions/trigger-musicbrainz",
+            content=b"\x80\x81",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 400
+        assert "Malformed JSON" in resp.json()["detail"]
 
     def test_trigger_musicbrainz_sanitised_body_decode_error_returns_400(self, proxy_client: TestClient) -> None:
         """POST trigger-musicbrainz returns 400 when sanitised body fails json.loads (lines 189-190)."""


### PR DESCRIPTION
Lands the `batch:dashboard-nits` work group — two small correctness fixes, one conventional commit per bead.

## Beads
- `discogsography-cu2.73` — queue-history raw ranges (1h/6h) no longer truncate float publish/deliver rates to int; sub-1 msg/s rates render correctly instead of showing 0 (dedicated `_round_rate` helper since rate columns are always floats, unlike the count gauges)
- `discogsography-cu2.84` — admin_proxy: a non-UTF-8 request body is normalized into `json.JSONDecodeError`, so every caller's existing handler returns 400 instead of an unhandled `UnicodeDecodeError` 500

## Tests
Regression tests for sub-1 rates surviving the raw-range path end-to-end and for non-UTF-8 bodies returning 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UCBSBYhPWx9ESjDDJxsmY