### PR TITLE
fix: Explore frontend correctness — races, error states, theme toggle, pagination (batch:frontend-correctness)

### DIFF
--- a/api/queries/user_queries.py
+++ b/api/queries/user_queries.py
@@ -45,7 +45,7 @@ async def get_user_collection(
            genres, styles,
            c.rating AS rating, c.date_added AS date_added,
            c.folder_id AS folder_id
-    ORDER BY c.date_added DESC
+    ORDER BY c.date_added DESC, r.id
     SKIP $offset LIMIT $limit
     """
     count_cypher = """
@@ -85,7 +85,7 @@ async def get_user_wantlist(
            artist_name AS artist, label_name AS label,
            genres, styles,
            w.rating AS rating, w.date_added AS date_added
-    ORDER BY w.date_added DESC
+    ORDER BY w.date_added DESC, r.id
     SKIP $offset LIMIT $limit
     """
     count_cypher = """

--- a/explore/__tests__/nlq-pill.test.js
+++ b/explore/__tests__/nlq-pill.test.js
@@ -273,6 +273,51 @@ describe('NlqPill state machine', () => {
         expect(document.querySelector('[data-testid="nlq-pill-answer"]')).not.toBeNull();
     });
 
+    it('ignores a second submit while a query is still loading, so only one stream is ever started', () => {
+        const onSubmit = vi.fn();
+        const pill = new NlqPill({ mountId: 'nlqPillMount', onSubmit });
+        pill.mount();
+        pill.expand();
+        const input = document.querySelector('[data-testid="nlq-pill-input"]');
+        input.value = 'show Radiohead';
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+
+        // Simulate the caller putting the pill into loading state for the
+        // in-flight request, then a re-entrant submit attempt while it spins.
+        pill.setLoading();
+        const loadingInput = document.querySelector('[data-testid="nlq-pill-input"]');
+        loadingInput.value = 'switch to trends';
+        loadingInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(pill.state).toBe('loading');
+    });
+
+    it('disables the input while loading so a second stream cannot be raced in', () => {
+        const pill = new NlqPill({ mountId: 'nlqPillMount' });
+        pill.mount();
+        pill.expand();
+        pill.setLoading();
+        const input = document.querySelector('[data-testid="nlq-pill-input"]');
+        expect(input.disabled).toBe(true);
+    });
+
+    it('allows a follow-up submit once the pill has left the loading state', () => {
+        const onSubmit = vi.fn();
+        const pill = new NlqPill({ mountId: 'nlqPillMount', onSubmit });
+        pill.mount();
+        pill.expand();
+        pill.setLoading();
+        pill.setAnswer({ summary: 'done', entities: [], appliedActions: [], skipped: 0 });
+
+        const input = document.querySelector('[data-testid="nlq-pill-input"]');
+        expect(input.disabled).toBe(false);
+        input.value = 'follow up';
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        expect(onSubmit).toHaveBeenCalledWith('follow up');
+    });
+
     it('Esc collapses from loading and from answered', () => {
         const pill = new NlqPill({ mountId: 'nlqPillMount' });
         pill.mount();

--- a/explore/__tests__/search.test.js
+++ b/explore/__tests__/search.test.js
@@ -476,6 +476,85 @@ describe('search pane', () => {
             expect(window.apiClient.search).toHaveBeenCalled();
         });
 
+        it('should reset selectedGenres when the query text changes on Enter', async () => {
+            window.apiClient.search.mockResolvedValue({
+                results: [{ name: 'X', type: 'artist', relevance: 1 }],
+                total: 1,
+                facets: { genre: { Rock: 10 } },
+                pagination: { has_more: false },
+            });
+
+            const input = document.getElementById('searchPaneInput');
+            input.value = 'beatles';
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            await new Promise(r => setTimeout(r, 10));
+
+            // Select the Rock genre facet chip.
+            const chip = document.getElementById('searchGenreFilter').querySelector('.search-chip');
+            chip.click();
+            await new Promise(r => setTimeout(r, 10));
+
+            // New, unrelated query — selectedGenres must not carry over.
+            window.apiClient.search.mockClear();
+            input.value = 'herbie hancock';
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            await new Promise(r => setTimeout(r, 10));
+
+            expect(window.apiClient.search).toHaveBeenCalledWith('herbie hancock', expect.any(Array), [], null, null, 20, 0);
+        });
+
+        it('should reset selectedGenres when the query text changes via search button', async () => {
+            window.apiClient.search.mockResolvedValue({
+                results: [{ name: 'X', type: 'artist', relevance: 1 }],
+                total: 1,
+                facets: { genre: { Rock: 10 } },
+                pagination: { has_more: false },
+            });
+
+            const input = document.getElementById('searchPaneInput');
+            const btn = document.getElementById('searchPaneBtn');
+            input.value = 'beatles';
+            btn.click();
+            await new Promise(r => setTimeout(r, 10));
+
+            const chip = document.getElementById('searchGenreFilter').querySelector('.search-chip');
+            chip.click();
+            await new Promise(r => setTimeout(r, 10));
+
+            window.apiClient.search.mockClear();
+            input.value = 'herbie hancock';
+            btn.click();
+            await new Promise(r => setTimeout(r, 10));
+
+            expect(window.apiClient.search).toHaveBeenCalledWith('herbie hancock', expect.any(Array), [], null, null, 20, 0);
+        });
+
+        it('should keep selectedGenres when re-submitting the same query', async () => {
+            window.apiClient.search.mockResolvedValue({
+                results: [{ name: 'X', type: 'artist', relevance: 1 }],
+                total: 1,
+                facets: { genre: { Rock: 10 } },
+                pagination: { has_more: false },
+            });
+
+            const input = document.getElementById('searchPaneInput');
+            input.value = 'beatles';
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            await new Promise(r => setTimeout(r, 10));
+
+            const chip = document.getElementById('searchGenreFilter').querySelector('.search-chip');
+            chip.click();
+            await new Promise(r => setTimeout(r, 10));
+
+            // Re-run the SAME query text (e.g. hitting Enter again) — the filter is
+            // still refining this query, so it must be kept.
+            window.apiClient.search.mockClear();
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            await new Promise(r => setTimeout(r, 10));
+
+            expect(window.apiClient.search).toHaveBeenCalledWith('beatles', expect.any(Array), ['Rock'], null, null, 20, 0);
+        });
+
         it('should deactivate genre chip on second click', async () => {
             window.apiClient.search.mockResolvedValue({
                 results: [{ name: 'X', type: 'artist', relevance: 1 }],

--- a/explore/__tests__/search.test.js
+++ b/explore/__tests__/search.test.js
@@ -246,6 +246,45 @@ describe('search pane', () => {
         });
     });
 
+    describe('request sequencing', () => {
+        it('should discard a stale response that resolves after a newer request', async () => {
+            let resolveFirst, resolveSecond;
+            window.apiClient.search
+                .mockReturnValueOnce(new Promise(r => { resolveFirst = r; }))
+                .mockReturnValueOnce(new Promise(r => { resolveSecond = r; }));
+
+            const input = document.getElementById('searchPaneInput');
+            input.value = 'radiohead';
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+            // A second, unrelated query is submitted before the first resolves.
+            input.value = 'herbie hancock';
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+            // Newer request resolves first — should render normally.
+            resolveSecond({
+                results: [{ name: 'Herbie Hancock', type: 'artist', relevance: 1 }],
+                total: 1,
+                facets: {},
+                pagination: { has_more: false },
+            });
+            await new Promise(r => setTimeout(r, 10));
+
+            // Stale (earlier) request resolves after — must not overwrite the render.
+            resolveFirst({
+                results: [{ name: 'Radiohead', type: 'artist', relevance: 1 }],
+                total: 1,
+                facets: {},
+                pagination: { has_more: false },
+            });
+            await new Promise(r => setTimeout(r, 10));
+
+            const resultsEl = document.getElementById('searchResults');
+            expect(resultsEl.textContent).toContain('Herbie Hancock');
+            expect(resultsEl.textContent).not.toContain('Radiohead');
+        });
+    });
+
     describe('highlight rendering', () => {
         it('should render highlighted text with bold elements', async () => {
             window.apiClient.search.mockResolvedValue({

--- a/explore/__tests__/theme.test.js
+++ b/explore/__tests__/theme.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { loadScript } from './helpers.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Set up the DOM elements required by theme.js.
@@ -168,5 +173,43 @@ describe('theme toggle (tri-state)', () => {
     it('should not crash when required DOM elements are missing', () => {
         document.body.textContent = '';
         expect(() => loadScript('theme.js')).not.toThrow();
+    });
+
+    it('should apply a persisted preference even when the toggle button markup is absent', () => {
+        // Regression: previously applyMode() was gated behind the toggle
+        // button + icon spans existing, so a stored preference was silently
+        // ignored whenever that markup was missing.
+        document.body.textContent = '';
+        localStorage.setItem('theme', 'dark');
+
+        loadScript('theme.js');
+
+        expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+
+    it('should apply the OS dark preference in auto mode even when the toggle button markup is absent', () => {
+        document.body.textContent = '';
+        globalThis.window.matchMedia = vi.fn((query) => ({
+            matches: query.includes('dark'),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+        }));
+
+        loadScript('theme.js');
+
+        expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+});
+
+describe('theme toggle markup', () => {
+    it('index.html wires up the #theme-toggle button and icon spans theme.js requires', () => {
+        const html = readFileSync(resolve(__dirname, '..', 'static', 'index.html'), 'utf-8');
+
+        expect(html).toContain('id="theme-toggle"');
+        expect(html).toContain('id="theme-icon-auto"');
+        expect(html).toContain('id="theme-icon-sun"');
+        expect(html).toContain('id="theme-icon-moon"');
+        // The toggle must be included as a real page script for it to run.
+        expect(html).toContain('js/theme.js');
     });
 });

--- a/explore/__tests__/user-panes.test.js
+++ b/explore/__tests__/user-panes.test.js
@@ -174,6 +174,29 @@ describe('UserPanes', () => {
             expect(body.querySelectorAll('.user-pane-empty')).toHaveLength(1);
             expect(body.textContent).toContain('Failed to load collection.');
         });
+
+        it('should discard a stale response that resolves after a newer request', async () => {
+            let resolveFirst, resolveSecond;
+            window.apiClient.getUserCollection
+                .mockReturnValueOnce(new Promise(r => { resolveFirst = r; }))
+                .mockReturnValueOnce(new Promise(r => { resolveSecond = r; }));
+
+            const first = userPanes.loadCollection(); // offset 0
+            userPanes._collectionOffset = 50;
+            const second = userPanes.loadCollection(); // offset 50 — supersedes the first
+
+            // Newer request resolves first — should render normally.
+            resolveSecond({ releases: [{ title: 'Second Page', artist: 'B', year: 2000 }], total: 100, has_more: true });
+            await second;
+
+            // Stale request resolves after — must be discarded, not overwrite the render.
+            resolveFirst({ releases: [{ title: 'First Page', artist: 'A', year: 1990 }], total: 100, has_more: true });
+            await first;
+
+            const body = document.getElementById('collectionBody');
+            expect(body.textContent).toContain('Second Page');
+            expect(body.textContent).not.toContain('First Page');
+        });
     });
 
     describe('loadWantlist', () => {
@@ -229,6 +252,27 @@ describe('UserPanes', () => {
             expect(body.querySelector('table')).toBeNull();
             expect(body.querySelectorAll('.user-pane-empty')).toHaveLength(1);
             expect(body.textContent).toContain('Failed to load wantlist.');
+        });
+
+        it('should discard a stale response that resolves after a newer request', async () => {
+            let resolveFirst, resolveSecond;
+            window.apiClient.getUserWantlist
+                .mockReturnValueOnce(new Promise(r => { resolveFirst = r; }))
+                .mockReturnValueOnce(new Promise(r => { resolveSecond = r; }));
+
+            const first = userPanes.loadWantlist(); // offset 0
+            userPanes._wantlistOffset = 50;
+            const second = userPanes.loadWantlist(); // offset 50 — supersedes the first
+
+            resolveSecond({ releases: [{ title: 'Second Page', artist: 'B', year: 2000 }], total: 100, has_more: true });
+            await second;
+
+            resolveFirst({ releases: [{ title: 'First Page', artist: 'A', year: 1990 }], total: 100, has_more: true });
+            await first;
+
+            const body = document.getElementById('wantlistBody');
+            expect(body.textContent).toContain('Second Page');
+            expect(body.textContent).not.toContain('First Page');
         });
     });
 
@@ -1294,6 +1338,37 @@ describe('UserPanes', () => {
             expect(body.querySelector('.gap-summary')).toBeNull();
             expect(body.querySelectorAll('.user-pane-empty')).toHaveLength(1);
             expect(body.textContent).toContain('Failed to load gap analysis.');
+        });
+
+        it('should discard a stale response that resolves after a newer request', async () => {
+            let resolveFirst, resolveSecond;
+            window.apiClient.getCollectionGaps
+                .mockReturnValueOnce(new Promise(r => { resolveFirst = r; }))
+                .mockReturnValueOnce(new Promise(r => { resolveSecond = r; }));
+
+            const first = userPanes.loadGapAnalysis('artist', '123'); // offset 0
+            userPanes._gapOffset = 50;
+            const second = userPanes.loadGapAnalysis('artist', '123'); // offset 50 — supersedes the first
+
+            resolveSecond({
+                entity: { name: 'Test', type: 'artist' },
+                summary: { total: 1, owned: 0, missing: 1 },
+                results: [{ title: 'Second Page Release', artist: 'B' }],
+                pagination: { total: 100, offset: 50, limit: 50, has_more: true },
+            });
+            await second;
+
+            resolveFirst({
+                entity: { name: 'Test', type: 'artist' },
+                summary: { total: 1, owned: 0, missing: 1 },
+                results: [{ title: 'First Page Release', artist: 'A' }],
+                pagination: { total: 100, offset: 0, limit: 50, has_more: true },
+            });
+            await first;
+
+            const body = document.getElementById('gapsBody');
+            expect(body.textContent).toContain('Second Page Release');
+            expect(body.textContent).not.toContain('First Page Release');
         });
     });
 

--- a/explore/__tests__/user-panes.test.js
+++ b/explore/__tests__/user-panes.test.js
@@ -156,6 +156,24 @@ describe('UserPanes', () => {
 
             expect(loading.classList.contains('active')).toBe(false);
         });
+
+        it('should replace the stale table instead of appending an error under it', async () => {
+            window.apiClient.getUserCollection.mockResolvedValue({
+                releases: [{ title: 'OK Computer', artist: 'Radiohead', year: 1997 }],
+                total: 1,
+                has_more: false,
+            });
+            await userPanes.loadCollection();
+            const body = document.getElementById('collectionBody');
+            expect(body.querySelector('table')).not.toBeNull();
+
+            window.apiClient.getUserCollection.mockResolvedValue(null);
+            await userPanes.loadCollection();
+
+            expect(body.querySelector('table')).toBeNull();
+            expect(body.querySelectorAll('.user-pane-empty')).toHaveLength(1);
+            expect(body.textContent).toContain('Failed to load collection.');
+        });
     });
 
     describe('loadWantlist', () => {
@@ -193,6 +211,24 @@ describe('UserPanes', () => {
 
             const body = document.getElementById('wantlistBody');
             expect(body.querySelector('table')).not.toBeNull();
+        });
+
+        it('should replace the stale table instead of appending an error under it', async () => {
+            window.apiClient.getUserWantlist.mockResolvedValue({
+                releases: [{ title: 'Loveless', artist: 'My Bloody Valentine', year: 1991 }],
+                total: 1,
+                has_more: false,
+            });
+            await userPanes.loadWantlist();
+            const body = document.getElementById('wantlistBody');
+            expect(body.querySelector('table')).not.toBeNull();
+
+            window.apiClient.getUserWantlist.mockResolvedValue(null);
+            await userPanes.loadWantlist();
+
+            expect(body.querySelector('table')).toBeNull();
+            expect(body.querySelectorAll('.user-pane-empty')).toHaveLength(1);
+            expect(body.textContent).toContain('Failed to load wantlist.');
         });
     });
 
@@ -1239,6 +1275,25 @@ describe('UserPanes', () => {
             await userPanes.loadGapAnalysis('artist', '123');
             const gapsPane = document.getElementById('gapsPane');
             expect(gapsPane.classList.contains('active')).toBe(true);
+        });
+
+        it('should replace the stale table instead of appending an error under it', async () => {
+            window.apiClient.getCollectionGaps.mockResolvedValue({
+                entity: { name: 'Test', type: 'artist' },
+                summary: { total: 1, owned: 0, missing: 1 },
+                results: [{ title: 'Missing Release', artist: 'Test Artist' }],
+                pagination: { total: 1, offset: 0, limit: 50, has_more: false },
+            });
+            await userPanes.loadGapAnalysis('artist', '123');
+            const body = document.getElementById('gapsBody');
+            expect(body.querySelector('.gap-summary')).not.toBeNull();
+
+            window.apiClient.getCollectionGaps.mockResolvedValue(null);
+            await userPanes.loadGapAnalysis('artist', '123');
+
+            expect(body.querySelector('.gap-summary')).toBeNull();
+            expect(body.querySelectorAll('.user-pane-empty')).toHaveLength(1);
+            expect(body.textContent).toContain('Failed to load gap analysis.');
         });
     });
 

--- a/explore/__tests__/user-panes.test.js
+++ b/explore/__tests__/user-panes.test.js
@@ -294,6 +294,18 @@ describe('UserPanes', () => {
             expect(body.querySelector('.user-pane-empty')).not.toBeNull();
         });
 
+        it('should render a distinct error state (not the empty-collection prompt) when the API returns null', async () => {
+            // apiClient returns null for a non-ok HTTP response — a server/network
+            // error, not a genuinely empty recommendations list.
+            window.apiClient.getUserRecommendations.mockResolvedValue(null);
+
+            await userPanes.loadRecommendations();
+
+            const body = document.getElementById('recommendationsBody');
+            expect(body.textContent).toContain('Failed to load recommendations');
+            expect(body.textContent).not.toContain('No recommendations yet');
+        });
+
         it('should render recommendation items', async () => {
             window.apiClient.getUserRecommendations.mockResolvedValue({
                 recommendations: [
@@ -570,11 +582,21 @@ describe('UserPanes', () => {
     });
 
     describe('_renderRecommendations', () => {
-        it('should render empty state for null data', () => {
+        it('should render an error state (not the empty-collection prompt) for null data', () => {
             const container = document.createElement('div');
             userPanes._renderRecommendations(container, null);
 
             expect(container.querySelector('.user-pane-empty')).not.toBeNull();
+            expect(container.textContent).toContain('Failed to load recommendations');
+            expect(container.textContent).not.toContain('No recommendations yet');
+        });
+
+        it('should render the empty-collection prompt for a genuinely empty recommendations array', () => {
+            const container = document.createElement('div');
+            userPanes._renderRecommendations(container, { recommendations: [] });
+
+            expect(container.querySelector('.user-pane-empty')).not.toBeNull();
+            expect(container.textContent).toContain('No recommendations yet');
         });
 
         it('should render recommendation with score', () => {

--- a/explore/static/index.html
+++ b/explore/static/index.html
@@ -479,6 +479,11 @@ body {
 
             <!-- Utilities: theme + auth -->
             <div class="navbar-utils">
+                <button type="button" class="navbar-icon-btn" id="theme-toggle" title="Toggle theme (auto → light → dark)">
+                    <span class="material-symbols-outlined" id="theme-icon-auto">brightness_auto</span>
+                    <span class="material-symbols-outlined hidden" id="theme-icon-sun">light_mode</span>
+                    <span class="material-symbols-outlined hidden" id="theme-icon-moon">dark_mode</span>
+                </button>
                 <div class="navbar-auth">
                     <div id="authButtons">
                         <button class="btn-outline-secondary btn-sm" id="navLoginBtn"

--- a/explore/static/js/nlq-pill.js
+++ b/explore/static/js/nlq-pill.js
@@ -218,6 +218,7 @@ export class NlqPill {
         input.placeholder = 'Ask anything about the music graph…';
         input.maxLength = 500;
         input.value = this._pendingInputValue || '';
+        input.disabled = this.state === 'loading';
         input.addEventListener('input', () => {
             this._pendingInputValue = input.value;
         });
@@ -328,6 +329,12 @@ export class NlqPill {
     }
 
     _submitQuery(query) {
+        // A second submit while the first is still in flight would race two
+        // independent SSE streams against the shared NlqActionApplier's single
+        // undo snapshot — whichever stream resolves last silently wins,
+        // corrupting the undo snapshot / displayed answer. Only one query may
+        // be in flight at a time.
+        if (this.state === 'loading') return;
         const trimmed = (query || '').trim();
         if (!trimmed) return;
         NlqSuggestions.addRecent(trimmed);

--- a/explore/static/js/search.js
+++ b/explore/static/js/search.js
@@ -82,15 +82,26 @@
 
     input.addEventListener('keydown', (e) => {
         if (e.key === 'Enter') {
+            resetGenresOnNewQuery();
             currentOffset = 0;
             triggerSearch();
         }
     });
 
     searchBtn.addEventListener('click', () => {
+        resetGenresOnNewQuery();
         currentOffset = 0;
         triggerSearch();
     });
+
+    // A genre facet chip is semantically coupled to the query that produced
+    // it — carrying it forward silently narrows (or zeroes) an unrelated
+    // query with no on-screen indication why. Clear it only when the query
+    // text actually changed; refining/re-running the same query keeps it.
+    function resetGenresOnNewQuery() {
+        const q = input.value.trim();
+        if (q !== lastQuery) selectedGenres = [];
+    }
 
     // ------------------------------------------------------------------
     // Core search

--- a/explore/static/js/search.js
+++ b/explore/static/js/search.js
@@ -24,6 +24,11 @@
     let lastQuery = '';
     let lastResult = null;
     let selectedGenres = [];
+    // Monotonic request id — discards a response from an earlier request that
+    // resolves after a newer one was issued (type-chip toggle, year debounce,
+    // genre chip, pagination, or a fresh Enter/search-button submit can all
+    // fire while a prior search is still in flight).
+    let searchRequestId = 0;
 
     // ------------------------------------------------------------------
     // Parse ts_headline highlight into DOM nodes (no innerHTML)
@@ -114,6 +119,8 @@
             return;
         }
 
+        const requestId = ++searchRequestId;
+
         lastQuery = q;
         setVisible(placeholder, false);
         setVisible(loadingEl, true);
@@ -126,6 +133,10 @@
         const yearMax = yearMaxEl.value ? parseInt(yearMaxEl.value, 10) : null;
 
         const data = await window.apiClient.search(q, types, selectedGenres, yearMin, yearMax, PAGE_SIZE, currentOffset);
+
+        // A newer search has since been issued — discard this stale response
+        // rather than let it overwrite results/pagination for the current one.
+        if (requestId !== searchRequestId) return;
 
         setVisible(loadingEl, false);
 

--- a/explore/static/js/theme.js
+++ b/explore/static/js/theme.js
@@ -5,12 +5,6 @@
 (function initThemeToggle() {
     'use strict';
 
-    const btn = document.getElementById('theme-toggle');
-    const autoIcon = document.getElementById('theme-icon-auto');
-    const sunIcon = document.getElementById('theme-icon-sun');
-    const moonIcon = document.getElementById('theme-icon-moon');
-    if (!btn || !autoIcon || !sunIcon || !moonIcon) return;
-
     function getMode() {
         return localStorage.getItem('theme') || 'auto';
     }
@@ -24,6 +18,23 @@
         }
     }
 
+    // Apply the persisted preference unconditionally — this must not depend on
+    // the toggle button existing so a stored choice is never silently ignored.
+    applyMode(getMode());
+
+    // Listen for OS-level theme changes — only applies when in auto mode
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+        if (getMode() === 'auto') {
+            document.documentElement.classList.toggle('dark', e.matches);
+        }
+    });
+
+    const btn = document.getElementById('theme-toggle');
+    const autoIcon = document.getElementById('theme-icon-auto');
+    const sunIcon = document.getElementById('theme-icon-sun');
+    const moonIcon = document.getElementById('theme-icon-moon');
+    if (!btn || !autoIcon || !sunIcon || !moonIcon) return;
+
     function updateIcons() {
         const mode = getMode();
         autoIcon.classList.toggle('hidden', mode !== 'auto');
@@ -31,7 +42,6 @@
         moonIcon.classList.toggle('hidden', mode !== 'dark');
     }
 
-    applyMode(getMode());
     updateIcons();
 
     const cycle = { auto: 'light', light: 'dark', dark: 'auto' };
@@ -45,12 +55,5 @@
         }
         applyMode(next);
         updateIcons();
-    });
-
-    // Listen for OS-level theme changes — only applies when in auto mode
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-        if (getMode() === 'auto') {
-            document.documentElement.classList.toggle('dark', e.matches);
-        }
     });
 })();

--- a/explore/static/js/user-panes.js
+++ b/explore/static/js/user-panes.js
@@ -14,6 +14,11 @@ class UserPanes {
         this._discogsOAuthState = null;
         this._tasteCache = null;
         this._tasteLoading = false;
+        // Monotonic request ids so an out-of-order (stale) fetch response
+        // can never overwrite the rows for a request issued after it.
+        this._collectionReqId = 0;
+        this._wantlistReqId = 0;
+        this._gapReqId = 0;
     }
 
     // ------------------------------------------------------------------ //
@@ -29,8 +34,12 @@ class UserPanes {
         const body = document.getElementById('collectionBody');
         if (loading) loading.classList.add('active');
 
+        const requestId = ++this._collectionReqId;
+        const requestOffset = this._collectionOffset;
         try {
-            const data = await window.apiClient.getUserCollection(token, this._pageSize, this._collectionOffset);
+            const data = await window.apiClient.getUserCollection(token, this._pageSize, requestOffset);
+            // A newer request has since been issued — discard this stale response.
+            if (requestId !== this._collectionReqId) return;
             if (!data) {
                 this._renderCollectionEmpty(body, 'Failed to load collection.');
                 return;
@@ -38,7 +47,7 @@ class UserPanes {
             this._collectionTotal = data.total;
             this._renderCollectionList(body, data);
         } finally {
-            if (loading) loading.classList.remove('active');
+            if (requestId === this._collectionReqId && loading) loading.classList.remove('active');
         }
     }
 
@@ -94,8 +103,12 @@ class UserPanes {
         const body = document.getElementById('wantlistBody');
         if (loading) loading.classList.add('active');
 
+        const requestId = ++this._wantlistReqId;
+        const requestOffset = this._wantlistOffset;
         try {
-            const data = await window.apiClient.getUserWantlist(token, this._pageSize, this._wantlistOffset);
+            const data = await window.apiClient.getUserWantlist(token, this._pageSize, requestOffset);
+            // A newer request has since been issued — discard this stale response.
+            if (requestId !== this._wantlistReqId) return;
             if (!data) {
                 this._renderWantlistEmpty(body, 'Failed to load wantlist.');
                 return;
@@ -103,7 +116,7 @@ class UserPanes {
             this._wantlistTotal = data.total;
             this._renderWantlistList(body, data);
         } finally {
-            if (loading) loading.classList.remove('active');
+            if (requestId === this._wantlistReqId && loading) loading.classList.remove('active');
         }
     }
 
@@ -800,6 +813,8 @@ class UserPanes {
         const body = document.getElementById('gapsBody');
         if (loading) loading.classList.add('active');
 
+        const requestId = ++this._gapReqId;
+        const requestOffset = this._gapOffset;
         try {
             // Load available formats for filter (once)
             if (!this._gapAvailableFormats) {
@@ -809,10 +824,12 @@ class UserPanes {
 
             const data = await window.apiClient.getCollectionGaps(token, entityType, entityId, {
                 limit: this._pageSize,
-                offset: this._gapOffset,
+                offset: requestOffset,
                 formats: this._gapFormats,
                 excludeWantlist: this._gapExcludeWantlist,
             });
+            // A newer request has since been issued — discard this stale response.
+            if (requestId !== this._gapReqId) return;
             if (!data) {
                 this._renderGapsEmpty(body, 'Failed to load gap analysis.');
                 return;
@@ -820,7 +837,7 @@ class UserPanes {
             this._gapTotal = data.pagination?.total || 0;
             this._renderGaps(body, data);
         } finally {
-            if (loading) loading.classList.remove('active');
+            if (requestId === this._gapReqId && loading) loading.classList.remove('active');
         }
     }
 

--- a/explore/static/js/user-panes.js
+++ b/explore/static/js/user-panes.js
@@ -183,7 +183,24 @@ class UserPanes {
         if (!container) return;
         container.replaceChildren();
 
-        if (!data || !data.recommendations || data.recommendations.length === 0) {
+        // apiClient returns null on a non-ok HTTP response (server/network error),
+        // which is distinct from a genuinely empty recommendations array — conflating
+        // the two misdirects the user into "sync your collection" when the real
+        // problem is a backend error.
+        if (!data) {
+            const errored = document.createElement('div');
+            errored.className = 'user-pane-empty';
+            const icon = document.createElement('span');
+            icon.className = 'material-symbols-outlined icon-3x mb-3';
+            icon.textContent = 'error_outline';
+            const msg = document.createElement('p');
+            msg.textContent = 'Failed to load recommendations. Please try again.';
+            errored.append(icon, msg);
+            container.appendChild(errored);
+            return;
+        }
+
+        if (!data.recommendations || data.recommendations.length === 0) {
             const empty = document.createElement('div');
             empty.className = 'user-pane-empty';
             const icon = document.createElement('span');

--- a/explore/static/js/user-panes.js
+++ b/explore/static/js/user-panes.js
@@ -69,6 +69,7 @@ class UserPanes {
 
     _renderCollectionEmpty(container, msg) {
         if (!container) return;
+        container.replaceChildren();
         const div = document.createElement('div');
         div.className = 'user-pane-empty';
         const icon = document.createElement('span');
@@ -133,6 +134,7 @@ class UserPanes {
 
     _renderWantlistEmpty(container, msg) {
         if (!container) return;
+        container.replaceChildren();
         const div = document.createElement('div');
         div.className = 'user-pane-empty';
         const icon = document.createElement('span');
@@ -1032,6 +1034,7 @@ class UserPanes {
 
     _renderGapsEmpty(container, msg) {
         if (!container) return;
+        container.replaceChildren();
         const div = document.createElement('div');
         div.className = 'user-pane-empty';
         const icon = document.createElement('span');

--- a/tests/api/test_user_queries.py
+++ b/tests/api/test_user_queries.py
@@ -236,6 +236,36 @@ class TestGetUserCollection:
         main_cypher = next((c for c in seen_cypher if "RETURN" in c and "r.catalog_number" in c), None)
         assert main_cypher is not None, f"Expected r.catalog_number in cypher; saw: {seen_cypher!r}"
 
+    @pytest.mark.asyncio
+    async def test_pagination_has_a_deterministic_tiebreaker(self) -> None:
+        """ORDER BY date_added alone has no unique secondary key, so same-day
+        items (e.g. a bulk import) can reappear on one page and be dropped from
+        another across separate SKIP/LIMIT executions. A tiebreaker on the
+        unique release id makes the total order deterministic.
+        """
+        from api.queries.user_queries import get_user_collection
+
+        seen_cypher: list[str] = []
+
+        async def _capture_run(*args: Any, **_kw: Any) -> _MockResult:
+            seen_cypher.append(args[0] if args else "")
+            if "count(r)" in seen_cypher[-1]:
+                return _MockResult(single={"total": 0})
+            return _MockResult(records=[])
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.run = AsyncMock(side_effect=_capture_run)
+        driver = MagicMock()
+        driver.session = MagicMock(return_value=mock_session)
+
+        await get_user_collection(driver, "user-1")
+
+        main_cypher = next((c for c in seen_cypher if "ORDER BY" in c), None)
+        assert main_cypher is not None
+        assert "ORDER BY c.date_added DESC, r.id" in main_cypher
+
 
 # ---------------------------------------------------------------------------
 # get_user_wantlist
@@ -271,6 +301,32 @@ class TestGetUserWantlist:
         results, total = await get_user_wantlist(driver, "user-2")
         assert results == []
         assert total == 0
+
+    @pytest.mark.asyncio
+    async def test_pagination_has_a_deterministic_tiebreaker(self) -> None:
+        """Same defect/fix as get_user_collection — see that test's docstring."""
+        from api.queries.user_queries import get_user_wantlist
+
+        seen_cypher: list[str] = []
+
+        async def _capture_run(*args: Any, **_kw: Any) -> _MockResult:
+            seen_cypher.append(args[0] if args else "")
+            if "count(r)" in seen_cypher[-1]:
+                return _MockResult(single={"total": 0})
+            return _MockResult(records=[])
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.run = AsyncMock(side_effect=_capture_run)
+        driver = MagicMock()
+        driver.session = MagicMock(return_value=mock_session)
+
+        await get_user_wantlist(driver, "user-2")
+
+        main_cypher = next((c for c in seen_cypher if "ORDER BY" in c), None)
+        assert main_cypher is not None
+        assert "ORDER BY w.date_added DESC, r.id" in main_cypher
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Lands the `batch:frontend-correctness` work group — eight frontend correctness fixes from the 2026-07-19 bug-hunt residue, one conventional commit per bead.

## Beads
- `discogsography-cu2.102` — selectedGenres resets when the search query text changes; a stale genre filter can no longer silently narrow/zero unrelated searches
- `discogsography-cu2.103` — search pane: monotonic request-id guard discards out-of-order fetch responses (stale results / pagination desync)
- `discogsography-cu2.104` — same guard pattern applied to the collection/wantlist/gap paginated loaders
- `discogsography-cu2.105` — recommendations pane distinguishes a load error from a genuinely empty list (no more misleading "No recommendations yet" on failure)
- `discogsography-cu2.89` — Ask pill refuses re-submit while a query is loading; no more racing SSE streams corrupting the undo snapshot
- `discogsography-cu2.90` — theme toggle wired up: theme.js required DOM ids that index.html never shipped. The feature is documented in explore/README.md and had purpose-built CSS, so the button/icons were added rather than deleting the module; preference application is now decoupled from the button so a persisted choice always applies
- `discogsography-cu2.91` — collection/wantlist reload failures clear the stale table before rendering the error (no duplicate/stale markup)
- `discogsography-cu2.95` — collection/wantlist pagination gains a deterministic tiebreaker; same-day items no longer shuffle across pages

## Tests
+512/−24 across 11 files — Vitest suites for the request-sequencing guards, error/empty state rendering, pill re-entry, and theme toggle; pytest coverage for the pagination tiebreaker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UCBSBYhPWx9ESjDDJxsmY