### PR TITLE
fix: deployment portability & config correctness — 6 bug-hunt findings (batch:deploy-config)

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -155,7 +155,14 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # The default GITHUB_TOKEN is intentionally excluded from triggering new
+          # workflow runs (GitHub's recursion-prevention rule), so a PR opened with
+          # it never fires build.yml's `pull_request` trigger and ships with zero CI
+          # checks. DEPENDENCY_UPDATE_PAT is a fine-grained PAT (or GitHub App
+          # installation token) with `contents: write` + `pull-requests: write` on
+          # this repo, added as a repo secret, so the PR triggers CI like any other.
+          # Falls back to GITHUB_TOKEN (PR still opens, just without CI) if unset.
+          token: ${{ secrets.DEPENDENCY_UPDATE_PAT || secrets.GITHUB_TOKEN }}
           branch: automation/updates
           delete-branch: true
           title: ${{ steps.summary.outputs.pr_title }}
@@ -174,14 +181,18 @@ jobs:
 
             - ✅ Updated dependencies to latest compatible versions
             - 🔒 All security patches applied
-            - 🧪 Tests have been run automatically
+            - 🧪 Lint/tests were run during the update; failures are reported as warnings
+              in the update-logs artifact and do **not** block this PR from being opened
 
             ### 🔍 Manual Verification Required
 
             Before merging, please:
 
             1. **Review dependency changes**: Check the Files tab for `uv.lock` changes
-            2. **Check CI status**: Ensure all checks pass
+            2. **Check CI status**: If `DEPENDENCY_UPDATE_PAT` is configured (see workflow
+               comments), this PR triggers the normal CI checks — ensure they pass. If not
+               configured, no automated checks run on this PR; review the `update-logs`
+               artifact from the workflow run and test locally before merging.
             3. **Test locally** (optional):
                ```bash
                git checkout automation/updates

--- a/common/config.py
+++ b/common/config.py
@@ -61,9 +61,22 @@ def _build_amqp_url() -> str:
 
 
 def _build_neo4j_uri() -> str:
-    """Build Neo4j bolt URI from plain hostname environment variable."""
+    """Build a Neo4j connection URI from environment variables.
+
+    NEO4J_HOST accepts two forms:
+
+    - a bare hostname (e.g. ``"localhost"`` or ``"neo4j"``) — wrapped as
+      ``bolt://<host>:<NEO4J_PORT or 7687>``, the historical default.
+    - a full connection URI (e.g. ``"neo4j+s://xxxxx.databases.neo4j.io"`` for
+      Neo4j Aura) — detected by the presence of a ``scheme://`` prefix and
+      passed through unchanged, so routing schemes (``neo4j://``,
+      ``neo4j+s://``) and non-default ports are honored as documented.
+    """
     host = getenv("NEO4J_HOST", "localhost")
-    return f"bolt://{host}:7687"
+    if "://" in host:
+        return host
+    port = getenv("NEO4J_PORT", "7687")
+    return f"bolt://{host}:{port}"
 
 
 def _coerce_port(value: str | None, default_port: int) -> int:

--- a/common/config.py
+++ b/common/config.py
@@ -699,8 +699,8 @@ class ApiConfig:
     # Admin dashboard — RabbitMQ management API
     rabbitmq_management_host: str = "rabbitmq"
     rabbitmq_management_port: int = 15672
-    rabbitmq_username: str = "guest"
-    rabbitmq_password: str = "guest"  # noqa: S105
+    rabbitmq_username: str = "discogsography"
+    rabbitmq_password: str = "discogsography"  # noqa: S105
 
     # Admin dashboard — metrics collection
     metrics_retention_days: int = 366
@@ -816,8 +816,8 @@ class ApiConfig:
             extractor_health_port=int(getenv("EXTRACTOR_HEALTH_PORT", "8000")),
             rabbitmq_management_host=getenv("RABBITMQ_MANAGEMENT_HOST", getenv("RABBITMQ_HOST", "rabbitmq")),
             rabbitmq_management_port=int(getenv("RABBITMQ_MANAGEMENT_PORT", "15672")),
-            rabbitmq_username=get_secret("RABBITMQ_USERNAME", "guest"),
-            rabbitmq_password=get_secret("RABBITMQ_PASSWORD") or "guest",
+            rabbitmq_username=get_secret("RABBITMQ_USERNAME", "discogsography"),
+            rabbitmq_password=get_secret("RABBITMQ_PASSWORD", "discogsography"),
             metrics_retention_days=metrics_retention_days,
             metrics_collection_interval=metrics_collection_interval,
         )

--- a/common/config.py
+++ b/common/config.py
@@ -595,6 +595,8 @@ class DashboardConfig:
     rabbitmq_username: str
     rabbitmq_password: str
     redis_host: str = "redis://localhost:6379/0"
+    rabbitmq_management_host: str = "rabbitmq"
+    rabbitmq_management_port: int = 15672
     cors_origins: list[str] | None = None  # None = default to localhost only
     cache_warming_enabled: bool = True  # Enable cache warming on service startup
     cache_webhook_secret: str | None = None  # Secret for cache invalidation webhooks
@@ -638,6 +640,8 @@ class DashboardConfig:
             redis_host=redis_host,
             rabbitmq_username=rabbitmq_username,
             rabbitmq_password=rabbitmq_password,
+            rabbitmq_management_host=getenv("RABBITMQ_MANAGEMENT_HOST", getenv("RABBITMQ_HOST", "rabbitmq")),
+            rabbitmq_management_port=int(getenv("RABBITMQ_MANAGEMENT_PORT", "15672")),
             cors_origins=cors_origins,
             cache_warming_enabled=cache_warming_enabled,
             cache_webhook_secret=cache_webhook_secret,

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -330,9 +330,11 @@ class DashboardApp:
                 return queues
 
             async with httpx.AsyncClient(timeout=5.0) as client:
-                # Use RabbitMQ management API with credentials from config
+                # Use RabbitMQ management API with host/credentials from config
+                management_host = self.config.rabbitmq_management_host
+                management_port = self.config.rabbitmq_management_port
                 response = await client.get(
-                    "http://rabbitmq:15672/api/queues",
+                    f"http://{management_host}:{management_port}/api/queues",
                     auth=(self.config.rabbitmq_username, self.config.rabbitmq_password),
                 )
 

--- a/dashboard/pyproject.toml
+++ b/dashboard/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 ]
 
 [project.scripts]
-dashboard = "dashboard:main"
+dashboard = "dashboard.dashboard:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["."]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -293,11 +293,14 @@ POSTGRES_DATABASE="discogsography_prod"
 **Performance Tuning**:
 
 ```bash
-# For services using asyncpg
-POSTGRES_POOL_MIN=10
-POSTGRES_POOL_MAX=20
-POSTGRES_COMMAND_TIMEOUT=30
+# Clamp the connection-pool min/max across the whole fleet (see the
+# "Connection-pool sizing" note above — per-service defaults otherwise apply)
+POSTGRES_POOL_MIN_SIZE=10
+POSTGRES_POOL_MAX_SIZE=20
 ```
+
+> Query timeout (30 seconds, see **Connection Details** above) is a fixed value in
+> code, not a configurable env var.
 
 ### Redis Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,8 +181,10 @@ NEO4J_HOST="neo4j"
 NEO4J_USERNAME="neo4j"
 NEO4J_PASSWORD="discogsography"
 
-# Neo4j Aura (cloud) — full URI supported
-NEO4J_HOST="xxxxx.databases.neo4j.io"
+# Neo4j Aura (cloud) — NEO4J_HOST accepts a full "scheme://host" URI, passed
+# through unchanged (Aura requires the neo4j+s:// routing+TLS scheme; do not
+# set NEO4J_TLS_ENABLED here — the scheme already encrypts the connection)
+NEO4J_HOST="neo4j+s://xxxxx.databases.neo4j.io"
 NEO4J_USERNAME="neo4j"
 NEO4J_PASSWORD="your-secure-password"
 
@@ -1039,8 +1041,10 @@ For production deployments, use `docker-compose.prod.yml` with `scripts/create-s
 Enable encryption for production:
 
 ```bash
-# Neo4j with TLS (bolt+s:// scheme constructed in code from hostname)
+# Neo4j with TLS (encrypted Bolt via NEO4J_TLS_ENABLED — see "Enabling TLS
+# for Neo4j" above; for Aura, pass a full "neo4j+s://host" URI instead)
 NEO4J_HOST=neo4j.example.com
+NEO4J_TLS_ENABLED=true
 
 # PostgreSQL hostname
 POSTGRES_HOST=postgres.example.com

--- a/explore/pyproject.toml
+++ b/explore/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 ]
 
 [project.scripts]
-explore = "explore:main"
+explore = "explore.explore:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["."]

--- a/schema-init/schema_init.py
+++ b/schema-init/schema_init.py
@@ -25,7 +25,7 @@ from common import (
     parse_postgres_host_port,
     setup_logging,
 )
-from common.config import get_secret
+from common.config import _build_neo4j_uri, get_secret
 from psycopg import sql
 
 from neo4j_schema import create_neo4j_schema
@@ -35,8 +35,7 @@ logger = structlog.get_logger(__name__)
 
 # ── Configuration from environment ───────────────────────────────────────────
 
-_neo4j_host = os.environ.get("NEO4J_HOST", "localhost")
-NEO4J_URI = f"bolt://{_neo4j_host}:7687"
+NEO4J_URI = _build_neo4j_uri()
 NEO4J_USERNAME = os.environ.get("NEO4J_USERNAME", "neo4j")
 NEO4J_PASSWORD = get_secret("NEO4J_PASSWORD", "discogsography")
 

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -456,6 +456,32 @@ class TestDashboardConfig:
 
         assert config.redis_host == "redis://myredis:6379/0"
 
+    def test_rabbitmq_management_host_defaults_to_rabbitmq_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """RABBITMQ_MANAGEMENT_HOST falls back to RABBITMQ_HOST — regression for the
+        dashboard's management-API call ignoring RABBITMQ_HOST and hardcoding 'rabbitmq'."""
+        from common import DashboardConfig
+
+        monkeypatch.delenv("RABBITMQ_MANAGEMENT_HOST", raising=False)
+        monkeypatch.setenv("RABBITMQ_HOST", "mq.internal")
+
+        config = DashboardConfig.from_env()
+
+        assert config.rabbitmq_management_host == "mq.internal"
+        assert config.rabbitmq_management_port == 15672
+
+    def test_rabbitmq_management_host_explicit_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """RABBITMQ_MANAGEMENT_HOST/_PORT take precedence over RABBITMQ_HOST."""
+        from common import DashboardConfig
+
+        monkeypatch.setenv("RABBITMQ_HOST", "rabbitmq-amqp")
+        monkeypatch.setenv("RABBITMQ_MANAGEMENT_HOST", "rabbitmq-mgmt")
+        monkeypatch.setenv("RABBITMQ_MANAGEMENT_PORT", "25672")
+
+        config = DashboardConfig.from_env()
+
+        assert config.rabbitmq_management_host == "rabbitmq-mgmt"
+        assert config.rabbitmq_management_port == 25672
+
 
 class TestExploreConfig:
     """Test ExploreConfig from_env."""

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -873,6 +873,50 @@ class TestApiConfigFromEnv:
         with pytest.raises(ValueError, match="JWT_SECRET_KEY"):
             ApiConfig.from_env()
 
+    def test_rabbitmq_management_credentials_default_to_discogsography(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """RABBITMQ_USERNAME/PASSWORD unset must default to 'discogsography' — matching
+        _build_amqp_url(), DashboardConfig, and docs/configuration.md — not 'guest',
+        which 401s against the discogsography-provisioned broker."""
+        monkeypatch.setenv("POSTGRES_HOST", "localhost")
+        monkeypatch.setenv("POSTGRES_USERNAME", "pguser")
+        monkeypatch.setenv("POSTGRES_PASSWORD", "pgpass")
+        monkeypatch.setenv("POSTGRES_DATABASE", "pgdb")
+        monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+        monkeypatch.setenv("NEO4J_HOST", "neo4j")
+        monkeypatch.setenv("NEO4J_USERNAME", "neo4j")
+        monkeypatch.setenv("NEO4J_PASSWORD", "neo4jpass")
+        monkeypatch.delenv("RABBITMQ_USERNAME", raising=False)
+        monkeypatch.delenv("RABBITMQ_PASSWORD", raising=False)
+
+        from common.config import ApiConfig
+
+        config = ApiConfig.from_env()
+        assert config.rabbitmq_username == "discogsography"
+        assert config.rabbitmq_password == "discogsography"
+
+    def test_rabbitmq_management_credentials_symmetric_get_secret(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Username and password must use the same get_secret(key, default) form —
+        regression for the prior asymmetry where password additionally fell back via
+        `or "guest"` on an empty string while username did not."""
+        monkeypatch.setenv("POSTGRES_HOST", "localhost")
+        monkeypatch.setenv("POSTGRES_USERNAME", "pguser")
+        monkeypatch.setenv("POSTGRES_PASSWORD", "pgpass")
+        monkeypatch.setenv("POSTGRES_DATABASE", "pgdb")
+        monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+        monkeypatch.setenv("NEO4J_HOST", "neo4j")
+        monkeypatch.setenv("NEO4J_USERNAME", "neo4j")
+        monkeypatch.setenv("NEO4J_PASSWORD", "neo4jpass")
+        monkeypatch.setenv("RABBITMQ_USERNAME", "")
+        monkeypatch.setenv("RABBITMQ_PASSWORD", "")
+
+        from common.config import ApiConfig
+
+        config = ApiConfig.from_env()
+        # Both pass an explicitly empty value through unchanged — same behavior,
+        # rather than password silently substituting a different fallback than username.
+        assert config.rabbitmq_username == ""
+        assert config.rabbitmq_password == ""
+
 
 class TestApiConfigNewFields:
     """Tests for new ApiConfig fields added in the security hardening."""

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -14,7 +14,13 @@ from common import (
     neo4j_security_kwargs,
     setup_logging,
 )
-from common.config import _build_postgres_connstr, get_secret, parse_postgres_host_port, resolve_postgres_pool_sizes
+from common.config import (
+    _build_neo4j_uri,
+    _build_postgres_connstr,
+    get_secret,
+    parse_postgres_host_port,
+    resolve_postgres_pool_sizes,
+)
 
 
 class TestExtractorConfig:
@@ -1257,6 +1263,40 @@ class TestInsightsConfig:
 
         config = InsightsConfig.from_env()
         assert config.schedule_hours == 24
+
+
+class TestBuildNeo4jUri:
+    """Tests for _build_neo4j_uri() — bare-hostname vs full-URI NEO4J_HOST handling."""
+
+    def test_bare_hostname_defaults_to_bolt_7687(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NEO4J_HOST", "neo4j")
+        monkeypatch.delenv("NEO4J_PORT", raising=False)
+        assert _build_neo4j_uri() == "bolt://neo4j:7687"
+
+    def test_missing_host_defaults_to_localhost(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NEO4J_HOST", raising=False)
+        monkeypatch.delenv("NEO4J_PORT", raising=False)
+        assert _build_neo4j_uri() == "bolt://localhost:7687"
+
+    def test_bare_hostname_honors_neo4j_port_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NEO4J_HOST", "neo4j")
+        monkeypatch.setenv("NEO4J_PORT", "17687")
+        assert _build_neo4j_uri() == "bolt://neo4j:17687"
+
+    def test_full_aura_uri_passed_through_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Documented Aura deployment: a full neo4j+s:// URI must not be re-wrapped in bolt://."""
+        monkeypatch.setenv("NEO4J_HOST", "neo4j+s://xxxxx.databases.neo4j.io")
+        assert _build_neo4j_uri() == "neo4j+s://xxxxx.databases.neo4j.io"
+
+    def test_full_neo4j_uri_with_custom_port_passed_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NEO4J_HOST", "neo4j://neo4j.example.com:8687")
+        assert _build_neo4j_uri() == "neo4j://neo4j.example.com:8687"
+
+    def test_full_uri_ignores_neo4j_port_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A full URI already carries its own port; NEO4J_PORT must not be applied to it."""
+        monkeypatch.setenv("NEO4J_HOST", "neo4j+s://xxxxx.databases.neo4j.io")
+        monkeypatch.setenv("NEO4J_PORT", "17687")
+        assert _build_neo4j_uri() == "neo4j+s://xxxxx.databases.neo4j.io"
 
 
 class TestNeo4jSecurityKwargs:

--- a/tests/common/test_console_entry_points.py
+++ b/tests/common/test_console_entry_points.py
@@ -1,0 +1,62 @@
+"""Regression tests for [project.scripts] console entry points.
+
+Covers discogsography-cu2.88: dashboard and explore declared their console script as
+`pkg:main` (e.g. `dashboard:main`), but with `packages = ["."]` the importable package
+is the directory's `__init__.py`, which never re-exports `main` — the real `main()`
+lives in the submodule (`dashboard.dashboard`, `explore.explore`). The generated
+console command therefore crashed with AttributeError on invocation. This resolves the
+declared entry point exactly as importlib.metadata's EntryPoint.load() would, without
+actually invoking main() (which starts a uvicorn server).
+"""
+
+from pathlib import Path
+import tomllib
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _entry_points(pyproject_path: Path) -> dict[str, str]:
+    with pyproject_path.open("rb") as f:
+        data = tomllib.load(f)
+    scripts: dict[str, str] = data["project"]["scripts"]
+    return scripts
+
+
+@pytest.mark.parametrize(
+    ("pyproject_relpath", "script_name"),
+    [
+        ("dashboard/pyproject.toml", "dashboard"),
+        ("explore/pyproject.toml", "explore"),
+    ],
+)
+def test_console_script_entry_point_resolves(pyproject_relpath: str, script_name: str) -> None:
+    """The declared `module:attr` entry point must import cleanly and expose a callable."""
+    entry_points = _entry_points(REPO_ROOT / pyproject_relpath)
+    assert script_name in entry_points
+
+    module_path, _, attr = entry_points[script_name].partition(":")
+    assert module_path and attr, f"entry point {entry_points[script_name]!r} is not in 'module:attr' form"
+
+    # Same resolution importlib.metadata.EntryPoint.load() performs: import the target
+    # module, then getattr() the callable — this is exactly what crashed before the fix
+    # (the entry point named the package, whose __init__.py never re-exports `main`).
+    import importlib
+
+    module = importlib.import_module(module_path)
+    target = getattr(module, attr)
+    assert callable(target)
+
+
+def test_dashboard_entry_point_names_the_submodule() -> None:
+    """Regression: must not regress to `dashboard:main` (package __init__, no `main`)."""
+    entry_points = _entry_points(REPO_ROOT / "dashboard" / "pyproject.toml")
+    assert entry_points["dashboard"] == "dashboard.dashboard:main"
+
+
+def test_explore_entry_point_names_the_submodule() -> None:
+    """Regression: must not regress to `explore:main` (package __init__, no `main`)."""
+    entry_points = _entry_points(REPO_ROOT / "explore" / "pyproject.toml")
+    assert entry_points["explore"] == "explore.explore:main"

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -633,6 +633,41 @@ class TestDashboardAppDataCollection:
                 assert queues[1].name == "discogsography.releases"
 
     @pytest.mark.asyncio
+    async def test_get_queue_info_uses_configured_management_host(self) -> None:
+        """The management API call must target config.rabbitmq_management_host/_port,
+        not a hardcoded 'rabbitmq' hostname — regression for a non-default RABBITMQ_HOST
+        silently producing empty queue metrics."""
+        mock_config = Mock()
+        mock_config.rabbitmq_username = "guest"
+        mock_config.rabbitmq_password = "guest"
+        mock_config.rabbitmq_management_host = "mq.internal"
+        mock_config.rabbitmq_management_port = 25672
+
+        with patch("dashboard.dashboard.get_config", return_value=mock_config):
+            app = DashboardApp()
+            app.rabbitmq = AsyncMock()
+
+            captured_urls: list[str] = []
+
+            async def mock_get(url: str, **_kwargs: Any) -> Mock:
+                captured_urls.append(url)
+                response = Mock()
+                response.status_code = 200
+                response.json = Mock(return_value=[])
+                return response
+
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_client.get = mock_get
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=None)
+                mock_client_class.return_value = mock_client
+
+                await app.get_queue_info("discogsography")
+
+            assert captured_urls == ["http://mq.internal:25672/api/queues"]
+
+    @pytest.mark.asyncio
     async def test_get_queue_info_no_rabbitmq(self) -> None:
         """Test getting queue info when RabbitMQ is not connected."""
         mock_config = Mock()

--- a/tests/workflows/test_update_dependencies_workflow.py
+++ b/tests/workflows/test_update_dependencies_workflow.py
@@ -1,0 +1,64 @@
+"""Regression tests for .github/workflows/update-dependencies.yml.
+
+Covers discogsography-cu2.69: the automated dependency-update PR was opened with the
+default GITHUB_TOKEN, which GitHub Actions excludes from triggering new workflow runs
+(recursion prevention) — so build.yml's `pull_request` trigger never fired and the PR
+shipped with zero CI checks, contradicting the PR body's "tests have been run
+automatically" / "check CI status" claims.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "update-dependencies.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
+    with WORKFLOW_PATH.open() as f:
+        return yaml.safe_load(f)
+
+
+def _create_pr_step(workflow_data: dict[str, Any]) -> dict[str, Any]:
+    steps = workflow_data["jobs"]["update-dependencies"]["steps"]
+    for step in steps:
+        if "Create Pull Request" in step.get("name", ""):
+            return step
+    raise AssertionError("Create Pull Request step not found in update-dependencies.yml")
+
+
+class TestCreatePullRequestToken:
+    """The PR-creation step must not rely solely on the default GITHUB_TOKEN."""
+
+    def test_token_prefers_a_pat_over_the_default_github_token(self, workflow: dict[str, Any]) -> None:
+        token_expr = _create_pr_step(workflow)["with"]["token"]
+
+        # A bare `${{ secrets.GITHUB_TOKEN }}` never triggers new workflow runs on the
+        # PR it opens (GitHub's recursion-prevention rule) — the expression must name a
+        # PAT/App-token secret ahead of the GITHUB_TOKEN fallback.
+        assert token_expr != "${{ secrets.GITHUB_TOKEN }}"
+        assert "secrets.GITHUB_TOKEN" not in token_expr.split("||")[0], (
+            "the first alternative in the token expression must be a dedicated PAT secret, not GITHUB_TOKEN"
+        )
+        assert "secrets." in token_expr
+
+    def test_token_still_falls_back_to_github_token(self, workflow: dict[str, Any]) -> None:
+        """If the PAT secret is unset, the step must still work (degrade to no-CI, not fail)."""
+        token_expr = _create_pr_step(workflow)["with"]["token"]
+        assert "secrets.GITHUB_TOKEN" in token_expr
+
+
+class TestPullRequestBodyIsNotMisleading:
+    """The PR body must not assert CI guarantees the workflow cannot provide."""
+
+    def test_body_does_not_claim_unqualified_automatic_test_success(self, workflow: dict[str, Any]) -> None:
+        body = _create_pr_step(workflow)["with"]["body"]
+        # The old body asserted "Tests have been run automatically" without qualifying
+        # that failures are only warned about, not blocking — misleading a reviewer who
+        # trusts the claim at face value.
+        assert "Tests have been run automatically" not in body


### PR DESCRIPTION
Lands the `batch:deploy-config` work group — six deployment-portability/config fixes, one conventional commit per bead.

## Beads
- `discogsography-cu2.100` — _build_neo4j_uri: a scheme-bearing NEO4J_HOST (e.g. `neo4j+s://…` for Aura) now passes through unchanged; bare hostnames gain a NEO4J_PORT override. Same fix reused in schema-init (was duplicating the hardcoded template); docs corrected where they overclaimed bolt+s support
- `discogsography-cu2.85` — dashboard get_queue_info() resolves the RabbitMQ management host from config instead of a hardcode; queue metrics work on non-default deployments
- `discogsography-cu2.101` — API RabbitMQ management credentials default to `discogsography`, matching the AMQP default and the documented management-API setup
- `discogsography-cu2.69` — dependency-update PRs can trigger CI: create-pull-request now prefers a `DEPENDENCY_UPDATE_PAT` secret (GITHUB_TOKEN never fires `pull_request` workflows by GitHub's recursion-prevention rule), falling back to GITHUB_TOKEN if unset; the PR body no longer claims tests ran when they didn't. **Requires adding the `DEPENDENCY_UPDATE_PAT` fine-grained PAT secret (contents: write, pull-requests: write) for full effect**
- `discogsography-cu2.87` — docs Performance-Tuning snippet uses the real env var names (POSTGRES_POOL_MIN_SIZE/POSTGRES_POOL_MAX_SIZE)
- `discogsography-cu2.88` — dashboard/explore console entry points target the submodule where main actually lives; the generated commands work again

## Tests
+331/−24 across 12 files, including a new workflow-lint test asserting the dependency-update workflow's token wiring, URI-builder tests for Aura/scheme/port cases, and dashboard config-resolution tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UCBSBYhPWx9ESjDDJxsmY