### PR TITLE
chore: replace Brevo with Resend for transactional email

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -52,10 +52,10 @@ DISCOGS_USER_AGENT="Discogsography/1.0 +https://github.com/SimplicityGuy/discogs
 # Required for TOTP 2FA. Without it, OAuth tokens are stored unencrypted and 2FA is disabled.
 ENCRYPTION_MASTER_KEY=your-base64-master-key-here
 
-# Optional — Brevo email for password reset notifications (when not set, reset links are logged)
-# BREVO_API_KEY=your-brevo-api-key
-# BREVO_SENDER_EMAIL=noreply@yourdomain.com
-# BREVO_SENDER_NAME=Discogsography
+# Optional — Resend email for password reset notifications (when not set, reset links are logged)
+# RESEND_API_KEY=your-resend-api-key
+# RESEND_SENDER_EMAIL=noreply@yourdomain.com
+# RESEND_SENDER_NAME=Discogsography
 
 # Optional — CORS
 CORS_ORIGINS="http://localhost:8003,http://localhost:8006"  # Comma-separated allowed origins

--- a/api/api.py
+++ b/api/api.py
@@ -35,7 +35,7 @@ from api.auth import (
 import api.dependencies as _dependencies
 from api.limiter import limiter
 from api.metrics_collector import MetricsBuffer, normalize_path, run_collector
-from api.notifications import BrevoNotificationChannel, LogNotificationChannel
+from api.notifications import LogNotificationChannel, ResendNotificationChannel
 from api.queries.search_queries import ALL_TYPES, execute_search
 import api.routers.admin as _admin_router
 import api.routers.app_tokens as _app_tokens_router
@@ -267,12 +267,12 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:  # pragma: no cover
         _config,
         _get_current_user,
         _create_access_token,
-        notification_channel=BrevoNotificationChannel(
-            api_key=_config.brevo_api_key,
-            sender_email=_config.brevo_sender_email,
-            sender_name=_config.brevo_sender_name,
+        notification_channel=ResendNotificationChannel(
+            api_key=_config.resend_api_key,
+            sender_email=_config.resend_sender_email,
+            sender_name=_config.resend_sender_name,
         )
-        if _config.brevo_api_key
+        if _config.resend_api_key
         else LogNotificationChannel(),
     )
     _snapshot_router.configure(

--- a/api/notifications.py
+++ b/api/notifications.py
@@ -1,18 +1,15 @@
 """Notification channel abstraction for user-facing messages."""
 
-import asyncio
 import html
 from typing import Protocol, runtime_checkable
 
-from brevo import Brevo
-from brevo.transactional_emails import (
-    SendTransacEmailRequestSender,
-    SendTransacEmailRequestToItem,
-)
+import httpx
 import structlog
 
 
 logger = structlog.get_logger(__name__)
+
+_RESEND_API_URL = "https://api.resend.com/emails"
 
 
 @runtime_checkable
@@ -32,16 +29,21 @@ class LogNotificationChannel:
         logger.info("🔑 Password reset link generated", email=email)
 
 
-class BrevoNotificationChannel:
-    """Notification channel that sends emails via Brevo transactional API."""
+class ResendNotificationChannel:
+    """Notification channel that sends emails via the Resend REST API.
+
+    Plain `httpx` POST — no vendor SDK. Resend has click/open tracking off by
+    default for every domain (no per-message field to disable), so the request
+    body carries no tracking parameter and outbound links are never rewritten.
+    """
 
     def __init__(self, api_key: str, sender_email: str, sender_name: str) -> None:
-        self._client = Brevo(api_key=api_key)
+        self._api_key = api_key
         self._sender_email = sender_email
         self._sender_name = sender_name
 
     async def send_password_reset(self, email: str, reset_url: str) -> None:
-        """Send a password reset email via Brevo."""
+        """Send a password reset email via Resend."""
         safe_url = html.escape(reset_url, quote=True)
         html_content = (
             "<html><body>"
@@ -57,23 +59,19 @@ class BrevoNotificationChannel:
         )
 
         logger.debug("🔑 Sending password reset email", email=email)
-        # Click tracking cannot be disabled per-message via the v3 transactional
-        # API — the SDK's `headers` field rejects standard email headers, and
-        # `X-Mailin-Track*` are SMTP-relay only. To prevent password reset URLs
-        # from being wrapped in a sendibt2.com redirect, click tracking must be
-        # turned off in the Brevo dashboard (Senders, Domains & IPs → your
-        # sending domain → Tracking, or Account Settings → Tracking).
         try:
-            await asyncio.to_thread(
-                self._client.transactional_emails.send_transac_email,
-                subject="Reset your Discogsography password",
-                html_content=html_content,
-                sender=SendTransacEmailRequestSender(
-                    name=self._sender_name,
-                    email=self._sender_email,
-                ),
-                to=[SendTransacEmailRequestToItem(email=email)],
-            )
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.post(
+                    _RESEND_API_URL,
+                    headers={"Authorization": f"Bearer {self._api_key}"},
+                    json={
+                        "from": f"{self._sender_name} <{self._sender_email}>",
+                        "to": [email],
+                        "subject": "Reset your Discogsography password",
+                        "html": html_content,
+                    },
+                )
+                response.raise_for_status()
             logger.info("📧 Password reset email sent", email=email)
         except Exception:
             logger.exception("❌ Failed to send password reset email", email=email)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
 license = {text = "PolyForm-Noncommercial-1.0.0"}
 dependencies = [
     "anthropic>=0.120.2",
-    "brevo-python>=4.0.10,<5",
     "cryptography>=50.0.0",
     "fastapi>=0.141.1",
     "httpx>=0.28.1",

--- a/common/config.py
+++ b/common/config.py
@@ -699,10 +699,10 @@ class ApiConfig:
     # reachable via the public explore proxy.
     insights_internal_secret: str | None = None
 
-    # Brevo email notifications
-    brevo_api_key: str | None = None
-    brevo_sender_email: str = "noreply@discogsography.com"
-    brevo_sender_name: str = "Discogsography"
+    # Resend email notifications
+    resend_api_key: str | None = None
+    resend_sender_email: str = "noreply@discogsography.com"
+    resend_sender_name: str = "Discogsography"
 
     # Admin dashboard — extractor connection.
     # No service named bare "extractor" exists (extractor runs as the two split
@@ -789,9 +789,9 @@ class ApiConfig:
 
         encryption_master_key = get_secret("ENCRYPTION_MASTER_KEY") or None
         insights_internal_secret = get_secret("INSIGHTS_INTERNAL_SECRET") or None
-        brevo_api_key = get_secret("BREVO_API_KEY") or None
-        brevo_sender_email = getenv("BREVO_SENDER_EMAIL", "noreply@discogsography.com")
-        brevo_sender_name = getenv("BREVO_SENDER_NAME", "Discogsography")
+        resend_api_key = get_secret("RESEND_API_KEY") or None
+        resend_sender_email = getenv("RESEND_SENDER_EMAIL", "noreply@discogsography.com")
+        resend_sender_name = getenv("RESEND_SENDER_NAME", "Discogsography")
 
         metrics_retention_days_str = getenv("METRICS_RETENTION_DAYS", "366")
         try:
@@ -826,9 +826,9 @@ class ApiConfig:
             snapshot_max_nodes=snapshot_max_nodes,
             encryption_master_key=encryption_master_key,
             insights_internal_secret=insights_internal_secret,
-            brevo_api_key=brevo_api_key,
-            brevo_sender_email=brevo_sender_email,
-            brevo_sender_name=brevo_sender_name,
+            resend_api_key=resend_api_key,
+            resend_sender_email=resend_sender_email,
+            resend_sender_name=resend_sender_name,
             extractor_host=getenv("EXTRACTOR_HOST", "extractor-discogs"),
             extractor_health_port=int(getenv("EXTRACTOR_HEALTH_PORT", "8000")),
             rabbitmq_management_host=getenv("RABBITMQ_MANAGEMENT_HOST", getenv("RABBITMQ_HOST", "rabbitmq")),

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,8 +14,8 @@ secrets:
   encryption_master_key:
     file: ./secrets/encryption_master_key.txt
   # Required for email delivery — create with: scripts/create-secrets.sh or manually
-  brevo_api_key:
-    file: ./secrets/brevo_api_key.txt
+  resend_api_key:
+    file: ./secrets/resend_api_key.txt
   nlq_api_key:
     file: ./secrets/nlq_api_key.txt
   postgres_password:
@@ -189,10 +189,10 @@ services:
       JWT_SECRET_KEY_FILE: /run/secrets/jwt_secret_key
       NEO4J_PASSWORD_FILE: /run/secrets/neo4j_password
       ENCRYPTION_MASTER_KEY_FILE: /run/secrets/encryption_master_key
-      # Optional — Brevo email (when not set, password reset links are logged)
-      BREVO_API_KEY_FILE: /run/secrets/brevo_api_key
-      BREVO_SENDER_EMAIL: "${BREVO_SENDER_EMAIL:-noreply@discogsography.com}"
-      BREVO_SENDER_NAME: "${BREVO_SENDER_NAME:-Discogsography}"
+      # Optional — Resend email (when not set, password reset links are logged)
+      RESEND_API_KEY_FILE: /run/secrets/resend_api_key
+      RESEND_SENDER_EMAIL: "${RESEND_SENDER_EMAIL:-noreply@discogsography.com}"
+      RESEND_SENDER_NAME: "${RESEND_SENDER_NAME:-Discogsography}"
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
       POSTGRES_USERNAME_FILE: /run/secrets/postgres_username
       NLQ_API_KEY_FILE: /run/secrets/nlq_api_key
@@ -202,7 +202,7 @@ services:
       - jwt_secret_key
       - neo4j_password
       - encryption_master_key
-      - brevo_api_key
+      - resend_api_key
       - nlq_api_key
       - postgres_username
       - postgres_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -254,9 +254,9 @@ services:
       NLQ_API_KEY: "${NLQ_API_KEY:-}"
       NLQ_MODEL: "${NLQ_MODEL:-claude-sonnet-4-20250514}"
       # Email notifications (optional — when not set, reset links are logged instead)
-      # BREVO_API_KEY: "${BREVO_API_KEY:-}"
-      # BREVO_SENDER_EMAIL: "${BREVO_SENDER_EMAIL:-noreply@discogsography.com}"
-      # BREVO_SENDER_NAME: "${BREVO_SENDER_NAME:-Discogsography}"
+      # RESEND_API_KEY: "${RESEND_API_KEY:-}"
+      # RESEND_SENDER_EMAIL: "${RESEND_SENDER_EMAIL:-noreply@discogsography.com}"
+      # RESEND_SENDER_NAME: "${RESEND_SENDER_NAME:-Discogsography}"
       # Encryption master key (optional — required for TOTP 2FA, derives OAuth + TOTP keys via HKDF)
       # ENCRYPTION_MASTER_KEY: "${ENCRYPTION_MASTER_KEY:-}"
       # Shared secret gating the internal /api/internal/insights/* router. MUST match the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -620,7 +620,7 @@ See [Insights README](../insights/README.md) for details.
 - Self-service password reset (Redis tokens, 15min TTL, anti-enumeration)
 - Optional TOTP 2FA with pyotp (QR code setup, recovery codes, brute-force lockout)
 - HKDF-SHA256 key derivation for per-purpose encryption (OAuth tokens, TOTP secrets)
-- Brevo transactional email integration (optional — falls back to log output)
+- Resend transactional email integration (optional — falls back to log output)
 
 **Configuration**:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -611,12 +611,12 @@ ENCRYPTION_MASTER_KEY="your-master-key-here"
 # INSIGHTS_INTERNAL_SECRET_FILE (Docker secret) in production.
 INSIGHTS_INTERNAL_SECRET="change-me-in-production"
 
-# Optional — Brevo transactional email for password reset notifications
+# Optional — Resend transactional email for password reset notifications
 # When not set, password reset links are logged to stdout instead of emailed.
-# Get your API key from https://app.brevo.com/settings/keys/api
-# BREVO_API_KEY="your-brevo-api-key"
-# BREVO_SENDER_EMAIL="noreply@yourdomain.com"   # Must be verified in Brevo
-# BREVO_SENDER_NAME="Discogsography"
+# Get your API key from https://resend.com/api-keys
+# RESEND_API_KEY="your-resend-api-key"
+# RESEND_SENDER_EMAIL="noreply@yourdomain.com"   # Must be verified in Resend
+# RESEND_SENDER_NAME="Discogsography"
 
 # Optional — CORS origins (comma-separated; omit to disable CORS)
 CORS_ORIGINS="http://localhost:8003,http://localhost:8006"
@@ -965,7 +965,7 @@ This creates `secrets/` with these files (all `chmod 600`, directory `chmod 700`
 
 ```
 secrets/
-├── brevo_api_key.txt         # Optional — Brevo API key
+├── resend_api_key.txt        # Optional — Resend API key
 ├── encryption_master_key.txt # base64(urandom(32))
 ├── jwt_secret_key.txt        # openssl rand -hex 32
 ├── neo4j_password.txt        # openssl rand -base64 24

--- a/docs/docker-security.md
+++ b/docs/docker-security.md
@@ -108,7 +108,7 @@ These secrets are **never passed as plain environment variables in production**.
 | Neo4j password         | (via entrypoint wrapper)            | `NEO4J_AUTH`                   |
 | JWT secret key         | `JWT_SECRET_KEY_FILE`               | `JWT_SECRET_KEY`               |
 | Encryption master key  | `ENCRYPTION_MASTER_KEY_FILE`        | `ENCRYPTION_MASTER_KEY`        |
-| Brevo API key          | `BREVO_API_KEY_FILE`                | `BREVO_API_KEY`                |
+| Resend API key         | `RESEND_API_KEY_FILE`               | `RESEND_API_KEY`               |
 
 The Dashboard's RabbitMQ management-API access reuses the same `RABBITMQ_USERNAME`/`RABBITMQ_PASSWORD` (or `_FILE`) credentials above — there is no separate management-only credential pair.
 
@@ -141,7 +141,7 @@ This creates `secrets/` (mode `700`) with one file per secret (mode `600`):
 secrets/
 ├── jwt_secret_key.txt          # openssl rand -hex 32
 ├── encryption_master_key.txt   # base64-urlsafe 32-byte HKDF master key
-├── brevo_api_key.txt           # Brevo API key (empty disables email delivery)
+├── resend_api_key.txt          # Resend API key (empty disables email delivery)
 ├── postgres_username.txt       # discogsography
 ├── postgres_password.txt       # openssl rand -base64 24
 ├── rabbitmq_username.txt       # discogsography

--- a/docs/superpowers/specs/2026-03-25-brevo-email-integration-design.md
+++ b/docs/superpowers/specs/2026-03-25-brevo-email-integration-design.md
@@ -1,7 +1,14 @@
 # Brevo Email Integration for Password Reset
 
+> **SUPERSEDED — historical record only.** Brevo was removed in
+> `discogsography-iew6`; nothing described below is in the codebase any more.
+> Brevo's free tier rewrote outbound links to inject click tracking with no way
+> to disable it, which made password-reset mail unusable. See
+> [Transactional Email Provider Decision](../../transactional-email-provider-decision.md)
+> for the evaluation and the replacement (Resend, over plain `httpx` REST).
+
 **Date:** 2026-03-25
-**Status:** Approved
+**Status:** Superseded (was: Approved)
 **Builds on:** PR #210 (password reset & TOTP 2FA)
 
 ## Overview

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
 [project.optional-dependencies]
 api = [
     "anthropic>=0.120.2",
-    "brevo-python>=4.0.10,<5",
     "cryptography>=50.0.0",
     "defusedxml>=0.7.1",
     "fastapi>=0.141.1",

--- a/scripts/create-secrets.sh
+++ b/scripts/create-secrets.sh
@@ -34,9 +34,9 @@ write_secret "jwt_secret_key.txt" "$(openssl rand -hex 32)"
 # HKDF master encryption key (derives OAuth + TOTP keys)
 write_secret "encryption_master_key.txt" "$(python3 -c 'import base64, os; print(base64.urlsafe_b64encode(os.urandom(32)).decode(), end="")')"
 
-# Brevo API key — required for prod email delivery; get from https://app.brevo.com/settings/keys/api
+# Resend API key — required for prod email delivery; get from https://resend.com/api-keys
 # When empty, password reset links are logged instead of emailed.
-write_secret "brevo_api_key.txt" "${BREVO_API_KEY:-}"
+write_secret "resend_api_key.txt" "${RESEND_API_KEY:-}"
 
 # PostgreSQL credentials
 write_secret "postgres_username.txt" "discogsography"

--- a/secrets.example/brevo_api_key.txt
+++ b/secrets.example/brevo_api_key.txt
@@ -1,3 +1,0 @@
-# Optional — get your API key from https://app.brevo.com/settings/keys/api
-# When not set, password reset links are logged to stdout instead of emailed.
-your-brevo-api-key-here

--- a/secrets.example/resend_api_key.txt
+++ b/secrets.example/resend_api_key.txt
@@ -1,0 +1,3 @@
+# Optional — get your API key from https://resend.com/api-keys
+# When not set, password reset links are logged to stdout instead of emailed.
+your-resend-api-key-here

--- a/tests/api/test_notifications.py
+++ b/tests/api/test_notifications.py
@@ -75,9 +75,9 @@ class TestResendNotificationChannel:
         assert "reset?token=abc" in body["html"]
         # No tracking field is ever sent — Resend has click/open tracking off
         # by default for every domain, so there is nothing to configure or
-        # disable per-message.
-        assert "tracking" not in body
-        assert "track" not in body
+        # disable per-message. Check every key, not just exact-name matches.
+        assert not [key for key in body if "track" in key.lower()]
+        assert set(body) == {"from", "to", "subject", "html"}
 
     @pytest.mark.asyncio
     async def test_outbound_link_delivered_byte_identical(self) -> None:
@@ -111,6 +111,37 @@ class TestResendNotificationChannel:
         assert reset_url in body["html"]
         assert "sendibt2.com" not in body["html"]
         assert body["html"].count(reset_url) == 1
+
+    @pytest.mark.asyncio
+    async def test_multi_param_link_round_trips_through_html_escaping(self) -> None:
+        """A URL with multiple query params survives HTML-escaping intact.
+
+        `&` is escaped to `&amp;` for valid HTML — that is correct and mail
+        clients unescape it. This asserts the escaping is the *only* thing
+        that happens to the URL: unescape the rendered href and the original
+        must come back exactly.
+        """
+        import html as html_module
+
+        from api.notifications import ResendNotificationChannel
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_client = _mock_async_client(mock_response)
+
+        reset_url = "https://discogsography.com/reset-password?token=abc123&source=email&ts=1234567890"
+
+        with patch("api.notifications.httpx.AsyncClient", return_value=mock_client):
+            channel = ResendNotificationChannel(
+                api_key="test-key",
+                sender_email="noreply@test.com",
+                sender_name="Test Sender",
+            )
+            await channel.send_password_reset("user@example.com", reset_url)
+
+        rendered = mock_client.post.call_args.kwargs["json"]["html"]
+        href = rendered.split('<a href="', 1)[1].split('"', 1)[0]
+        assert html_module.unescape(href) == reset_url
 
     @pytest.mark.asyncio
     async def test_send_password_reset_swallows_api_error(self) -> None:

--- a/tests/api/test_notifications.py
+++ b/tests/api/test_notifications.py
@@ -1,7 +1,8 @@
 """Tests for api/notifications.py — notification channel implementations."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 
@@ -23,63 +24,127 @@ class TestLogNotificationChannel:
         assert isinstance(channel, NotificationChannel)
 
 
-class TestBrevoNotificationChannel:
-    """Tests for BrevoNotificationChannel."""
+def _mock_async_client(mock_response: MagicMock) -> MagicMock:
+    """Build a mock httpx.AsyncClient whose `.post()` returns `mock_response`."""
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return mock_client
+
+
+class TestResendNotificationChannel:
+    """Tests for ResendNotificationChannel."""
 
     @pytest.mark.asyncio
     async def test_implements_notification_channel_protocol(self) -> None:
-        from api.notifications import BrevoNotificationChannel, NotificationChannel
+        from api.notifications import NotificationChannel, ResendNotificationChannel
 
-        with patch("api.notifications.Brevo"):
-            channel = BrevoNotificationChannel(
-                api_key="test-key",
-                sender_email="noreply@test.com",
-                sender_name="Test",
-            )
+        channel = ResendNotificationChannel(
+            api_key="test-key",
+            sender_email="noreply@test.com",
+            sender_name="Test",
+        )
         assert isinstance(channel, NotificationChannel)
 
     @pytest.mark.asyncio
-    async def test_send_password_reset_calls_brevo_api(self) -> None:
-        from api.notifications import BrevoNotificationChannel
+    async def test_send_password_reset_calls_resend_api(self) -> None:
+        from api.notifications import ResendNotificationChannel
 
-        mock_client = MagicMock()
-        with patch("api.notifications.Brevo", return_value=mock_client):
-            channel = BrevoNotificationChannel(
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_client = _mock_async_client(mock_response)
+
+        with patch("api.notifications.httpx.AsyncClient", return_value=mock_client):
+            channel = ResendNotificationChannel(
                 api_key="test-key",
                 sender_email="noreply@test.com",
                 sender_name="Test Sender",
             )
+            await channel.send_password_reset("user@example.com", "https://example.com/reset?token=abc")
 
-        await channel.send_password_reset("user@example.com", "https://example.com/reset?token=abc")
+        mock_client.post.assert_called_once()
+        call_args, call_kwargs = mock_client.post.call_args
+        assert call_args[0] == "https://api.resend.com/emails"
+        assert call_kwargs["headers"] == {"Authorization": "Bearer test-key"}
 
-        mock_client.transactional_emails.send_transac_email.assert_called_once()
-        call_kwargs = mock_client.transactional_emails.send_transac_email.call_args
-        assert call_kwargs.kwargs["subject"] == "Reset your Discogsography password"
-        assert "reset?token=abc" in call_kwargs.kwargs["html_content"]
-        assert call_kwargs.kwargs["sender"].email == "noreply@test.com"
-        assert call_kwargs.kwargs["sender"].name == "Test Sender"
-        assert call_kwargs.kwargs["to"][0].email == "user@example.com"
-        # Brevo's v3 transactional API rejects standard email headers (the SDK's
-        # `headers` field only accepts `sender.ip`, `X-Mailin-custom`, etc.), so
-        # `X-Mailin-Track*` cannot disable click tracking per-message — that
-        # must be turned off in the Brevo dashboard. We assert no headers field
-        # is sent so dead/misleading code can't reappear.
-        assert "headers" not in call_kwargs.kwargs
+        body = call_kwargs["json"]
+        assert body["from"] == "Test Sender <noreply@test.com>"
+        assert body["to"] == ["user@example.com"]
+        assert body["subject"] == "Reset your Discogsography password"
+        assert "reset?token=abc" in body["html"]
+        # No tracking field is ever sent — Resend has click/open tracking off
+        # by default for every domain, so there is nothing to configure or
+        # disable per-message.
+        assert "tracking" not in body
+        assert "track" not in body
+
+    @pytest.mark.asyncio
+    async def test_outbound_link_delivered_byte_identical(self) -> None:
+        """No click-tracking rewrite — the whole reason this channel exists.
+
+        Assert the exact reset URL handed to `send_password_reset` appears
+        byte-identical in the JSON body posted to the Resend API — not
+        wrapped, shortened, or redirected through a tracking domain.
+        """
+        from api.notifications import ResendNotificationChannel
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_client = _mock_async_client(mock_response)
+
+        reset_url = "https://discogsography.com/reset-password?token=abcDEF123-xyz_789"
+
+        with patch("api.notifications.httpx.AsyncClient", return_value=mock_client):
+            channel = ResendNotificationChannel(
+                api_key="test-key",
+                sender_email="noreply@test.com",
+                sender_name="Test Sender",
+            )
+            await channel.send_password_reset("user@example.com", reset_url)
+
+        body = mock_client.post.call_args.kwargs["json"]
+        # The link is HTML-escaped for safe embedding (quotes/entities), but the
+        # URL itself — scheme, host, path, and every query parameter — must
+        # survive unrewritten: no sendibt2.com-style redirect, no query params
+        # appended or stripped, no shortened form.
+        assert reset_url in body["html"]
+        assert "sendibt2.com" not in body["html"]
+        assert body["html"].count(reset_url) == 1
 
     @pytest.mark.asyncio
     async def test_send_password_reset_swallows_api_error(self) -> None:
-        from api.notifications import BrevoNotificationChannel
+        from api.notifications import ResendNotificationChannel
 
         mock_client = MagicMock()
-        mock_client.transactional_emails.send_transac_email.side_effect = RuntimeError("API error")
+        mock_client.post = AsyncMock(side_effect=httpx.HTTPError("API error"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
 
-        with patch("api.notifications.Brevo", return_value=mock_client):
-            channel = BrevoNotificationChannel(
+        with patch("api.notifications.httpx.AsyncClient", return_value=mock_client):
+            channel = ResendNotificationChannel(
                 api_key="test-key",
                 sender_email="noreply@test.com",
                 sender_name="Test",
             )
 
-        # Should not raise — errors are logged but swallowed to avoid
-        # breaking the password reset UX when email delivery fails
-        await channel.send_password_reset("user@example.com", "https://example.com/reset")
+            # Should not raise — errors are logged but swallowed to avoid
+            # breaking the password reset UX when email delivery fails
+            await channel.send_password_reset("user@example.com", "https://example.com/reset")
+
+    @pytest.mark.asyncio
+    async def test_send_password_reset_swallows_non_2xx_response(self) -> None:
+        from api.notifications import ResendNotificationChannel
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock(side_effect=httpx.HTTPStatusError("bad request", request=MagicMock(), response=MagicMock()))
+        mock_client = _mock_async_client(mock_response)
+
+        with patch("api.notifications.httpx.AsyncClient", return_value=mock_client):
+            channel = ResendNotificationChannel(
+                api_key="test-key",
+                sender_email="noreply@test.com",
+                sender_name="Test",
+            )
+
+            await channel.send_password_reset("user@example.com", "https://example.com/reset")

--- a/uv.lock
+++ b/uv.lock
@@ -171,21 +171,6 @@ wheels = [
 ]
 
 [[package]]
-name = "brevo-python"
-version = "4.0.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/92/79/573272ac0ac158e5498690daf06452fbca1785dcd1f85bdcb7bcda86d090/brevo_python-4.0.10.tar.gz", hash = "sha256:3ba2808937556b02d7afe4aaf6392438e1af3a8db77ef97349e46307bbf27311", size = 428199, upload-time = "2026-04-10T14:10:25.699Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/b7/cf28d6ac954cc98f2f5297f52bc57f3032f6360e0ad77d1fb36518ef4691/brevo_python-4.0.10-py3-none-any.whl", hash = "sha256:4fb38f4143ce2c440b35e574696f2ae667cf6454d592409af7750eb675703de0", size = 877575, upload-time = "2026-04-10T14:10:24.21Z" },
-]
-
-[[package]]
 name = "cachecontrol"
 version = "0.14.4"
 source = { registry = "https://pypi.org/simple" }
@@ -438,7 +423,6 @@ dependencies = [
 all = [
     { name = "anthropic" },
     { name = "bandit" },
-    { name = "brevo-python" },
     { name = "cryptography" },
     { name = "defusedxml" },
     { name = "fastapi" },
@@ -476,7 +460,6 @@ all = [
 ]
 api = [
     { name = "anthropic" },
-    { name = "brevo-python" },
     { name = "cryptography" },
     { name = "defusedxml" },
     { name = "fastapi" },
@@ -588,7 +571,6 @@ requires-dist = [
     { name = "aio-pika", specifier = ">=10.0.1" },
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.120.2" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.9.4" },
-    { name = "brevo-python", marker = "extra == 'api'", specifier = ">=4.0.10,<5" },
     { name = "cryptography", marker = "extra == 'api'", specifier = ">=50.0.0" },
     { name = "defusedxml", marker = "extra == 'api'", specifier = ">=0.7.1" },
     { name = "dict-hash", specifier = ">=1.3.7" },
@@ -689,7 +671,6 @@ version = "0.1.0"
 source = { editable = "api" }
 dependencies = [
     { name = "anthropic" },
-    { name = "brevo-python" },
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -707,7 +688,6 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.120.2" },
-    { name = "brevo-python", specifier = ">=4.0.10,<5" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "fastapi", specifier = ">=0.141.1" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
Closes `discogsography-iew6`. Implements the decision record filed by `discogsography-eef5` (#443).

## What changed

Brevo is gone. `ResendNotificationChannel` replaces `BrevoNotificationChannel` behind the unchanged `NotificationChannel` protocol — a plain `httpx` POST to `https://api.resend.com/emails`, **no vendor SDK**. `brevo-python` is dropped from both `pyproject.toml` files with nothing added back, which also retires the `<5` pin and the major-migration treadmill that motivated the spike in the first place. The `asyncio.to_thread` wrapper goes away with it: `httpx.AsyncClient` is natively async.

Config follows: `brevo_*` → `resend_*` in `common/config.py`, `RESEND_API_KEY` read through the existing `get_secret()` helper so `RESEND_API_KEY_FILE` works unchanged, and the Docker secret renamed to `resend_api_key` across both compose files. The unset-key fallback to `LogNotificationChannel` is preserved — local dev still works without a provider account.

## The point of the change

Brevo's free tier rewrote every outbound link through a `sendibt2.com` redirect with no per-message way to disable it. Resend has click and open tracking **off by default for every domain**, so the request body carries no tracking parameter at all — there is nothing to remember to switch off.

Two tests hold that line:

- `test_outbound_link_delivered_byte_identical` — the exact reset URL appears unmodified in the JSON body handed to httpx, exactly once, with no redirect host.
- `test_multi_param_link_round_trips_through_html_escaping` — a URL with multiple query params survives. `html.escape` turns `&` into `&amp;` for valid HTML, which is correct and mail clients undo it; this asserts that escaping is the *only* transform, by unescaping the rendered href and comparing to the original.

## Review notes

The second test and the tightened key assertions were added on review. The original `assert "track" not in body` checked dict *keys*, not substrings, against a body that only ever has four keys — it passed trivially. It now scans every key and pins the exact key set.

`docs/superpowers/specs/2026-03-25-brevo-email-integration-design.md` is kept as a dated historical record but bannered as superseded, pointing at the decision record. The remaining `grep -i brevo` hits are that banner and the decision record itself, both of which name Brevo on purpose.

Validation: `just lint`, `just typecheck`, and `just test-api` all pass (1783 passed, 98% coverage).

## Not done — needs a human

The bead's "a real password-reset email verified end-to-end" criterion is **not** satisfied. It needs a Resend account, an API key, and a verified `discogsography.com` sending domain (SPF + DKIM), none of which an agent can provision. Steps: create the account, verify the domain, write the key to `secrets/resend_api_key.txt`, then trigger one reset and confirm the link arrives unrewritten.

⚠️ That verification will currently fail — but not because of this change. `discogsography-m414` (P1, filed during this review) records that `api/routers/auth.py:294` builds the reset link as a bare relative URL, `/?reset_token=...`, which no mail client can resolve. It was equally broken under Brevo. Fix that first, or the end-to-end check will look like a Resend problem when it isn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxTkpnDHFTeHzURyp58TNk