### PR TITLE
ci: pin hadolint to 2.14.0 to match the pre-commit hook

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -53,7 +53,12 @@ jobs:
       - name: 🔧 Install arkade
         uses: alexellis/arkade-get@1eef818e467c387d3f50cfe0d2c565d1cbe82b03  # master
         with:
-          hadolint: latest
+          # Must match the hadolint hook rev in .pre-commit-config.yaml — that hook is
+          # `language: system`, so it lints with whatever binary is on PATH. Leaving this
+          # as `latest` meant CI silently linted with newer rules than any developer had,
+          # and a new hadolint release turned every PR red on untouched Dockerfiles.
+          # Bump both sites together.
+          hadolint: 2.14.0
 
       - name: 🦀 Setup Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -58,7 +58,8 @@ jobs:
           # as `latest` meant CI silently linted with newer rules than any developer had,
           # and a new hadolint release turned every PR red on untouched Dockerfiles.
           # Bump both sites together.
-          hadolint: 2.14.0
+          # Tag form (v-prefixed) — arkade resolves this against hadolint's release tags.
+          hadolint: v2.14.0
 
       - name: 🦀 Setup Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,9 @@ repos:
   - repo: https://github.com/hadolint/hadolint
     rev: 4e697ba704fd23b2409b947a319c19c3ee54d24f  # frozen: v2.14.0
     hooks:
+      # `language: system` — lints with the hadolint binary on PATH, not this rev.
+      # CI installs that binary in .github/workflows/code-quality.yml; keep the two
+      # versions in lockstep or CI and local will enforce different rule sets.
       - id: hadolint
 
   - repo: https://github.com/IamTheFij/docker-pre-commit


### PR DESCRIPTION
Closes `discogsography-kaeu`. **Merge this first** — #444 and #445 are both red because of it.

## The break

`.github/workflows/code-quality.yml` installed hadolint via arkade as `hadolint: latest`, while `.pre-commit-config.yaml` freezes the hook at `v2.14.0`. The hook is `language: system`, so it lints with whatever binary is on PATH — v2.14.0 locally, `latest` in CI.

A newer hadolint started enforcing DL3025 / DL3064 / DL3066 across essentially every Dockerfile in the repo, and the pre-commit path runs at hadolint's default `info` failure threshold, so those warnings fail the job.

The tell: **main is red at `293c29b`** — PR #443, a docs-only commit containing nothing but markdown. A markdown change cannot break Dockerfile linting. Every open PR inherits the failure regardless of content, and `just lint` passes locally throughout, so the break is invisible until CI runs.

## The fix

Pin CI to `2.14.0`, matching the frozen hook rev, and cross-reference both sites so a future bump moves them together.

## Not fixed here

`docker-validate.yml` runs hadolint-action with an explicit `failure-threshold: error`; the pre-commit path uses the default `info`. That inconsistency is the underlying reason a routine upstream rule addition became an outage rather than a warning — a pin stops today's bleeding but the next hadolint bump will reintroduce it. Worth reconciling, but it changes lint strictness repo-wide, so it belongs in its own change rather than riding along with a CI hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxTkpnDHFTeHzURyp58TNk