### PR TITLE
chore(mcp-server): migrate to mcp 2.x and lift the <2 cap

### DIFF
--- a/mcp-server/mcp_server/server.py
+++ b/mcp-server/mcp_server/server.py
@@ -22,7 +22,8 @@ from typing import Any
 from urllib.parse import quote as _url_quote
 
 import httpx
-from mcp.server.fastmcp import Context, FastMCP
+from mcp.server import MCPServer
+from mcp.server.mcpserver import Context
 import structlog
 
 
@@ -53,7 +54,7 @@ class AppContext:
 
 
 @asynccontextmanager
-async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:  # noqa: ARG001
+async def app_lifespan(server: MCPServer) -> AsyncIterator[AppContext]:  # noqa: ARG001
     """Initialize HTTP client on startup, close on shutdown."""
     base_url = getenv("API_BASE_URL", "http://localhost:8004")
 
@@ -67,7 +68,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:  # noqa: A
 # Server instance
 # ---------------------------------------------------------------------------
 
-mcp = FastMCP(
+mcp = MCPServer(
     "Discogsography",
     lifespan=app_lifespan,
     instructions=(
@@ -85,8 +86,12 @@ mcp = FastMCP(
 # ---------------------------------------------------------------------------
 
 
-def _ctx(ctx: Context) -> AppContext:
-    return ctx.request_context.lifespan_context  # type: ignore[no-any-return]
+def _ctx(ctx: Context[AppContext, Any]) -> AppContext:
+    # Context is generic over the lifespan type in v2, so parameterizing it types
+    # `lifespan_context` as AppContext instead of dict[str, Any] — no cast, no ignore.
+    # Tool signatures use the same parameterized form; the SDK injects on the Context
+    # origin, so the type argument is invisible to it and never reaches a tool schema.
+    return ctx.request_context.lifespan_context
 
 
 async def _api_get(app: AppContext, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -156,10 +161,10 @@ async def _call_shared_find_path(app: AppContext, **kwargs: Any) -> dict[str, An
 
 @mcp.tool()
 async def search(
+    ctx: Context[AppContext, Any],
     query: str,
     types: str = "artist,label,master,release",
     limit: int = 20,
-    ctx: Context = None,  # type: ignore[assignment]
 ) -> dict[str, Any]:
     """Search the music database across artists, labels, masters, and releases.
 
@@ -197,8 +202,8 @@ async def search(
 
 @mcp.tool()
 async def get_artist_details(
+    ctx: Context[AppContext, Any],
     artist_id: str,
-    ctx: Context = None,  # type: ignore[assignment]
 ) -> dict[str, Any]:
     """Get detailed information about an artist.
 
@@ -216,8 +221,8 @@ async def get_artist_details(
 
 @mcp.tool()
 async def get_label_details(
+    ctx: Context[AppContext, Any],
     label_id: str,
-    ctx: Context = None,  # type: ignore[assignment]
 ) -> dict[str, Any]:
     """Get detailed information about a record label.
 
@@ -235,8 +240,8 @@ async def get_label_details(
 
 @mcp.tool()
 async def get_release_details(
+    ctx: Context[AppContext, Any],
     release_id: str,
-    ctx: Context = None,  # type: ignore[assignment]
 ) -> dict[str, Any]:
     """Get detailed information about a release (album, single, etc.).
 
@@ -254,8 +259,8 @@ async def get_release_details(
 
 @mcp.tool()
 async def get_genre_details(
+    ctx: Context[AppContext, Any],
     genre_name: str,
-    ctx: Context = None,  # type: ignore[assignment]
 ) -> dict[str, Any]:
     """Get detailed information about a music genre.
 
@@ -270,8 +275,8 @@ async def get_genre_details(
 
 @mcp.tool()
 async def get_style_details(
+    ctx: Context[AppContext, Any],
     style_name: str,
-    ctx: Context = None,  # type: ignore[assignment]
 ) -> dict[str, Any]:
     """Get detailed information about a music style (sub-genre).
 
@@ -291,12 +296,12 @@ async def get_style_details(
 
 @mcp.tool()
 async def find_path(
+    ctx: Context[AppContext, Any],
     from_name: str,
     from_type: str,
     to_name: str,
     to_type: str,
     max_depth: int = 10,
-    ctx: Context = None,  # type: ignore[assignment]
 ) -> dict[str, Any]:
     """Find the shortest path between two entities in the knowledge graph.
 
@@ -338,9 +343,9 @@ async def find_path(
 
 @mcp.tool()
 async def get_trends(
+    ctx: Context[AppContext, Any],
     name: str,
     entity_type: str = "artist",
-    ctx: Context = None,  # type: ignore[assignment]
 ) -> dict[str, Any]:
     """Get the release timeline for an entity (releases per year).
 
@@ -372,7 +377,7 @@ async def get_trends(
 
 @mcp.tool()
 async def get_graph_stats(
-    ctx: Context = None,  # type: ignore[assignment]
+    ctx: Context[AppContext, Any],
 ) -> dict[str, Any]:
     """Get an overview of the knowledge graph — total counts for each entity type.
 
@@ -390,9 +395,9 @@ async def get_graph_stats(
 
 @mcp.tool()
 async def get_collaborators(
+    ctx: Context[AppContext, Any],
     artist_id: str,
     limit: int = 20,
-    ctx: Context = None,  # type: ignore[assignment]
 ) -> dict[str, Any]:
     """Find artists who collaborate with a given artist through shared releases.
 
@@ -420,7 +425,7 @@ async def get_collaborators(
 
 @mcp.tool()
 async def get_genre_tree(
-    ctx: Context = None,  # type: ignore[assignment]
+    ctx: Context[AppContext, Any],
 ) -> dict[str, Any]:
     """Get the full genre/style hierarchy from the knowledge graph.
 
@@ -439,8 +444,8 @@ async def get_genre_tree(
 
 @mcp.tool()
 async def nlq_query(
+    ctx: Context[AppContext, Any],
     query: str,
-    ctx: Context = None,  # type: ignore[assignment]
 ) -> dict[str, Any]:
     """Ask a natural language question about the music knowledge graph.
 
@@ -479,7 +484,13 @@ def main() -> None:
     if transport not in _VALID_TRANSPORTS:
         transport = "stdio"
 
-    mcp.run(transport=transport)  # type: ignore[arg-type]
+    # v2 overloads `run` per transport, each with its own keyword set, so a `str`
+    # matches no variant. Branch on the validated value instead of casting — this
+    # keeps the call type-checked rather than silencing it.
+    if transport == "streamable-http":
+        mcp.run(transport="streamable-http")
+    else:
+        mcp.run(transport="stdio")
 
 
 if __name__ == "__main__":

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 license = {text = "PolyForm-Noncommercial-1.0.0"}
 dependencies = [
     "httpx>=0.28.1",
-    "mcp[cli]>=1.28.1,<2",
+    "mcp[cli]>=2.0.0",
     "structlog>=26.1.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ schema-init = [
     "structlog>=26.1.0",
 ]
 mcp-server = [
-    "mcp[cli]>=1.28.1,<2",
+    "mcp[cli]>=2.0.0",
     "structlog>=26.1.0",
 ]
 all = [

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dashboard'", specifier = ">=0.28.1" },
     { name = "httpx", marker = "extra == 'explore'", specifier = ">=0.28.1" },
     { name = "httpx", marker = "extra == 'insights'", specifier = ">=0.28.1" },
-    { name = "mcp", extras = ["cli"], marker = "extra == 'mcp-server'", specifier = ">=1.28.1,<2" },
+    { name = "mcp", extras = ["cli"], marker = "extra == 'mcp-server'", specifier = ">=2.0.0" },
     { name = "multidict", specifier = ">=6.7.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.3.0" },
     { name = "neo4j-rust-ext", specifier = ">=6.2.0.0" },
@@ -861,7 +861,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
+    { name = "mcp", extras = ["cli"], specifier = ">=2.0.0" },
     { name = "structlog", specifier = ">=26.1.0" },
 ]
 
@@ -1064,6 +1064,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1105,12 +1118,18 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -1302,15 +1321,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "sse-starlette" },
@@ -1319,15 +1338,28 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
 ]
 
 [package.optional-dependencies]
 cli = [
     { name = "python-dotenv" },
     { name = "typer" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -1522,6 +1554,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -1914,20 +1958,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
     { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
     { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
-]
-
-[[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]
@@ -2407,6 +2437,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes `discogsography-ihe6`. Third of three follow-ups; siblings are #450 (hadolint) and #451 (semgrep).

## Why the cap existed

mcp 2.0.0 removes `mcp.server.fastmcp` outright. `server.py` imports `FastMCP` and `Context` from it at module scope, so under 2.0.0 the MCP server raises `ModuleNotFoundError` before it starts. mypy reported 27 errors, but those were downstream of a hard runtime break — the cap in #447 was holding back a broken server, not a typing inconvenience.

## The migration

- **`FastMCP` → `MCPServer`**, from `mcp.server`; `Context` now from `mcp.server.mcpserver`
- **Context injection changed.** v2 injects by type annotation, so the 12 `ctx: Context = None  # type: ignore[assignment]` sentinels become plain annotated parameters. They had to move to **first position** — without a default they can no longer follow defaulted parameters.
- **`Context` is generic over the lifespan type.** Using `Context[AppContext, Any]` types `lifespan_context` as `AppContext` directly, so the `no-any-return` ignore in `_ctx` is retired rather than swapped for a cast.
- **`run()` is overloaded per transport**, each with its own keyword set, so a `str` matches no variant. Branch on the already-validated value instead of casting — the call stays type-checked.

## Verification

mypy passing is not sufficient here, since the failure mode is runtime. Checked directly:

- server imports; `type(mcp).__name__ == "MCPServer"`
- **all 12 tools register**
- **`ctx` does not leak into any tool's input schema** — `search` still exposes exactly `query`/`types`/`limit`, required `query`. This was the specific risk in promoting `ctx` to a real parameter.
- `just test-mcp-server` — 45 passed
- full suite — 3675 passed; `just lint`, mypy clean across 117 files

The `<2` cap is lifted in both `pyproject.toml` and `mcp-server/pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxTkpnDHFTeHzURyp58TNk