### PR TITLE
ci: reconcile the hadolint failure threshold and take v2.15.1

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -57,9 +57,10 @@ jobs:
           # `language: system`, so it lints with whatever binary is on PATH. Leaving this
           # as `latest` meant CI silently linted with newer rules than any developer had,
           # and a new hadolint release turned every PR red on untouched Dockerfiles.
-          # Bump both sites together.
+          # Bump both sites together; the hook also pins --failure-threshold error, which
+          # is what makes a rule addition a warning rather than an outage.
           # Tag form (v-prefixed) — arkade resolves this against hadolint's release tags.
-          hadolint: v2.14.0
+          hadolint: v2.15.1
 
       - name: 🦀 Setup Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,15 +54,18 @@ repos:
         args: [-x, "tests", -s, "B608"]  # B608 skipped: all user input uses parameterized %s queries
 
   - repo: https://github.com/hadolint/hadolint
-    # HELD at v2.14.0 — do not let `just update-deps` bump this alone. v2.15.1 adds
-    # DL3025/DL3064/DL3066, which fire across every Dockerfile here; taking it means
-    # fixing those findings and bumping the CI pin in the same change (discogsography-kaeu).
-    rev: 4e697ba704fd23b2409b947a319c19c3ee54d24f  # frozen: v2.14.0
+    rev: 2eece55955ced00200be9729e9728cb7dacca505  # frozen: v2.15.1
     hooks:
       # `language: system` — lints with the hadolint binary on PATH, not this rev.
       # CI installs that binary in .github/workflows/code-quality.yml; keep the two
       # versions in lockstep or CI and local will enforce different rule sets.
       - id: hadolint
+        # Match docker-validate.yml, which has always used `failure-threshold: error`.
+        # Without this the hook runs at hadolint's default of `info`, so the two paths
+        # enforced different policies and any upstream rule added at info/warning level
+        # became a CI outage instead of a warning. That is exactly how v2.15.1's
+        # DL3025/DL3064/DL3066 took main red on a docs-only commit.
+        args: ["--failure-threshold", "error"]
 
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: f626253b23de45412865c07fd076ff95d4cd77a7  # frozen: v3.0.1


### PR DESCRIPTION
Closes `discogsography-he4k`. Fixes the root cause the #446 pin only papered over.

## The real bug

`docker-validate.yml` has always run hadolint-action with `failure-threshold: error`. The pre-commit hook ran with hadolint's **default** threshold of `info`. Two invocations, two different policies — so any rule upstream adds at info or warning level fails the build rather than warning.

That asymmetry, not the version number, is what let v2.15.1's DL3025/DL3064/DL3066 turn main red on a commit containing only markdown. The pin in #446 stopped the bleeding; it did not remove the trap, and `just update-deps` had already tried to bump the hook past it once (reverted in #447).

## Verified, not assumed

Ran hadolint **v2.15.1** against all 11 tracked Dockerfiles:

| | result |
|---|---|
| default threshold (`info`) | **fails** |
| `--failure-threshold error` | **passes — 0 of 11 files fail** |
| findings | 16 warning, 11 info, **0 error** |

So aligning the threshold is sufficient to make the upgrade safe. The v2.14.0 hold is lifted and both pins move to v2.15.1 together.

## Deliberately not fixed here

The 27 warning/info findings stay. DL3025 (JSON notation for CMD/ENTRYPOINT) and DL3064 (sensitive data in ARG/ENV) deserve a real look, but bundling ~27 Dockerfile edits into a CI-policy change would obscure both halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxTkpnDHFTeHzURyp58TNk