### PR TITLE
fix(api): build the password reset link from an absolute APP_BASE_URL

### DIFF
--- a/.github/workflows/docker-compose-validate.yml
+++ b/.github/workflows/docker-compose-validate.yml
@@ -29,6 +29,14 @@ jobs:
           docker-compose: ${{ env.COMPOSE_VERSION }}
 
       - name: 📋 Validate docker-compose syntax
+        env:
+          # The prod overlay declares APP_BASE_URL with `:?`, so an unset value is a
+          # hard error — that is deliberate, to stop a production stack booting with
+          # a localhost default and mailing every user a link to their own machine.
+          # `config` evaluates interpolation, so this job has to supply a value. The
+          # value is irrelevant; only that it is set. Do not "fix" this by weakening
+          # the `:?` in docker-compose.prod.yml to a default.
+          APP_BASE_URL: "https://ci.invalid"
         run: |
           docker-compose config --quiet
           echo "✅ docker-compose.yml is valid"

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -277,7 +277,7 @@ async def get_me(
 @limiter.limit("3/minute")
 async def reset_request(request: Request, body: ResetRequestModel) -> JSONResponse:  # noqa: ARG001
     """Request a password reset. Same response whether email exists or not."""
-    if _pool is None or _redis is None:
+    if _pool is None or _redis is None or _config is None:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service not ready")
 
     async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
@@ -291,7 +291,9 @@ async def reset_request(request: Request, body: ResetRequestModel) -> JSONRespon
             900,  # 15 min TTL
             json.dumps({"user_id": str(user["id"]), "email": user["email"]}),
         )
-        reset_url = f"/?reset_token={token}"
+        # Must be absolute: this link is emailed, and a mail client has no base
+        # URL to resolve a relative href against.
+        reset_url = f"{_config.app_base_url}/?reset_token={token}"
         if _notification_channel:
             await _notification_channel.send_password_reset(user["email"], reset_url)
 

--- a/common/config.py
+++ b/common/config.py
@@ -689,6 +689,11 @@ class ApiConfig:
     # When unset, the OAuth 1.0a "out-of-band" flow is used and the user has to
     # paste a verifier code shown by Discogs back into the app.
     discogs_oauth_callback_url: str | None = None
+    # Public origin of the user-facing frontend (explore), used to build absolute
+    # links in outbound email. Distinct from API_BASE_URL, which is the internal
+    # service-to-service address of the API itself and is not reachable from a
+    # user's mail client. Any trailing slash is stripped on load.
+    app_base_url: str = "http://localhost:8006"
     cors_origins: list[str] | None = None
     snapshot_ttl_days: int = 28
     snapshot_max_nodes: int = 100
@@ -787,6 +792,8 @@ class ApiConfig:
 
         pool_min, pool_max = resolve_postgres_pool_sizes(default_min=2, default_max=8)
 
+        app_base_url = getenv("APP_BASE_URL", "http://localhost:8006").rstrip("/")
+
         encryption_master_key = get_secret("ENCRYPTION_MASTER_KEY") or None
         insights_internal_secret = get_secret("INSIGHTS_INTERNAL_SECRET") or None
         brevo_api_key = get_secret("BREVO_API_KEY") or None
@@ -821,6 +828,7 @@ class ApiConfig:
             neo4j_password=cast("str", neo4j_password),
             postgres_pool_min_size=pool_min,
             postgres_pool_max_size=pool_max,
+            app_base_url=app_base_url,
             cors_origins=cors_origins,
             snapshot_ttl_days=snapshot_ttl_days,
             snapshot_max_nodes=snapshot_max_nodes,

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -186,6 +186,10 @@ services:
   api:
     restart: always
     environment:
+      # REQUIRED in production: the public origin of the Explore frontend.
+      # Password reset emails embed this as an absolute link, so the localhost
+      # default would mail every recipient a link to their own machine.
+      APP_BASE_URL: "${APP_BASE_URL:?APP_BASE_URL must be set to the public frontend origin}"
       JWT_SECRET_KEY_FILE: /run/secrets/jwt_secret_key
       NEO4J_PASSWORD_FILE: /run/secrets/neo4j_password
       ENCRYPTION_MASTER_KEY_FILE: /run/secrets/encryption_master_key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,6 +228,9 @@ services:
     hostname: api
     user: "${UID:-1000}:${GID:-1000}"
     environment:
+      # Public origin of the Explore frontend — used to build absolute links in
+      # outbound email. Must be reachable from the recipient's mail client.
+      APP_BASE_URL: "${APP_BASE_URL:-http://localhost:8006}"
       JWT_ALGORITHM: HS256
       JWT_EXPIRE_MINUTES: "60"
       # IMPORTANT: Override JWT_SECRET_KEY with a random 256-bit key in production!

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -352,8 +352,16 @@ REDIS_PASSWORD_FILE="/run/secrets/redis_password"
 | `JWT_EXPIRE_MINUTES`           | Token lifetime in minutes                                         | `30`    | No        |
 | `DISCOGS_USER_AGENT`           | User-Agent for Discogs API requests                               | (none)  | Yes (API) |
 | `DISCOGS_OAUTH_CALLBACK_URL`   | Public callback URL Discogs redirects to after the user authorizes the app. When unset, the OAuth flow falls back to the out-of-band (OOB) mode where the user copy/pastes a verifier code into the app. When set, the value must exactly match the **Callback URL** field on your Discogs developer app settings page and point at `oauth-discogs-callback.html` on the Explore frontend (e.g. `https://your-host/oauth-discogs-callback.html`). | (none)  | No        |
+| `APP_BASE_URL`                 | Public origin of the user-facing Explore frontend, used to build absolute links in outbound email (currently the password reset link). Must be reachable from a recipient's mail client — a relative or internal-only URL produces an unclickable link. Any trailing slash is stripped. | `http://localhost:8006` | Yes in production |
 
 **Used By**: API
+
+**`APP_BASE_URL` vs `API_BASE_URL`**: these are different addresses and are easy to confuse.
+`API_BASE_URL` is the internal service-to-service address of the API (e.g. `http://api:8004`),
+used by Explore, Insights, and the MCP server. `APP_BASE_URL` is the **public** origin a real
+user's browser reaches — the one that must appear in email. In production, leaving
+`APP_BASE_URL` at its localhost default means every password reset link mails out pointing at
+the recipient's own machine.
 
 **JWT Details**:
 

--- a/tests/api/test_auth_router.py
+++ b/tests/api/test_auth_router.py
@@ -72,6 +72,61 @@ class TestResetRequest:
         response = test_client.post("/api/auth/reset-request", json={"email": " Test@Example.COM "})
         assert response.status_code == 200
 
+    def test_reset_link_is_absolute_and_uses_app_base_url(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,  # noqa: ARG002  # required so setex is stubbed
+    ) -> None:
+        """The emailed link must be absolute — a mail client cannot resolve a relative href."""
+        mock_cur.fetchone = AsyncMock(return_value=make_sample_user_row())
+        channel = AsyncMock()
+        original_config = auth_router._config
+        original_channel = auth_router._notification_channel
+        auth_router._config = replace(original_config, app_base_url="https://discogsography.example")
+        auth_router._notification_channel = channel
+        try:
+            response = test_client.post("/api/auth/reset-request", json={"email": TEST_USER_EMAIL})
+        finally:
+            auth_router._config = original_config
+            auth_router._notification_channel = original_channel
+
+        assert response.status_code == 200
+        sent_url = channel.send_password_reset.call_args.args[1]
+        assert sent_url.startswith("https://discogsography.example/?reset_token=")
+        # Guard the regression directly: a bare relative path is what broke this.
+        assert not sent_url.startswith("/")
+
+    def test_reset_link_tolerates_trailing_slash_in_base_url(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,  # noqa: ARG002  # required so setex is stubbed
+    ) -> None:
+        """A trailing slash on the configured base must not produce a double slash."""
+        from common.config import ApiConfig
+
+        mock_cur.fetchone = AsyncMock(return_value=make_sample_user_row())
+        channel = AsyncMock()
+        original_config = auth_router._config
+        original_channel = auth_router._notification_channel
+        # from_env() strips the trailing slash on load, so go through it rather
+        # than constructing the field directly.
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("APP_BASE_URL", "https://discogsography.example/")
+            mp.setenv("JWT_SECRET_KEY", "x" * 32)
+            loaded = ApiConfig.from_env()
+        auth_router._config = replace(original_config, app_base_url=loaded.app_base_url)
+        auth_router._notification_channel = channel
+        try:
+            test_client.post("/api/auth/reset-request", json={"email": TEST_USER_EMAIL})
+        finally:
+            auth_router._config = original_config
+            auth_router._notification_channel = original_channel
+
+        sent_url = channel.send_password_reset.call_args.args[1]
+        assert sent_url.startswith("https://discogsography.example/?reset_token=")
+
 
 class TestResetConfirm:
     """Tests for POST /api/auth/reset-confirm."""


### PR DESCRIPTION
Closes `discogsography-m414`.

## The bug

`api/routers/auth.py` built the emailed reset link as `reset_url = f"/?reset_token={token}"` — a bare relative path — and handed it straight to the notification channel, which embedded it as `<a href="/?reset_token=...">` in the outbound HTML.

A mail client has no base URL to resolve a relative href against, so the reset button in the email has never been clickable. This is provider-independent: it was equally broken under Brevo and is untouched by the Resend swap in #444. It surfaced while reviewing that PR.

## The fix

New `APP_BASE_URL` env var → `ApiConfig.app_base_url`, default `http://localhost:8006`. That default is the **Explore** frontend, which is what actually consumes the token — `explore/static/js/app.js` reads the `reset_token` query param. Trailing slashes are stripped on load, so a base configured as `https://host/` can't produce a double slash.

**This is deliberately not `API_BASE_URL`.** That one is the internal service-to-service address of the API (`http://api:8004`) used by Explore, Insights, and the MCP server — not an address a recipient's mail client can reach. The two are now documented side by side in `docs/configuration.md` specifically to stop them being confused.

`docker-compose.prod.yml` declares it as `${APP_BASE_URL:?...}` so a production stack fails fast at startup rather than silently mailing every user a link to their own machine.

## Tests

- `test_reset_link_is_absolute_and_uses_app_base_url` — captures the URL handed to the notification channel, asserts it starts with the configured origin, and asserts it does **not** start with `/` (guarding the exact regression).
- `test_reset_link_tolerates_trailing_slash_in_base_url` — round-trips through `ApiConfig.from_env()` so the stripping is tested where it actually happens, not on a hand-built field.

`just lint`, `just typecheck`, and `just test-api` pass — 1782 passed, 98% coverage.

## Merge note

Branched from `main`, so it does not include #444. Both PRs touch `common/config.py` and both compose files, but in non-adjacent regions — this one sits next to `discogs_oauth_callback_url`, deliberately away from the Brevo/Resend block. Whichever lands second should merge cleanly; if not, the conflict is mechanical.

Worth landing this **before** the live end-to-end email verification that #444 still needs, or that check will fail on this bug and look like a Resend problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxTkpnDHFTeHzURyp58TNk