### PR TITLE
fix: concurrency, messaging & resource reliability — 9 bug-hunt findings (batch:p2-concurrency-messaging)

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -103,8 +103,15 @@ def get_health_data() -> dict[str, Any]:
     }
 
 
-def _create_access_token(user_id: str, email: str) -> tuple[str, int]:
-    """Create a HS256 JWT access token. Returns (token, expires_in_seconds)."""
+def _create_access_token(user_id: str, email: str, issued_at: int | None = None) -> tuple[str, int]:
+    """Create a HS256 JWT access token. Returns (token, expires_in_seconds).
+
+    ``issued_at`` lets a caller stamp the token with the moment the credential it
+    was derived from was verified, instead of the (later) moment of minting. A
+    password change committing in between must invalidate the new token, and the
+    `iat <= password_changed` predicate can only see that if `iat` predates the
+    change (discogsography-jxmn).
+    """
     if _config is None:
         raise RuntimeError("Service not initialized")
 
@@ -114,7 +121,7 @@ def _create_access_token(user_id: str, email: str) -> tuple[str, int]:
         "sub": user_id,
         "email": email,
         "exp": int(expire.timestamp()),
-        "iat": int(datetime.now(UTC).timestamp()),
+        "iat": issued_at if issued_at is not None else int(datetime.now(UTC).timestamp()),
         "jti": secrets.token_hex(16),
     }
 

--- a/api/auth.py
+++ b/api/auth.py
@@ -192,10 +192,17 @@ def hash_recovery_code(code: str) -> str:
     return hashlib.sha256(code.encode("utf-8")).hexdigest()
 
 
-def create_challenge_token(user_id: str, email: str, secret_key: str) -> str:
+def create_challenge_token(user_id: str, email: str, secret_key: str, issued_at: int | None = None) -> str:
     """Create a short-lived 2FA challenge JWT (5 min TTL).
 
     This token proves the password was correct but is NOT a full access token.
+
+    ``issued_at`` lets the caller stamp the token with the moment the password
+    was READ rather than the moment the token was minted. Password verification
+    is deliberately slow (PBKDF2, 100k iterations), and a password change that
+    commits inside that window must invalidate the credential derived from the
+    old password — which only works if ``iat`` predates the change marker
+    (discogsography-jxmn).
     """
     expire = datetime.now(UTC) + timedelta(minutes=5)
     payload: dict[str, Any] = {
@@ -203,7 +210,7 @@ def create_challenge_token(user_id: str, email: str, secret_key: str) -> str:
         "email": email,
         "type": "2fa_challenge",
         "exp": int(expire.timestamp()),
-        "iat": int(datetime.now(UTC).timestamp()),
+        "iat": issued_at if issued_at is not None else int(datetime.now(UTC).timestamp()),
         "jti": secrets.token_hex(16),
     }
     header = b64url_encode(json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode())

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -23,6 +23,7 @@ from api.auth import (
     generate_totp_secret,
     get_totp_encryption_key,
     hash_recovery_code,
+    token_revocation_reason,
     verify_totp_code,
 )
 from api.limiter import limiter
@@ -55,6 +56,25 @@ _create_access_token_fn: Any = None
 _notification_channel: Any = None
 
 _security = HTTPBearer()
+
+
+async def _reject_stale_challenge(payload: dict[str, Any]) -> None:
+    """Reject a 2FA challenge that the user's credentials have outlived.
+
+    A challenge token proves knowledge of the password that was current when it
+    was minted, and it stays redeemable for its full 5-minute TTL. Redeeming it
+    mints a fresh access token whose `iat` is necessarily AFTER the
+    `password_changed:{user_id}` marker, so the marker — enforced only at
+    access-token validation — could never invalidate it. The invariant ("no
+    credential derived from the pre-change password may be honored") has to be
+    enforced at the MINT site too, against the challenge's own `iat`
+    (discogsography-jxmn).
+    """
+    if await token_revocation_reason(payload, _redis) is not None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Challenge invalidated by password change",
+        )
 
 
 def configure(
@@ -153,6 +173,13 @@ async def login(request: Request, body: LoginRequest) -> JSONResponse:  # noqa: 
             detail="Service not ready",
         )
 
+    # Stamped BEFORE the password is read, and used as the `iat` of whatever
+    # credential this login mints. _verify_password is deliberately slow
+    # (PBKDF2, 100k iterations); a password change committing inside that window
+    # must invalidate this login, which the `iat <= password_changed` predicate
+    # can only see if `iat` predates the marker (discogsography-jxmn).
+    credential_issued_at = int(datetime.now(UTC).timestamp())
+
     async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
         await execute_sql(
             cur,
@@ -185,7 +212,7 @@ async def login(request: Request, body: LoginRequest) -> JSONResponse:  # noqa: 
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Service not ready (Redis required for 2FA)",
             )
-        challenge = create_challenge_token(str(user["id"]), user["email"], _config.jwt_secret_key)
+        challenge = create_challenge_token(str(user["id"]), user["email"], _config.jwt_secret_key, issued_at=credential_issued_at)
         challenge_payload = decode_token(challenge, _config.jwt_secret_key)
         jti = challenge_payload["jti"]
         # Store challenge JTI in Redis with 5 min TTL
@@ -198,7 +225,7 @@ async def login(request: Request, body: LoginRequest) -> JSONResponse:  # noqa: 
             }
         )
 
-    access_token, expires_in = _create_access_token_fn(str(user["id"]), user["email"])
+    access_token, expires_in = _create_access_token_fn(str(user["id"]), user["email"], issued_at=credential_issued_at)
     logger.info("✅ User logged in", email=body.email)
 
     return JSONResponse(
@@ -513,6 +540,8 @@ async def twofa_verify(request: Request, body: TwoFactorVerifyModel) -> JSONResp
     if not jti:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid challenge token")
 
+    await _reject_stale_challenge(payload)
+
     # Verify challenge exists (without consuming) before checking lockout,
     # so locked-out users don't waste their challenge token.
     challenge_key = f"2fa_challenge:{jti}"
@@ -604,8 +633,10 @@ async def twofa_verify(request: Request, body: TwoFactorVerifyModel) -> JSONResp
             (user_id,),
         )
 
-    # Issue access token
-    access_token, expires_in = _create_access_token_fn(user_id, email)
+    # Issue access token, stamped with the CHALLENGE's iat: the credential this
+    # token derives from is the password proven at login, so a password change
+    # after that moment must invalidate it too (discogsography-jxmn).
+    access_token, expires_in = _create_access_token_fn(user_id, email, issued_at=payload.get("iat"))
     logger.info("✅ 2FA verification successful", user_id=user_id)
     return JSONResponse(
         content={
@@ -635,6 +666,8 @@ async def twofa_recovery(request: Request, body: TwoFactorRecoveryModel) -> JSON
     jti = payload.get("jti")
     if not jti:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid challenge token")
+
+    await _reject_stale_challenge(payload)
 
     # Verify the challenge EXISTS (without consuming) before validating the code,
     # so a mistyped recovery code does not burn the challenge token. The challenge
@@ -684,8 +717,8 @@ async def twofa_recovery(request: Request, body: TwoFactorRecoveryModel) -> JSON
     # Recovery code redeemed — now consume the challenge so it cannot be replayed.
     await _redis.getdel(challenge_key)
 
-    # Issue access token
-    access_token, expires_in = _create_access_token_fn(user_id, email)
+    # Issue access token, stamped with the CHALLENGE's iat (see twofa_verify).
+    access_token, expires_in = _create_access_token_fn(user_id, email, issued_at=payload.get("iat"))
     logger.info("✅ 2FA recovery code used", user_id=user_id, remaining_codes=len(remaining))
 
     content: dict[str, Any] = {

--- a/brainzgraphinator/brainzgraphinator.py
+++ b/brainzgraphinator/brainzgraphinator.py
@@ -19,7 +19,9 @@ from common import (
     AsyncResilientNeo4jDriver,
     AsyncResilientRabbitMQ,
     BrainzgraphinatorConfig,
+    DatabaseUnavailableError,
     HealthServer,
+    OutageBackoff,
     neo4j_security_kwargs,
     setup_logging,
 )
@@ -41,6 +43,11 @@ last_message_time = {
     "releases": 0.0,
 }
 completed_files: set[str] = set()  # Track which files have completed processing
+
+# Throttles requeues while Neo4j is unavailable, so an outage cannot burn the
+# quorum queue's x-delivery-limit budget and dead-letter valid records
+# (discogsography-rb05).
+outage_backoff = OutageBackoff("brainzgraphinator")
 
 # Consumer management
 consumer_tags: dict[str, str] = {}  # {"artists": "consumer-tag-123", ...}
@@ -652,6 +659,9 @@ def make_message_handler(data_type: str, enrich_fn: Any) -> Any:
 
             await message.ack()
 
+            # Neo4j answered — clear the outage backoff.
+            outage_backoff.reset()
+
             # Increment counts only after successful processing and ack
             message_counts[data_type] += 1
             last_message_time[data_type] = time.time()
@@ -660,11 +670,18 @@ def make_message_handler(data_type: str, enrich_fn: Any) -> Any:
                     f"📊 Enriched {data_type} in Neo4j",
                     message_counts=message_counts[data_type],
                 )
-        except (ServiceUnavailable, SessionExpired) as e:
+        except (ServiceUnavailable, SessionExpired, DatabaseUnavailableError) as e:
             logger.warning(
                 f"⚠️ Neo4j unavailable, will retry {data_type} message",
                 error=str(e),
             )
+            # Pause before requeueing. The main queues are quorum queues with
+            # x-delivery-limit=20, a budget with no time dimension: requeueing
+            # immediately burns all 20 redeliveries in ~3 minutes and RabbitMQ
+            # dead-letters a perfectly valid record mid-outage. Prefetch here is
+            # 200, so an unthrottled Neo4j outage puts 200 messages on that
+            # treadmill at once (discogsography-rb05).
+            await outage_backoff.wait()
             try:
                 await message.nack(requeue=True)
             except Exception as nack_error:  # noqa: BLE001 - the nack path itself is best-effort; the broker will redeliver

--- a/brainztableinator/brainztableinator.py
+++ b/brainztableinator/brainztableinator.py
@@ -19,7 +19,9 @@ from common import (
     AsyncPostgreSQLPool,
     AsyncResilientRabbitMQ,
     BrainztableinatorConfig,
+    DatabaseUnavailableError,
     HealthServer,
+    OutageBackoff,
     parse_postgres_host_port,
     setup_logging,
 )
@@ -58,6 +60,11 @@ last_message_time = {
     "releases": 0.0,
 }
 completed_files: set[str] = set()  # Track which files have completed processing
+
+# Throttles requeues while PostgreSQL is unavailable, so an outage cannot burn
+# the quorum queue's x-delivery-limit budget and dead-letter valid records
+# (discogsography-rb05).
+outage_backoff = OutageBackoff("brainztableinator")
 current_task = None
 current_progress = 0.0
 
@@ -872,6 +879,9 @@ async def on_data_message(message: AbstractIncomingMessage, data_type: str) -> N
 
         await message.ack()
 
+        # PostgreSQL answered — clear the outage backoff.
+        outage_backoff.reset()
+
         # Increment counter and update last message time only after successful ack
         if data_type in message_counts:
             message_counts[data_type] += 1
@@ -883,8 +893,14 @@ async def on_data_message(message: AbstractIncomingMessage, data_type: str) -> N
                     data_type=data_type,
                 )
 
-    except (InterfaceError, OperationalError) as e:
+    except (InterfaceError, OperationalError, DatabaseUnavailableError) as e:
         logger.warning("⚠️ Database connection issue, will retry", error=str(e))
+        # Pause before requeueing. The main queues are quorum queues with
+        # x-delivery-limit=20 — a budget with no time dimension — so requeueing
+        # immediately spends all 20 redeliveries in ~3 minutes and RabbitMQ
+        # dead-letters a perfectly valid record part-way through a routine
+        # database maintenance window (discogsography-rb05).
+        await outage_backoff.wait()
         await message.nack(requeue=True)
     except DataError as e:
         # Malformed data that deterministically fails a column cast (e.g. a

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -51,6 +51,7 @@ from common.neo4j_resilient import (
     with_neo4j_retry,
 )
 from common.oauth import _build_oauth_header, _hmac_sha1_signature, _oauth_escape
+from common.outage_backoff import OutageBackoff
 from common.postgres_resilient import (
     AsyncPostgreSQLPool,
     AsyncResilientPostgreSQL,
@@ -114,6 +115,7 @@ __all__ = [
     "GraphinatorConfig",
     "HealthServer",
     "InsightsConfig",
+    "OutageBackoff",
     "PhaseStatus",
     "ProcessingDecision",
     "ProcessingPhase",

--- a/common/db_resilience.py
+++ b/common/db_resilience.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import Callable
+import contextlib
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -326,6 +327,9 @@ class AsyncResilientConnection[T]:
         backoff: ExponentialBackoff | None = None,
         max_retries: int = 3,
         name: str = "AsyncConnection",
+        health_check_ttl: float = 30.0,
+        unhealthy_threshold: int = 3,
+        close_grace_period: float = 30.0,
     ):
         self.connection_factory = connection_factory
         self.connection_test = connection_test
@@ -333,8 +337,20 @@ class AsyncResilientConnection[T]:
         self.backoff = backoff or ExponentialBackoff()
         self.max_retries = max_retries
         self.name = name
+        # Seconds a successful health probe is trusted before re-probing.
+        self.health_check_ttl = health_check_ttl
+        # Consecutive failed probes required before a live connection is replaced.
+        self.unhealthy_threshold = unhealthy_threshold
+        # Seconds a replaced connection is left open so in-flight borrowers can drain.
+        self.close_grace_period = close_grace_period
         self._connection: T | None = None
         self._lock: asyncio.Lock | None = None
+        self._last_healthy_at: float = 0.0
+        self._failed_probes: int = 0
+        # Connections detached from the manager but not yet closed, and the
+        # tasks that will close them (discogsography-4ajv).
+        self._draining: list[Any] = []
+        self._close_tasks: set[asyncio.Task[None]] = set()
 
     async def _aclose_connection(self, connection: Any) -> None:
         """Best-effort close of a connection, dispatching aclose()/close() like close()."""
@@ -351,20 +367,103 @@ class AsyncResilientConnection[T]:
         except Exception as e:
             logger.warning(f"⚠️ {self.name}: Error closing connection: {e}")
 
+    async def _probe_connection(self, connection: T) -> bool:
+        """Run the health check, never letting it raise."""
+        try:
+            return bool(await self._test_connection(connection))
+        except Exception as e:
+            logger.warning(f"⚠️ {self.name}: Connection test failed: {e}")
+            return False
+
+    async def _connection_is_usable(self, connection: T) -> bool:
+        """Decide whether an existing connection may still be handed out.
+
+        Two guards keep a merely BUSY connection from being torn down
+        (discogsography-4ajv):
+
+        * a successful probe is trusted for ``health_check_ttl`` seconds, so
+          borrowing does not pay a health round trip per call — that round trip
+          is also what made the pool-starvation trigger reachable; and
+        * ``unhealthy_threshold`` CONSECUTIVE probe failures are required before
+          the connection is declared dead. One failure is not proof the server
+          is gone: a pool-acquisition timeout means every slot is busy, i.e. the
+          connection is working, and replacing it would abort the in-flight work
+          of every other coroutine holding a session borrowed from it.
+        """
+        now = time.monotonic()
+        if self._last_healthy_at and now - self._last_healthy_at < self.health_check_ttl:
+            return True
+
+        if await self._probe_connection(connection):
+            self._failed_probes = 0
+            self._last_healthy_at = now
+            return True
+
+        self._failed_probes += 1
+        if self._failed_probes < self.unhealthy_threshold:
+            logger.warning(
+                f"⚠️ {self.name}: Health check failed ({self._failed_probes}/{self.unhealthy_threshold}) — "
+                "keeping the existing connection; in-flight borrowers must not be aborted on one probe"
+            )
+            return True
+
+        logger.error(f"❌ {self.name}: Health check failed {self._failed_probes} consecutive times — replacing the connection")
+        return False
+
+    def _schedule_deferred_close(self, connection: Any) -> None:
+        """Close a replaced connection only after in-flight borrowers can drain.
+
+        The manager's lock serializes access to the HANDLE, never use of the
+        object: a caller keeps using a session borrowed from it long after
+        get_connection() returned, and the neo4j driver documents close() as
+        NOT concurrency-safe with live sessions. So the replaced connection is
+        detached immediately and closed after ``close_grace_period``
+        (discogsography-4ajv).
+        """
+        if connection is None:
+            return
+        self._draining.append(connection)
+        task = asyncio.create_task(self._close_after_grace(connection))
+        self._close_tasks.add(task)
+        task.add_done_callback(self._close_tasks.discard)
+
+    async def _close_after_grace(self, connection: Any) -> None:
+        """Wait out the grace period, then close a detached connection."""
+        if self.close_grace_period > 0:
+            await asyncio.sleep(self.close_grace_period)
+        try:
+            await self._aclose_connection(connection)
+        finally:
+            with contextlib.suppress(ValueError):
+                self._draining.remove(connection)
+
+    async def _drain_deferred_closes(self) -> None:
+        """Close every detached connection immediately (explicit shutdown)."""
+        for task in list(self._close_tasks):
+            task.cancel()
+        self._close_tasks.clear()
+        draining, self._draining = self._draining, []
+        for connection in draining:
+            await self._aclose_connection(connection)
+
     async def get_connection(self) -> T:
         """Get a healthy connection, creating or reconnecting if needed."""
         if self._lock is None:
             self._lock = asyncio.Lock()
         async with self._lock:
-            if self._connection and await self._test_connection(self._connection):
-                return self._connection
+            connection = self._connection
+            if connection is not None:
+                if await self._connection_is_usable(connection):
+                    return connection
 
-            # The existing connection is unhealthy. Close and discard it BEFORE reconnecting —
-            # otherwise the retry loop overwrites self._connection and orphans the old object
-            # (e.g. a whole Neo4j driver pool of 50 sockets that GC cannot close via __del__).
-            if self._connection is not None:
-                await self._aclose_connection(self._connection)
+                # Declared dead. Detach it BEFORE reconnecting — otherwise the retry loop
+                # overwrites self._connection and orphans the old object (e.g. a whole Neo4j
+                # driver pool of 50 sockets that GC cannot close via __del__) — but close it
+                # on a grace timer rather than out from under live sessions.
                 self._connection = None
+                self._failed_probes = 0
+                self._last_healthy_at = 0.0
+                self._schedule_deferred_close(connection)
 
             # Connection is not healthy, try to create new one
             retry_count = 0
@@ -392,6 +491,10 @@ class AsyncResilientConnection[T]:
 
                     conn = await self.circuit_breaker.call_async(create_connection)
                     self._connection = cast("T", conn)
+                    # create_connection already health-checked it — don't re-probe
+                    # borrowers for another health_check_ttl seconds.
+                    self._last_healthy_at = time.monotonic()
+                    self._failed_probes = 0
                     logger.info(f"✅ {self.name}: Connection established successfully")
                     return cast("T", conn)
 
@@ -425,9 +528,12 @@ class AsyncResilientConnection[T]:
         if self._lock is None:
             self._lock = asyncio.Lock()
         async with self._lock:
+            await self._drain_deferred_closes()
             if self._connection is not None:
                 await self._aclose_connection(self._connection)
                 self._connection = None
+            self._last_healthy_at = 0.0
+            self._failed_probes = 0
 
 
 # Context managers for resilient connections

--- a/common/db_resilience.py
+++ b/common/db_resilience.py
@@ -316,6 +316,12 @@ class ResilientConnection[T]:
                 self._connection = None
 
 
+def _consume_task_exception(task: "asyncio.Task[Any]") -> None:
+    """Retrieve a finished task's exception so asyncio does not warn about it."""
+    if not task.cancelled():
+        task.exception()
+
+
 class AsyncResilientConnection[T]:
     """Async version of resilient database connection."""
 
@@ -330,6 +336,7 @@ class AsyncResilientConnection[T]:
         health_check_ttl: float = 30.0,
         unhealthy_threshold: int = 3,
         close_grace_period: float = 30.0,
+        reconnect_cooldown: float = 5.0,
     ):
         self.connection_factory = connection_factory
         self.connection_test = connection_test
@@ -343,10 +350,18 @@ class AsyncResilientConnection[T]:
         self.unhealthy_threshold = unhealthy_threshold
         # Seconds a replaced connection is left open so in-flight borrowers can drain.
         self.close_grace_period = close_grace_period
+        # Seconds after a fully failed reconnect cycle during which callers fail
+        # fast instead of each repeating the cycle (discogsography-y1qn).
+        self.reconnect_cooldown = reconnect_cooldown
         self._connection: T | None = None
         self._lock: asyncio.Lock | None = None
         self._last_healthy_at: float = 0.0
         self._failed_probes: int = 0
+        # The single in-flight reconnect cycle, shared by all waiters, plus the
+        # memo of the last failed one.
+        self._reconnect_task: asyncio.Task[T] | None = None
+        self._last_failure_at: float | None = None
+        self._last_failure_error: Exception | None = None
         # Connections detached from the manager but not yet closed, and the
         # tasks that will close them (discogsography-4ajv).
         self._draining: list[Any] = []
@@ -366,6 +381,12 @@ class AsyncResilientConnection[T]:
                     connection.close()
         except Exception as e:
             logger.warning(f"⚠️ {self.name}: Error closing connection: {e}")
+
+    def _get_lock(self) -> asyncio.Lock:
+        """Return the handle lock, creating it lazily on the running event loop."""
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+        return self._lock
 
     async def _probe_connection(self, connection: T) -> bool:
         """Run the health check, never letting it raise."""
@@ -439,6 +460,11 @@ class AsyncResilientConnection[T]:
 
     async def _drain_deferred_closes(self) -> None:
         """Close every detached connection immediately (explicit shutdown)."""
+        if self._reconnect_task is not None and not self._reconnect_task.done():
+            self._reconnect_task.cancel()
+        self._reconnect_task = None
+        self._last_failure_at = None
+        self._last_failure_error = None
         for task in list(self._close_tasks):
             task.cancel()
         self._close_tasks.clear()
@@ -447,9 +473,23 @@ class AsyncResilientConnection[T]:
             await self._aclose_connection(connection)
 
     async def get_connection(self) -> T:
-        """Get a healthy connection, creating or reconnecting if needed."""
+        """Get a healthy connection, creating or reconnecting if needed.
+
+        The manager's lock guards ONLY the connection handle. The reconnect
+        cycle — up to ``max_retries`` driver-creation attempts, each of which can
+        block for the driver's whole acquisition timeout, plus the backoff
+        sleeps between them — runs OUTSIDE the lock as a single shared task
+        (discogsography-y1qn). Before the fix, the first caller held the process
+        singleton lock for the entire failed cycle, every other coroutine in the
+        process queued behind it, and each waiter then re-ran the full cycle
+        itself, so the k-th caller failed only after roughly k cycles. Now
+        concurrent callers join the one in-flight reconnect, and callers arriving
+        inside ``reconnect_cooldown`` of a failed cycle fail fast instead of
+        repeating it.
+        """
         if self._lock is None:
             self._lock = asyncio.Lock()
+
         async with self._lock:
             connection = self._connection
             if connection is not None:
@@ -465,51 +505,80 @@ class AsyncResilientConnection[T]:
                 self._last_healthy_at = 0.0
                 self._schedule_deferred_close(connection)
 
-            # Connection is not healthy, try to create new one
-            retry_count = 0
-            last_error = None
+            # Fail fast if another coroutine just burned a full failed cycle:
+            # repeating it would only stack another multi-minute wait onto a
+            # caller that is going to fail anyway.
+            if self._last_failure_at is not None and time.monotonic() - self._last_failure_at < self.reconnect_cooldown:
+                raise ConnectionEstablishmentError(
+                    f"{self.name}: Connection unavailable — a reconnect cycle failed less than {self.reconnect_cooldown:.0f}s ago"
+                ) from self._last_failure_error
 
-            while retry_count < self.max_retries:
-                try:
-                    logger.info(f"🔄 {self.name}: Creating new connection (attempt {retry_count + 1}/{self.max_retries})")
+            if self._reconnect_task is None or self._reconnect_task.done():
+                self._reconnect_task = asyncio.create_task(self._reconnect())
+                # Mark the failure retrieved even if every waiter is cancelled,
+                # so a failed cycle cannot log "exception was never retrieved".
+                self._reconnect_task.add_done_callback(_consume_task_exception)
+            task = self._reconnect_task
 
-                    async def create_connection() -> T:
-                        if asyncio.iscoroutinefunction(self.connection_factory):
-                            conn = await self.connection_factory()
-                        else:
-                            conn = self.connection_factory()
-                        if asyncio.iscoroutinefunction(self.connection_test):
-                            test_ok = await self.connection_test(conn)
-                        else:
-                            test_ok = self.connection_test(conn)
-                        if not test_ok:
-                            # Close the just-built connection before discarding it, so a failed
-                            # health test does not leak a fresh pool/socket per attempt.
-                            await self._aclose_connection(conn)
-                            raise ConnectionEstablishmentError("Connection test failed")
-                        return cast("T", conn)
+        # Awaited WITHOUT the lock so borrowers of a still-healthy connection
+        # (and close()) are never blocked behind a reconnect, and so every
+        # concurrent caller joins the SAME cycle instead of running its own.
+        # Shielded so one cancelled waiter cannot cancel the shared cycle.
+        return await asyncio.shield(task)
 
-                    conn = await self.circuit_breaker.call_async(create_connection)
+    async def _reconnect(self) -> T:
+        """Run the retry/backoff cycle, publishing the result under the lock."""
+        retry_count = 0
+        last_error: Exception | None = None
+
+        while retry_count < self.max_retries:
+            try:
+                logger.info(f"🔄 {self.name}: Creating new connection (attempt {retry_count + 1}/{self.max_retries})")
+
+                async def create_connection() -> T:
+                    if asyncio.iscoroutinefunction(self.connection_factory):
+                        conn = await self.connection_factory()
+                    else:
+                        conn = self.connection_factory()
+                    if asyncio.iscoroutinefunction(self.connection_test):
+                        test_ok = await self.connection_test(conn)
+                    else:
+                        test_ok = self.connection_test(conn)
+                    if not test_ok:
+                        # Close the just-built connection before discarding it, so a failed
+                        # health test does not leak a fresh pool/socket per attempt.
+                        await self._aclose_connection(conn)
+                        raise ConnectionEstablishmentError("Connection test failed")
+                    return cast("T", conn)
+
+                conn = await self.circuit_breaker.call_async(create_connection)
+
+                # Publishing the handle is the only step that needs the lock.
+                async with self._get_lock():
                     self._connection = cast("T", conn)
                     # create_connection already health-checked it — don't re-probe
                     # borrowers for another health_check_ttl seconds.
                     self._last_healthy_at = time.monotonic()
                     self._failed_probes = 0
-                    logger.info(f"✅ {self.name}: Connection established successfully")
-                    return cast("T", conn)
+                    self._last_failure_at = None
+                    self._last_failure_error = None
+                logger.info(f"✅ {self.name}: Connection established successfully")
+                return cast("T", conn)
 
-                except Exception as e:
-                    last_error = e
-                    retry_count += 1
+            except Exception as e:
+                last_error = e
+                retry_count += 1
 
-                    if retry_count < self.max_retries:
-                        delay = self.backoff.get_delay(retry_count - 1)
-                        logger.warning(f"⚠️ {self.name}: Connection attempt {retry_count} failed: {e}. Retrying in {delay:.1f} seconds...")
-                        await asyncio.sleep(delay)
-                    else:
-                        logger.error(f"❌ {self.name}: All connection attempts failed")
+                if retry_count < self.max_retries:
+                    delay = self.backoff.get_delay(retry_count - 1)
+                    logger.warning(f"⚠️ {self.name}: Connection attempt {retry_count} failed: {e}. Retrying in {delay:.1f} seconds...")
+                    await asyncio.sleep(delay)
+                else:
+                    logger.error(f"❌ {self.name}: All connection attempts failed")
 
-            raise ConnectionEstablishmentError(f"{self.name}: Failed to establish connection after {self.max_retries} attempts") from last_error
+        self._last_failure_at = time.monotonic()
+        self._last_failure_error = last_error
+        raise ConnectionEstablishmentError(f"{self.name}: Failed to establish connection after {self.max_retries} attempts") from last_error
 
     async def _test_connection(self, connection: T) -> bool:
         """Test if connection is healthy."""

--- a/common/neo4j_resilient.py
+++ b/common/neo4j_resilient.py
@@ -167,6 +167,9 @@ class AsyncResilientNeo4jDriver(AsyncResilientConnection[Any]):
         if self._lock is None:
             self._lock = asyncio.Lock()
         async with self._lock:
+            # Drivers replaced by a reconnect are closed on a grace timer; an
+            # explicit shutdown closes them now (discogsography-4ajv).
+            await self._drain_deferred_closes()
             if self._connection:
                 try:
                     await self._connection.close()
@@ -175,6 +178,8 @@ class AsyncResilientNeo4jDriver(AsyncResilientConnection[Any]):
                     logger.warning(f"⚠️ Error closing async Neo4j driver: {e}")
                 finally:
                     self._connection = None
+            self._last_healthy_at = 0.0
+            self._failed_probes = 0
 
 
 # Helper function to handle transaction retries

--- a/common/outage_backoff.py
+++ b/common/outage_backoff.py
@@ -1,0 +1,86 @@
+"""Backoff for per-message consumers that requeue on a database outage.
+
+Per-message consumers handle "the database is down" by
+``nack(requeue=True)``. Their main queues are quorum queues declared with
+``x-delivery-limit: 20``, so every redelivery spends part of a FIXED budget with
+no time dimension: with no pause between cycles a message is redelivered every
+few seconds and reaches 20 deliveries in ~3 minutes, at which point RabbitMQ
+dead-letters a perfectly valid record. A sustained outage therefore drains the
+head of the queue into the DLQ — silent data loss from a routine maintenance
+window (discogsography-rb05).
+
+The batch-mode consumers dodged this by moving retry state out of the broker and
+into process memory (deque + backoff). The per-message consumers keep retry state
+in the broker, so the only lever is to slow the treadmill down: hold the delivery
+for a growing delay before nacking, so 20 deliveries span an outage-sized window
+instead of a coffee break.
+"""
+
+import asyncio
+
+import structlog
+
+
+logger = structlog.get_logger(__name__)
+
+# Delay applied before the FIRST requeue of an outage, in seconds.
+DEFAULT_INITIAL_DELAY = 2.0
+# Ceiling for the per-redelivery delay, in seconds. With x-delivery-limit=20 a
+# capped delay of 60s buys ~20 minutes of outage tolerance per message.
+DEFAULT_MAX_DELAY = 60.0
+
+
+class OutageBackoff:
+    """Growing delay applied before requeueing during a backend outage.
+
+    One instance per consumer process. It is deliberately NOT per-message: the
+    thing being throttled is the outage, and every in-flight delivery is hitting
+    the same dead backend.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        initial_delay: float = DEFAULT_INITIAL_DELAY,
+        max_delay: float = DEFAULT_MAX_DELAY,
+        multiplier: float = 2.0,
+    ) -> None:
+        self.name = name
+        self.initial_delay = initial_delay
+        self.max_delay = max_delay
+        self.multiplier = multiplier
+        self._consecutive_failures = 0
+
+    @property
+    def consecutive_failures(self) -> int:
+        """Number of consecutive transient failures since the last success."""
+        return self._consecutive_failures
+
+    def reset(self) -> None:
+        """Record a success — the backend is answering again."""
+        self._consecutive_failures = 0
+
+    def next_delay(self) -> float:
+        """Count one transient failure and return the delay to apply."""
+        self._consecutive_failures += 1
+        return min(
+            self.initial_delay * (self.multiplier ** (self._consecutive_failures - 1)),
+            self.max_delay,
+        )
+
+    async def wait(self) -> float:
+        """Count a transient failure and sleep for the resulting delay.
+
+        Call this immediately BEFORE ``message.nack(requeue=True)`` so the
+        redelivery that follows costs wall-clock time rather than just another
+        slot of the quorum queue's delivery budget.
+        """
+        delay = self.next_delay()
+        logger.warning(
+            "⏳ Backing off before requeue — backend unavailable",
+            consumer=self.name,
+            delay_seconds=round(delay, 1),
+            consecutive_failures=self._consecutive_failures,
+        )
+        await asyncio.sleep(delay)
+        return delay

--- a/explore/explore.py
+++ b/explore/explore.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Explore service for interactive graph exploration of Discogs data."""
 
+import asyncio
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
@@ -100,6 +101,17 @@ _PROXY_SKIP_HEADERS = frozenset({"host", "content-length", "transfer-encoding", 
 # api/routers/nlq.py) for the NLQ 'Ask' streaming endpoint.
 _STREAMING_CONTENT_TYPE_PREFIX = "text/event-stream"
 
+# Total budget for connect/write/pool, and the default read budget for every
+# BUFFERED proxied response.
+_PROXY_TIMEOUT_SECONDS = 150.0
+
+# The only upstream paths that stream (SSE). The timeout has to be chosen before
+# the response's content-type is known, so the read timeout may only be disabled
+# for these — disabling it for every request meant a stalled upstream wedged a
+# buffered request forever, pinning an httpx pool connection and a server task
+# with no deadline until the pool was exhausted (discogsography-gav8).
+_STREAMING_PATHS = frozenset({"nlq/query"})
+
 _http_client: httpx.AsyncClient | None = None
 
 
@@ -108,6 +120,26 @@ def _get_http_client() -> httpx.AsyncClient:
         msg = "HTTP client not initialized — service not started"
         raise RuntimeError(msg)
     return _http_client
+
+
+def _is_streaming_path(path: str) -> bool:
+    """Whether this upstream path returns an SSE stream."""
+    return path.strip("/") in _STREAMING_PATHS
+
+
+def _proxy_timeout(path: str) -> httpx.Timeout:
+    """Build the per-request timeout, disabling the read budget for SSE only.
+
+    An SSE response may legitimately go quiet between events for longer than the
+    total timeout (e.g. a long Anthropic generation phase), so streaming paths
+    get `read=None`. Every other path keeps a bounded read timeout: without it
+    `client.send()`/`aread()` on a buffered response had no deadline at all, and
+    a stalled-but-connected upstream (hung Neo4j query, half-open TCP after an
+    OOM-kill) parked the request forever (discogsography-gav8).
+    """
+    if _is_streaming_path(path):
+        return httpx.Timeout(_PROXY_TIMEOUT_SECONDS, read=None)
+    return httpx.Timeout(_PROXY_TIMEOUT_SECONDS)
 
 
 @app.api_route("/api/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
@@ -150,16 +182,22 @@ async def proxy_api(path: str, request: Request) -> Response:
         params=httpx.QueryParams(tuple(request.query_params.multi_items())),
         content=await request.body(),
         headers=forward_headers,
-        # Disable the read timeout: an SSE response may legitimately go quiet
-        # between events for longer than the client's total 150s timeout without
-        # being stalled (e.g. a long Anthropic generation phase). Connect/write/pool
-        # timeouts are unchanged so a genuinely dead upstream is still caught.
-        timeout=httpx.Timeout(150.0, read=None),
+        # Read timeout disabled for SSE paths only — see _proxy_timeout.
+        timeout=_proxy_timeout(path),
     )
 
     try:
-        proxied = await client.send(req, stream=True)
-    except httpx.TimeoutException:
+        if _is_streaming_path(path):
+            # The read timeout is disabled for this path, and httpx's read
+            # timeout also covers waiting for the response HEADERS — so bound
+            # the header phase explicitly. Otherwise an upstream that accepts
+            # the connection and then stalls before responding parks this task
+            # (and its pool connection) with no deadline at all.
+            async with asyncio.timeout(_PROXY_TIMEOUT_SECONDS):
+                proxied = await client.send(req, stream=True)
+        else:
+            proxied = await client.send(req, stream=True)
+    except (httpx.TimeoutException, TimeoutError):
         logger.warning("⚠️ Proxy request timed out", path=path)
         return JSONResponse(content={"error": "Request timed out"}, status_code=504)
     except httpx.HTTPError as exc:
@@ -185,15 +223,16 @@ async def proxy_api(path: str, request: Request) -> Response:
 
     try:
         await proxied.aread()
-    except httpx.TimeoutException:
-        await proxied.aclose()
+    except (httpx.TimeoutException, TimeoutError):
         logger.warning("⚠️ Proxy request timed out", path=path)
         return JSONResponse(content={"error": "Request timed out"}, status_code=504)
     except httpx.HTTPError as exc:
-        await proxied.aclose()
         logger.error("❌ Proxy request failed", path=path, error=describe_exception(exc))
         return JSONResponse(content={"error": "Upstream service error"}, status_code=502)
-    await proxied.aclose()
+    finally:
+        # finally, not per-branch: a client disconnect cancels this task mid-read,
+        # and the pool connection must be released on that path too.
+        await proxied.aclose()
 
     return Response(content=proxied.content, status_code=proxied.status_code, headers=response_headers)
 

--- a/extractor/src/message_queue.rs
+++ b/extractor/src/message_queue.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use lapin::{BasicProperties, Channel, Connection, ConnectionProperties, ExchangeKind, options::*, types::FieldTable};
+use lapin::{BasicProperties, Channel, Confirmation, Connection, ConnectionProperties, ExchangeKind, options::*, types::FieldTable};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -14,6 +14,19 @@ use crate::types::{DataMessage, DataType, ExtractionCompleteMessage, FileComplet
 #[allow(dead_code)]
 const DEFAULT_EXCHANGE_PREFIX: &str = "discogsography-discogs";
 const AMQP_EXCHANGE_TYPE: ExchangeKind = ExchangeKind::Fanout;
+
+/// Deadline for a publisher-confirm to come back from the broker.
+///
+/// Publisher confirms are enabled (`confirm_select`), and awaiting the confirm
+/// future had no timeout. When RabbitMQ trips a memory or `disk_free` alarm it
+/// stops acking publishes while leaving the connection TCP-connected, so
+/// `get_channel`'s reconnect path — which only fires on a DISCONNECTED channel —
+/// never triggers. The publisher task then parks forever, the bounded
+/// batch channel fills, the batcher blocks on `send().await`, and the whole
+/// per-file pipeline wedges. The shutdown flag is only polled BETWEEN files, so
+/// SIGTERM cannot break it and the container is SIGKILLed
+/// (discogsography-rehd).
+const PUBLISH_CONFIRM_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[cfg_attr(feature = "test-support", mockall::automock)]
 #[async_trait]
@@ -131,6 +144,32 @@ impl MessageQueue {
             .with_delivery_mode(2) // Persistent
     }
 
+    /// Await a publisher-confirm under a bounded deadline.
+    ///
+    /// A stalled broker (resource alarm / flow control) keeps the connection up
+    /// while withholding acks, so an unbounded await never resolves. Timing out
+    /// turns the wedge into an error the caller can count and retry, and lets
+    /// the task fail cleanly instead of parking the whole pipeline
+    /// (discogsography-rehd).
+    async fn await_confirm<F>(confirm_future: F) -> Result<()>
+    where
+        F: std::future::Future<Output = lapin::Result<Confirmation>>,
+    {
+        let confirm = match tokio::time::timeout(PUBLISH_CONFIRM_TIMEOUT, confirm_future).await {
+            Ok(result) => result.context("Failed to confirm message delivery")?,
+            Err(_) => {
+                error!("❌ Publisher confirm timed out after {:?} — broker may be under a resource alarm", PUBLISH_CONFIRM_TIMEOUT);
+                return Err(anyhow::anyhow!("Timed out after {:?} waiting for publisher confirm", PUBLISH_CONFIRM_TIMEOUT));
+            }
+        };
+
+        if !confirm.is_ack() {
+            return Err(anyhow::anyhow!("Message was not acknowledged by broker"));
+        }
+
+        Ok(())
+    }
+
     async fn get_channel(&self) -> Result<Channel> {
         // Fast path: check if channel is connected under read lock
         {
@@ -190,16 +229,12 @@ impl MessagePublisher for MessageQueue {
         let exchange_name = self.exchange_name(data_type);
         let payload = serde_json::to_vec(&message).context("Failed to serialize message")?;
 
-        let confirm = channel
+        let publish = channel
             .basic_publish(exchange_name.as_str().into(), "".into(), BasicPublishOptions::default(), &payload, Self::message_properties())
             .await
-            .context("Failed to publish message")?
-            .await
-            .context("Failed to confirm message delivery")?;
+            .context("Failed to publish message")?;
 
-        if !confirm.is_ack() {
-            return Err(anyhow::anyhow!("Message was not acknowledged by broker"));
-        }
+        Self::await_confirm(publish).await?;
 
         Ok(())
     }
@@ -211,16 +246,12 @@ impl MessagePublisher for MessageQueue {
         for message in messages {
             let payload = serde_json::to_vec(&Message::Data(message)).context("Failed to serialize message")?;
 
-            let confirm = channel
+            let publish = channel
                 .basic_publish(exchange_name.as_str().into(), "".into(), BasicPublishOptions::default(), &payload, Self::message_properties())
                 .await
-                .context("Failed to publish message")?
-                .await
-                .context("Failed to confirm message delivery")?;
+                .context("Failed to publish message")?;
 
-            if !confirm.is_ack() {
-                return Err(anyhow::anyhow!("Message was not acknowledged by broker"));
-            }
+            Self::await_confirm(publish).await?;
         }
 
         Ok(())

--- a/extractor/src/tests/message_queue_tests.rs
+++ b/extractor/src/tests/message_queue_tests.rs
@@ -307,3 +307,40 @@ async fn test_new_connection_failure_with_retries() {
     let err_msg = format!("{}", result.err().unwrap());
     assert!(err_msg.contains("Failed to connect to AMQP broker after retries"), "Unexpected error: {}", err_msg);
 }
+
+// ── Publisher-confirm timeout (discogsography-rehd) ────────────────────────────
+
+#[tokio::test]
+async fn test_await_confirm_accepts_ack() {
+    let result = MessageQueue::await_confirm(async { Ok(Confirmation::Ack(None)) }).await;
+    assert!(result.is_ok(), "an acked publish must succeed");
+}
+
+#[tokio::test]
+async fn test_await_confirm_rejects_nack() {
+    let result = MessageQueue::await_confirm(async { Ok(Confirmation::Nack(None)) }).await;
+    let err = result.expect_err("a nacked publish must be an error");
+    assert!(err.to_string().contains("not acknowledged"), "unexpected error: {}", err);
+}
+
+#[tokio::test(start_paused = true)]
+async fn test_await_confirm_times_out_on_stall() {
+    // A broker under a memory / disk_free alarm keeps the connection up while
+    // withholding acks, so the confirm future never resolves. Without a
+    // deadline the publisher task parks forever, the bounded batch channel
+    // fills, the batcher blocks, and the whole per-file pipeline wedges —
+    // SIGTERM cannot break it because the shutdown flag is only polled between
+    // files.
+    let stalled = std::future::pending::<lapin::Result<Confirmation>>();
+
+    let result = MessageQueue::await_confirm(stalled).await;
+
+    let err = result.expect_err("a stalled confirm must time out, not hang");
+    assert!(err.to_string().contains("Timed out"), "unexpected error: {}", err);
+}
+
+#[test]
+fn test_publish_confirm_timeout_is_bounded() {
+    assert!(PUBLISH_CONFIRM_TIMEOUT > Duration::ZERO);
+    assert!(PUBLISH_CONFIRM_TIMEOUT <= Duration::from_secs(60));
+}

--- a/graphinator/batch_processor.py
+++ b/graphinator/batch_processor.py
@@ -104,6 +104,14 @@ class Neo4jBatchProcessor:
         # Lazy-initialized in first async method to avoid binding to wrong event loop.
         self._flush_semaphore: asyncio.Semaphore | None = None
 
+        # Per-data-type flush mutex — serializes flushes of the SAME data type.
+        # The locks are created lazily (never in __init__) because an
+        # asyncio.Lock binds to the event loop running at creation time.
+        # Without this, two flushes of one data type interleave and a healthy
+        # batch's success path resets _consecutive_failures, defeating the
+        # bounded poison guard forever (discogsography-2sm3).
+        self._flush_locks: dict[str, asyncio.Lock] = {}
+
         # Adaptive batch sizing — reduces under Neo4j pressure, recovers on success
         # Per-data-type so pressure on one type doesn't affect others
         self._effective_batch_size: dict[str, int] = {
@@ -217,11 +225,46 @@ class Neo4jBatchProcessor:
 
         return True
 
+    def _get_flush_lock(self, data_type: str) -> asyncio.Lock:
+        """Return the per-data-type flush mutex, creating it lazily.
+
+        An asyncio.Lock binds to the running event loop at creation time, so it
+        must never be created in __init__ or at module scope.
+        """
+        lock = self._flush_locks.get(data_type)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._flush_locks[data_type] = lock
+        return lock
+
     async def _flush_queue(self, data_type: str) -> None:
+        """Flush one batch for a data type, serialized against other flushes of it.
+
+        Concurrent callers for the SAME data type queue on a per-type mutex.
+        Serializing them is what makes the bounded poison guard work: a failed
+        poison batch is re-enqueued at the FRONT of the deque, so the next flush
+        of that type necessarily re-includes it and increments
+        _consecutive_failures. Without the mutex, a concurrently in-flight
+        healthy batch could succeed and reset the counter to zero, so the DLQ
+        nack branch never fired and the poison batch retried forever
+        (discogsography-2sm3).
+
+        Args:
+            data_type: The data type queue to flush
+        """
+        if not self.queues[data_type]:
+            return
+
+        async with self._get_flush_lock(data_type):
+            await self._flush_queue_locked(data_type)
+
+    async def _flush_queue_locked(self, data_type: str) -> None:
         """Flush a queue by processing all pending messages.
 
         Uses a semaphore to limit concurrent Neo4j operations across data types,
         exponential backoff on Neo4j errors, and adaptive batch sizing.
+
+        The caller MUST hold this data type's flush lock.
 
         Args:
             data_type: The data type queue to flush

--- a/graphinator/batch_processor.py
+++ b/graphinator/batch_processor.py
@@ -104,6 +104,16 @@ class Neo4jBatchProcessor:
         # Lazy-initialized in first async method to avoid binding to wrong event loop.
         self._flush_semaphore: asyncio.Semaphore | None = None
 
+        # Batches of each data type currently popped from the deque but not yet
+        # written/acked. A popped batch lives in a task-local list, so queue
+        # depth alone is blind to it (discogsography-uo8g).
+        self._in_flight: dict[str, int] = {
+            "artists": 0,
+            "labels": 0,
+            "masters": 0,
+            "releases": 0,
+        }
+
         # Per-data-type flush mutex — serializes flushes of the SAME data type.
         # The locks are created lazily (never in __init__) because an
         # asyncio.Lock binds to the event loop running at creation time.
@@ -237,6 +247,18 @@ class Neo4jBatchProcessor:
             self._flush_locks[data_type] = lock
         return lock
 
+    async def _wait_for_in_flight(self, data_type: str) -> None:
+        """Block until no batch of this data type is mid-write.
+
+        _flush_queue pops its batch into a task-local list before awaiting the
+        database, so an empty deque does NOT mean this type's writes are
+        committed. The per-type flush mutex is held for the whole
+        pop -> write -> ack cycle, so acquiring it gives callers the
+        happens-before edge they need (discogsography-uo8g).
+        """
+        async with self._get_flush_lock(data_type):
+            return
+
     async def _flush_queue(self, data_type: str) -> None:
         """Flush one batch for a data type, serialized against other flushes of it.
 
@@ -256,7 +278,11 @@ class Neo4jBatchProcessor:
             return
 
         async with self._get_flush_lock(data_type):
-            await self._flush_queue_locked(data_type)
+            self._in_flight[data_type] += 1
+            try:
+                await self._flush_queue_locked(data_type)
+            finally:
+                self._in_flight[data_type] -= 1
 
     async def _flush_queue_locked(self, data_type: str) -> None:
         """Flush a queue by processing all pending messages.
@@ -1220,7 +1246,14 @@ class Neo4jBatchProcessor:
             return as a completed file.
         """
         retries = 0
-        while self.queues.get(data_type):
+        while True:
+            # A concurrent flush may hold a popped batch that is still being
+            # written. Wait it out BEFORE judging the queue empty, or this
+            # returns while writes for this data type are still landing
+            # (discogsography-uo8g).
+            await self._wait_for_in_flight(data_type)
+            if not self.queues.get(data_type):
+                return True
             prev_len = len(self.queues[data_type])
             wait = self._backoff_until[data_type] - time.time()
             if wait > 0:
@@ -1239,7 +1272,6 @@ class Neo4jBatchProcessor:
                     max_retries=self.config.max_flush_retries,
                 )
                 return False
-        return True
 
     async def periodic_flush(self) -> None:
         """Background task that periodically flushes queues.
@@ -1268,6 +1300,7 @@ class Neo4jBatchProcessor:
             "processed": self.processed_counts.copy(),
             "batches": self.batch_counts.copy(),
             "pending": {k: len(v) for k, v in self.queues.items()},
+            "in_flight": self._in_flight.copy(),
             "effective_batch_size": self._effective_batch_size.copy(),
             "configured_batch_size": self.config.batch_size,
             "consecutive_failures": self._consecutive_failures.copy(),

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -19,11 +19,13 @@ from common import (
     AsyncResilientRabbitMQ,
     GraphinatorConfig,
     HealthServer,
+    OutageBackoff,
     neo4j_security_kwargs,
     normalize_record,
     setup_logging,
 )
 from common.credit_roles import categorize_role
+from common.db_resilience import DatabaseUnavailableError
 from neo4j.exceptions import ServiceUnavailable, SessionExpired, TransientError
 from orjson import loads
 
@@ -39,6 +41,12 @@ message_counts = {"artists": 0, "labels": 0, "masters": 0, "releases": 0}
 progress_interval = 100  # Log progress every 100 messages
 last_message_time = {"artists": 0.0, "labels": 0.0, "masters": 0.0, "releases": 0.0}
 completed_files: set[str] = set()  # Track which files have completed processing
+
+# Non-batch mode only: throttles requeues while Neo4j is unavailable, so an
+# outage cannot burn the quorum queue's x-delivery-limit budget and dead-letter
+# valid records. Batch mode gets the same protection from _flush_queue's
+# re-enqueue+backoff, which never nacks (discogsography-rb05).
+outage_backoff = OutageBackoff("graphinator")
 # Track which data types have delivered an extraction_complete signal. Stub
 # cleanup and aggregate stats are deferred until EVERY type has signalled, so
 # cross-type stub creation (release batches MERGE Artist/Label/Master stubs)
@@ -1492,6 +1500,9 @@ def make_message_handler(
             # if ack raises (exception handler would attempt nack on already-acked msg)
             await message.ack()
 
+            # Neo4j answered — clear the outage backoff.
+            outage_backoff.reset()
+
             message_counts[data_type] += 1
             last_message_time[data_type] = time.time()
             if message_counts[data_type] % progress_interval == 0:
@@ -1510,11 +1521,15 @@ def make_message_handler(
                     f"🔄 Skipped {data_type[:-1]} (no changes needed)",
                     record_id=record_id,
                 )
-        except (ServiceUnavailable, SessionExpired) as e:
+        except (ServiceUnavailable, SessionExpired, DatabaseUnavailableError) as e:
             logger.warning(
                 f"⚠️ Neo4j unavailable, will retry {data_type[:-1]} message",
                 error=str(e),
             )
+            # Pause before requeueing — x-delivery-limit=20 is a budget with no
+            # time dimension, so unthrottled requeues dead-letter valid records
+            # within minutes of a Neo4j outage (discogsography-rb05).
+            await outage_backoff.wait()
             try:
                 await message.nack(requeue=True)
             except Exception as nack_error:  # noqa: BLE001 - the nack path itself is best-effort; the broker will redeliver

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -51,7 +51,18 @@ outage_backoff = OutageBackoff("graphinator")
 # cleanup and aggregate stats are deferred until EVERY type has signalled, so
 # cross-type stub creation (release batches MERGE Artist/Label/Master stubs)
 # has fully stopped before we DETACH DELETE.
+#
+# This set is only a CACHE of the durable latch stored in Neo4j (see
+# _load_extraction_signals). Acking a signal destroys the only other copy — the
+# queued message — so a restart between the first and last signal used to lose
+# them all: the final signal then found 1-of-4, deferred forever, and post-import
+# maintenance silently never ran. The latch is also keyed by extraction VERSION,
+# so a long-lived process cannot carry a completed run's signals into the next
+# dump and fire maintenance while other queues are still importing
+# (discogsography-tk7v).
 extraction_complete_signals: set[str] = set()
+extraction_complete_version: str | None = None
+EXTRACTION_LATCH_UNKNOWN_VERSION = "unknown"
 # Post-import maintenance runs DETACHED from the AMQP delivery that triggers it
 # (see check_file_completion). Strong references are held here so the loop cannot
 # garbage-collect the task mid-flight.
@@ -514,6 +525,78 @@ async def _recover_consumers() -> None:
         consumer_tags.clear()
 
 
+async def _load_extraction_signals(version: str) -> set[str]:
+    """Read the durable extraction_complete latch for this version from Neo4j.
+
+    Returns the set of data types that have already signalled. Raises if Neo4j
+    cannot answer — the caller must requeue rather than assume "none signalled",
+    which would re-run maintenance state from scratch (discogsography-tk7v).
+    """
+    if graph is None:
+        return set()
+
+    async with graph.session(database="neo4j") as session:
+        result = await session.run(
+            "MATCH (m:ExtractionCompletion {version: $version}) RETURN m.signals AS signals",
+            version=version,
+        )
+        record = await result.single()
+
+    if record is None or record["signals"] is None:
+        return set()
+    return {str(signal) for signal in record["signals"]}
+
+
+async def _persist_extraction_signals(version: str, signals: set[str]) -> None:
+    """Write the extraction_complete latch for this version to Neo4j.
+
+    Called BEFORE the trigger message is acked, so the coordination state
+    outlives the delivery that carried it.
+    """
+    if graph is None:
+        return
+
+    async with graph.session(database="neo4j") as session:
+        await session.run(
+            """
+            MERGE (m:ExtractionCompletion {version: $version})
+            ON CREATE SET m.created_at = datetime()
+            SET m.signals = $signals, m.updated_at = datetime()
+            """,
+            version=version,
+            signals=sorted(signals),
+        )
+
+
+async def _sync_extraction_signals(version: str) -> None:
+    """Refresh the in-memory latch cache from Neo4j for this extraction version.
+
+    On a version change the cache is rebuilt from that version's durable latch
+    (usually empty), so signals from a previous dump can never satisfy the
+    all-four check for the new one.
+    """
+    global extraction_complete_signals, extraction_complete_version
+
+    if extraction_complete_version == version:
+        return
+
+    persisted = await _load_extraction_signals(version)
+    if extraction_complete_version is not None:
+        logger.info(
+            "🔄 New extraction version — resetting the completion latch",
+            previous_version=extraction_complete_version,
+            version=version,
+        )
+    extraction_complete_signals = persisted
+    extraction_complete_version = version
+    if persisted:
+        logger.info(
+            "📥 Restored extraction_complete signals",
+            version=version,
+            received=sorted(persisted),
+        )
+
+
 async def check_file_completion(
     data: dict[str, Any], data_type: str, message: AbstractIncomingMessage
 ) -> bool:
@@ -574,8 +657,24 @@ async def check_file_completion(
             return True
 
         # Record this type's completion signal (idempotent — safe under
-        # nack/requeue redelivery).
-        extraction_complete_signals.add(data_type)
+        # nack/requeue redelivery) in Neo4j BEFORE acking. The ack destroys the
+        # queued message, which was otherwise the only durable copy of this
+        # coordination state (discogsography-tk7v).
+        version = str(data.get("version") or EXTRACTION_LATCH_UNKNOWN_VERSION)
+        try:
+            await _sync_extraction_signals(version)
+            extraction_complete_signals.add(data_type)
+            await _persist_extraction_signals(version, extraction_complete_signals)
+        except Exception as e:  # noqa: BLE001 - a lost latch write must requeue, never ack
+            logger.error(
+                "❌ Failed to persist extraction_complete latch — requeueing the signal",
+                data_type=data_type,
+                version=version,
+                error=str(e),
+            )
+            extraction_complete_signals.discard(data_type)
+            await message.nack(requeue=True)
+            return True
 
         # Defer stub cleanup and stats until EVERY data type has signalled
         # extraction_complete. The four fanout queues drain at very different

--- a/tableinator/batch_processor.py
+++ b/tableinator/batch_processor.py
@@ -108,6 +108,14 @@ class PostgreSQLBatchProcessor:
         # simultaneously and exhausting the PostgreSQL connection pool
         self._flush_semaphore: asyncio.Semaphore | None = None
 
+        # Per-data-type flush mutex — serializes flushes of the SAME data type.
+        # The locks are created lazily (never in __init__) because an
+        # asyncio.Lock binds to the event loop running at creation time.
+        # Without this, two flushes of one data type interleave and a healthy
+        # batch's success path resets _consecutive_failures, defeating the
+        # bounded poison guard forever (discogsography-2sm3).
+        self._flush_locks: dict[str, asyncio.Lock] = {}
+
         # Adaptive batch sizing — reduces under PostgreSQL pressure, recovers on success
         # Per-data-type so pressure on one type doesn't affect others
         self._effective_batch_size: dict[str, int] = {
@@ -225,11 +233,46 @@ class PostgreSQLBatchProcessor:
 
         return True
 
+    def _get_flush_lock(self, data_type: str) -> asyncio.Lock:
+        """Return the per-data-type flush mutex, creating it lazily.
+
+        An asyncio.Lock binds to the running event loop at creation time, so it
+        must never be created in __init__ or at module scope.
+        """
+        lock = self._flush_locks.get(data_type)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._flush_locks[data_type] = lock
+        return lock
+
     async def _flush_queue(self, data_type: str) -> None:
+        """Flush one batch for a data type, serialized against other flushes of it.
+
+        Concurrent callers for the SAME data type queue on a per-type mutex.
+        Serializing them is what makes the bounded poison guard work: a failed
+        poison batch is re-enqueued at the FRONT of the deque, so the next flush
+        of that type necessarily re-includes it and increments
+        _consecutive_failures. Without the mutex, a concurrently in-flight
+        healthy batch could succeed and reset the counter to zero, so the DLQ
+        nack branch never fired and the poison batch retried forever
+        (discogsography-2sm3).
+
+        Args:
+            data_type: The data type queue to flush
+        """
+        if not self.queues[data_type]:
+            return
+
+        async with self._get_flush_lock(data_type):
+            await self._flush_queue_locked(data_type)
+
+    async def _flush_queue_locked(self, data_type: str) -> None:
         """Flush a queue by processing all pending messages.
 
         Uses a semaphore to limit concurrent PostgreSQL operations across data types,
         exponential backoff on PostgreSQL errors, and adaptive batch sizing.
+
+        The caller MUST hold this data type's flush lock.
 
         Args:
             data_type: The data type queue to flush

--- a/tableinator/batch_processor.py
+++ b/tableinator/batch_processor.py
@@ -108,6 +108,16 @@ class PostgreSQLBatchProcessor:
         # simultaneously and exhausting the PostgreSQL connection pool
         self._flush_semaphore: asyncio.Semaphore | None = None
 
+        # Batches of each data type currently popped from the deque but not yet
+        # written/acked. A popped batch lives in a task-local list, so queue
+        # depth alone is blind to it (discogsography-uo8g).
+        self._in_flight: dict[str, int] = {
+            "artists": 0,
+            "labels": 0,
+            "masters": 0,
+            "releases": 0,
+        }
+
         # Per-data-type flush mutex — serializes flushes of the SAME data type.
         # The locks are created lazily (never in __init__) because an
         # asyncio.Lock binds to the event loop running at creation time.
@@ -245,6 +255,18 @@ class PostgreSQLBatchProcessor:
             self._flush_locks[data_type] = lock
         return lock
 
+    async def _wait_for_in_flight(self, data_type: str) -> None:
+        """Block until no batch of this data type is mid-write.
+
+        _flush_queue pops its batch into a task-local list before awaiting the
+        database, so an empty deque does NOT mean this type's writes are
+        committed. The per-type flush mutex is held for the whole
+        pop -> write -> ack cycle, so acquiring it gives callers the
+        happens-before edge they need (discogsography-uo8g).
+        """
+        async with self._get_flush_lock(data_type):
+            return
+
     async def _flush_queue(self, data_type: str) -> None:
         """Flush one batch for a data type, serialized against other flushes of it.
 
@@ -264,7 +286,11 @@ class PostgreSQLBatchProcessor:
             return
 
         async with self._get_flush_lock(data_type):
-            await self._flush_queue_locked(data_type)
+            self._in_flight[data_type] += 1
+            try:
+                await self._flush_queue_locked(data_type)
+            finally:
+                self._in_flight[data_type] -= 1
 
     async def _flush_queue_locked(self, data_type: str) -> None:
         """Flush a queue by processing all pending messages.
@@ -595,7 +621,14 @@ class PostgreSQLBatchProcessor:
             return as a completed file.
         """
         retries = 0
-        while self.queues.get(data_type):
+        while True:
+            # A concurrent flush may hold a popped batch that is still being
+            # written. Wait it out BEFORE judging the queue empty, or this
+            # returns while writes for this data type are still landing
+            # (discogsography-uo8g).
+            await self._wait_for_in_flight(data_type)
+            if not self.queues.get(data_type):
+                return True
             prev_len = len(self.queues[data_type])
             wait = self._backoff_until[data_type] - time.time()
             if wait > 0:
@@ -614,7 +647,6 @@ class PostgreSQLBatchProcessor:
                     max_retries=self.config.max_flush_retries,
                 )
                 return False
-        return True
 
     async def periodic_flush(self) -> None:
         """Background task that periodically flushes queues.
@@ -643,6 +675,7 @@ class PostgreSQLBatchProcessor:
             "processed": self.processed_counts.copy(),
             "batches": self.batch_counts.copy(),
             "pending": {k: len(v) for k, v in self.queues.items()},
+            "in_flight": self._in_flight.copy(),
             "effective_batch_size": self._effective_batch_size.copy(),
             "configured_batch_size": self.config.batch_size,
             "consecutive_failures": self._consecutive_failures.copy(),

--- a/tableinator/tableinator.py
+++ b/tableinator/tableinator.py
@@ -17,7 +17,9 @@ from common import (
     DISCOGS_EXCHANGE_PREFIX,
     AsyncPostgreSQLPool,
     AsyncResilientRabbitMQ,
+    DatabaseUnavailableError,
     HealthServer,
+    OutageBackoff,
     TableinatorConfig,
     normalize_record,
     parse_postgres_host_port,
@@ -40,6 +42,12 @@ message_counts = {"artists": 0, "labels": 0, "masters": 0, "releases": 0}
 progress_interval = 100  # Log progress every 100 messages
 last_message_time = {"artists": 0.0, "labels": 0.0, "masters": 0.0, "releases": 0.0}
 completed_files: set[str] = set()  # Track which files have completed processing
+
+# Non-batch mode only: throttles requeues while PostgreSQL is unavailable, so an
+# outage cannot burn the quorum queue's x-delivery-limit budget and dead-letter
+# valid records. Batch mode gets the same protection from _flush_queue's
+# re-enqueue+backoff, which never nacks (discogsography-rb05).
+outage_backoff = OutageBackoff("tableinator")
 current_task = None
 current_progress = 0.0
 
@@ -848,6 +856,9 @@ async def on_data_message(message: AbstractIncomingMessage, data_type: str) -> N
 
         await message.ack()
 
+        # PostgreSQL answered — clear the outage backoff.
+        outage_backoff.reset()
+
         # Increment counter and log progress only after successful DB write and ack
         if data_type in message_counts:
             message_counts[data_type] += 1
@@ -859,8 +870,12 @@ async def on_data_message(message: AbstractIncomingMessage, data_type: str) -> N
                     data_type=data_type,
                 )
 
-    except (InterfaceError, OperationalError) as e:
+    except (InterfaceError, OperationalError, DatabaseUnavailableError) as e:
         logger.warning("⚠️ Database connection issue, will retry", error=str(e))
+        # Pause before requeueing — x-delivery-limit=20 is a budget with no time
+        # dimension, so unthrottled requeues dead-letter valid records within
+        # minutes of a database outage (discogsography-rb05).
+        await outage_backoff.wait()
         await message.nack(requeue=True)
     except Exception as e:  # noqa: BLE001 - per-message fault must nack rather than kill the consumer
         logger.error("❌ Failed to process message", data_type=data_type, error=str(e))

--- a/tests/api/test_auth_router.py
+++ b/tests/api/test_auth_router.py
@@ -38,6 +38,20 @@ def _make_encrypted_totp_secret() -> tuple[str, str]:
     return secret, encrypted
 
 
+def _challenge_only_get(value: str = TEST_USER_ID) -> AsyncMock:
+    """Build a redis.get mock that answers ONLY the 2fa_challenge key.
+
+    A blanket truthy get() also answers `revoked:jti:*` and
+    `password_changed:*`, which the challenge-staleness guard added for
+    discogsography-jxmn then (correctly) treats as an invalidated challenge.
+    """
+
+    async def _get(key: str) -> str | None:
+        return value if key.startswith("2fa_challenge:") else None
+
+    return AsyncMock(side_effect=_get)
+
+
 class TestResetRequest:
     """Tests for POST /api/auth/reset-request."""
 
@@ -566,7 +580,7 @@ class TestTwoFactorVerifyFull:
         secret, encrypted_secret = _make_encrypted_totp_secret()
         challenge_token = _make_challenge_token()
 
-        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.get = _challenge_only_get()
         mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
         mock_redis.delete = AsyncMock()
         mock_cur.fetchone = AsyncMock(
@@ -604,7 +618,7 @@ class TestTwoFactorVerifyFull:
         _secret, encrypted_secret = _make_encrypted_totp_secret()
         challenge_token = _make_challenge_token()
 
-        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.get = _challenge_only_get()
         mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
         mock_cur.fetchone = AsyncMock(
             return_value={
@@ -641,7 +655,7 @@ class TestTwoFactorVerifyFull:
         _secret, encrypted_secret = _make_encrypted_totp_secret()
         challenge_token = _make_challenge_token()
 
-        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.get = _challenge_only_get()
         mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
         # locked_until is in the future
         locked_until = datetime.now(UTC) + timedelta(minutes=10)
@@ -694,7 +708,7 @@ class TestTwoFactorVerifyFull:
         _secret, encrypted_secret = _make_encrypted_totp_secret()
         challenge_token = _make_challenge_token()
 
-        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.get = _challenge_only_get()
         mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
         mock_cur.fetchone = AsyncMock(
             return_value={
@@ -756,7 +770,7 @@ class TestTwoFactorRecoveryFull:
         plaintext_codes, hashed_codes = self._make_recovery_setup()
         challenge_token = _make_challenge_token()
 
-        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.get = _challenge_only_get()
         mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
         mock_redis.delete = AsyncMock()
         mock_cur.fetchone = AsyncMock(return_value={"totp_recovery_codes": json.dumps(hashed_codes)})
@@ -780,7 +794,7 @@ class TestTwoFactorRecoveryFull:
         _plaintext_codes, _hashed_codes = self._make_recovery_setup()
         challenge_token = _make_challenge_token()
 
-        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.get = _challenge_only_get()
         mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
         # The atomic UPDATE ... WHERE totp_recovery_codes ? %s matches no row for
         # an unknown code, so RETURNING yields nothing (fetchone -> None).
@@ -808,7 +822,7 @@ class TestTwoFactorRecoveryFull:
         last_hashed = [hash_recovery_code(last_code)]
         challenge_token = _make_challenge_token()
 
-        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.get = _challenge_only_get()
         mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
         mock_redis.delete = AsyncMock()
         # After the atomic UPDATE removes the last code, RETURNING yields an empty array.
@@ -834,7 +848,7 @@ class TestTwoFactorRecoveryFull:
         """No recovery codes stored should return 401."""
         challenge_token = _make_challenge_token()
 
-        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.get = _challenge_only_get()
         mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
         # No stored codes -> the guarded UPDATE matches no row -> RETURNING None.
         mock_cur.fetchone = AsyncMock(return_value=None)
@@ -854,7 +868,7 @@ class TestTwoFactorRecoveryFull:
         """No user row should return 401."""
         challenge_token = _make_challenge_token()
 
-        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.get = _challenge_only_get()
         mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
         mock_cur.fetchone = AsyncMock(return_value=None)
 
@@ -1142,7 +1156,7 @@ class TestTwoFactorVerifyEdgeCases:
         secret, encrypted_secret = _make_encrypted_totp_secret()
         token = _make_challenge_token()
 
-        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.get = _challenge_only_get()
         # getdel returns None — another request consumed the challenge between the
         # existence check and this success-path consume.
         mock_redis.getdel = AsyncMock(return_value=None)
@@ -1286,7 +1300,7 @@ class TestTwoFactorStateMachineRegressions:
         _secret, encrypted_secret = _make_encrypted_totp_secret()
         challenge_token = _make_challenge_token()
 
-        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.get = _challenge_only_get()
         mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
         mock_cur.fetchone = AsyncMock(return_value={"totp_secret": encrypted_secret, "totp_failed_attempts": 0, "totp_locked_until": None})
 
@@ -1314,7 +1328,7 @@ class TestTwoFactorStateMachineRegressions:
         _secret, encrypted_secret = _make_encrypted_totp_secret()
         challenge_token = _make_challenge_token()
 
-        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.get = _challenge_only_get()
         mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
         mock_cur.fetchone = AsyncMock(return_value={"totp_secret": encrypted_secret, "totp_failed_attempts": 0, "totp_locked_until": None})
 
@@ -1344,7 +1358,7 @@ class TestTwoFactorStateMachineRegressions:
         challenge_token = _make_challenge_token()
 
         past = datetime.now(UTC) - timedelta(minutes=1)
-        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.get = _challenge_only_get()
         mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
         mock_cur.fetchone = AsyncMock(return_value={"totp_secret": encrypted_secret, "totp_failed_attempts": 5, "totp_locked_until": past})
 
@@ -1373,7 +1387,7 @@ class TestTwoFactorStateMachineRegressions:
         plaintext_codes, _hashed_codes = generate_recovery_codes()
         challenge_token = _make_challenge_token()
 
-        mock_redis.get = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.get = _challenge_only_get()
         mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
         # RETURNING yields the array after the used code was removed atomically.
         mock_cur.fetchone = AsyncMock(return_value={"totp_recovery_codes": json.dumps([])})
@@ -1470,3 +1484,195 @@ class TestChangePassword:
         )
         assert response.status_code == 404
         assert response.json()["detail"] == "User not found"
+
+
+class TestChallengeSurvivesPasswordChange:
+    """Regression tests for discogsography-jxmn (2FA challenge outlives a reset)."""
+
+    @staticmethod
+    def _redis_with_password_change(changed_at: int) -> AsyncMock:
+        """redis.get answering both the challenge key and password_changed."""
+
+        async def _get(key: str) -> str | None:
+            if key.startswith("2fa_challenge:"):
+                return TEST_USER_ID
+            if key == f"password_changed:{TEST_USER_ID}":
+                return str(changed_at)
+            return None
+
+        redis = AsyncMock()
+        redis.get = AsyncMock(side_effect=_get)
+        redis.getdel = AsyncMock(return_value=TEST_USER_ID)
+        redis.setex = AsyncMock()
+        redis.delete = AsyncMock()
+        return redis
+
+    def test_verify_rejects_stale_challenge(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """A challenge minted before a password reset must not mint a token.
+
+        The attacker knows the old password (the exact scenario a reset
+        remediates) and holds a phished TOTP code. Before the fix, the challenge
+        stayed redeemable for its full 5-minute TTL and the token it minted had
+        an `iat` AFTER the password_changed marker, so it validated forever.
+        """
+        secret, encrypted_secret = _make_encrypted_totp_secret()
+        issued_at = int(datetime.now(UTC).timestamp()) - 60
+        challenge_token = create_challenge_token(TEST_USER_ID, TEST_USER_EMAIL, TEST_JWT_SECRET, issued_at=issued_at)
+
+        stale = self._redis_with_password_change(issued_at + 10)
+        mock_redis.get = stale.get
+        mock_redis.getdel = stale.getdel
+        mock_cur.fetchone = AsyncMock(
+            return_value={
+                "totp_secret": encrypted_secret,
+                "totp_failed_attempts": 0,
+                "totp_locked_until": None,
+            }
+        )
+
+        original_config = auth_router._config
+        auth_router._config = replace(original_config, encryption_master_key=_TEST_MASTER_KEY)
+        try:
+            response = test_client.post(
+                "/api/auth/2fa/verify",
+                json={"challenge_token": challenge_token, "code": pyotp.TOTP(secret).now()},
+            )
+        finally:
+            auth_router._config = original_config
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Challenge invalidated by password change"
+        mock_redis.getdel.assert_not_awaited()
+
+    def test_verify_rejects_same_second_change(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """Inclusive comparison: same-second change still invalidates (CLAUDE.md)."""
+        secret, encrypted_secret = _make_encrypted_totp_secret()
+        issued_at = int(datetime.now(UTC).timestamp()) - 30
+        challenge_token = create_challenge_token(TEST_USER_ID, TEST_USER_EMAIL, TEST_JWT_SECRET, issued_at=issued_at)
+
+        stale = self._redis_with_password_change(issued_at)
+        mock_redis.get = stale.get
+        mock_redis.getdel = stale.getdel
+        mock_cur.fetchone = AsyncMock(
+            return_value={
+                "totp_secret": encrypted_secret,
+                "totp_failed_attempts": 0,
+                "totp_locked_until": None,
+            }
+        )
+
+        original_config = auth_router._config
+        auth_router._config = replace(original_config, encryption_master_key=_TEST_MASTER_KEY)
+        try:
+            response = test_client.post(
+                "/api/auth/2fa/verify",
+                json={"challenge_token": challenge_token, "code": pyotp.TOTP(secret).now()},
+            )
+        finally:
+            auth_router._config = original_config
+
+        assert response.status_code == 401
+
+    def test_recovery_rejects_pre_change_challenge(
+        self,
+        test_client: TestClient,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """The recovery-code path carries the identical defect and fix."""
+        issued_at = int(datetime.now(UTC).timestamp()) - 60
+        challenge_token = create_challenge_token(TEST_USER_ID, TEST_USER_EMAIL, TEST_JWT_SECRET, issued_at=issued_at)
+
+        stale = self._redis_with_password_change(issued_at + 10)
+        mock_redis.get = stale.get
+        mock_redis.getdel = stale.getdel
+
+        response = test_client.post(
+            "/api/auth/2fa/recovery",
+            json={"challenge_token": challenge_token, "code": "AAAA-BBBB"},
+        )
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Challenge invalidated by password change"
+
+    def test_verify_token_uses_challenge_iat(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """The minted access token carries the challenge's iat, not `now`.
+
+        Otherwise a password change landing between the staleness check and the
+        mint would produce a token the marker can never invalidate.
+        """
+        from api.auth import decode_token
+
+        secret, encrypted_secret = _make_encrypted_totp_secret()
+        issued_at = int(datetime.now(UTC).timestamp()) - 120
+        challenge_token = create_challenge_token(TEST_USER_ID, TEST_USER_EMAIL, TEST_JWT_SECRET, issued_at=issued_at)
+
+        mock_redis.get = _challenge_only_get()
+        mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
+        mock_cur.fetchone = AsyncMock(
+            return_value={
+                "totp_secret": encrypted_secret,
+                "totp_failed_attempts": 0,
+                "totp_locked_until": None,
+            }
+        )
+
+        original_config = auth_router._config
+        auth_router._config = replace(original_config, encryption_master_key=_TEST_MASTER_KEY)
+        try:
+            response = test_client.post(
+                "/api/auth/2fa/verify",
+                json={"challenge_token": challenge_token, "code": pyotp.TOTP(secret).now()},
+            )
+        finally:
+            auth_router._config = original_config
+
+        assert response.status_code == 200
+        minted = decode_token(response.json()["access_token"], TEST_JWT_SECRET)
+        assert minted["iat"] == issued_at
+
+    def test_login_token_iat_precedes_password_read(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+    ) -> None:
+        """The login mint is stamped before hashed_password is read.
+
+        PBKDF2 verification takes ~100ms; a password change committing inside
+        that window must invalidate the token it produces.
+        """
+        from api.auth import _hash_password, decode_token
+
+        before = int(datetime.now(UTC).timestamp())
+        mock_cur.fetchone = AsyncMock(
+            return_value={
+                "id": TEST_USER_ID,
+                "email": TEST_USER_EMAIL,
+                "hashed_password": _hash_password("testpassword"),
+                "is_active": True,
+                "totp_enabled": False,
+            }
+        )
+
+        response = test_client.post(
+            "/api/auth/login",
+            json={"email": TEST_USER_EMAIL, "password": "testpassword"},
+        )
+
+        assert response.status_code == 200
+        minted = decode_token(response.json()["access_token"], TEST_JWT_SECRET)
+        assert minted["iat"] <= before

--- a/tests/brainzgraphinator/test_brainzgraphinator.py
+++ b/tests/brainzgraphinator/test_brainzgraphinator.py
@@ -2116,3 +2116,54 @@ class TestRecoverConsumersClearsTagsBrainzgraphinator:
 
         bg.consumer_tags = {}
         bg.queues = {}
+
+
+class TestOutageRequeueBackoff:
+    """Regression tests for discogsography-rb05 (Neo4j outage → dead-lettering)."""
+
+    @pytest.mark.asyncio
+    @patch("brainzgraphinator.brainzgraphinator.shutdown_requested", False)
+    async def test_neo4j_outage_engages_throttle(self, mock_neo4j_driver: MagicMock, sample_artist_record: dict[str, Any]) -> None:
+        """Prefetch here is 200, so an unthrottled outage puts 200 messages on
+        the redelivery treadmill at once and dead-letters them within minutes.
+        """
+        from common.outage_backoff import OutageBackoff
+
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        mock_message.body = dumps(sample_artist_record)
+
+        mock_session = await mock_neo4j_driver.session(database="neo4j").__aenter__()
+        mock_session.execute_write.side_effect = ServiceUnavailable("Neo4j is down")
+        backoff = OutageBackoff("test")
+
+        with (
+            patch("brainzgraphinator.brainzgraphinator.graph", mock_neo4j_driver),
+            patch("brainzgraphinator.brainzgraphinator.outage_backoff", backoff),
+        ):
+            await on_artist_message(mock_message)
+
+        assert backoff.consecutive_failures == 1
+        mock_message.nack.assert_called_once_with(requeue=True)
+
+    @pytest.mark.asyncio
+    @patch("brainzgraphinator.brainzgraphinator.shutdown_requested", False)
+    async def test_driver_unavailable_is_transient(self, mock_neo4j_driver: MagicMock, sample_artist_record: dict[str, Any]) -> None:
+        """DatabaseUnavailableError from the resilience layer is an outage too."""
+        from common.db_resilience import DatabaseUnavailableError
+        from common.outage_backoff import OutageBackoff
+
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        mock_message.body = dumps(sample_artist_record)
+
+        mock_session = await mock_neo4j_driver.session(database="neo4j").__aenter__()
+        mock_session.execute_write.side_effect = DatabaseUnavailableError("circuit open")
+        backoff = OutageBackoff("test")
+
+        with (
+            patch("brainzgraphinator.brainzgraphinator.graph", mock_neo4j_driver),
+            patch("brainzgraphinator.brainzgraphinator.outage_backoff", backoff),
+        ):
+            await on_artist_message(mock_message)
+
+        assert backoff.consecutive_failures == 1
+        mock_message.nack.assert_called_once_with(requeue=True)

--- a/tests/brainztableinator/test_brainztableinator.py
+++ b/tests/brainztableinator/test_brainztableinator.py
@@ -3102,3 +3102,104 @@ class TestRecoverConsumersClearsTagsBrainztableinator:
 
         bt.consumer_tags = {}
         bt.queues = {}
+
+
+class TestOutageRequeueBackoff:
+    """Regression tests for discogsography-rb05 (outage → mass dead-lettering)."""
+
+    @staticmethod
+    def _pool_raising(error: Exception) -> MagicMock:
+        mock_pool = MagicMock()
+        mock_conn_cm = AsyncMock()
+        mock_conn_cm.__aenter__ = AsyncMock(side_effect=error)
+        mock_conn_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_pool.connection = MagicMock(return_value=mock_conn_cm)
+        return mock_pool
+
+    @pytest.mark.asyncio
+    async def test_db_outage_waits_before_requeue(self):
+        """A transient DB failure must engage the throttle before requeueing.
+
+        The main queues are quorum queues with x-delivery-limit=20 — a budget
+        with no time dimension. Before the fix each redelivery cycle cost ~10s,
+        so a message hit 20 deliveries in ~3 minutes and RabbitMQ dead-lettered
+        a perfectly valid record part-way through a routine maintenance window.
+        """
+        from psycopg.errors import OperationalError
+
+        from common.outage_backoff import OutageBackoff
+
+        mock_message = AsyncMock()
+        mock_message.body = b'{"id": "550e8400-e29b-41d4-a716-446655440000", "name": "Test"}'
+        backoff = OutageBackoff("test", initial_delay=7.0, max_delay=7.0)
+
+        with (
+            patch("brainztableinator.brainztableinator.shutdown_requested", False),
+            patch("brainztableinator.brainztableinator.completed_files", set()),
+            patch(
+                "brainztableinator.brainztableinator.connection_pool",
+                self._pool_raising(OperationalError("server closed")),
+            ),
+            patch("brainztableinator.brainztableinator.outage_backoff", backoff),
+            patch.dict("brainztableinator.brainztableinator.PROCESSORS", {"artists": AsyncMock()}),
+        ):
+            await on_data_message(mock_message, "artists")
+
+        assert backoff.consecutive_failures == 1, "the requeue must be throttled during an outage"
+        mock_message.nack.assert_called_once_with(requeue=True)
+        mock_message.ack.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pool_unavailable_is_transient(self):
+        """DatabaseUnavailableError from the pool is an outage, not a poison record."""
+        from common.db_resilience import DatabaseUnavailableError
+        from common.outage_backoff import OutageBackoff
+
+        mock_message = AsyncMock()
+        mock_message.body = b'{"id": "550e8400-e29b-41d4-a716-446655440000", "name": "Test"}'
+        backoff = OutageBackoff("test", initial_delay=3.0, max_delay=3.0)
+
+        with (
+            patch("brainztableinator.brainztableinator.shutdown_requested", False),
+            patch("brainztableinator.brainztableinator.completed_files", set()),
+            patch(
+                "brainztableinator.brainztableinator.connection_pool",
+                self._pool_raising(DatabaseUnavailableError("pool exhausted")),
+            ),
+            patch("brainztableinator.brainztableinator.outage_backoff", backoff),
+            patch.dict("brainztableinator.brainztableinator.PROCESSORS", {"artists": AsyncMock()}),
+        ):
+            await on_data_message(mock_message, "artists")
+
+        assert backoff.consecutive_failures == 1
+        mock_message.nack.assert_called_once_with(requeue=True)
+
+    @pytest.mark.asyncio
+    async def test_success_resets_the_throttle(self):
+        """A successful write clears the outage counter."""
+        from common.outage_backoff import OutageBackoff
+
+        mock_message = AsyncMock()
+        mock_message.body = b'{"id": "550e8400-e29b-41d4-a716-446655440000", "name": "Test"}'
+        backoff = OutageBackoff("test")
+        backoff.next_delay()
+
+        mock_pool = MagicMock()
+        mock_conn = AsyncMock()
+        mock_conn.transaction = MagicMock(return_value=AsyncMock())
+        mock_conn_cm = AsyncMock()
+        mock_conn_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_pool.connection = MagicMock(return_value=mock_conn_cm)
+
+        with (
+            patch("brainztableinator.brainztableinator.shutdown_requested", False),
+            patch("brainztableinator.brainztableinator.completed_files", set()),
+            patch("brainztableinator.brainztableinator.connection_pool", mock_pool),
+            patch("brainztableinator.brainztableinator.outage_backoff", backoff),
+            patch.dict("brainztableinator.brainztableinator.PROCESSORS", {"artists": AsyncMock()}),
+        ):
+            await on_data_message(mock_message, "artists")
+
+        mock_message.ack.assert_called_once()
+        assert backoff.consecutive_failures == 0

--- a/tests/common/test_db_resilience.py
+++ b/tests/common/test_db_resilience.py
@@ -7,6 +7,11 @@ from unittest.mock import Mock
 import pytest
 
 from common.db_resilience import CircuitBreaker, CircuitBreakerConfig, CircuitState, ExponentialBackoff
+from common.outage_backoff import OutageBackoff as _OutageBackoff
+
+
+# Captured before the suite-wide fast_outage_backoff fixture replaces it.
+_REAL_OUTAGE_WAIT = _OutageBackoff.wait
 
 
 class TestCircuitBreaker:
@@ -1468,3 +1473,46 @@ class TestReconnectDoesNotHoldLock:
 
         assert await manager.get_connection() is conn
         assert factory.call_count == 2
+
+
+class TestOutageBackoff:
+    """Tests for the per-message consumer outage throttle (discogsography-rb05)."""
+
+    def test_delay_grows_and_is_capped(self) -> None:
+        from common.outage_backoff import OutageBackoff
+
+        backoff = OutageBackoff("test", initial_delay=1.0, max_delay=8.0, multiplier=2.0)
+
+        assert [backoff.next_delay() for _ in range(6)] == [1.0, 2.0, 4.0, 8.0, 8.0, 8.0]
+        assert backoff.consecutive_failures == 6
+
+    def test_success_resets_the_run(self) -> None:
+        from common.outage_backoff import OutageBackoff
+
+        backoff = OutageBackoff("test", initial_delay=1.0, max_delay=8.0)
+
+        backoff.next_delay()
+        backoff.next_delay()
+        backoff.reset()
+
+        assert backoff.consecutive_failures == 0
+        assert backoff.next_delay() == 1.0
+
+    @pytest.mark.asyncio
+    async def test_wait_sleeps_for_the_delay(self) -> None:
+        """The throttle really sleeps — that wall-clock cost IS the fix.
+
+        Calls the implementation captured at import time, since the suite-wide
+        `fast_outage_backoff` fixture replaces `wait` to keep other tests quick.
+        """
+        from unittest.mock import AsyncMock as _AsyncMock, patch as _patch
+
+        from common.outage_backoff import OutageBackoff
+
+        backoff = OutageBackoff("test", initial_delay=2.5, max_delay=30.0)
+
+        with _patch("asyncio.sleep", new_callable=_AsyncMock) as sleep:
+            delay = await _REAL_OUTAGE_WAIT(backoff)
+
+        assert delay == 2.5
+        sleep.assert_awaited_once_with(2.5)

--- a/tests/common/test_db_resilience.py
+++ b/tests/common/test_db_resilience.py
@@ -1346,3 +1346,125 @@ class TestConnectionTeardownHysteresis:
 
         # Exactly one call: the health test run while creating the connection.
         assert connection_test.call_count == 1
+
+
+class TestReconnectDoesNotHoldLock:
+    """Regression tests for discogsography-y1qn (lock held across retry/backoff)."""
+
+    @pytest.mark.asyncio
+    async def test_healthy_callers_not_blocked(self) -> None:
+        """A slow reconnect must not block callers of a healthy connection.
+
+        Before the fix the whole retry/backoff cycle ran under the process
+        singleton lock, so every Neo4j session acquisition in the process — API
+        requests, dashboard polls, batch flushes — queued behind one caller's
+        multi-minute outage cycle.
+        """
+        from common.db_resilience import AsyncResilientConnection
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+        conn = _FakeAsyncConn()
+
+        async def slow_factory() -> _FakeAsyncConn:
+            started.set()
+            await release.wait()
+            return conn
+
+        manager: AsyncResilientConnection[_FakeAsyncConn] = AsyncResilientConnection(
+            slow_factory,
+            Mock(return_value=True),
+            health_check_ttl=60.0,
+        )
+        # Pretend a healthy connection is already published.
+        existing = _FakeAsyncConn()
+        manager._connection = existing
+        manager._last_healthy_at = time.monotonic()
+
+        # Force a reconnect by expiring the cached health and failing the probe
+        # threshold, using a second manager so the first stays healthy.
+        reconnecting: AsyncResilientConnection[_FakeAsyncConn] = AsyncResilientConnection(
+            slow_factory,
+            Mock(return_value=True),
+        )
+        waiter = asyncio.create_task(reconnecting.get_connection())
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+
+        # While that cycle is parked mid-factory, the healthy manager must serve
+        # immediately, and the reconnecting manager's own lock must be free.
+        assert await asyncio.wait_for(manager.get_connection(), timeout=1.0) is existing
+        assert not reconnecting._get_lock().locked(), "reconnect must not hold the handle lock"
+
+        release.set()
+        assert await asyncio.wait_for(waiter, timeout=1.0) is conn
+
+    @pytest.mark.asyncio
+    async def test_waiters_share_one_reconnect_cycle(self) -> None:
+        """Concurrent callers join ONE cycle instead of each running their own.
+
+        Before the fix the k-th queued caller failed only after roughly k full
+        cycles (max_retries attempts plus backoff sleeps each).
+        """
+        from common.db_resilience import AsyncResilientConnection
+
+        attempts = 0
+        release = asyncio.Event()
+
+        async def slow_factory() -> _FakeAsyncConn:
+            nonlocal attempts
+            attempts += 1
+            await release.wait()
+            return _FakeAsyncConn()
+
+        manager: AsyncResilientConnection[_FakeAsyncConn] = AsyncResilientConnection(slow_factory, Mock(return_value=True))
+
+        waiters = [asyncio.create_task(manager.get_connection()) for _ in range(8)]
+        await asyncio.sleep(0)
+        release.set()
+        results = await asyncio.wait_for(asyncio.gather(*waiters), timeout=2.0)
+
+        assert attempts == 1, "one shared reconnect cycle, not one per caller"
+        assert len({id(conn) for conn in results}) == 1
+
+    @pytest.mark.asyncio
+    async def test_cooldown_fails_fast_after_cycle(self) -> None:
+        """A caller arriving right after a failed cycle fails fast."""
+        from common.db_resilience import AsyncResilientConnection, ConnectionEstablishmentError
+
+        factory = Mock(side_effect=RuntimeError("Neo4j is down"))
+        manager: AsyncResilientConnection[object] = AsyncResilientConnection(
+            factory,
+            Mock(return_value=True),
+            max_retries=1,
+            reconnect_cooldown=60.0,
+        )
+
+        with pytest.raises(ConnectionEstablishmentError):
+            await manager.get_connection()
+        assert factory.call_count == 1
+
+        with pytest.raises(ConnectionEstablishmentError, match="reconnect cycle failed"):
+            await manager.get_connection()
+
+        # No second cycle was run — the caller failed fast on the memo.
+        assert factory.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_cooldown_expiry_allows_retry(self) -> None:
+        """Once the cooldown lapses, a caller may run a fresh cycle."""
+        from common.db_resilience import AsyncResilientConnection, ConnectionEstablishmentError
+
+        conn = _FakeAsyncConn()
+        factory = Mock(side_effect=[RuntimeError("Neo4j is down"), conn])
+        manager: AsyncResilientConnection[_FakeAsyncConn] = AsyncResilientConnection(
+            factory,
+            Mock(return_value=True),
+            max_retries=1,
+            reconnect_cooldown=0.0,
+        )
+
+        with pytest.raises(ConnectionEstablishmentError):
+            await manager.get_connection()
+
+        assert await manager.get_connection() is conn
+        assert factory.call_count == 2

--- a/tests/common/test_db_resilience.py
+++ b/tests/common/test_db_resilience.py
@@ -1,5 +1,6 @@
 """Tests for database resilience utilities."""
 
+import asyncio
 import time
 from unittest.mock import Mock
 
@@ -1158,7 +1159,12 @@ class TestResilientConnectionCloseOnReplace:
 
     @pytest.mark.asyncio
     async def test_cu2_33_async_closes_old_connection_on_replace(self) -> None:
-        """Async: the old unhealthy connection must be closed before reconnecting."""
+        """Async: the old unhealthy connection must be closed before reconnecting.
+
+        Health caching and teardown hysteresis are disabled here so a single
+        failed probe replaces the connection; both are covered on their own by
+        TestConnectionTeardownHysteresis (discogsography-4ajv).
+        """
         from common.db_resilience import AsyncResilientConnection
 
         old_conn = _FakeAsyncConn()
@@ -1166,10 +1172,18 @@ class TestResilientConnectionCloseOnReplace:
         connection_factory = Mock(side_effect=[old_conn, new_conn])
         connection_test = Mock(side_effect=[True, False, True])
 
-        manager = AsyncResilientConnection(connection_factory, connection_test)
+        manager = AsyncResilientConnection(
+            connection_factory,
+            connection_test,
+            health_check_ttl=0.0,
+            unhealthy_threshold=1,
+            close_grace_period=0.0,
+        )
         assert await manager.get_connection() is old_conn
         assert await manager.get_connection() is new_conn
 
+        # The replaced connection is closed by a deferred task (zero grace here).
+        await asyncio.sleep(0)
         assert old_conn.closed_count == 1
         assert manager._connection is new_conn
 
@@ -1187,3 +1201,148 @@ class TestResilientConnectionCloseOnReplace:
         assert await manager.get_connection() is good_conn
 
         assert bad_conn.closed_count == 1
+
+
+class TestConnectionTeardownHysteresis:
+    """Regression tests for discogsography-4ajv (health-check TOCTOU teardown)."""
+
+    @pytest.mark.asyncio
+    async def test_single_failed_probe_keeps_connection(self) -> None:
+        """A lone failed probe must NOT close a connection with live borrowers.
+
+        Before the fix, one failed `RETURN 1` — which a saturated pool produces
+        purely from load, since session acquisition blocks up to
+        connection_acquisition_timeout and then raises — closed the shared
+        driver out from under every in-flight session.
+        """
+        from common.db_resilience import AsyncResilientConnection
+
+        conn = _FakeAsyncConn()
+        connection_factory = Mock(return_value=conn)
+        # Healthy at creation, then two probe failures (below the threshold of 3).
+        connection_test = Mock(side_effect=[True, False, False])
+
+        manager = AsyncResilientConnection(
+            connection_factory,
+            connection_test,
+            health_check_ttl=0.0,
+            unhealthy_threshold=3,
+            close_grace_period=0.0,
+        )
+
+        assert await manager.get_connection() is conn
+        assert await manager.get_connection() is conn
+        assert await manager.get_connection() is conn
+
+        await asyncio.sleep(0)
+        assert conn.closed_count == 0, "a busy connection must not be torn down"
+        assert connection_factory.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_replace_after_threshold_failures(self) -> None:
+        """Consecutive failures beyond the threshold DO replace the connection."""
+        from common.db_resilience import AsyncResilientConnection
+
+        old_conn = _FakeAsyncConn()
+        new_conn = _FakeAsyncConn()
+        connection_factory = Mock(side_effect=[old_conn, new_conn])
+        connection_test = Mock(side_effect=[True, False, False, True])
+
+        manager = AsyncResilientConnection(
+            connection_factory,
+            connection_test,
+            health_check_ttl=0.0,
+            unhealthy_threshold=2,
+            close_grace_period=0.0,
+        )
+
+        assert await manager.get_connection() is old_conn
+        assert await manager.get_connection() is old_conn  # first failure tolerated
+        assert await manager.get_connection() is new_conn  # second failure replaces
+
+        await asyncio.sleep(0)
+        assert old_conn.closed_count == 1
+
+    @pytest.mark.asyncio
+    async def test_probe_success_resets_failure_run(self) -> None:
+        """Failures must be CONSECUTIVE — a success in between resets the run."""
+        from common.db_resilience import AsyncResilientConnection
+
+        conn = _FakeAsyncConn()
+        connection_factory = Mock(return_value=conn)
+        connection_test = Mock(side_effect=[True, False, True, False])
+
+        manager = AsyncResilientConnection(
+            connection_factory,
+            connection_test,
+            health_check_ttl=0.0,
+            unhealthy_threshold=2,
+            close_grace_period=0.0,
+        )
+
+        for _ in range(4):
+            assert await manager.get_connection() is conn
+
+        await asyncio.sleep(0)
+        assert conn.closed_count == 0
+        assert connection_factory.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_replaced_connection_close_deferred(self) -> None:
+        """The replaced connection is detached at once but closed only later.
+
+        neo4j documents driver.close() as NOT concurrency-safe with live
+        sessions, so borrowers get a grace period to drain.
+        """
+        from common.db_resilience import AsyncResilientConnection
+
+        old_conn = _FakeAsyncConn()
+        new_conn = _FakeAsyncConn()
+        connection_factory = Mock(side_effect=[old_conn, new_conn])
+        connection_test = Mock(side_effect=[True, False, True])
+
+        manager = AsyncResilientConnection(
+            connection_factory,
+            connection_test,
+            health_check_ttl=0.0,
+            unhealthy_threshold=1,
+            close_grace_period=60.0,
+        )
+
+        assert await manager.get_connection() is old_conn
+        assert await manager.get_connection() is new_conn
+
+        await asyncio.sleep(0)
+        assert old_conn.closed_count == 0, "borrowers must be allowed to drain"
+        assert old_conn in manager._draining
+
+        # An explicit shutdown closes the draining connection immediately.
+        await manager.close()
+        assert old_conn.closed_count == 1
+        assert manager._draining == []
+
+    @pytest.mark.asyncio
+    async def test_healthy_probe_cached_for_ttl(self) -> None:
+        """A successful probe is trusted for health_check_ttl — no probe per call.
+
+        The per-call `RETURN 1` was both a throughput cap (every query paid an
+        extra round trip serialized behind one lock) and the mechanism that made
+        the pool-starvation teardown reachable.
+        """
+        from common.db_resilience import AsyncResilientConnection
+
+        conn = _FakeAsyncConn()
+        connection_factory = Mock(return_value=conn)
+        connection_test = Mock(return_value=True)
+
+        manager = AsyncResilientConnection(
+            connection_factory,
+            connection_test,
+            health_check_ttl=60.0,
+        )
+
+        for _ in range(5):
+            assert await manager.get_connection() is conn
+
+        # Exactly one call: the health test run while creating the connection.
+        assert connection_test.call_count == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -423,3 +423,21 @@ def reset_global_state() -> Iterator[None]:
         extractor.extractor.shutdown_requested = False
     except (ImportError, AttributeError):
         pass
+
+
+@pytest.fixture(autouse=True)
+def fast_outage_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the consumer requeue throttle from adding real delay to tests.
+
+    Per-message consumers pause before nack(requeue=True) so a backend outage
+    cannot burn the quorum queue's x-delivery-limit budget
+    (discogsography-rb05). The delay is real seconds in production; tests keep
+    the accounting (consecutive_failures) but skip the sleep. The sleep itself
+    is covered directly in tests/common/test_db_resilience.py.
+    """
+    from common.outage_backoff import OutageBackoff
+
+    async def _wait(self: OutageBackoff) -> float:
+        return self.next_delay()
+
+    monkeypatch.setattr(OutageBackoff, "wait", _wait)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -441,3 +441,29 @@ def fast_outage_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
         return self.next_delay()
 
     monkeypatch.setattr(OutageBackoff, "wait", _wait)
+
+
+@pytest.fixture(autouse=True)
+def in_memory_extraction_latch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep graphinator's extraction_complete latch in memory for most tests.
+
+    The latch is durable (a Neo4j :ExtractionCompletion node keyed by extraction
+    version) so acked signals survive a restart — discogsography-tk7v. Existing
+    tests drive the in-memory cache directly and mock the driver, so the load
+    helper mirrors that cache and the persist helper is a no-op here; the
+    durability itself is covered by tests that patch these helpers explicitly.
+    """
+    try:
+        import graphinator.graphinator as g
+    except ImportError:
+        return
+
+    async def _load(_version: str) -> set[str]:
+        return set(g.extraction_complete_signals)
+
+    async def _persist(_version: str, _signals: set[str]) -> None:
+        return None
+
+    monkeypatch.setattr(g, "_load_extraction_signals", _load)
+    monkeypatch.setattr(g, "_persist_extraction_signals", _persist)
+    monkeypatch.setattr(g, "extraction_complete_version", None)

--- a/tests/explore/test_explore_api.py
+++ b/tests/explore/test_explore_api.py
@@ -1180,6 +1180,32 @@ class TestExploreServiceEndpoints:
         """discogsography-cu2.63: the per-request read timeout must be disabled so a
         long-running SSE response isn't aborted just because the upstream goes quiet
         between events for longer than the total request timeout.
+
+        discogsography-gav8: that only applies to the SSE path. The timeout is
+        chosen before the content-type is known, so `read=None` is keyed on the
+        request path instead of being applied to every proxied request.
+        """
+        import httpx
+
+        mock_client = self._mock_buffered_proxy_client(200, b"{}", {"content-type": "application/json"})
+
+        with patch("explore.explore._get_http_client", return_value=mock_client):
+            response = explore_client.post("/api/nlq/query", json={"question": "who?"})
+
+        assert response.status_code == 200
+        _method_args, build_kwargs = mock_client.build_request.call_args
+        timeout = build_kwargs["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.read is None
+
+    def test_proxy_bounds_read_on_buffered(self, explore_client: TestClient) -> None:
+        """Regression (discogsography-gav8): buffered paths keep a read deadline.
+
+        Before the fix every proxied request was built with `read=None`, so a
+        stalled-but-connected upstream parked `client.send()`/`aread()` forever:
+        each wedged request pinned an httpx pool connection and a server task
+        with no deadline, and once ~100 accumulated the whole /api/* surface
+        returned 504 while /health still reported healthy.
         """
         import httpx
 
@@ -1192,7 +1218,62 @@ class TestExploreServiceEndpoints:
         _method_args, build_kwargs = mock_client.build_request.call_args
         timeout = build_kwargs["timeout"]
         assert isinstance(timeout, httpx.Timeout)
-        assert timeout.read is None
+        assert timeout.read == 150.0
+        assert timeout.connect == 150.0
+        assert timeout.pool == 150.0
+
+    def test_proxy_read_stall_returns_504(self, explore_client: TestClient) -> None:
+        """A body read that times out is reported as 504, and the response closed.
+
+        The `except httpx.TimeoutException` around `aread()` was dead code while
+        the read timeout was disabled (discogsography-gav8).
+        """
+        import httpx
+
+        mock_client = self._mock_buffered_proxy_client(200, b"{}", {"content-type": "application/json"})
+        proxied = mock_client.send.return_value
+        proxied.aread = AsyncMock(side_effect=httpx.ReadTimeout("body stalled"))
+
+        with patch("explore.explore._get_http_client", return_value=mock_client):
+            response = explore_client.get("/api/autocomplete?q=radio&type=artist")
+
+        assert response.status_code == 504
+        proxied.aclose.assert_awaited_once()
+
+    def test_proxy_closes_response_on_success(self, explore_client: TestClient) -> None:
+        """The pool connection is released on every exit path (try/finally)."""
+        mock_client = self._mock_buffered_proxy_client(200, b"{}", {"content-type": "application/json"})
+        proxied = mock_client.send.return_value
+
+        with patch("explore.explore._get_http_client", return_value=mock_client):
+            response = explore_client.get("/api/autocomplete?q=radio&type=artist")
+
+        assert response.status_code == 200
+        proxied.aclose.assert_awaited_once()
+
+    def test_sse_header_phase_bounded(self, explore_client: TestClient) -> None:
+        """The SSE path bounds the header wait even with read=None.
+
+        httpx's read timeout also covers waiting for response headers, so an
+        upstream that connects and then never responds would otherwise park the
+        request with no deadline at all.
+        """
+        import asyncio
+
+        import httpx
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.build_request = MagicMock(return_value=MagicMock())
+        mock_client.send = AsyncMock(side_effect=TimeoutError)
+
+        with (
+            patch("explore.explore._get_http_client", return_value=mock_client),
+            patch("explore.explore.asyncio.timeout", wraps=asyncio.timeout) as mock_timeout,
+        ):
+            response = explore_client.post("/api/nlq/query", json={"question": "who?"})
+
+        assert response.status_code == 504
+        mock_timeout.assert_called_once_with(150.0)
 
     def test_proxy_timeout_returns_504(self, explore_client: TestClient) -> None:
         """Proxy timeout returns 504 with error message."""

--- a/tests/graphinator/test_batch_processor.py
+++ b/tests/graphinator/test_batch_processor.py
@@ -2074,3 +2074,75 @@ class TestSameTypeFlushSerialization:
 
         assert nacked == ["poison"], "poison batch must reach the DLQ nack path"
         assert "poison" not in acked
+
+
+class TestDrainWaitsForInFlight:
+    """Regression tests for discogsography-uo8g (drain blind to popped batches)."""
+
+    @pytest.mark.asyncio
+    async def test_in_flight_tracked_while_writing(self) -> None:
+        """A popped-but-unwritten batch is counted, not invisible."""
+        config = BatchConfig(batch_size=1, min_batch_size=1, backoff_initial=0.0)
+        processor = Neo4jBatchProcessor(MagicMock(), config)
+
+        writing = asyncio.Event()
+        release = asyncio.Event()
+
+        async def process(_messages: list[PendingMessage]) -> set[int]:
+            writing.set()
+            await release.wait()
+            return set()
+
+        processor._process_artists_batch = AsyncMock(side_effect=process)  # type: ignore[method-assign]
+        processor.queues["artists"].append(PendingMessage("artists", {"id": "1", "name": "x", "sha256": "h"}, AsyncMock(), AsyncMock()))
+
+        flush = asyncio.create_task(processor._flush_queue("artists"))
+        await asyncio.wait_for(writing.wait(), timeout=1.0)
+
+        # The deque is empty — the batch lives in a task-local list.
+        assert not processor.queues["artists"]
+        assert processor._in_flight["artists"] == 1
+        assert processor.get_stats()["in_flight"]["artists"] == 1
+
+        release.set()
+        await asyncio.wait_for(flush, timeout=1.0)
+        assert processor._in_flight["artists"] == 0
+
+    @pytest.mark.asyncio
+    async def test_drain_blocks_on_in_flight_batch(self) -> None:
+        """flush_queue must not report drained while a write is still landing.
+
+        Before the fix the drain condition was `while self.queues.get(data_type)`,
+        so with the deque momentarily empty it returned True while a concurrent
+        release batch was still MERGE-ing stub nodes. graphinator then started
+        cleanup_all_stub_nodes(), whose DETACH DELETE raced those very writes —
+        the exact race the all-signals deferral exists to prevent.
+        """
+        config = BatchConfig(batch_size=1, min_batch_size=1, backoff_initial=0.0)
+        processor = Neo4jBatchProcessor(MagicMock(), config)
+
+        writing = asyncio.Event()
+        release = asyncio.Event()
+        completed: list[str] = []
+
+        async def process(_messages: list[PendingMessage]) -> set[int]:
+            writing.set()
+            await release.wait()
+            completed.append("write")
+            return set()
+
+        processor._process_artists_batch = AsyncMock(side_effect=process)  # type: ignore[method-assign]
+        processor.queues["artists"].append(PendingMessage("artists", {"id": "1", "name": "x", "sha256": "h"}, AsyncMock(), AsyncMock()))
+
+        in_flight_flush = asyncio.create_task(processor._flush_queue("artists"))
+        await asyncio.wait_for(writing.wait(), timeout=1.0)
+
+        drain = asyncio.create_task(processor.flush_queue("artists"))
+        for _ in range(10):
+            await asyncio.sleep(0)
+        assert not drain.done(), "drain returned while a batch was still in flight"
+
+        release.set()
+        assert await asyncio.wait_for(drain, timeout=1.0) is True
+        await asyncio.wait_for(in_flight_flush, timeout=1.0)
+        assert completed == ["write"], "the write must complete before the drain returns"

--- a/tests/graphinator/test_batch_processor.py
+++ b/tests/graphinator/test_batch_processor.py
@@ -2005,3 +2005,72 @@ class TestReleaseCatalogNumber:
 
         _, first_kwargs = captured[0]
         assert first_kwargs["releases"][0]["metadata"] == {"catalog_number": "PRI-001"}
+
+
+class TestSameTypeFlushSerialization:
+    """Regression (discogsography-2sm3): flushes of one data type are serialized."""
+
+    @pytest.mark.asyncio
+    async def test_flush_locks_are_created_lazily(self) -> None:
+        """asyncio.Lock must never be built in __init__ (wrong event loop)."""
+        processor = Neo4jBatchProcessor(MagicMock())
+
+        assert processor._flush_locks == {}
+
+        lock = processor._get_flush_lock("artists")
+
+        assert isinstance(lock, asyncio.Lock)
+        assert processor._get_flush_lock("artists") is lock
+
+    @pytest.mark.asyncio
+    async def test_concurrent_success_cannot_reset_poison(self) -> None:
+        """Regression (discogsography-2sm3): a concurrent healthy flush of the
+        SAME data type must not reset the poison counter.
+
+        Before the fix, `_flush_queue` had no per-data-type mutex. A failed
+        poison batch was re-enqueued at the FRONT of the deque while another
+        in-flight flush of the same type — which popped healthy messages from
+        behind it — completed afterwards and reset `_consecutive_failures` to 0.
+        The bounded poison guard therefore never reached `max_poison_retries`,
+        so the poison batch was never dead-lettered and its deliveries pinned
+        the prefetch window forever.
+        """
+        config = BatchConfig(
+            batch_size=1,
+            min_batch_size=1,
+            max_poison_retries=3,
+            backoff_initial=0.0,
+        )
+        processor = Neo4jBatchProcessor(MagicMock(), config)
+
+        async def process(messages: list[PendingMessage]) -> set[int]:
+            # Yield so concurrent flushes genuinely interleave.
+            await asyncio.sleep(0)
+            if any(msg.data.get("id") == "poison" for msg in messages):
+                raise ValueError("data-induced ClientError")
+            return set()
+
+        processor._process_artists_batch = AsyncMock(side_effect=process)  # type: ignore[method-assign]
+
+        acked: list[str] = []
+        nacked: list[str] = []
+
+        def make_msg(data_id: str) -> PendingMessage:
+            async def ack() -> None:
+                acked.append(data_id)
+
+            async def nack() -> None:
+                nacked.append(data_id)
+
+            return PendingMessage("artists", {"id": data_id, "name": "x", "sha256": "h"}, ack, nack)
+
+        processor.queues["artists"].append(make_msg("poison"))
+        for i in range(20):
+            processor.queues["artists"].append(make_msg(f"healthy-{i}"))
+
+        # Twelve concurrent flushes of the SAME data type — exactly the
+        # interleaving aio-pika's task-per-delivery model produces.
+        await asyncio.gather(*[processor._flush_queue("artists") for _ in range(12)])
+
+        assert nacked == ["poison"], "poison batch must reach the DLQ nack path"
+        assert "poison" not in acked

--- a/tests/graphinator/test_extraction_latch_durable.py
+++ b/tests/graphinator/test_extraction_latch_durable.py
@@ -1,0 +1,195 @@
+"""Regression tests for discogsography-tk7v.
+
+The extraction_complete latch used to be a process-local set. Each signal was
+acked — destroying the only durable copy, the queued message — while the set was
+never persisted. A restart between the first and the last signal therefore lost
+every recorded signal: the final signal found 1-of-4, logged "Deferring stub
+cleanup until all data types complete", acked, and waited forever. No further
+extraction_complete is ever published for a version, so stub cleanup and the
+genre/style/label aggregates silently never ran.
+
+The latch is now a Neo4j :ExtractionCompletion node keyed by extraction version,
+written BEFORE the signal is acked and reloaded on the next signal. Keying by
+version also stops a long-lived process from carrying a finished run's signals
+into the next dump and firing maintenance while other queues still import.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from aio_pika.abc import AbstractIncomingMessage
+import pytest
+
+import graphinator.graphinator as g
+
+
+# Captured before the suite-wide in_memory_extraction_latch fixture replaces them.
+_REAL_LOAD = g._load_extraction_signals
+_REAL_PERSIST = g._persist_extraction_signals
+
+
+def _signal(version: str = "20260101") -> dict[str, Any]:
+    return {"type": "extraction_complete", "version": version}
+
+
+class FakeLatchStore:
+    """In-memory stand-in for the Neo4j :ExtractionCompletion node."""
+
+    def __init__(self, initial: dict[str, set[str]] | None = None) -> None:
+        self.rows: dict[str, set[str]] = initial or {}
+        self.writes: list[tuple[str, set[str]]] = []
+
+    async def load(self, version: str) -> set[str]:
+        return set(self.rows.get(version, set()))
+
+    async def persist(self, version: str, signals: set[str]) -> None:
+        self.rows[version] = set(signals)
+        self.writes.append((version, set(signals)))
+
+
+@pytest.fixture
+def latch(monkeypatch: pytest.MonkeyPatch) -> FakeLatchStore:
+    """Replace the Neo4j-backed latch helpers with a durable in-test store."""
+    store = FakeLatchStore()
+    monkeypatch.setattr(g, "_load_extraction_signals", store.load)
+    monkeypatch.setattr(g, "_persist_extraction_signals", store.persist)
+    monkeypatch.setattr(g, "extraction_complete_signals", set())
+    monkeypatch.setattr(g, "extraction_complete_version", None)
+    return store
+
+
+@pytest.mark.asyncio
+async def test_signal_persisted_before_ack(latch: FakeLatchStore) -> None:
+    """The latch write happens before the delivery is destroyed by the ack."""
+    message = AsyncMock(spec=AbstractIncomingMessage)
+
+    handled = await g.check_file_completion(_signal(), "artists", message)
+
+    assert handled is True
+    assert latch.rows["20260101"] == {"artists"}
+    message.ack.assert_awaited_once()
+    message.nack.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_restart_recovers_acked_signals(latch: FakeLatchStore) -> None:  # noqa: ARG001  # fixture installs the durable store
+    """Signals acked before a restart still count toward the all-four check.
+
+    artists/labels/masters signal hours before releases finishes draining; a
+    deploy in that window used to erase them.
+    """
+    for data_type in ("artists", "labels", "masters"):
+        await g.check_file_completion(_signal(), data_type, AsyncMock(spec=AbstractIncomingMessage))
+
+    # Simulate a container restart: process-local state is gone, Neo4j is not.
+    g.extraction_complete_signals = set()
+    g.extraction_complete_version = None
+
+    with patch.object(g, "start_post_import_maintenance") as start:
+        await g.check_file_completion(_signal(), "releases", AsyncMock(spec=AbstractIncomingMessage))
+
+    assert g.extraction_complete_signals == {"artists", "labels", "masters", "releases"}
+    start.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_partial_signals_still_defer(latch: FakeLatchStore) -> None:  # noqa: ARG001  # fixture installs the durable store
+    """Recovering the latch must not fire maintenance early."""
+    await g.check_file_completion(_signal(), "artists", AsyncMock(spec=AbstractIncomingMessage))
+
+    g.extraction_complete_signals = set()
+    g.extraction_complete_version = None
+
+    with patch.object(g, "start_post_import_maintenance") as start:
+        await g.check_file_completion(_signal(), "labels", AsyncMock(spec=AbstractIncomingMessage))
+
+    start.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_new_version_resets_the_latch(latch: FakeLatchStore) -> None:
+    """A completed run's signals must not satisfy the NEXT dump's check.
+
+    The latch was never cleared, so a process that survived into the next
+    monthly dump fired cleanup on the first signal it saw — DETACH DELETE-ing
+    stubs while the release queue was still hours from done.
+    """
+    for data_type in ("artists", "labels", "masters", "releases"):
+        with patch.object(g, "start_post_import_maintenance"):
+            await g.check_file_completion(_signal("20260101"), data_type, AsyncMock(spec=AbstractIncomingMessage))
+
+    assert g.extraction_complete_signals == set(g.DATA_TYPES)
+
+    with patch.object(g, "start_post_import_maintenance") as start:
+        await g.check_file_completion(_signal("20260201"), "artists", AsyncMock(spec=AbstractIncomingMessage))
+
+    start.assert_not_called()
+    assert g.extraction_complete_signals == {"artists"}
+    assert latch.rows["20260201"] == {"artists"}
+    assert latch.rows["20260101"] == set(g.DATA_TYPES)
+
+
+@pytest.mark.asyncio
+async def test_latch_write_failure_requeues(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the latch cannot be written, the signal must be requeued, not acked.
+
+    Acking an unpersisted signal loses it exactly as before.
+    """
+
+    async def _boom(_version: str, _signals: set[str]) -> None:
+        raise RuntimeError("Neo4j unavailable")
+
+    monkeypatch.setattr(g, "_load_extraction_signals", AsyncMock(return_value=set()))
+    monkeypatch.setattr(g, "_persist_extraction_signals", _boom)
+    monkeypatch.setattr(g, "extraction_complete_signals", set())
+    monkeypatch.setattr(g, "extraction_complete_version", None)
+
+    message = AsyncMock(spec=AbstractIncomingMessage)
+    handled = await g.check_file_completion(_signal(), "artists", message)
+
+    assert handled is True
+    message.nack.assert_awaited_once_with(requeue=True)
+    message.ack.assert_not_called()
+    assert g.extraction_complete_signals == set()
+
+
+@pytest.mark.asyncio
+async def test_load_reads_the_version_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_load_extraction_signals queries the node for exactly this version."""
+    record = {"signals": ["artists", "labels"]}
+    result = AsyncMock()
+    result.single = AsyncMock(return_value=record)
+    session = AsyncMock()
+    session.run = AsyncMock(return_value=result)
+    session_cm = AsyncMock()
+    session_cm.__aenter__ = AsyncMock(return_value=session)
+    session_cm.__aexit__ = AsyncMock(return_value=None)
+    driver = AsyncMock()
+    driver.session = lambda **_kwargs: session_cm
+
+    monkeypatch.setattr(g, "graph", driver)
+    signals = await _REAL_LOAD("20260101")
+
+    assert signals == {"artists", "labels"}
+    assert session.run.await_args.kwargs["version"] == "20260101"
+
+
+@pytest.mark.asyncio
+async def test_persist_writes_the_version_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_persist_extraction_signals MERGEs the node for this version."""
+    session = AsyncMock()
+    session.run = AsyncMock()
+    session_cm = AsyncMock()
+    session_cm.__aenter__ = AsyncMock(return_value=session)
+    session_cm.__aexit__ = AsyncMock(return_value=None)
+    driver = AsyncMock()
+    driver.session = lambda **_kwargs: session_cm
+
+    monkeypatch.setattr(g, "graph", driver)
+    await _REAL_PERSIST("20260101", {"labels", "artists"})
+
+    cypher = session.run.await_args.args[0]
+    assert "MERGE (m:ExtractionCompletion {version: $version})" in cypher
+    assert session.run.await_args.kwargs["signals"] == ["artists", "labels"]

--- a/tests/graphinator/test_graphinator.py
+++ b/tests/graphinator/test_graphinator.py
@@ -4718,3 +4718,54 @@ class TestMaintenanceUnderMemoryPressure:
         assert len(run_calls) == 4
         # One settle between each pair of labels — not before the first.
         assert sleeps == [7.5, 7.5, 7.5]
+
+
+class TestOutageRequeueBackoff:
+    """Regression tests for discogsography-rb05 (mirror of the brainz consumers)."""
+
+    @pytest.mark.asyncio
+    @patch("graphinator.graphinator.shutdown_requested", False)
+    async def test_neo4j_outage_engages_throttle(self, sample_artist_data: dict[str, Any]) -> None:
+        """Non-batch mode must throttle requeues during a Neo4j outage.
+
+        x-delivery-limit=20 is a budget with no time dimension: unthrottled
+        requeues dead-letter perfectly valid records within minutes.
+        """
+        from neo4j.exceptions import ServiceUnavailable
+
+        from common.outage_backoff import OutageBackoff
+
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        mock_message.body = json.dumps(sample_artist_data).encode()
+        backoff = OutageBackoff("test")
+
+        with (
+            patch("graphinator.graphinator.graph") as mock_graph,
+            patch("graphinator.graphinator.outage_backoff", backoff),
+        ):
+            mock_graph.session.side_effect = ServiceUnavailable("Connection lost")
+            await on_artist_message(mock_message)
+
+        assert backoff.consecutive_failures == 1
+        mock_message.nack.assert_called_once_with(requeue=True)
+
+    @pytest.mark.asyncio
+    @patch("graphinator.graphinator.shutdown_requested", False)
+    async def test_driver_unavailable_is_transient(self, sample_artist_data: dict[str, Any]) -> None:
+        """DatabaseUnavailableError from the resilience layer is an outage too."""
+        from common.db_resilience import DatabaseUnavailableError
+        from common.outage_backoff import OutageBackoff
+
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        mock_message.body = json.dumps(sample_artist_data).encode()
+        backoff = OutageBackoff("test")
+
+        with (
+            patch("graphinator.graphinator.graph") as mock_graph,
+            patch("graphinator.graphinator.outage_backoff", backoff),
+        ):
+            mock_graph.session.side_effect = DatabaseUnavailableError("circuit open")
+            await on_artist_message(mock_message)
+
+        assert backoff.consecutive_failures == 1
+        mock_message.nack.assert_called_once_with(requeue=True)

--- a/tests/tableinator/test_batch_processor.py
+++ b/tests/tableinator/test_batch_processor.py
@@ -1677,3 +1677,78 @@ class TestFlushQueuePublicMethod:
             mock_sleep.assert_called_once()
             wait_arg = mock_sleep.call_args[0][0]
             assert wait_arg > 0
+
+
+class TestSameTypeFlushSerialization:
+    """Regression (discogsography-2sm3): flushes of one data type are serialized."""
+
+    @pytest.mark.asyncio
+    async def test_flush_locks_are_created_lazily(self) -> None:
+        """asyncio.Lock must never be built in __init__ (wrong event loop)."""
+        processor = PostgreSQLBatchProcessor(MagicMock())
+
+        assert processor._flush_locks == {}
+
+        lock = processor._get_flush_lock("artists")
+
+        assert isinstance(lock, asyncio.Lock)
+        assert processor._get_flush_lock("artists") is lock
+
+    @pytest.mark.asyncio
+    async def test_concurrent_success_cannot_reset_poison(self) -> None:
+        """Regression (discogsography-2sm3): a concurrent healthy flush of the
+        SAME data type must not reset the poison counter.
+
+        Before the fix, `_flush_queue` had no per-data-type mutex. A failed
+        poison batch was re-enqueued at the FRONT of the deque while another
+        in-flight flush of the same type — which popped healthy messages from
+        behind it — completed afterwards and reset `_consecutive_failures` to 0.
+        The bounded poison guard therefore never reached `max_poison_retries`,
+        so the poison batch was never dead-lettered and its deliveries pinned
+        the prefetch window forever.
+        """
+        config = BatchConfig(
+            batch_size=1,
+            min_batch_size=1,
+            max_poison_retries=3,
+            backoff_initial=0.0,
+        )
+        processor = PostgreSQLBatchProcessor(MagicMock(), config=config)
+
+        async def process(_data_type: str, messages: list[PendingMessage]) -> None:
+            # Yield so concurrent flushes genuinely interleave.
+            await asyncio.sleep(0)
+            if any(msg.data_id == "poison" for msg in messages):
+                raise ValueError("invalid jsonb")
+
+        processor._process_batch = AsyncMock(side_effect=process)  # type: ignore[method-assign]
+
+        acked: list[str] = []
+        nacked: list[str] = []
+
+        def make_msg(data_id: str) -> PendingMessage:
+            async def ack() -> None:
+                acked.append(data_id)
+
+            async def nack() -> None:
+                nacked.append(data_id)
+
+            return PendingMessage(
+                data_type="artists",
+                data_id=data_id,
+                data={"id": data_id},
+                sha256="h",
+                ack_callback=ack,
+                nack_callback=nack,
+            )
+
+        processor.queues["artists"].append(make_msg("poison"))
+        for i in range(20):
+            processor.queues["artists"].append(make_msg(f"healthy-{i}"))
+
+        # Twelve concurrent flushes of the SAME data type — exactly the
+        # interleaving aio-pika's task-per-delivery model produces.
+        await asyncio.gather(*[processor._flush_queue("artists") for _ in range(12)])
+
+        assert nacked == ["poison"], "poison batch must reach the DLQ nack path"
+        assert "poison" not in acked

--- a/tests/tableinator/test_batch_processor.py
+++ b/tests/tableinator/test_batch_processor.py
@@ -1752,3 +1752,80 @@ class TestSameTypeFlushSerialization:
 
         assert nacked == ["poison"], "poison batch must reach the DLQ nack path"
         assert "poison" not in acked
+
+
+class TestDrainWaitsForInFlight:
+    """Regression tests for discogsography-uo8g (drain blind to popped batches)."""
+
+    @staticmethod
+    def _msg(data_id: str) -> PendingMessage:
+        return PendingMessage(
+            data_type="artists",
+            data_id=data_id,
+            data={"id": data_id},
+            sha256="h",
+            ack_callback=AsyncMock(),
+            nack_callback=AsyncMock(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_in_flight_tracked_while_writing(self) -> None:
+        """A popped-but-unwritten batch is counted, not invisible."""
+        config = BatchConfig(batch_size=1, min_batch_size=1, backoff_initial=0.0)
+        processor = PostgreSQLBatchProcessor(MagicMock(), config=config)
+
+        writing = asyncio.Event()
+        release = asyncio.Event()
+
+        async def process(_data_type: str, _messages: list[PendingMessage]) -> None:
+            writing.set()
+            await release.wait()
+
+        processor._process_batch = AsyncMock(side_effect=process)  # type: ignore[method-assign]
+        processor.queues["artists"].append(self._msg("1"))
+
+        flush = asyncio.create_task(processor._flush_queue("artists"))
+        await asyncio.wait_for(writing.wait(), timeout=1.0)
+
+        assert not processor.queues["artists"]
+        assert processor._in_flight["artists"] == 1
+        assert processor.get_stats()["in_flight"]["artists"] == 1
+
+        release.set()
+        await asyncio.wait_for(flush, timeout=1.0)
+        assert processor._in_flight["artists"] == 0
+
+    @pytest.mark.asyncio
+    async def test_drain_blocks_on_in_flight_batch(self) -> None:
+        """flush_queue must not report drained while a write is still landing.
+
+        tableinator's `file_complete` handler treats a True return as "every
+        row for this file is committed" (discogsography-uo8g).
+        """
+        config = BatchConfig(batch_size=1, min_batch_size=1, backoff_initial=0.0)
+        processor = PostgreSQLBatchProcessor(MagicMock(), config=config)
+
+        writing = asyncio.Event()
+        release = asyncio.Event()
+        completed: list[str] = []
+
+        async def process(_data_type: str, _messages: list[PendingMessage]) -> None:
+            writing.set()
+            await release.wait()
+            completed.append("write")
+
+        processor._process_batch = AsyncMock(side_effect=process)  # type: ignore[method-assign]
+        processor.queues["artists"].append(self._msg("1"))
+
+        in_flight_flush = asyncio.create_task(processor._flush_queue("artists"))
+        await asyncio.wait_for(writing.wait(), timeout=1.0)
+
+        drain = asyncio.create_task(processor.flush_queue("artists"))
+        for _ in range(10):
+            await asyncio.sleep(0)
+        assert not drain.done(), "drain returned while a batch was still in flight"
+
+        release.set()
+        assert await asyncio.wait_for(drain, timeout=1.0) is True
+        await asyncio.wait_for(in_flight_flush, timeout=1.0)
+        assert completed == ["write"], "the write must complete before the drain returns"

--- a/tests/tableinator/test_tableinator.py
+++ b/tests/tableinator/test_tableinator.py
@@ -3170,3 +3170,56 @@ class TestMainFullRun:
             mod.shutdown_requested = original_shutdown
             mod.consumer_cancel_tasks.clear()
             mod.consumer_cancel_tasks.update(original_cancel_tasks)
+
+
+class TestOutageRequeueBackoff:
+    """Regression tests for discogsography-rb05 (mirror of the brainz consumers)."""
+
+    @pytest.mark.asyncio
+    @patch("tableinator.tableinator.shutdown_requested", False)
+    async def test_db_outage_engages_throttle(self, sample_artist_data: dict[str, Any]) -> None:
+        """Non-batch mode must throttle requeues during a PostgreSQL outage."""
+        from psycopg.errors import OperationalError
+
+        from common.outage_backoff import OutageBackoff
+
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        mock_message.body = json.dumps(sample_artist_data).encode()
+        mock_message.routing_key = "artists"
+
+        mock_pool = MagicMock()
+        mock_pool.connection.side_effect = OperationalError("Database unavailable")
+        backoff = OutageBackoff("test")
+
+        with (
+            patch("tableinator.tableinator.connection_pool", mock_pool),
+            patch("tableinator.tableinator.outage_backoff", backoff),
+        ):
+            await on_data_message(mock_message, "artists")
+
+        assert backoff.consecutive_failures == 1
+        mock_message.nack.assert_called_once_with(requeue=True)
+
+    @pytest.mark.asyncio
+    @patch("tableinator.tableinator.shutdown_requested", False)
+    async def test_pool_unavailable_is_transient(self, sample_artist_data: dict[str, Any]) -> None:
+        """The pool's own DatabaseUnavailableError is an outage, not a poison record."""
+        from common.db_resilience import DatabaseUnavailableError
+        from common.outage_backoff import OutageBackoff
+
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        mock_message.body = json.dumps(sample_artist_data).encode()
+        mock_message.routing_key = "artists"
+
+        mock_pool = MagicMock()
+        mock_pool.connection.side_effect = DatabaseUnavailableError("circuit open")
+        backoff = OutageBackoff("test")
+
+        with (
+            patch("tableinator.tableinator.connection_pool", mock_pool),
+            patch("tableinator.tableinator.outage_backoff", backoff),
+        ):
+            await on_data_message(mock_message, "artists")
+
+        assert backoff.consecutive_failures == 1
+        mock_message.nack.assert_called_once_with(requeue=True)


### PR DESCRIPTION
Fixes 9 priority-2 concurrency/messaging/resource findings from the 2026-08-10 bug hunt (run `wf_646d4b21`), one commit per bead.

## Batch processors & consumers
- **discogsography-2sm3** — same-type flushes are serialized so the poison-batch guard can actually fire (concurrent-flush counter reset defeated it).
- **discogsography-uo8g** — flush drain now waits for in-flight popped batches, so extraction_complete stub cleanup can't race a live batch.
- **discogsography-rb05** — per-message consumers throttle requeues during a sustained backend outage instead of mass dead-lettering through the quorum delivery limit.
- **discogsography-tk7v** — the extraction_complete latch is persisted in Neo4j instead of a process-local set, surviving restarts between signals.

## Shared connection management (common/)
- **discogsography-4ajv** — a failed health probe no longer closes a shared Neo4j driver other coroutines are using (TOCTOU).
- **discogsography-y1qn** — the reconnect/backoff cycle runs outside the singleton connection lock, so healthy callers aren't serialized behind a reconnecting one.

## API / explore / extractor
- **discogsography-jxmn** — 2FA challenge tokens issued before a password change/reset are rejected (inclusive `<=` comparison, consistent with JWT invalidation).
- **discogsography-gav8** — the explore proxy's disabled read timeout now applies only to SSE paths; regular proxied responses get a bounded timeout again.
- **discogsography-rehd** — the Rust extractor bounds its AMQP publish-confirm await with a timeout instead of wedging indefinitely under RabbitMQ stalls.

Validation: local ruff ✅ · mypy ✅ · cargo fmt/clippy ✅ — full test suites run in CI per dispatch policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrLwHwMcu3cuQJh8cc1SyW