### PR TITLE
fix: extractor robustness & data-safety — 5 bug-hunt findings (batch:p2-extractor)

### DIFF
--- a/docs/state-marker-system.md
+++ b/docs/state-marker-system.md
@@ -104,7 +104,7 @@ When the extractor restarts, it checks the state marker and makes one of three d
 
 **Triggered when:**
 
-- Download phase failed
+- Download phase failed or was interrupted **and** no file has finished processing yet
 - State marker is corrupted
 - Force reprocess flag is set
 
@@ -120,6 +120,9 @@ When the extractor restarts, it checks the state marker and makes one of three d
 
 - Processing phase is `in_progress`
 - Processing phase `failed` but can recover
+- Download phase failed or was interrupted but at least one file already finished
+  processing — downloads are idempotent and self-heal via checksum verification, so
+  completed processing progress is never discarded to recover a download
 
 **Action:**
 

--- a/extractor/src/discogs_downloader.rs
+++ b/extractor/src/discogs_downloader.rs
@@ -638,11 +638,27 @@ impl Downloader {
         Err(last_error.unwrap_or_else(|| anyhow::anyhow!("Download failed after {} attempts", MAX_DOWNLOAD_RETRIES)))
     }
 
+    /// Persist the checksum-trust database.
+    ///
+    /// Written to a temp file, fsynced, then atomically renamed over the final path —
+    /// the same durability contract as [`StateMarker::save`]. A plain in-place write
+    /// leaves a truncated (or zero-byte) file if the process is killed mid-write, and
+    /// a corrupt metadata file used to wedge startup permanently.
     pub fn save_metadata(&self) -> Result<()> {
         let metadata_file = self.output_directory.join(".discogs_metadata.json");
+        let tmp_file = self.output_directory.join(".discogs_metadata.json.tmp");
         let json = serde_json::to_string_pretty(&self.metadata).context("Failed to serialize metadata")?;
 
-        std::fs::write(metadata_file, json).context("Failed to save metadata")?;
+        {
+            use std::io::Write;
+            // Path is built from operator-controlled config plus a hardcoded literal.
+            let mut file = std::fs::File::create(&tmp_file).context("Failed to create metadata temp file")?; // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
+            file.write_all(json.as_bytes()).context("Failed to write metadata temp file")?;
+            // fsync before rename so the rename cannot expose an empty file after a crash.
+            file.sync_all().context("Failed to fsync metadata temp file")?;
+        }
+
+        std::fs::rename(&tmp_file, &metadata_file).context("Failed to save metadata")?;
 
         Ok(())
     }
@@ -656,9 +672,26 @@ fn load_metadata(output_directory: &Path) -> Result<HashMap<String, LocalFileInf
         return Ok(HashMap::new());
     }
 
-    let json = std::fs::read_to_string(metadata_file).context("Failed to read metadata file")?; // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
+    let json = std::fs::read_to_string(&metadata_file).context("Failed to read metadata file")?; // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
 
-    serde_json::from_str(&json).context("Failed to parse metadata")
+    match serde_json::from_str(&json) {
+        Ok(metadata) => Ok(metadata),
+        Err(e) => {
+            // The metadata file is a download cache, not a hard integrity requirement:
+            // treating a corrupt one as fatal crash-looped the service forever. Quarantine
+            // it and start fresh — the worst case is re-verifying/re-downloading dumps,
+            // which `should_download` already handles safely via checksums.
+            warn!("⚠️ Failed to parse metadata file, starting with empty metadata: {}", e);
+
+            let corrupt_path = output_directory.join(".discogs_metadata.json.corrupt");
+            match std::fs::rename(&metadata_file, &corrupt_path) {
+                Ok(()) => warn!("⚠️ Quarantined corrupt metadata file to: {}", corrupt_path.display()),
+                Err(rename_err) => warn!("⚠️ Failed to quarantine corrupt metadata file: {}", rename_err),
+            }
+
+            Ok(HashMap::new())
+        }
+    }
 }
 
 /// Compute a SHA-256 checksum for a local file. Callers only ever pass paths built from

--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -97,6 +97,13 @@ pub async fn process_discogs_data(
     // Record extraction start time for consumer cleanup coordination
     let extraction_started_at = chrono::Utc::now();
 
+    // Mirror of the MusicBrainz guard: never begin a new run (status Running, S3 listing,
+    // multi-GB downloads) when shutdown has already been requested. (discogsography-l114)
+    if shutdown_flag.load(Ordering::SeqCst) {
+        info!("🛑 Shutdown requested, not starting Discogs extraction");
+        return Ok(false);
+    }
+
     // Reset progress for new run
     {
         let mut s = state.write().await;
@@ -1099,15 +1106,51 @@ pub(crate) fn discogs_unreachable_backoff(attempt: u32) -> Duration {
     DISCOGS_UNREACHABLE_BASE_DELAY.saturating_mul(multiplier).min(DISCOGS_UNREACHABLE_MAX_DELAY)
 }
 
+/// Outcome of waiting for the Discogs extractor to go idle.
+///
+/// A plain `Ok(())` used to mean BOTH "Discogs is idle, go ahead" and "shutdown was
+/// requested, stop" — so a SIGTERM arriving during the (multi-hour) wait launched a
+/// brand-new MusicBrainz extraction run instead of exiting. (discogsography-l114)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WaitOutcome {
+    /// Discogs is idle (or unreachable / unparseable) — start the MusicBrainz run.
+    Proceed,
+    /// Shutdown was requested while waiting — do not start any new work.
+    Shutdown,
+}
+
+/// Sleep for `duration`, returning early as soon as shutdown is requested.
+///
+/// Returns `true` if shutdown was observed. The wait between Discogs health polls is an
+/// hour in production; an uninterruptible sleep there means SIGTERM is not even noticed
+/// until long after Docker's stop grace period has elapsed and SIGKILL has landed.
+async fn sleep_unless_shutdown(duration: Duration, shutdown_flag: &AtomicBool) -> bool {
+    const SLICE: Duration = Duration::from_millis(250);
+
+    let deadline = Instant::now() + duration;
+    loop {
+        if shutdown_flag.load(Ordering::SeqCst) {
+            return true;
+        }
+
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return false;
+        }
+
+        sleep(remaining.min(SLICE)).await;
+    }
+}
+
 /// Wait until the Discogs extractor is not actively extracting.
-pub async fn wait_for_discogs_idle(url: &str, shutdown_flag: &AtomicBool) -> Result<()> {
+pub async fn wait_for_discogs_idle(url: &str, shutdown_flag: &AtomicBool) -> Result<WaitOutcome> {
     wait_for_discogs_idle_with_interval(url, shutdown_flag, DISCOGS_POLL_INTERVAL).await
 }
 
 /// Internal implementation with configurable poll interval (for testing). `poll_interval`
 /// governs only the "Discogs is busy" (status == "running") wait; an unreachable endpoint
 /// always uses the short escalating backoff from `discogs_unreachable_backoff`.
-pub async fn wait_for_discogs_idle_with_interval(url: &str, shutdown_flag: &AtomicBool, poll_interval: Duration) -> Result<()> {
+pub async fn wait_for_discogs_idle_with_interval(url: &str, shutdown_flag: &AtomicBool, poll_interval: Duration) -> Result<WaitOutcome> {
     let client = reqwest::Client::builder().timeout(DISCOGS_HEALTH_TIMEOUT).build()?;
 
     let mut unreachable_count: u32 = 0;
@@ -1115,7 +1158,7 @@ pub async fn wait_for_discogs_idle_with_interval(url: &str, shutdown_flag: &Atom
     loop {
         if shutdown_flag.load(Ordering::SeqCst) {
             info!("🛑 Shutdown requested, stopping Discogs health check wait");
-            return Ok(());
+            return Ok(WaitOutcome::Shutdown);
         }
 
         match client.get(url).send().await {
@@ -1129,15 +1172,18 @@ pub async fn wait_for_discogs_idle_with_interval(url: &str, shutdown_flag: &Atom
                             info!("⏳ Discogs extraction in progress, waiting before starting MusicBrainz extraction...");
                         } else {
                             info!("✅ Discogs extractor idle (status: {}), proceeding with MusicBrainz extraction", status);
-                            return Ok(());
+                            return Ok(WaitOutcome::Proceed);
                         }
                     }
                     Err(e) => {
                         warn!("⚠️ Failed to parse Discogs health response: {}, proceeding", e);
-                        return Ok(());
+                        return Ok(WaitOutcome::Proceed);
                     }
                 }
-                tokio::time::sleep(poll_interval).await;
+                if sleep_unless_shutdown(poll_interval, shutdown_flag).await {
+                    info!("🛑 Shutdown requested, stopping Discogs health check wait");
+                    return Ok(WaitOutcome::Shutdown);
+                }
             }
             Err(_) => {
                 unreachable_count += 1;
@@ -1146,14 +1192,17 @@ pub async fn wait_for_discogs_idle_with_interval(url: &str, shutdown_flag: &Atom
                         "⚠️ Discogs health endpoint unreachable after {} attempts, proceeding with MusicBrainz extraction",
                         DISCOGS_MAX_UNREACHABLE_RETRIES
                     );
-                    return Ok(());
+                    return Ok(WaitOutcome::Proceed);
                 }
                 let backoff = discogs_unreachable_backoff(unreachable_count);
                 warn!(
                     "⚠️ Discogs health endpoint unreachable (attempt {}/{}), retrying in {:?}...",
                     unreachable_count, DISCOGS_MAX_UNREACHABLE_RETRIES, backoff
                 );
-                tokio::time::sleep(backoff).await;
+                if sleep_unless_shutdown(backoff, shutdown_flag).await {
+                    info!("🛑 Shutdown requested, stopping Discogs health check wait");
+                    return Ok(WaitOutcome::Shutdown);
+                }
             }
         }
     }
@@ -1176,8 +1225,12 @@ pub async fn run_musicbrainz_loop(
 
     info!("🎵 Starting MusicBrainz extraction...");
 
-    // Wait for Discogs extractor to finish before starting MusicBrainz
-    wait_for_discogs_idle(&config.discogs_health_url, &shutdown_flag).await?;
+    // Wait for Discogs extractor to finish before starting MusicBrainz. A shutdown during
+    // that wait must exit — NOT fall through into a brand-new multi-hour extraction run.
+    if wait_for_discogs_idle(&config.discogs_health_url, &shutdown_flag).await? == WaitOutcome::Shutdown {
+        info!("🛑 Shutdown requested while waiting for Discogs, skipping MusicBrainz extraction");
+        return Ok(());
+    }
 
     let success =
         process_musicbrainz_data(config.clone(), state.clone(), shutdown_flag.clone(), force_reprocess, mq_factory.clone(), compiled_rules.clone())
@@ -1214,8 +1267,13 @@ pub async fn run_musicbrainz_loop(
             _ = sleep(check_interval) => {
                 info!("🔄 Starting periodic check for new MusicBrainz dumps...");
                 // Wait for Discogs extractor to finish before starting MusicBrainz
-                if let Err(e) = wait_for_discogs_idle(&config.discogs_health_url, &shutdown_flag).await {
-                    error!("❌ Failed to check Discogs health: {}", e);
+                match wait_for_discogs_idle(&config.discogs_health_url, &shutdown_flag).await {
+                    Ok(WaitOutcome::Shutdown) => {
+                        info!("🛑 Shutdown requested while waiting for Discogs, skipping periodic MusicBrainz check");
+                        break;
+                    }
+                    Ok(WaitOutcome::Proceed) => {}
+                    Err(e) => error!("❌ Failed to check Discogs health: {}", e),
                 }
                 let start = Instant::now();
                 match process_musicbrainz_data(config.clone(), state.clone(), shutdown_flag.clone(), false, mq_factory.clone(), compiled_rules.clone()).await {
@@ -1234,8 +1292,13 @@ pub async fn run_musicbrainz_loop(
             trigger_force_reprocess = wait_for_trigger(&trigger) => {
                 info!("🔄 MusicBrainz extraction triggered via API (force_reprocess={})...", trigger_force_reprocess);
                 // Wait for Discogs extractor to finish before starting MusicBrainz
-                if let Err(e) = wait_for_discogs_idle(&config.discogs_health_url, &shutdown_flag).await {
-                    error!("❌ Failed to check Discogs health: {}", e);
+                match wait_for_discogs_idle(&config.discogs_health_url, &shutdown_flag).await {
+                    Ok(WaitOutcome::Shutdown) => {
+                        info!("🛑 Shutdown requested while waiting for Discogs, skipping triggered MusicBrainz extraction");
+                        break;
+                    }
+                    Ok(WaitOutcome::Proceed) => {}
+                    Err(e) => error!("❌ Failed to check Discogs health: {}", e),
                 }
                 let start = Instant::now();
                 match process_musicbrainz_data(config.clone(), state.clone(), shutdown_flag.clone(), trigger_force_reprocess, mq_factory.clone(), compiled_rules.clone()).await {
@@ -1273,6 +1336,14 @@ pub async fn process_musicbrainz_data(
 
     let extraction_started_at = chrono::Utc::now();
 
+    // Never start a new run under shutdown: the prelude below (multi-GB download, dump
+    // discovery, AMQP setup, full artist.jsonl.xz scan) has no natural exit point, and
+    // the first per-file check comes far too late for any stop grace period.
+    if shutdown_flag.load(Ordering::SeqCst) {
+        info!("🛑 Shutdown requested, not starting MusicBrainz extraction");
+        return Ok(false);
+    }
+
     // Reset progress for new run
     {
         let mut s = state.write().await;
@@ -1287,6 +1358,13 @@ pub async fn process_musicbrainz_data(
     // Download latest MusicBrainz dump if needed
     let downloader = MbDownloader::new(config.musicbrainz_root.clone(), config.musicbrainz_dump_url.clone());
     let download_result = downloader.download_latest().await?;
+
+    // The download can take hours; do not follow it with the equally long map-building
+    // and per-file passes if shutdown arrived in the meantime.
+    if shutdown_flag.load(Ordering::SeqCst) {
+        info!("🛑 Shutdown requested after MusicBrainz download, stopping before processing");
+        return Ok(false);
+    }
     let version = download_result.version().to_string();
     let versioned_root = config.musicbrainz_root.join(&version);
     info!("📋 Using MusicBrainz dump version: {} from {:?}", version, versioned_root);

--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -149,6 +149,9 @@ pub async fn process_discogs_data(
             return Ok(true);
         }
         ProcessingDecision::Reprocess => {
+            // Safe to discard the marker: should_process() only returns Reprocess when no
+            // file has finished processing (otherwise it returns Continue, so an
+            // interrupted download-verification pass cannot wipe processing progress).
             warn!("⚠️ Will re-download and re-process version {}", version);
             state_marker = StateMarker::new(version.clone());
         }

--- a/extractor/src/message_queue.rs
+++ b/extractor/src/message_queue.rs
@@ -28,6 +28,34 @@ const AMQP_EXCHANGE_TYPE: ExchangeKind = ExchangeKind::Fanout;
 /// (discogsography-rehd).
 const PUBLISH_CONFIRM_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Decide whether a publisher confirm actually proves delivery.
+///
+/// A broker ack only proves the message was RECEIVED, not that it was ROUTED: a fanout
+/// exchange with zero bound queues acks and drops. Publishing with `mandatory` makes the
+/// broker return such a message, and `returned` carries that `basic.return` — which must
+/// be treated as a failure so the file stays pending instead of being durably marked
+/// Completed while every record was discarded.
+///
+/// Scope limit: `mandatory` only detects total unroutability. If one consumer has
+/// declared and bound its queue but another has not, the message is routable and this
+/// check passes — partial-consumer loss is out of scope here.
+fn check_confirmation(exchange_name: &str, acked: bool, returned: Option<(u16, String)>) -> Result<()> {
+    if let Some((reply_code, reply_text)) = returned {
+        return Err(anyhow::anyhow!(
+            "Message to exchange '{}' was returned as unroutable ({} {}) — no consumer queue is bound",
+            exchange_name,
+            reply_code,
+            reply_text
+        ));
+    }
+
+    if !acked {
+        return Err(anyhow::anyhow!("Message was not acknowledged by broker"));
+    }
+
+    Ok(())
+}
+
 #[cfg_attr(feature = "test-support", mockall::automock)]
 #[async_trait]
 pub trait MessagePublisher: Send + Sync {
@@ -151,23 +179,44 @@ impl MessageQueue {
     /// turns the wedge into an error the caller can count and retry, and lets
     /// the task fail cleanly instead of parking the whole pipeline
     /// (discogsography-rehd).
-    async fn await_confirm<F>(confirm_future: F) -> Result<()>
+    async fn await_confirm<F>(confirm_future: F) -> Result<Confirmation>
     where
         F: std::future::Future<Output = lapin::Result<Confirmation>>,
     {
-        let confirm = match tokio::time::timeout(PUBLISH_CONFIRM_TIMEOUT, confirm_future).await {
-            Ok(result) => result.context("Failed to confirm message delivery")?,
+        match tokio::time::timeout(PUBLISH_CONFIRM_TIMEOUT, confirm_future).await {
+            Ok(result) => result.context("Failed to confirm message delivery"),
             Err(_) => {
                 error!("❌ Publisher confirm timed out after {:?} — broker may be under a resource alarm", PUBLISH_CONFIRM_TIMEOUT);
-                return Err(anyhow::anyhow!("Timed out after {:?} waiting for publisher confirm", PUBLISH_CONFIRM_TIMEOUT));
+                Err(anyhow::anyhow!("Timed out after {:?} waiting for publisher confirm", PUBLISH_CONFIRM_TIMEOUT))
             }
-        };
-
-        if !confirm.is_ack() {
-            return Err(anyhow::anyhow!("Message was not acknowledged by broker"));
         }
+    }
 
-        Ok(())
+    /// Publish options for every extractor publish.
+    ///
+    /// `mandatory` is required for correctness, not politeness: a publisher confirm on a
+    /// fanout exchange with zero bound queues still returns `basic.ack`, so without this
+    /// flag the broker silently drops the message and the extractor records the file as
+    /// Completed. With `mandatory` set, an unroutable message comes back as a
+    /// `basic.return` attached to the confirmation and is treated as a delivery failure.
+    fn publish_options() -> BasicPublishOptions {
+        BasicPublishOptions { mandatory: true, ..Default::default() }
+    }
+
+    /// Publish one already-serialized payload and require both a broker ack and proof
+    /// that the message was routable.
+    async fn publish_payload(&self, channel: &Channel, exchange_name: &str, payload: &[u8]) -> Result<()> {
+        let publish = channel
+            .basic_publish(exchange_name.into(), "".into(), Self::publish_options(), payload, Self::message_properties())
+            .await
+            .context("Failed to publish message")?;
+
+        let confirm = Self::await_confirm(publish).await?;
+
+        let acked = confirm.is_ack();
+        let returned = confirm.take_message().map(|returned| (returned.reply_code, returned.reply_text.to_string()));
+
+        check_confirmation(exchange_name, acked, returned)
     }
 
     async fn get_channel(&self) -> Result<Channel> {
@@ -229,14 +278,7 @@ impl MessagePublisher for MessageQueue {
         let exchange_name = self.exchange_name(data_type);
         let payload = serde_json::to_vec(&message).context("Failed to serialize message")?;
 
-        let publish = channel
-            .basic_publish(exchange_name.as_str().into(), "".into(), BasicPublishOptions::default(), &payload, Self::message_properties())
-            .await
-            .context("Failed to publish message")?;
-
-        Self::await_confirm(publish).await?;
-
-        Ok(())
+        self.publish_payload(&channel, &exchange_name, &payload).await
     }
 
     async fn publish_batch(&self, messages: Vec<DataMessage>, data_type: DataType) -> Result<()> {
@@ -246,12 +288,7 @@ impl MessagePublisher for MessageQueue {
         for message in messages {
             let payload = serde_json::to_vec(&Message::Data(message)).context("Failed to serialize message")?;
 
-            let publish = channel
-                .basic_publish(exchange_name.as_str().into(), "".into(), BasicPublishOptions::default(), &payload, Self::message_properties())
-                .await
-                .context("Failed to publish message")?;
-
-            Self::await_confirm(publish).await?;
+            self.publish_payload(&channel, &exchange_name, &payload).await?;
         }
 
         Ok(())

--- a/extractor/src/parser.rs
+++ b/extractor/src/parser.rs
@@ -12,6 +12,14 @@ use tracing::{debug, error, warn};
 
 use crate::types::{DataMessage, DataType};
 
+/// Maximum number of malformed XML records tolerated (skipped) per dump file.
+///
+/// A handful of poison records in a multi-GB monthly dump must not abort the whole
+/// file — that would leave the file permanently un-completable and re-published from
+/// record 0 on every restart. A large number of errors, on the other hand, means the
+/// file is genuinely unusable (wrong file, truncated download), so parsing aborts.
+const MAX_MALFORMED_RECORDS_PER_FILE: u64 = 100;
+
 /// Represents an element being parsed with its attributes and children
 #[derive(Debug)]
 struct ElementContext {
@@ -133,6 +141,13 @@ impl XmlParser {
 
         let mut reader = Reader::from_reader(buf_reader);
 
+        // Discogs dumps are known to ship records containing a bare `&` that does not
+        // start an entity reference (e.g. `<title>Tom & Jerry</title>`). quick-xml < 0.39
+        // emitted those bytes as text; 0.39+ returns `IllFormed(UnclosedReference)` unless
+        // `allow_dangling_amp` is set. Restore the tolerant behaviour so a single legacy
+        // escaping defect does not abort a multi-GB dump.
+        reader.config_mut().allow_dangling_amp = true;
+
         let mut buf = Vec::new();
         let mut record_count = 0u64;
         let mut in_target_element = false;
@@ -141,6 +156,12 @@ impl XmlParser {
         let mut element_stack: Vec<ElementContext> = Vec::new();
         // Track depth in the overall document
         let mut depth = 0usize;
+
+        // Per-record fault isolation state: a malformed record is dropped and the parser
+        // resynchronizes on the next `<target_element>` start instead of aborting the file.
+        let mut malformed_records = 0u64;
+        let mut resyncing = false;
+        let mut last_error_position = u64::MAX;
 
         // Determine the target element based on data type
         let target_element = match self.data_type {
@@ -152,8 +173,61 @@ impl XmlParser {
         };
 
         loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(e)) => {
+            let event = match reader.read_event_into(&mut buf) {
+                Ok(event) => event,
+                Err(e) => {
+                    let position = reader.buffer_position();
+                    malformed_records += 1;
+
+                    // A repeated error at the same byte offset means the reader made no
+                    // forward progress and cannot recover — abort rather than spin forever.
+                    if position == last_error_position {
+                        error!("❌ Unrecoverable XML error at position {} (no forward progress): {}", position, e);
+                        return Err(e).context(format!("Unrecoverable XML parse error at position {position}"));
+                    }
+                    if malformed_records > MAX_MALFORMED_RECORDS_PER_FILE {
+                        error!(
+                            "❌ Aborting {:?}: more than {} malformed XML records (last at position {}): {}",
+                            file_path, MAX_MALFORMED_RECORDS_PER_FILE, position, e
+                        );
+                        return Err(e).context(format!("Exceeded malformed-record budget of {MAX_MALFORMED_RECORDS_PER_FILE} in {file_path:?}"));
+                    }
+
+                    warn!(
+                        "⚠️ Skipping malformed XML record at position {} ({}/{} tolerated), resyncing on next <{}>: {}",
+                        position, malformed_records, MAX_MALFORMED_RECORDS_PER_FILE, target_element, e
+                    );
+                    last_error_position = position;
+
+                    // Discard the partially-built record and resynchronize.
+                    element_stack.clear();
+                    in_target_element = false;
+                    resyncing = true;
+
+                    buf.clear();
+                    continue;
+                }
+            };
+
+            // While resyncing, ignore everything until the next record start; document
+            // depth is unreliable after an error, so it is re-anchored here.
+            if resyncing {
+                match &event {
+                    Event::Start(e) | Event::Empty(e) if e.name().as_ref() == target_element.as_bytes() => {
+                        debug!("🔄 Resynchronized on <{}> at position {}", target_element, reader.buffer_position());
+                        resyncing = false;
+                        depth = 1;
+                    }
+                    Event::Eof => break,
+                    _ => {
+                        buf.clear();
+                        continue;
+                    }
+                }
+            }
+
+            match event {
+                Event::Start(e) => {
                     let name = String::from_utf8_lossy(e.name().as_ref()).to_string();
                     depth += 1;
 
@@ -168,7 +242,7 @@ impl XmlParser {
                     }
                 }
 
-                Ok(Event::Empty(e)) => {
+                Event::Empty(e) => {
                     // Self-closing element like <artist id="123" />
                     let name = String::from_utf8_lossy(e.name().as_ref()).to_string();
                     depth += 1;
@@ -209,7 +283,7 @@ impl XmlParser {
                     depth = depth.saturating_sub(1);
                 }
 
-                Ok(Event::End(e)) => {
+                Event::End(e) => {
                     let name = String::from_utf8_lossy(e.name().as_ref()).to_string();
 
                     if in_target_element && let Some(context) = element_stack.pop() {
@@ -263,7 +337,7 @@ impl XmlParser {
                     depth = depth.saturating_sub(1);
                 }
 
-                Ok(Event::Text(e)) => {
+                Event::Text(e) => {
                     if in_target_element
                         && let Some(context) = element_stack.last_mut()
                         && let Ok(text) = e.decode()
@@ -274,7 +348,7 @@ impl XmlParser {
 
                 // In quick-xml 0.39+, entity references (&amp; &lt; etc.) are emitted as
                 // separate GeneralRef events rather than being included in Event::Text bytes.
-                Ok(Event::GeneralRef(e)) => {
+                Event::GeneralRef(e) => {
                     if in_target_element && let Some(context) = element_stack.last_mut() {
                         if e.is_char_ref() {
                             match e.resolve_char_ref() {
@@ -301,23 +375,22 @@ impl XmlParser {
                     }
                 }
 
-                Ok(Event::CData(e)) => {
+                Event::CData(e) => {
                     if in_target_element && let Some(context) = element_stack.last_mut() {
                         context.text_content.push_str(&String::from_utf8_lossy(&e));
                     }
                 }
 
-                Ok(Event::Eof) => break,
-
-                Err(e) => {
-                    error!("❌ Error parsing XML at position {}: {}", reader.buffer_position(), e);
-                    return Err(e.into());
-                }
+                Event::Eof => break,
 
                 _ => {} // Ignore other events (comments, declarations, etc.)
             }
 
             buf.clear();
+        }
+
+        if malformed_records > 0 {
+            warn!("⚠️ Skipped {} malformed XML record(s) while parsing {:?} ({} records parsed)", malformed_records, file_path, record_count);
         }
 
         debug!("✅ Finished parsing {} records from {:?}", record_count, file_path);

--- a/extractor/src/state_marker.rs
+++ b/extractor/src/state_marker.rs
@@ -240,17 +240,37 @@ impl StateMarker {
         musicbrainz_root.join(version).join(format!(".mb_extraction_status_{}.json", version))
     }
 
+    /// Number of files that have finished processing.
+    pub fn completed_file_count(&self) -> usize {
+        self.processing_phase.progress_by_file.values().filter(|s| s.status == PhaseStatus::Completed).count()
+    }
+
     /// Check if we should re-process, continue, or skip
     pub fn should_process(&self) -> ProcessingDecision {
-        // If download failed, need to re-download
-        if self.download_phase.status == PhaseStatus::Failed {
-            warn!("⚠️ Download phase failed, will re-download");
-            return ProcessingDecision::Reprocess;
-        }
+        // A failed or interrupted download phase normally means "start over". That is
+        // only safe while nothing has been processed yet: the download layer is
+        // idempotent and self-healing (checksums re-download exactly what is missing or
+        // corrupt), whereas processing progress costs hours of parsing and tens of
+        // millions of republished messages to rebuild. A resumed run re-enters the
+        // download phase on every cycle just to re-verify already-present dumps, so a
+        // crash inside that window must not demote completed files.
+        let download_incomplete = self.download_phase.status == PhaseStatus::Failed || self.download_phase.status == PhaseStatus::InProgress;
 
-        // If download was interrupted (still InProgress), need to re-download
-        if self.download_phase.status == PhaseStatus::InProgress {
-            warn!("⚠️ Download phase interrupted, will re-download");
+        if download_incomplete {
+            let completed = self.completed_file_count();
+            if completed > 0 {
+                warn!(
+                    "⚠️ Download phase {:?} but {} file(s) already processed, will resume (downloads self-heal via checksums)",
+                    self.download_phase.status, completed
+                );
+                return ProcessingDecision::Continue;
+            }
+
+            if self.download_phase.status == PhaseStatus::Failed {
+                warn!("⚠️ Download phase failed, will re-download");
+            } else {
+                warn!("⚠️ Download phase interrupted, will re-download");
+            }
             return ProcessingDecision::Reprocess;
         }
 

--- a/extractor/src/tests/downloader_tests.rs
+++ b/extractor/src/tests/downloader_tests.rs
@@ -66,8 +66,12 @@ async fn test_load_metadata_invalid_json() {
 
     std::fs::write(&metadata_path, "invalid json").unwrap();
 
-    let result = load_metadata(temp_dir.path());
-    assert!(result.is_err());
+    // A corrupt metadata cache is recoverable (bead discogsography-fsmp): it is
+    // quarantined and loading falls back to an empty map instead of wedging startup.
+    let loaded = load_metadata(temp_dir.path()).expect("corrupt metadata must not be fatal");
+    assert!(loaded.is_empty());
+    assert!(!metadata_path.exists());
+    assert!(temp_dir.path().join(".discogs_metadata.json.corrupt").exists());
 }
 
 #[tokio::test]

--- a/extractor/src/tests/extractor_tests.rs
+++ b/extractor/src/tests/extractor_tests.rs
@@ -1255,8 +1255,9 @@ async fn test_completed_transitions_to_waiting_in_loop() {
 }
 
 mod wait_for_discogs_idle_tests {
-    use crate::extractor::{wait_for_discogs_idle, wait_for_discogs_idle_with_interval};
-    use std::sync::atomic::AtomicBool;
+    use crate::extractor::{WaitOutcome, wait_for_discogs_idle, wait_for_discogs_idle_with_interval};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use tokio::time::Duration;
 
     #[tokio::test]
@@ -1274,7 +1275,7 @@ mod wait_for_discogs_idle_tests {
         let url = format!("{}/health", server.url());
         let result = wait_for_discogs_idle(&url, &shutdown).await;
 
-        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), WaitOutcome::Proceed);
         mock.assert_async().await;
     }
 
@@ -1293,7 +1294,7 @@ mod wait_for_discogs_idle_tests {
         let url = format!("{}/health", server.url());
         let result = wait_for_discogs_idle(&url, &shutdown).await;
 
-        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), WaitOutcome::Proceed);
         mock.assert_async().await;
     }
 
@@ -1312,7 +1313,7 @@ mod wait_for_discogs_idle_tests {
         let url = format!("{}/health", server.url());
         let result = wait_for_discogs_idle(&url, &shutdown).await;
 
-        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), WaitOutcome::Proceed);
         mock.assert_async().await;
     }
 
@@ -1333,7 +1334,7 @@ mod wait_for_discogs_idle_tests {
         let url = format!("{}/health", server.url());
         let result = wait_for_discogs_idle(&url, &shutdown).await;
 
-        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), WaitOutcome::Proceed);
         mock.assert_async().await;
     }
 
@@ -1361,7 +1362,7 @@ mod wait_for_discogs_idle_tests {
         let url = format!("{}/health", server.url());
         let result = wait_for_discogs_idle_with_interval(&url, &shutdown, Duration::from_millis(10)).await;
 
-        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), WaitOutcome::Proceed);
     }
 
     #[tokio::test]
@@ -1381,7 +1382,59 @@ mod wait_for_discogs_idle_tests {
         let url = "http://127.0.0.1:19999/health";
         let result = wait_for_discogs_idle_with_interval(url, &shutdown, Duration::from_millis(10)).await;
 
-        assert!(result.is_ok());
+        // discogsography-l114: a shutdown must be distinguishable from "Discogs is idle",
+        // otherwise the caller falls through and starts a whole new extraction run.
+        assert_eq!(result.unwrap(), WaitOutcome::Shutdown);
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_while_discogs_busy() {
+        // Discogs keeps reporting "running" (the multi-hour park). SIGTERM arrives mid-wait:
+        // the wait must end promptly and report Shutdown, not Proceed.
+        let mut server = mockito::Server::new_async().await;
+        let _mock_running = server
+            .mock("GET", "/health")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"extraction_status": "running"}"#)
+            .create_async()
+            .await;
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let url = format!("{}/health", server.url());
+
+        let flag = shutdown.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            flag.store(true, Ordering::SeqCst);
+        });
+
+        // A poll interval far longer than the test timeout proves the sleep is interruptible.
+        let outcome = tokio::time::timeout(Duration::from_secs(10), wait_for_discogs_idle_with_interval(&url, &shutdown, Duration::from_secs(3600)))
+            .await
+            .expect("wait must observe shutdown instead of sleeping out the poll interval");
+
+        assert_eq!(outcome.unwrap(), WaitOutcome::Shutdown);
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_during_unreachable_retry_backoff() {
+        // Same guarantee on the unreachable-endpoint retry path.
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let flag = shutdown.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            flag.store(true, Ordering::SeqCst);
+        });
+
+        let url = "http://127.0.0.1:19999/health";
+        let outcome = tokio::time::timeout(Duration::from_secs(10), wait_for_discogs_idle_with_interval(url, &shutdown, Duration::from_secs(3600)))
+            .await
+            .expect("wait must return once shutdown is observed");
+
+        // Either the retries were exhausted first (Proceed) or shutdown won — but it must
+        // never hang, and once the flag is set the loop must stop waiting.
+        assert!(matches!(outcome.unwrap(), WaitOutcome::Shutdown | WaitOutcome::Proceed));
     }
 
     #[tokio::test]
@@ -1402,7 +1455,7 @@ mod wait_for_discogs_idle_tests {
         let elapsed = start.elapsed();
 
         assert!(result.is_ok(), "must give up after DISCOGS_MAX_UNREACHABLE_RETRIES, not hang for poll_interval-per-attempt");
-        assert!(result.unwrap().is_ok());
+        assert_eq!(result.unwrap().unwrap(), WaitOutcome::Proceed);
         assert!(elapsed < Duration::from_secs(5), "unreachable retries must not wait a full poll_interval per attempt: took {:?}", elapsed);
     }
 }

--- a/extractor/src/tests/message_queue_tests.rs
+++ b/extractor/src/tests/message_queue_tests.rs
@@ -317,10 +317,11 @@ async fn test_await_confirm_accepts_ack() {
 }
 
 #[tokio::test]
-async fn test_await_confirm_rejects_nack() {
-    let result = MessageQueue::await_confirm(async { Ok(Confirmation::Nack(None)) }).await;
-    let err = result.expect_err("a nacked publish must be an error");
-    assert!(err.to_string().contains("not acknowledged"), "unexpected error: {}", err);
+async fn test_await_confirm_passes_nack_through() {
+    // Nack rejection itself lives in check_confirmation (discogsography-i3h2);
+    // await_confirm's contract is to surface the confirmation for that check.
+    let confirm = MessageQueue::await_confirm(async { Ok(Confirmation::Nack(None)) }).await.expect("a resolved confirm must not error");
+    assert!(!confirm.is_ack(), "a nack must surface to the caller for check_confirmation");
 }
 
 #[tokio::test(start_paused = true)]
@@ -343,4 +344,43 @@ async fn test_await_confirm_times_out_on_stall() {
 fn test_publish_confirm_timeout_is_bounded() {
     assert!(PUBLISH_CONFIRM_TIMEOUT > Duration::ZERO);
     assert!(PUBLISH_CONFIRM_TIMEOUT <= Duration::from_secs(60));
+}
+
+/// Regression for discogsography-i3h2: publishes must be mandatory, otherwise the broker
+/// acks and silently drops messages that route to zero queues.
+#[test]
+fn test_publish_options_are_mandatory() {
+    let options = MessageQueue::publish_options();
+    assert!(options.mandatory, "publishes must be mandatory so unroutable messages are returned, not dropped");
+    assert!(!options.immediate, "immediate is deprecated by RabbitMQ and must stay off");
+}
+
+#[test]
+fn test_confirmation_ack_without_return() {
+    // The healthy case: acked and routed.
+    assert!(check_confirmation("discogsography-discogs-artists", true, None).is_ok());
+}
+
+#[test]
+fn test_confirmation_returned_is_failure() {
+    // RabbitMQ answers a mandatory publish that matched no queue with basic.return
+    // FOLLOWED BY basic.ack — the ack alone must not be read as delivery.
+    let err = check_confirmation("discogsography-discogs-artists", true, Some((312, "NO_ROUTE".to_string())))
+        .expect_err("an unroutable message must fail the publish");
+    let message = err.to_string();
+    assert!(message.contains("discogsography-discogs-artists"), "error should name the exchange: {message}");
+    assert!(message.contains("NO_ROUTE") && message.contains("312"), "error should carry the broker's reason: {message}");
+}
+
+#[test]
+fn test_confirmation_nack_is_failure() {
+    let err = check_confirmation("discogsography-discogs-artists", false, None).expect_err("a nack must fail the publish");
+    assert!(err.to_string().contains("not acknowledged"), "unexpected error: {err}");
+}
+
+#[test]
+fn test_confirmation_nack_with_return() {
+    // A nack that also carries a returned message reports the routing failure.
+    let err = check_confirmation("discogsography-discogs-releases", false, Some((312, "NO_ROUTE".to_string()))).expect_err("must fail");
+    assert!(err.to_string().contains("unroutable"), "unexpected error: {err}");
 }

--- a/extractor/src/tests/state_marker_tests.rs
+++ b/extractor/src/tests/state_marker_tests.rs
@@ -436,3 +436,67 @@ async fn test_all_files_complete_before_crash_keeps_original_start_time() {
     // extraction_complete on this branch must still use the original start time.
     assert_eq!(resumed.processing_phase.started_at, Some(original_started_at));
 }
+
+/// Regression for discogsography-21tg: a resumed run re-enters the download phase on
+/// every cycle (to re-verify already-present dumps). A crash inside that window left
+/// `download_phase = InProgress` on disk, which used to demote the whole marker to
+/// Reprocess and wipe every completed file. Completed processing progress must survive.
+#[test]
+fn test_interrupted_download_retains_progress() {
+    let mut marker = StateMarker::new("20260801".to_string());
+
+    // Run 1: artists + labels + masters processed, releases still pending.
+    marker.start_processing(4);
+    for file in ["discogs_20260801_artists.xml.gz", "discogs_20260801_labels.xml.gz", "discogs_20260801_masters.xml.gz"] {
+        marker.start_file_processing(file);
+        marker.complete_file_processing(file, 1000);
+    }
+    assert_eq!(marker.completed_file_count(), 3);
+
+    // Run 2: resumed run re-enters the download phase, then is killed mid-verification.
+    marker.start_download(4);
+    assert_eq!(marker.download_phase.status, PhaseStatus::InProgress);
+
+    // Run 3: must resume, not reprocess.
+    assert_eq!(marker.should_process(), ProcessingDecision::Continue);
+
+    let all_files = vec![
+        "discogs_20260801_artists.xml.gz".to_string(),
+        "discogs_20260801_labels.xml.gz".to_string(),
+        "discogs_20260801_masters.xml.gz".to_string(),
+        "discogs_20260801_releases.xml.gz".to_string(),
+    ];
+    assert_eq!(marker.pending_files(&all_files), vec!["discogs_20260801_releases.xml.gz".to_string()]);
+}
+
+/// Same protection for a download phase that recorded an outright failure: downloads
+/// are idempotent and self-heal via checksum verification, so they are never a reason
+/// to re-publish tens of millions of already-processed records.
+#[test]
+fn test_failed_download_keeps_progress() {
+    let mut marker = StateMarker::new("20260801".to_string());
+    marker.start_processing(2);
+    marker.start_file_processing("discogs_20260801_artists.xml.gz");
+    marker.complete_file_processing("discogs_20260801_artists.xml.gz", 500);
+
+    marker.download_phase.status = PhaseStatus::Failed;
+
+    assert_eq!(marker.should_process(), ProcessingDecision::Continue);
+    assert_eq!(marker.completed_file_count(), 1);
+}
+
+/// With nothing processed yet there is no progress worth protecting, so an interrupted
+/// download still means "start over".
+#[test]
+fn test_interrupted_download_no_progress() {
+    let mut marker = StateMarker::new("20260801".to_string());
+    marker.start_download(4);
+    assert_eq!(marker.completed_file_count(), 0);
+    assert_eq!(marker.should_process(), ProcessingDecision::Reprocess);
+
+    // An in-flight (not yet completed) file is not progress either.
+    marker.start_processing(4);
+    marker.start_file_processing("discogs_20260801_artists.xml.gz");
+    assert_eq!(marker.completed_file_count(), 0);
+    assert_eq!(marker.should_process(), ProcessingDecision::Reprocess);
+}

--- a/extractor/tests/downloader_test.rs
+++ b/extractor/tests/downloader_test.rs
@@ -301,9 +301,58 @@ async fn test_corrupted_metadata_handling() {
     let metadata_path = temp_dir.path().join(".discogs_metadata.json");
     fs::write(&metadata_path, "not valid json {{{").await.unwrap();
 
-    // Attempting to load should fail
-    let result = Downloader::new(temp_dir.path().to_path_buf()).await;
-    assert!(result.is_err(), "Should fail with corrupted metadata");
+    // A corrupt metadata cache must not wedge startup (bead discogsography-fsmp):
+    // it is quarantined and startup continues with empty metadata.
+    let downloader = Downloader::new(temp_dir.path().to_path_buf()).await.expect("corrupt metadata must not fail startup");
+    assert!(downloader.metadata.is_empty());
+
+    assert!(!metadata_path.exists(), "corrupt metadata file should be moved aside");
+    let quarantined = temp_dir.path().join(".discogs_metadata.json.corrupt");
+    assert!(quarantined.exists(), "corrupt metadata file should be quarantined");
+    assert_eq!(fs::read_to_string(&quarantined).await.unwrap(), "not valid json {{{");
+}
+
+#[tokio::test]
+async fn test_truncated_metadata_recovery() {
+    // A SIGKILL / power loss during a plain in-place write used to leave a truncated or
+    // zero-byte file, which parsed as an error and crash-looped the service forever.
+    for contents in ["", "{\"discogs_20260801_artists.xml.gz\":{\"path\":\"/discogs-data/dis"] {
+        let temp_dir = TempDir::new().unwrap();
+        let metadata_path = temp_dir.path().join(".discogs_metadata.json");
+        fs::write(&metadata_path, contents).await.unwrap();
+
+        let downloader = Downloader::new(temp_dir.path().to_path_buf()).await.expect("truncated metadata must not fail startup");
+        assert!(downloader.metadata.is_empty());
+        assert!(!metadata_path.exists(), "truncated metadata file should be moved aside");
+    }
+}
+
+#[tokio::test]
+async fn test_metadata_write_is_atomic() {
+    // save_metadata must go through a temp file + rename, leaving no partial state.
+    let temp_dir = TempDir::new().unwrap();
+    let mut downloader = Downloader::new(temp_dir.path().to_path_buf()).await.unwrap();
+
+    downloader.metadata.insert(
+        "discogs_20260801_artists.xml.gz".to_string(),
+        LocalFileInfo {
+            path: "/discogs-data/discogs_20260801_artists.xml.gz".to_string(),
+            checksum: "abc123".to_string(),
+            version: "202608".to_string(),
+            size: 4096,
+        },
+    );
+    downloader.save_metadata().unwrap();
+
+    let metadata_path = temp_dir.path().join(".discogs_metadata.json");
+    let tmp_path = temp_dir.path().join(".discogs_metadata.json.tmp");
+    assert!(metadata_path.exists(), "metadata file should exist after save");
+    assert!(!tmp_path.exists(), "temp file should be renamed away, not left behind");
+
+    // The persisted bytes must be complete and re-loadable.
+    let reloaded = Downloader::new(temp_dir.path().to_path_buf()).await.unwrap();
+    assert_eq!(reloaded.metadata.len(), 1);
+    assert_eq!(reloaded.metadata["discogs_20260801_artists.xml.gz"].checksum, "abc123");
 }
 
 #[tokio::test]

--- a/extractor/tests/extractor_di_test.rs
+++ b/extractor/tests/extractor_di_test.rs
@@ -1794,19 +1794,23 @@ async fn test_process_discogs_data_shutdown_before_files_does_not_finalize() {
     let state = Arc::new(RwLock::new(ExtractorState::default()));
     let shutdown = Arc::new(tokio::sync::Notify::new());
 
-    // Shutdown already requested by the time processing reaches the file loop.
+    // Shutdown already requested when the run is entered.
     let shutdown_flag = Arc::new(AtomicBool::new(true));
 
+    // Since discogsography-l114 the run bails out before touching the downloader at all:
+    // starting a multi-GB download under shutdown guarantees a SIGKILL mid-transfer.
     let mut mock_dl = MockDataSource::new();
     mock_dl
         .expect_list_s3_files()
+        .times(0)
         .returning(|| Ok(vec![S3FileInfo { name: "data/discogs_20260101_artists.xml.gz".to_string(), size: 1000 }]));
     mock_dl
         .expect_get_latest_monthly_files()
+        .times(0)
         .returning(|_| Ok(vec![S3FileInfo { name: "discogs_20260101_artists.xml.gz".to_string(), size: 1000 }]));
-    mock_dl.expect_set_state_marker().times(1).returning(|_, _| ());
-    mock_dl.expect_download_discogs_data().times(1).returning(|| Ok(vec!["discogs_20260101_artists.xml.gz".to_string()]));
-    mock_dl.expect_take_state_marker().times(1).returning(|| Some(StateMarker::new("20260101".to_string())));
+    mock_dl.expect_set_state_marker().times(0).returning(|_, _| ());
+    mock_dl.expect_download_discogs_data().times(0).returning(|| Ok(vec!["discogs_20260101_artists.xml.gz".to_string()]));
+    mock_dl.expect_take_state_marker().times(0).returning(|| Some(StateMarker::new("20260101".to_string())));
 
     let mut mock_mq = MockMessagePublisher::new();
     mock_mq.expect_setup_exchange().returning(|_| Ok(()));
@@ -1824,8 +1828,9 @@ async fn test_process_discogs_data_shutdown_before_files_does_not_finalize() {
     assert!(!result.unwrap(), "a shutdown-interrupted run must return false (not complete)");
 
     let s = state.read().await;
-    // The pending file was skipped, so nothing completed and the run is not marked Completed.
+    // Nothing completed, and the run never even flipped the status to Running.
     assert_ne!(s.extraction_status, ExtractionStatus::Completed, "an interrupted run must not report Completed");
+    assert_ne!(s.extraction_status, ExtractionStatus::Running, "a run entered under shutdown must not announce itself as Running");
     assert!(!s.completed_files.contains("discogs_20260101_artists.xml.gz"), "skipped file must not be marked completed");
 }
 
@@ -2374,4 +2379,38 @@ async fn test_process_musicbrainz_data_send_file_complete_failure_preserves_xz()
 
     // .jsonl.xz files should still be present
     assert!(versioned.join("artist.jsonl.xz").exists(), "artist.jsonl.xz should remain");
+}
+
+/// Regression for discogsography-l114: SIGTERM during the wait-for-Discogs-idle window
+/// used to fall through into a brand-new MusicBrainz run — a multi-GB download plus a
+/// full artist.jsonl.xz scan, none of which checks the shutdown flag — so the container
+/// never exited within the stop grace period and was SIGKILLed mid-download. A run
+/// entered under shutdown must bail out before doing any of that work.
+#[tokio::test]
+async fn test_musicbrainz_run_bails_under_shutdown() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut config = test_config(temp_dir.path());
+    config.musicbrainz_root = temp_dir.path().to_path_buf();
+    // Deliberately unroutable: reaching the network at all would be a bug here.
+    config.musicbrainz_dump_url = "http://127.0.0.1:19999/json-dumps/".to_string();
+    let config = Arc::new(config);
+
+    let state = Arc::new(RwLock::new(ExtractorState::default()));
+    let shutdown_flag = Arc::new(AtomicBool::new(true));
+
+    let mut mock_mq = MockMessagePublisher::new();
+    mock_mq.expect_setup_exchange().times(0).returning(|_| Ok(()));
+    mock_mq.expect_publish_batch().times(0).returning(|_, _| Ok(()));
+    mock_mq.expect_close().times(0).returning(|| Ok(()));
+    let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
+
+    let started = std::time::Instant::now();
+    let result = extractor::extractor::process_musicbrainz_data(config, state.clone(), shutdown_flag, false, factory, None).await;
+
+    assert!(result.is_ok(), "shutdown must not surface as Err: {result:?}");
+    assert!(!result.unwrap(), "a run that never started must not report success");
+    assert!(started.elapsed() < std::time::Duration::from_secs(5), "must bail immediately, not attempt a download");
+
+    let s = state.read().await;
+    assert_ne!(s.extraction_status, ExtractionStatus::Running, "a run entered under shutdown must not announce itself as Running");
 }

--- a/extractor/tests/parser_test.rs
+++ b/extractor/tests/parser_test.rs
@@ -557,7 +557,8 @@ async fn test_parse_large_batch_with_logging() {
 
 #[tokio::test]
 async fn test_parse_malformed_xml() {
-    // Test XML parsing error handling (covers lines 262-264)
+    // Malformed XML is fault-isolated per record (bead discogsography-7ykt): the bad
+    // record is dropped and parsing continues instead of aborting the whole dump file.
     let xml_content = r#"<?xml version="1.0" encoding="UTF-8"?>
 <artists>
     <artist id="1">
@@ -572,12 +573,14 @@ async fn test_parse_malformed_xml() {
     temp_file.write_all(&compressed).unwrap();
     temp_file.flush().unwrap();
 
-    let (sender, _receiver) = mpsc::channel(10);
+    let (sender, mut receiver) = mpsc::channel(10);
     let parser = XmlParser::new(DataType::Artists, sender);
-    let result = parser.parse_file(temp_file.path()).await;
+    let count = parser.parse_file(temp_file.path()).await.expect("a single malformed record must not fail the file");
 
-    // Should return an error for malformed XML
-    assert!(result.is_err());
+    // The malformed record is skipped, not emitted, and the file completes normally.
+    assert_eq!(count, 0);
+    let received = tokio::time::timeout(tokio::time::Duration::from_millis(100), receiver.recv()).await;
+    assert!(received.is_err(), "malformed record must not be published");
 }
 
 #[tokio::test]
@@ -646,4 +649,94 @@ async fn test_parse_numeric_char_ref() {
     // &#169; is the copyright symbol ©
     let name = message.data["name"].as_str().unwrap();
     assert!(name.contains("©") || name.contains("169"), "Should resolve numeric char ref, got: {}", name);
+}
+
+/// Helper: gzip `xml_content` into a temp file for `parse_file`.
+fn gzip_to_temp_file(xml_content: &str) -> NamedTempFile {
+    let mut temp_file = NamedTempFile::new().unwrap();
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(xml_content.as_bytes()).unwrap();
+    let compressed = encoder.finish().unwrap();
+    temp_file.write_all(&compressed).unwrap();
+    temp_file.flush().unwrap();
+    temp_file
+}
+
+#[tokio::test]
+async fn test_parse_bare_ampersand_in_text() {
+    // Discogs dumps historically ship unescaped `&` in text. quick-xml 0.39+ treats a
+    // dangling `&` as IllFormed unless allow_dangling_amp is set; that must not abort
+    // the file (bead discogsography-7ykt).
+    let xml_content = r#"<?xml version="1.0" encoding="UTF-8"?>
+<artists>
+    <artist id="1"><name>Artist One</name></artist>
+    <artist id="2"><name>Tom & Jerry</name></artist>
+    <artist id="3"><name>Artist Three</name></artist>
+</artists>"#;
+
+    let temp_file = gzip_to_temp_file(xml_content);
+
+    let (sender, mut receiver) = mpsc::channel(10);
+    let parser = XmlParser::new(DataType::Artists, sender);
+    let count = parser.parse_file(temp_file.path()).await.unwrap();
+    drop(parser); // release the sender so the drain loop below terminates
+
+    assert_eq!(count, 3, "a bare ampersand must not abort the dump");
+
+    let mut ids = Vec::new();
+    let mut names = Vec::new();
+    while let Some(message) = receiver.recv().await {
+        ids.push(message.id.clone());
+        names.push(message.data["name"].as_str().unwrap_or_default().to_string());
+    }
+    assert_eq!(ids, vec!["1", "2", "3"]);
+    assert!(names[1].contains("Tom") && names[1].contains("Jerry"), "text around the bare & should be preserved, got: {}", names[1]);
+}
+
+#[tokio::test]
+async fn test_parse_skips_malformed_record() {
+    // A mismatched end tag is a hard XML error: the offending record is dropped and
+    // parsing resynchronizes on the next <artist> instead of aborting the file.
+    let xml_content = r#"<?xml version="1.0" encoding="UTF-8"?>
+<artists>
+    <artist id="1"><name>Good One</name></artist>
+    <artist id="2"><name>Poison</nome></artist>
+    <artist id="3"><name>Good Three</name></artist>
+    <artist id="4"><name>Good Four</name></artist>
+</artists>"#;
+
+    let temp_file = gzip_to_temp_file(xml_content);
+
+    let (sender, mut receiver) = mpsc::channel(10);
+    let parser = XmlParser::new(DataType::Artists, sender);
+    let count = parser.parse_file(temp_file.path()).await.expect("one poison record must not fail the file");
+    drop(parser); // release the sender so the drain loop below terminates
+
+    let mut ids = Vec::new();
+    while let Some(message) = receiver.recv().await {
+        ids.push(message.id.clone());
+    }
+
+    assert_eq!(count as usize, ids.len());
+    assert!(ids.contains(&"1".to_string()), "records before the poison record must still be emitted: {ids:?}");
+    assert!(ids.contains(&"3".to_string()) && ids.contains(&"4".to_string()), "parser must resynchronize after the poison record: {ids:?}");
+    assert!(!ids.contains(&"2".to_string()), "the malformed record itself must be dropped: {ids:?}");
+}
+
+#[tokio::test]
+async fn test_parse_aborts_past_error_budget() {
+    // Beyond the tolerated malformed-record budget the file is considered unusable.
+    let mut xml_content = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<artists>\n");
+    for i in 0..200 {
+        xml_content.push_str(&format!("    <artist id=\"{i}\"><name>Bad {i}</nome></artist>\n"));
+    }
+    xml_content.push_str("</artists>");
+
+    let temp_file = gzip_to_temp_file(&xml_content);
+
+    let (sender, _receiver) = mpsc::channel(1024);
+    let parser = XmlParser::new(DataType::Artists, sender);
+    let result = parser.parse_file(temp_file.path()).await;
+
+    assert!(result.is_err(), "a file that is malformed throughout must still fail");
 }


### PR DESCRIPTION
Fixes 5 priority-2 Rust extractor findings from the 2026-08-10 bug hunt (run `wf_646d4b21`), one commit per bead.

- **discogsography-7ykt** — a single malformed XML record is isolated (counted, logged, skipped) instead of aborting the entire dump file and wedging the extractor.
- **discogsography-fsmp** — `.discogs_metadata.json` is written atomically (temp + rename) and a truncated/corrupt file is recovered from instead of fatally wedging startup.
- **discogsography-21tg** — a restart or transient error during a processing-resume run no longer demotes the state marker and loses completed-import standing.
- **discogsography-i3h2** — publishes are `mandatory` and a `basic.return` on the confirmation is treated as a delivery failure, so unroutable messages can't be silently acked away; composed with the publish-confirm timeout from #460 in a single `publish_payload` helper.
- **discogsography-l114** — SIGTERM during a MusicBrainz run no longer lets the extractor launch a fresh full extraction on the way down.

Rebase note: `i3h2` conflicted with #460's confirm-timeout in `message_queue.rs`; resolved by folding the timeout into `publish_payload` (`await_confirm` now returns the `Confirmation` for the routability check). cargo fmt/clippy/test all green locally after resolution (1,100+ Rust tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrLwHwMcu3cuQJh8cc1SyW