### PR TITLE
fix: frontend & app-logic correctness — 8 bug-hunt findings (batch:p2-frontend-logic)

### DIFF
--- a/api/nlq/tools.py
+++ b/api/nlq/tools.py
@@ -557,13 +557,16 @@ class NLQToolRunner:
                 entities.append({"id": item.get("id", ""), "name": item.get("name", ""), "type": item.get("type", "")})
 
         elif tool_name == "autocomplete":
-            entity_type = "unknown"
+            # AUTOCOMPLETE_DISPATCH handlers never return a "type" key on
+            # their result items, so this branch used to hardcode "unknown"
+            # unconditionally — discarding the requested type even though
+            # _handle_autocomplete knows it. Mirror the explore_entity
+            # convention: read the propagated _entity_type from the tool
+            # result (discogsography-apt8).
+            etype = entity_type or result.get("_entity_type", "")
             for item in result.get("results", []):
                 entity: dict[str, str] = {"id": item.get("id", ""), "name": item.get("name", "")}
-                if "type" in item:
-                    entity["type"] = item["type"]
-                else:
-                    entity["type"] = entity_type
+                entity["type"] = item.get("type") or etype
                 entities.append(entity)
 
         elif tool_name == "explore_entity":
@@ -573,12 +576,21 @@ class NLQToolRunner:
                 entities.append({"id": result.get("id", ""), "name": result.get("name", ""), "type": etype})
 
         elif tool_name == "find_path":
+            from api.queries.neo4j_queries import node_label_to_type  # noqa: PLC0415
+
+            # find_shortest_path only ever returns raw Neo4j "labels"
+            # (never "type"). Normalize through the same lowercase
+            # vocabulary /api/path uses (node_label_to_type) so this mirror
+            # site cannot diverge from it again — the raw-label fallback
+            # this replaced shipped mixed-case types like "Artist" that
+            # broke (id, type) dedup against every other producer, which
+            # always emits lowercase (discogsography-apt8).
             for node in result.get("nodes", []):
                 entities.append(
                     {
                         "id": node.get("id", ""),
                         "name": node.get("name", ""),
-                        "type": node.get("type", node.get("labels", [""])[0] if node.get("labels") else ""),
+                        "type": node.get("type") or node_label_to_type(node.get("labels", [])),
                     }
                 )
 
@@ -613,7 +625,11 @@ class NLQToolRunner:
         if handler is None:
             return {"error": f"Unknown autocomplete type: {entity_type}"}
         results = await handler(self._driver, query, limit)
-        return {"results": results}
+        # Propagate the requested type for extract_entities to fall back to
+        # (mirrors the explore_entity "_entity_type" convention) — the
+        # autocomplete handlers never return a "type" key on their result
+        # items (discogsography-apt8).
+        return {"results": results, "_entity_type": entity_type}
 
     async def _handle_explore_entity(self, params: dict[str, Any], _user_id: str | None) -> dict[str, Any]:
         from api.queries import neo4j_queries  # noqa: PLC0415

--- a/api/queries/credits_queries.py
+++ b/api/queries/credits_queries.py
@@ -143,10 +143,11 @@ async def get_person_connections(
         WHERE hop2.name <> $name AND hop2.name <> hop1.name
         WITH hop1, direct_shared, hop2, count(DISTINCT r2) AS hop2_shared
         WITH hop1, direct_shared,
-             CASE WHEN hop2 IS NOT NULL
-                  THEN collect(DISTINCT {name: hop2.name, via: hop1.name, shared: hop2_shared})[..10]
-                  ELSE []
-             END AS second_hops
+             [x IN collect(DISTINCT
+                 CASE WHEN hop2 IS NOT NULL
+                      THEN {name: hop2.name, via: hop1.name, shared: hop2_shared}
+                 END
+             ) WHERE x IS NOT NULL][..10] AS second_hops
         RETURN hop1.name AS name, direct_shared AS shared_count, second_hops
         """
     return await run_query(driver, cypher, name=name, limit=limit)

--- a/api/queries/neo4j_queries.py
+++ b/api/queries/neo4j_queries.py
@@ -913,6 +913,25 @@ EXPLORE_DISPATCH: dict[str, Any] = {
     "style": explore_style,
 }
 
+_VALID_PATH_TYPES = frozenset(EXPLORE_DISPATCH.keys())
+
+
+def node_label_to_type(labels: list[str]) -> str:
+    """Convert a Neo4j label list to a lowercase entity type string.
+
+    Single source of truth for normalizing raw Neo4j labels (e.g. "Artist",
+    "Release") into the lowercase entity-type vocabulary the rest of the API
+    uses. Both api/routers/explore.py's /api/path endpoint and the NLQ
+    find_path tool (api/nlq/tools.py) build entities from the same
+    find_shortest_path node shape and must not diverge (discogsography-apt8).
+    """
+    for label in labels:
+        lower = label.lower()
+        if lower in _VALID_PATH_TYPES:
+            return lower
+    return labels[0].lower() if labels else "unknown"
+
+
 AUTOCOMPLETE_DISPATCH: dict[str, Any] = {
     "artist": autocomplete_artist,
     "genre": autocomplete_genre,

--- a/api/queries/recommend_queries.py
+++ b/api/queries/recommend_queries.py
@@ -425,11 +425,12 @@ async def get_explore_traversal(
     MATCH path = (start)-[:{_PATH_REL_TYPES}*1..{hops}]-(discovered)
     WHERE discovered <> start
       AND (discovered:Artist OR discovered:Label OR discovered:Genre OR discovered:Style)
-    WITH DISTINCT discovered,
+    WITH discovered,
          [n IN nodes(path) | coalesce(n.name, n.title, n.id)] AS path_names,
          [r IN relationships(path) | type(r)] AS rel_types,
          length(path) AS dist
     ORDER BY dist
+    WITH discovered, collect({{path_names: path_names, rel_types: rel_types, dist: dist}})[0] AS best
     RETURN coalesce(discovered.id, discovered.name) AS id,
            coalesce(discovered.name, discovered.id) AS name,
            CASE
@@ -438,7 +439,8 @@ async def get_explore_traversal(
              WHEN discovered:Genre THEN 'genre'
              WHEN discovered:Style THEN 'style'
            END AS type,
-           path_names, rel_types, dist
+           best.path_names AS path_names, best.rel_types AS rel_types, best.dist AS dist
+    ORDER BY best.dist
     LIMIT 100
     """
     return await run_query(driver, cypher, entity_id=entity_id)

--- a/api/routers/explore.py
+++ b/api/routers/explore.py
@@ -27,6 +27,7 @@ from api.queries.neo4j_queries import (
     get_genre_emergence,
     get_graph_stats,
     get_year_range,
+    node_label_to_type,
 )
 
 
@@ -350,15 +351,10 @@ _VALID_PATH_TYPES = frozenset(EXPLORE_DISPATCH.keys())
 # _MAX_PATH_DEPTH / _DEFAULT_PATH_DEPTH are re-exported (aliased on import,
 # above) from neo4j_queries — the single source of truth for shortestPath
 # depth bounds, also used by the NLQ find_path tool handler.
-
-
-def _node_label_to_type(labels: list[str]) -> str:
-    """Convert a Neo4j label list to a lowercase entity type string."""
-    for label in labels:
-        lower = label.lower()
-        if lower in _VALID_PATH_TYPES:
-            return lower
-    return labels[0].lower() if labels else "unknown"
+# node_label_to_type is likewise re-exported from neo4j_queries — the single
+# source of truth for normalizing raw Neo4j labels, also used by the NLQ
+# find_path tool handler (api/nlq/tools.py) so the two mirror sites cannot
+# diverge again (discogsography-apt8).
 
 
 @router.get("/api/path")
@@ -433,7 +429,7 @@ async def find_path(
         PathNode(
             id=str(n["id"]),
             name=str(n["name"]),
-            type=_node_label_to_type(n["labels"]),
+            type=node_label_to_type(n["labels"]),
             rel=raw_rels[i - 1] if i > 0 else None,
         )
         for i, n in enumerate(raw_nodes)

--- a/api/routers/extraction_analysis.py
+++ b/api/routers/extraction_analysis.py
@@ -611,6 +611,37 @@ def _extract_xml_field_value(xml_text: str, field: str) -> str | None:
     return text.strip() if text and text.strip() else None
 
 
+def _find_json_field_value(node: Any, leaf: str) -> Any:
+    """Recursively search a parsed JSON value for a key named *leaf*.
+
+    Mirrors ``_extract_xml_field_value``'s ``root.iter(leaf)`` recursive
+    search. The flagged .json file is the PRE-normalization, XML-shaped
+    record (dot-notation rule fields like "genres.genre" match the raw XML
+    structure, so the parsed JSON nests the leaf under a container key —
+    e.g. ``{"genres": {"genre": [...]}}``). A top-level-only lookup misses
+    fields the XML search finds, causing correctly-parsed records to be
+    falsely classified as ``parsing_error`` (discogsography-bfcm).
+
+    Returns the first matching value found via depth-first search (dict keys
+    checked before descending into nested containers, matching
+    ElementTree.iter's document-order semantics closely enough for this
+    purpose), or None if the key never appears anywhere in the structure.
+    """
+    if isinstance(node, dict):
+        if leaf in node:
+            return node[leaf]
+        for value in node.values():
+            found = _find_json_field_value(value, leaf)
+            if found is not None:
+                return found
+    elif isinstance(node, list):
+        for item in node:
+            found = _find_json_field_value(item, leaf)
+            if found is not None:
+                return found
+    return None
+
+
 def _classify_violation(
     violation: dict[str, Any],
     flagged_dir: Path,
@@ -637,9 +668,14 @@ def _classify_violation(
     else:
         xml_value = _extract_xml_field_value(raw_xml, field) if field else None
 
-        # Extract JSON value: support dot-notation — use the last segment as the key
+        # Extract JSON value: support dot-notation — search recursively for
+        # the leaf key, mirroring the XML side's root.iter(leaf) fallback.
+        # A top-level-only .get(leaf) misses nested container fields (e.g.
+        # "genres.genre" -> {"genres": {"genre": [...]}}) that the parser
+        # handled correctly, systematically miscounting them as parsing
+        # errors (discogsography-bfcm).
         leaf = field.rsplit(".", maxsplit=1)[-1] if field else field
-        raw_json_val = parsed_json.get(leaf)
+        raw_json_val = _find_json_field_value(parsed_json, leaf) if leaf else None
         json_value = str(raw_json_val).strip() if raw_json_val is not None and str(raw_json_val).strip() else None
 
         if xml_value and not json_value:

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -508,6 +508,21 @@ class DashboardApp:
                 self.websocket_connections -= disconnected
                 WEBSOCKET_CONNECTIONS.set(len(self.websocket_connections))
 
+            # A send failure here can mean either a genuinely dead socket OR
+            # a still-live one that merely stalled past _WS_SEND_TIMEOUT_SECONDS
+            # (asyncio.wait_for cancels send_text but never closes the
+            # connection). Eviction from websocket_connections alone leaves
+            # that second case as a zombie: the endpoint's keep-alive loop
+            # (`while True: await websocket.receive_text()`) blocks forever on
+            # a healthy connection, so it never notices and never closes, and
+            # the client's `ws.onclose` — its ONLY reconnect trigger — never
+            # fires. The dashboard then shows a live-looking, permanently
+            # frozen UI. Close each evicted socket best-effort, outside the
+            # lock (mirroring the send path), so the client always reconnects.
+            for websocket in disconnected:
+                with contextlib.suppress(Exception):
+                    await websocket.close(code=1011)
+
 
 # Create the dashboard app instance
 dashboard: DashboardApp | None = None

--- a/dashboard/static/admin.html
+++ b/dashboard/static/admin.html
@@ -721,7 +721,7 @@
                         <span class="material-symbols-outlined text-sm t-dim">history</span> Admin Audit Log
                     </h3>
                     <div class="flex items-center gap-3">
-                        <select id="al-action-filter" class="text-xs border b-theme rounded px-2 py-1"
+                        <select id="al-action-filter" class="text-xs border b-theme rounded px-2 py-1">
                             <option value="">All Actions</option>
                             <option value="admin.login">Login</option>
                             <option value="admin.logout">Logout</option>

--- a/dashboard/static/admin.js
+++ b/dashboard/static/admin.js
@@ -2143,14 +2143,18 @@ class AdminDashboard {
             const tbody = document.getElementById('ea-cmp-tbody');
             if (!summary || !tableWrap || !tbody) return;
 
-            const totalA = data.total_a ?? 0;
-            const totalB = data.total_b ?? 0;
+            // The API (extraction_analysis.compare_versions) returns per-rule
+            // deltas under `details` — not `delta` — and does not send
+            // total_a/total_b directly; derive them by summing count_a/count_b
+            // across all rules (discogsography-c892).
+            const deltas = data.details || [];
+            const totalA = deltas.reduce((sum, d) => sum + (d.count_a ?? 0), 0);
+            const totalB = deltas.reduce((sum, d) => sum + (d.count_b ?? 0), 0);
             const delta = totalB - totalA;
             const sign = delta > 0 ? '+' : '';
             summary.textContent = `${vA}: ${totalA.toLocaleString()} violations → ${vB}: ${totalB.toLocaleString()} violations (${sign}${delta.toLocaleString()})`;
             summary.style.display = '';
 
-            const deltas = data.delta || [];
             if (deltas.length === 0) {
                 tbody.replaceChildren(_emptyRow(5, 'No differences found.'));
             } else {

--- a/explore/__tests__/app.test.js
+++ b/explore/__tests__/app.test.js
@@ -1520,6 +1520,13 @@ describe('ExploreApp helper methods', () => {
     });
 
     describe('ExploreApp._loadTrends', () => {
+        beforeEach(() => {
+            // See the matching comment in the _loadExplore describe block:
+            // reset the URL so a prior test's pushState doesn't trigger an
+            // ambient _restoreFromUrl load that races the call under test.
+            history.replaceState(null, '', '/');
+        });
+
         it('should set primaryTrendsData when not in compare mode', async () => {
             window.apiClient.getTrends.mockResolvedValue({ name: 'Radiohead', years: [] });
             const app = new ExploreApp();
@@ -1539,6 +1546,32 @@ describe('ExploreApp helper methods', () => {
             await app._loadTrends('Unknown', 'artist');
 
             expect(app.primaryTrendsData).toBeNull();
+        });
+
+        it('should discard a stale trends response that resolves after a newer request (discogsography-5fg0)', async () => {
+            // User selects Miles Davis, then quickly Radiohead. If the Miles
+            // Davis response arrives after Radiohead's, it must not
+            // overwrite the chart.
+            let resolveMiles;
+            const milesPromise = new Promise((resolve) => { resolveMiles = resolve; });
+            window.apiClient.getTrends
+                .mockReturnValueOnce(milesPromise)
+                .mockResolvedValueOnce({ name: 'Radiohead', years: [] });
+
+            const app = new ExploreApp();
+            app.compareMode = false;
+            app.primaryTrendsData = null;
+
+            const milesLoad = app._loadTrends('Miles Davis', 'artist');
+            const radioheadLoad = app._loadTrends('Radiohead', 'artist');
+
+            await radioheadLoad;
+            expect(app.primaryTrendsData).toEqual({ name: 'Radiohead', years: [] });
+
+            resolveMiles({ name: 'Miles Davis', years: [] });
+            await milesLoad;
+
+            expect(app.primaryTrendsData).toEqual({ name: 'Radiohead', years: [] });
         });
     });
 
@@ -1896,6 +1929,16 @@ describe('ExploreApp helper methods', () => {
     });
 
     describe('ExploreApp._loadExplore', () => {
+        beforeEach(() => {
+            // A prior test's _pushState (called from _onSearch) leaves
+            // window.location.search populated with name/type params. The
+            // constructor's unawaited `_initAuth().then(_restoreFromUrl)`
+            // picks those up and fires a second, ambient _loadExplore call
+            // that races the one under test — reset the URL so each test
+            // constructs a clean ExploreApp with no ambient restore.
+            history.replaceState(null, '', '/');
+        });
+
         it('should call apiClient.explore and initialize timeline', async () => {
             const exploreData = { center: { id: 'Radiohead', type: 'artist' }, categories: [] };
             window.apiClient.explore.mockResolvedValue(exploreData);
@@ -1956,6 +1999,39 @@ describe('ExploreApp helper methods', () => {
             await app._loadExplore('Radiohead', 'artist');
 
             expect(window.apiClient.getUserStatus).toHaveBeenCalled();
+        });
+
+        it('should discard a stale explore response that resolves after a newer request (discogsography-5fg0)', async () => {
+            // User selects artist A, then quickly artist B. A's response
+            // arrives after B's — the graph must end up showing B, not A.
+            let resolveA;
+            const aPromise = new Promise((resolve) => { resolveA = resolve; });
+            const dataA = { center: { id: 'A', type: 'artist' }, categories: [] };
+            const dataB = { center: { id: 'B', type: 'artist' }, categories: [] };
+            window.apiClient.explore
+                .mockReturnValueOnce(aPromise)
+                .mockResolvedValueOnce(dataB);
+            window.authManager.isLoggedIn.mockReturnValue(false);
+            window.apiClient.getYearRange.mockResolvedValue({ min_year: 1950, max_year: 2023 });
+            window.apiClient.getGenreEmergence.mockResolvedValue({ genres: [], styles: [] });
+
+            const app = new ExploreApp();
+            app.graph.setExploreData = vi.fn();
+            app.graph._pendingExpands = 0;
+            app.graph.onExpandsComplete = null;
+            app.graph.nodes = [];
+
+            const loadA = app._loadExplore('A', 'artist');
+            const loadB = app._loadExplore('B', 'artist');
+
+            await loadB;
+            expect(app.graph.setExploreData).toHaveBeenCalledWith(dataB);
+            app.graph.setExploreData.mockClear();
+
+            resolveA(dataA);
+            await loadA;
+
+            expect(app.graph.setExploreData).not.toHaveBeenCalled();
         });
     });
 

--- a/explore/__tests__/autocomplete.test.js
+++ b/explore/__tests__/autocomplete.test.js
@@ -293,6 +293,34 @@ describe('Autocomplete', () => {
 
             expect(instance.activeIndex).toBe(-1);
         });
+
+        it('should discard a stale response that resolves after a newer request (discogsography-5fg0)', async () => {
+            // Simulate a broad/slow query ('bea') that resolves AFTER a
+            // narrower/faster query ('beatles') fired right after it — the
+            // 300ms debounce only cancels the pending timer, not an
+            // already-dispatched fetch.
+            let resolveBea;
+            const beaPromise = new Promise((resolve) => { resolveBea = resolve; });
+            window.apiClient.autocomplete
+                .mockReturnValueOnce(beaPromise)
+                .mockResolvedValueOnce([{ name: 'The Beatles' }]);
+
+            const firstSearch = instance._search('bea');
+            const secondSearch = instance._search('beatles');
+
+            // 'beatles' (the newer, narrower request) resolves first.
+            await secondSearch;
+            expect(instance.results).toEqual([{ name: 'The Beatles' }]);
+
+            // The stale 'bea' response arrives late and must NOT overwrite
+            // the results or reset the keyboard-navigation index.
+            instance.activeIndex = 3;
+            resolveBea([{ name: 'Beach House' }, { name: 'Beach Boys' }]);
+            await firstSearch;
+
+            expect(instance.results).toEqual([{ name: 'The Beatles' }]);
+            expect(instance.activeIndex).toBe(3);
+        });
     });
 
     describe('outside click', () => {

--- a/explore/__tests__/graph.test.js
+++ b/explore/__tests__/graph.test.js
@@ -240,6 +240,57 @@ describe('GraphVisualization', () => {
             // the previous session's year filter.
             expect(window.apiClient.expand).toHaveBeenCalledWith('Radiohead', 'artist', 'releases', 30, 0, null);
         });
+
+        it('should discard a stale category expansion from a superseded search (discogsography-5fg0)', async () => {
+            // Search #1 (Rock) starts expanding cat-releases; before that
+            // network call resolves, the user starts search #2 (Prince),
+            // which does NOT have a cat-releases category with the same id
+            // reused across entities in real usage. Simulate the stale
+            // response finally resolving after search #2 has already begun.
+            let resolveRockExpand;
+            const rockExpandPromise = new Promise((resolve) => { resolveRockExpand = resolve; });
+            window.apiClient.expand.mockReturnValueOnce(rockExpandPromise);
+
+            const rockData = {
+                center: { id: 'rock', name: 'Rock', type: 'genre' },
+                categories: [
+                    { id: 'cat-releases', name: 'Releases', category: 'releases', count: 5 },
+                ],
+            };
+            graph.setExploreData(rockData);
+            // Let the microtask queue turn so _expandCategory starts and awaits.
+            await Promise.resolve();
+
+            // User moves on before Rock's expand resolves.
+            const princeData = {
+                center: { id: 'prince', name: 'Prince', type: 'artist' },
+                categories: [
+                    { id: 'cat-labels', name: 'Labels', category: 'labels', count: 3 },
+                ],
+            };
+            window.apiClient.expand.mockResolvedValueOnce({
+                children: [{ id: 'wb', name: 'Warner Bros', type: 'label' }],
+                total: 1, limit: 30, has_more: false, offset: 0,
+            });
+            graph.setExploreData(princeData);
+            expect(graph.centerName).toBe('Prince');
+
+            const pendingBeforeStaleResolve = graph._pendingExpands;
+
+            // Rock's stale expand finally resolves.
+            resolveRockExpand({
+                children: [{ id: '1', name: 'Rock Album', type: 'release' }],
+                total: 1, limit: 30, has_more: false, offset: 0,
+            });
+            await new Promise(r => setTimeout(r, 10));
+
+            // The stale response must not have pushed a Rock release node
+            // under Prince's graph, nor mutated Prince's pending-expand
+            // counter or centerName.
+            expect(graph.nodes.find(n => n.id === 'child-release-1')).toBeUndefined();
+            expect(graph.centerName).toBe('Prince');
+            expect(graph._pendingExpands).toBeLessThanOrEqual(pendingBeforeStaleResolve);
+        });
     });
 
     describe('_addLoadMoreNode', () => {
@@ -677,7 +728,7 @@ describe('GraphVisualization', () => {
                 });
 
             graph._pendingExpands = 1;
-            await graph._fetchComparisonData('cat-releases', 'Radiohead', 'artist', 'releases');
+            await graph._fetchComparisonData(graph._generation, 'cat-releases', 'Radiohead', 'artist', 'releases');
 
             const aOnly = graph.nodes.find(n => n.id === 'child-release-1');
             const both = graph.nodes.find(n => n.id === 'child-release-2');
@@ -695,7 +746,7 @@ describe('GraphVisualization', () => {
             window.apiClient.expand.mockRejectedValue(new Error('fail'));
 
             graph._pendingExpands = 1;
-            await graph._fetchComparisonData('cat-releases', 'Radiohead', 'artist', 'releases');
+            await graph._fetchComparisonData(graph._generation, 'cat-releases', 'Radiohead', 'artist', 'releases');
 
             const toast = document.getElementById('shareToast');
             expect(toast.classList.contains('show')).toBe(true);
@@ -813,7 +864,7 @@ describe('GraphVisualization', () => {
             });
 
             graph._pendingExpands = 1;
-            await graph._expandCategoryFiltered('cat-releases', 'Radiohead', 'artist', 'releases');
+            await graph._expandCategoryFiltered(graph._generation, 'cat-releases', 'Radiohead', 'artist', 'releases');
 
             expect(window.apiClient.expand).toHaveBeenCalledWith('Radiohead', 'artist', 'releases', 30, 0, 1990);
             expect(graph.nodes.find(n => n.id === 'child-release-1')).toBeDefined();
@@ -1149,7 +1200,7 @@ describe('GraphVisualization', () => {
             graph._pendingExpands = 1;
 
             const checkSpy = vi.spyOn(graph, '_checkExpandsDone');
-            await graph._expandCategory('cat-releases', 'Radiohead', 'artist', 'releases');
+            await graph._expandCategory(graph._generation, 'cat-releases', 'Radiohead', 'artist', 'releases');
 
             expect(graph._pendingExpands).toBe(0);
             expect(checkSpy).toHaveBeenCalled();
@@ -1172,7 +1223,7 @@ describe('GraphVisualization', () => {
                 total: 2, limit: 30, has_more: false, offset: 0,
             });
 
-            await graph._expandCategory('cat-releases', 'Radiohead', 'artist', 'releases');
+            await graph._expandCategory(graph._generation, 'cat-releases', 'Radiohead', 'artist', 'releases');
 
             // Should have the pre-existing one plus the new one
             const childNodes = graph.nodes.filter(n => n.id.startsWith('child-'));
@@ -1187,7 +1238,7 @@ describe('GraphVisualization', () => {
                 total: 50, limit: 30, has_more: true, offset: 0,
             });
 
-            await graph._expandCategory('cat-releases', 'Radiohead', 'artist', 'releases');
+            await graph._expandCategory(graph._generation, 'cat-releases', 'Radiohead', 'artist', 'releases');
 
             const loadMore = graph.nodes.find(n => n.isLoadMore);
             expect(loadMore).toBeDefined();
@@ -1333,7 +1384,7 @@ describe('GraphVisualization', () => {
                 });
 
             graph._pendingExpands = 1;
-            await graph._fetchComparisonData('cat-releases', 'Radiohead', 'artist', 'releases');
+            await graph._fetchComparisonData(graph._generation, 'cat-releases', 'Radiohead', 'artist', 'releases');
 
             const catNode = graph.nodes.find(n => n.id === 'cat-releases');
             expect(catNode.name).toContain('1');
@@ -1360,7 +1411,7 @@ describe('GraphVisualization', () => {
                 });
 
             graph._pendingExpands = 1;
-            await graph._fetchComparisonData('cat-releases', 'Radiohead', 'artist', 'releases');
+            await graph._fetchComparisonData(graph._generation, 'cat-releases', 'Radiohead', 'artist', 'releases');
 
             // child-release-1 should NOT be duplicated
             const matching = graph.nodes.filter(n => n.id === 'child-release-1');

--- a/explore/__tests__/insights.test.js
+++ b/explore/__tests__/insights.test.js
@@ -385,6 +385,33 @@ describe('InsightsPanel', () => {
             expect(chip1.classList.contains('active')).toBe(true);
             expect(chip2.classList.contains('active')).toBe(false);
         });
+
+        it('should discard a stale response for a genre the user has since navigated away from (discogsography-5fg0)', async () => {
+            // A slower request for the previously-clicked genre ('Jazz')
+            // resolves AFTER a faster request for the newly-clicked genre
+            // ('Classical'). The stale response must not overwrite the chart.
+            let resolveJazz;
+            const jazzPromise = new Promise((resolve) => { resolveJazz = resolve; });
+            window.apiClient = {
+                getInsightsGenreTrends: vi.fn()
+                    .mockReturnValueOnce(jazzPromise)
+                    .mockResolvedValueOnce({ genre: 'Classical', trends: [{ decade: 1990, release_count: 5 }] }),
+            };
+            const renderSpy = vi.spyOn(window.insightsPanel, '_renderGenreTrends');
+
+            const jazzLoad = window.insightsPanel._loadGenreTrends('Jazz');
+            const classicalLoad = window.insightsPanel._loadGenreTrends('Classical');
+
+            await classicalLoad;
+            expect(renderSpy).toHaveBeenCalledWith({ genre: 'Classical', trends: [{ decade: 1990, release_count: 5 }] });
+            renderSpy.mockClear();
+
+            resolveJazz({ genre: 'Jazz', trends: [{ decade: 1980, release_count: 3 }] });
+            await jazzLoad;
+
+            expect(renderSpy).not.toHaveBeenCalled();
+            expect(window.insightsPanel._selectedGenre).toBe('Classical');
+        });
     });
 
     describe('_renderGenreTrends', () => {

--- a/explore/static/js/app.js
+++ b/explore/static/js/app.js
@@ -365,6 +365,10 @@ class ExploreApp {
 
         // Request counter for preventing stale node-click responses
         this._nodeClickRequestId = 0;
+        // Request counters for preventing stale explore/trends responses
+        // (mirrors _nodeClickRequestId — see discogsography-5fg0)
+        this._exploreRequestId = 0;
+        this._trendsRequestId = 0;
 
         // Initialize components
         this.autocomplete = new Autocomplete();
@@ -947,11 +951,16 @@ class ExploreApp {
     }
 
     async _loadExplore(name, type) {
+        // Guard against out-of-order responses: mirrors the _nodeClickRequestId
+        // pattern (discogsography-5fg0) so a slower earlier explore load can
+        // never clobber a faster, more recent one.
+        const requestId = ++this._exploreRequestId;
         const loading = document.getElementById('graphLoading');
         loading.classList.add('active');
         let loaded = false;
         try {
             const data = await window.apiClient.explore(name, type);
+            if (requestId !== this._exploreRequestId) return;
             if (data) {
                 await new Promise((resolve) => {
                     // Set callback BEFORE setExploreData to avoid race where
@@ -967,12 +976,16 @@ class ExploreApp {
                         resolve();
                     }
                 });
+                if (requestId !== this._exploreRequestId) return;
                 // Decorate release nodes with ownership badges if logged in
                 await this._decorateOwnership();
+                if (requestId !== this._exploreRequestId) return;
                 loaded = true;
             }
         } finally {
-            loading.classList.remove('active');
+            if (requestId === this._exploreRequestId) {
+                loading.classList.remove('active');
+            }
         }
         // Initialize timeline scrubber after spinner is dismissed (don't auto-show)
         if (loaded) {
@@ -1075,10 +1088,15 @@ class ExploreApp {
     }
 
     async _loadTrends(name, type) {
+        // Guard against out-of-order responses (discogsography-5fg0): mirrors
+        // _nodeClickRequestId — bail before touching the chart if a newer
+        // trends request has since been issued.
+        const requestId = ++this._trendsRequestId;
         const loading = document.getElementById('trendsLoading');
         loading.classList.add('active');
         try {
             const data = await window.apiClient.getTrends(name, type);
+            if (requestId !== this._trendsRequestId) return;
             if (data) {
                 if (this.compareMode && this.primaryTrendsData) {
                     this.trends.addComparison(data);
@@ -1096,7 +1114,9 @@ class ExploreApp {
                 }
             }
         } finally {
-            loading.classList.remove('active');
+            if (requestId === this._trendsRequestId) {
+                loading.classList.remove('active');
+            }
         }
     }
 

--- a/explore/static/js/autocomplete.js
+++ b/explore/static/js/autocomplete.js
@@ -13,6 +13,11 @@ class Autocomplete {
         this.activeIndex = -1;
         this.results = [];
         this.onSelect = null;
+        // Request counter guarding against out-of-order responses — mirrors
+        // search.js's searchRequestId (discogsography-5fg0): the 300ms
+        // debounce only cancels the pending timer, not an already-dispatched
+        // fetch, so two queries can be in flight and resolve out of order.
+        this._reqId = 0;
 
         this._bindEvents();
     }
@@ -45,8 +50,11 @@ class Autocomplete {
     }
 
     async _search(query) {
+        const requestId = ++this._reqId;
         const type = window.exploreApp ? window.exploreApp.searchType : 'artist';
-        this.results = await window.apiClient.autocomplete(query, type);
+        const results = await window.apiClient.autocomplete(query, type);
+        if (requestId !== this._reqId) return;
+        this.results = results;
         this.activeIndex = -1;
         this._render();
     }

--- a/explore/static/js/graph.js
+++ b/explore/static/js/graph.js
@@ -17,6 +17,13 @@ class GraphVisualization {
         this.expandedCategories = new Set();
         this._pendingExpands = 0;
         this._loadingCategories = new Set();
+        // Monotonically increasing generation token. Bumped by every method
+        // that starts a new load/session (setExploreData, restoreSnapshot,
+        // setBeforeYear, setCompareYears). In-flight async expand/fetch calls
+        // capture the generation at start and re-check it after every await,
+        // discarding stale work instead of mutating state that belongs to a
+        // newer session (discogsography-5fg0).
+        this._generation = 0;
 
         // Track per-category pagination state: categoryId → {offset, limit, total, parentName, parentType, category}
         this._categoryMeta = new Map();
@@ -174,6 +181,9 @@ class GraphVisualization {
      * Returns a promise that resolves when all expansions are complete.
      */
     setExploreData(data) {
+        // New session: invalidate any in-flight expansions from a prior call.
+        const gen = ++this._generation;
+
         // Stop any existing simulation
         if (this.simulation) {
             this.simulation.stop();
@@ -244,20 +254,25 @@ class GraphVisualization {
         // Expand all categories concurrently, render once when all are done
         this._pendingExpands = expandable.length;
         expandable.forEach(cat => {
-            this._expandCategory(cat.id, center.name, center.type, cat.category);
+            this._expandCategory(gen, cat.id, center.name, center.type, cat.category);
         });
     }
 
-    async _expandCategory(categoryId, parentName, parentType, category) {
+    async _expandCategory(gen, categoryId, parentName, parentType, category) {
         if (this.expandedCategories.has(categoryId)) {
-            this._pendingExpands--;
-            this._checkExpandsDone();
+            if (gen === this._generation) {
+                this._pendingExpands--;
+                this._checkExpandsDone();
+            }
             return;
         }
         this.expandedCategories.add(categoryId);
 
         try {
             const data = await window.apiClient.expand(parentName, parentType, category, 30, 0, this.beforeYear);
+            // Stale response: a newer setExploreData/setBeforeYear/etc. has
+            // superseded this session — discard rather than corrupt it.
+            if (gen !== this._generation) return;
             const { children, total, limit, has_more } = data;
 
             // Store pagination state for this category
@@ -289,8 +304,10 @@ class GraphVisualization {
                 this._addLoadMoreNode(categoryId, total - children.length);
             }
         } finally {
-            this._pendingExpands--;
-            this._checkExpandsDone();
+            if (gen === this._generation) {
+                this._pendingExpands--;
+                this._checkExpandsDone();
+            }
         }
     }
 
@@ -317,6 +334,7 @@ class GraphVisualization {
     }
 
     async _loadMoreCategory(d) {
+        const gen = this._generation;
         const meta = this._categoryMeta.get(d.categoryId);
         if (!meta) return;
         if (this._loadingCategories.has(d.categoryId)) return;
@@ -325,6 +343,8 @@ class GraphVisualization {
         try {
             const { parentName, parentType, category, offset, limit, total } = meta;
             const data = await window.apiClient.expand(parentName, parentType, category, limit, offset, this.beforeYear);
+            // Stale response: a newer session has superseded this one.
+            if (gen !== this._generation) return;
             const { children, has_more } = data;
 
             // Remove the load-more node and its link
@@ -609,6 +629,9 @@ class GraphVisualization {
      * @param {{id: string, type: string}} center
      */
     restoreSnapshot(snapshotNodes, center) {
+        // New session: invalidate any in-flight expansions from a prior call.
+        ++this._generation;
+
         if (this.simulation) {
             this.simulation.stop();
             this.simulation = null;
@@ -666,6 +689,8 @@ class GraphVisualization {
      * @param {number|null} year - Year to filter to, or null to clear
      */
     async setBeforeYear(year) {
+        // New session: invalidate any in-flight expansions from a prior call.
+        const gen = ++this._generation;
         this.beforeYear = year;
 
         // Re-expand all categories with the new year filter
@@ -706,14 +731,16 @@ class GraphVisualization {
         }
 
         for (const cat of categories) {
-            this._expandCategoryFiltered(cat.catId, cat.parentName, cat.parentType, cat.category);
+            this._expandCategoryFiltered(gen, cat.catId, cat.parentName, cat.parentType, cat.category);
         }
     }
 
-    async _expandCategoryFiltered(categoryId, parentName, parentType, category) {
+    async _expandCategoryFiltered(gen, categoryId, parentName, parentType, category) {
         this.expandedCategories.add(categoryId);
         try {
             const data = await window.apiClient.expand(parentName, parentType, category, 30, 0, this.beforeYear);
+            // Stale response: a newer session has superseded this one.
+            if (gen !== this._generation) return;
             const { children, total, limit, has_more } = data;
 
             this._categoryMeta.set(categoryId, {
@@ -747,8 +774,10 @@ class GraphVisualization {
                 this._addLoadMoreNode(categoryId, total - children.length);
             }
         } finally {
-            this._pendingExpands--;
-            this._checkExpandsDone();
+            if (gen === this._generation) {
+                this._pendingExpands--;
+                this._checkExpandsDone();
+            }
         }
     }
 
@@ -758,6 +787,8 @@ class GraphVisualization {
      * @param {number} yearB - Later year
      */
     async setCompareYears(yearA, yearB) {
+        // New session: invalidate any in-flight expansions from a prior call.
+        const gen = ++this._generation;
         this.compareMode = true;
         this.compareYearA = yearA;
         this.compareYearB = yearB;
@@ -800,14 +831,14 @@ class GraphVisualization {
         }
 
         for (const cat of categories) {
-            this._fetchComparisonData(cat.catId, cat.parentName, cat.parentType, cat.category);
+            this._fetchComparisonData(gen, cat.catId, cat.parentName, cat.parentType, cat.category);
         }
     }
 
     /**
      * Fetch data for both years and diff, then insert merged nodes.
      */
-    async _fetchComparisonData(categoryId, parentName, parentType, category) {
+    async _fetchComparisonData(gen, categoryId, parentName, parentType, category) {
         this.expandedCategories.add(categoryId);
         try {
             // Parallel fetch for both years
@@ -828,6 +859,9 @@ class GraphVisualization {
                 }
                 return;
             }
+
+            // Stale response: a newer session has superseded this one.
+            if (gen !== this._generation) return;
 
             // Build lookup maps keyed by composite type:id
             const mapA = new Map();
@@ -883,8 +917,10 @@ class GraphVisualization {
 
             // No load-more in comparison mode
         } finally {
-            this._pendingExpands--;
-            this._checkExpandsDone();
+            if (gen === this._generation) {
+                this._pendingExpands--;
+                this._checkExpandsDone();
+            }
         }
     }
 

--- a/explore/static/js/insights.js
+++ b/explore/static/js/insights.js
@@ -130,6 +130,11 @@ class InsightsPanel {
         });
 
         const data = await window.apiClient.getInsightsGenreTrends(genre);
+        // Guard against out-of-order responses (discogsography-5fg0): a
+        // slower request for a previously-selected genre can resolve after
+        // a faster one for the currently-selected genre. Bail if the
+        // response is no longer for the active chip.
+        if (this._selectedGenre !== genre) return;
         this._renderGenreTrends(data);
     }
 

--- a/tests/api/nlq/test_tools.py
+++ b/tests/api/nlq/test_tools.py
@@ -130,6 +130,10 @@ async def test_execute_autocomplete(runner: NLQToolRunner) -> None:
     ):
         result = await runner.execute("autocomplete", {"type": "artist", "query": "radio"})
     assert result["results"] == ac_items
+    # Regression for discogsography-apt8: the requested type must be
+    # propagated so extract_entities can tag results correctly instead of
+    # falling back to "unknown".
+    assert result["_entity_type"] == "artist"
 
 
 @pytest.mark.asyncio
@@ -493,6 +497,23 @@ def test_extract_entities_from_autocomplete(runner: NLQToolRunner) -> None:
     assert entities[0]["name"] == "Radiohead"
 
 
+def test_extract_entities_from_autocomplete_uses_propagated_entity_type(runner: NLQToolRunner) -> None:
+    """Regression for discogsography-apt8.
+
+    AUTOCOMPLETE_DISPATCH handlers never return a "type" key on their result
+    items, so extract_entities used to hardcode "unknown" for every
+    autocomplete-derived entity, unconditionally discarding the requested
+    type — even though _handle_autocomplete knows it and now propagates it
+    via the "_entity_type" key (mirroring the explore_entity convention).
+    """
+    result: dict[str, Any] = {
+        "results": [{"id": "45", "name": "Aphex Twin"}],
+        "_entity_type": "artist",
+    }
+    entities = runner.extract_entities("autocomplete", result)
+    assert entities == [{"id": "45", "name": "Aphex Twin", "type": "artist"}]
+
+
 def test_extract_entities_from_explore(runner: NLQToolRunner) -> None:
     """Extract entities from explore_entity results (flat dict from explore handlers)."""
     result: dict[str, Any] = {"id": "a1", "name": "Radiohead", "release_count": 42, "_entity_type": "artist"}
@@ -512,6 +533,30 @@ def test_extract_entities_from_path(runner: NLQToolRunner) -> None:
     }
     entities = runner.extract_entities("find_path", result)
     assert len(entities) == 2
+
+
+def test_extract_entities_from_path_normalizes_raw_neo4j_labels(runner: NLQToolRunner) -> None:
+    """Regression for discogsography-apt8.
+
+    find_shortest_path only ever returns raw Neo4j "labels" (never "type"),
+    so extract_entities used to fall back to the raw, mixed-case label
+    ("Artist", "Release") instead of normalizing it like /api/path's
+    node_label_to_type does — breaking (id, type) dedup against every other
+    NLQ entity producer, which always emits lowercase types, and shipping a
+    "Release" chip that /api/explore rejects (Release is not explorable).
+    """
+    result: dict[str, Any] = {
+        "nodes": [
+            {"id": "a1", "name": "Kraftwerk", "labels": ["Artist"]},
+            {"id": "r1", "name": "Autobahn", "labels": ["Release"]},
+        ],
+        "rels": ["BY"],
+    }
+    entities = runner.extract_entities("find_path", result)
+    assert entities == [
+        {"id": "a1", "name": "Kraftwerk", "type": "artist"},
+        {"id": "r1", "name": "Autobahn", "type": "release"},
+    ]
 
 
 def test_extract_entities_autocomplete_with_type_key(runner: NLQToolRunner) -> None:

--- a/tests/api/test_credits_queries.py
+++ b/tests/api/test_credits_queries.py
@@ -164,6 +164,49 @@ class TestGetPersonConnections:
         result = await get_person_connections(driver, "Test", depth=5, limit=50)
         assert result == []
 
+    @pytest.mark.asyncio
+    async def test_depth_2_cypher_is_valid_grouping_not_just_mocked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Regression for discogsography-4828.
+
+        The depth>=2 branch used to wrap `collect(DISTINCT {...})` in a CASE
+        that referenced `hop2` OUTSIDE the aggregation, which Neo4j rejects at
+        compile time ("Aggregation column contains implicit grouping
+        expressions: hop2") — a real ClientError the mocked driver in the
+        other tests here can never surface. Verified against a live Neo4j 5
+        instance (both that the pre-fix Cypher raises exactly that error and
+        that the fixed Cypher executes and returns the expected rows).
+
+        Pin the structural fix in source form: the CASE referencing `hop2`
+        must be nested INSIDE the collect(...) call's argument list, not
+        wrapped around it.
+        """
+        captured: dict[str, str] = {}
+
+        async def _fake_run_query(_driver: Any, cypher: str, **_params: Any) -> list[dict[str, Any]]:
+            captured["cypher"] = cypher
+            return []
+
+        monkeypatch.setattr("api.queries.credits_queries.run_query", _fake_run_query)
+
+        driver = _make_mock_driver(query_returns=[])
+        await get_person_connections(driver, "Test", depth=2, limit=50)
+
+        cypher = captured["cypher"]
+        collect_start = cypher.index("collect(DISTINCT")
+        collect_end = cypher.index(")", cypher.index("END", collect_start)) + 1
+        case_idx = cypher.index("CASE WHEN hop2 IS NOT NULL")
+
+        # The CASE referencing hop2 must be nested inside collect(...)'s
+        # argument list, not wrapped around it — otherwise hop2 is a bare
+        # grouping-key violation outside the aggregate.
+        assert collect_start < case_idx < collect_end, (
+            "The `CASE WHEN hop2 IS NOT NULL` branch must be INSIDE "
+            "collect(DISTINCT ...)'s arguments, not wrapped around the whole "
+            "collect(...) call — the latter is the exact pre-fix defect "
+            "(discogsography-4828) that Neo4j rejects as an implicit "
+            "grouping expression."
+        )
+
 
 class TestAutocompletePerson:
     """Tests for autocomplete_person."""

--- a/tests/api/test_extraction_analysis.py
+++ b/tests/api/test_extraction_analysis.py
@@ -1395,6 +1395,88 @@ class TestClassifyViolationBothPresent:
         assert result["json_value"] == "1990"
 
 
+class TestFindJsonFieldValue:
+    """Regression tests for discogsography-bfcm."""
+
+    def test_finds_top_level_key(self) -> None:
+        import api.routers.extraction_analysis as ea
+
+        assert ea._find_json_field_value({"name": "Rock"}, "name") == "Rock"
+
+    def test_finds_nested_key_under_container(self) -> None:
+        """The pre-normalization JSON shape nests dot-notation leaves under
+        a container key — e.g. {"genres": {"genre": [...]}} for a
+        "genres.genre" rule field — which a top-level-only lookup misses.
+        """
+        import api.routers.extraction_analysis as ea
+
+        parsed = {"genres": {"genre": ["Rock", "Pop"]}}
+        assert ea._find_json_field_value(parsed, "genre") == ["Rock", "Pop"]
+
+    def test_finds_key_nested_under_a_sibling_container(self) -> None:
+        """Mirrors the real Discogs artist shape: <aliases><name>X</name></aliases>
+        unwraps to {"aliases": {"name": [...]}} — "name" nested one level
+        under the "aliases" container, not at the record's top level.
+        """
+        import api.routers.extraction_analysis as ea
+
+        parsed = {"aliases": {"name": ["Alias A", "Alias B"]}}
+        assert ea._find_json_field_value(parsed, "name") == ["Alias A", "Alias B"]
+
+    def test_finds_key_nested_inside_a_list_of_dicts(self) -> None:
+        import api.routers.extraction_analysis as ea
+
+        parsed = {"items": [{"other": 1}, {"name": "Found Me"}]}
+        assert ea._find_json_field_value(parsed, "name") == "Found Me"
+
+    def test_returns_none_when_key_absent_anywhere(self) -> None:
+        import api.routers.extraction_analysis as ea
+
+        assert ea._find_json_field_value({"genres": {"style": ["Punk"]}}, "genre") is None
+
+
+class TestClassifyViolationNestedJsonField:
+    """Regression tests for discogsography-bfcm.
+
+    A rule on a nested dot-notation field (e.g. "genres.genre") must not be
+    falsely classified as parsing_error just because the JSON value lives
+    under a container key that a top-level-only lookup would miss.
+    """
+
+    def test_nested_field_present_in_both_is_source_issue_not_parsing_error(self, tmp_path: Path) -> None:
+        import api.routers.extraction_analysis as ea
+
+        entity_dir = tmp_path / "releases"
+        entity_dir.mkdir(parents=True)
+        (entity_dir / "1.xml").write_text("<release><genres><genre>Rock</genre></genres></release>")
+        # Pre-normalization JSON shape: the parser handled this correctly,
+        # but the value lives under the "genres" container, not top-level.
+        (entity_dir / "1.json").write_text(json.dumps({"genres": {"genre": "Rock"}}))
+
+        violation = {"record_id": "1", "rule": "genre-not-recognized", "severity": "warning", "field": "genres.genre"}
+        result = ea._classify_violation(violation, tmp_path, "releases")
+
+        assert result["classification"] != "parsing_error"
+        assert result["classification"] == "source_issue"
+        assert result["xml_value"] == "Rock"
+        assert result["json_value"] == "Rock"
+
+    def test_nested_field_missing_from_both_is_source_issue(self, tmp_path: Path) -> None:
+        import api.routers.extraction_analysis as ea
+
+        entity_dir = tmp_path / "releases"
+        entity_dir.mkdir(parents=True)
+        (entity_dir / "2.xml").write_text("<release><genres></genres></release>")
+        (entity_dir / "2.json").write_text(json.dumps({"genres": {}}))
+
+        violation = {"record_id": "2", "rule": "genre-not-recognized", "severity": "warning", "field": "genres.genre"}
+        result = ea._classify_violation(violation, tmp_path, "releases")
+
+        assert result["classification"] == "source_issue"
+        assert result["xml_value"] is None
+        assert result["json_value"] is None
+
+
 class TestCompareVersionsEdgeCases:
     def test_removed_rule_in_version_b(self, test_client: TestClient, tmp_path: Path) -> None:
         """Rule present in A but absent in B is counted as improved/removed_rules (lines 540-542)."""

--- a/tests/api/test_recommend_queries.py
+++ b/tests/api/test_recommend_queries.py
@@ -780,6 +780,43 @@ class TestGetExploreTraversal:
         # Should NOT have called Neo4j at all
         driver.session.return_value.__aenter__.return_value.run.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_cypher_dedupes_per_discovered_node_not_per_path(self) -> None:
+        """Regression for discogsography-6mvm.
+
+        `WITH DISTINCT discovered, path_names, rel_types, dist` dedupes the
+        whole PATH tuple, not the discovered node — an artist with N releases
+        on one label produced N duplicate rows for that label (one per
+        distinct path), crowding real discoveries out of the LIMIT 100 cut.
+        Verified directly against a live Neo4j 5 instance (docker): the
+        pre-fix query returned 5 duplicate rows for a single label reached via
+        5 releases, the fixed query returns exactly 1 (shortest path kept).
+
+        Pin the structural fix: dedup must aggregate per `discovered` (via
+        `collect(...)[0]` after an `ORDER BY dist`, which keeps the shortest
+        path), not just `DISTINCT` the raw per-path tuple.
+        """
+        from api.queries.recommend_queries import get_explore_traversal
+
+        driver = _make_driver(records=[])
+        await get_explore_traversal(driver, "artist", "a1", hops=2)
+        call_args = driver.session.return_value.__aenter__.return_value.run.call_args
+        cypher = call_args[0][0]
+
+        # The old buggy pattern must be gone.
+        assert "WITH DISTINCT discovered," not in cypher
+
+        # Discovered nodes must be collapsed via an aggregation keyed on
+        # `discovered` alone, ordered by distance so collect(...)[0] is the
+        # shortest path.
+        assert "ORDER BY dist" in cypher
+        assert "WITH discovered, collect(" in cypher
+        assert ")[0] AS best" in cypher
+        # And the final RETURN/ORDER BY/LIMIT must operate on the collapsed
+        # per-node aggregate, not the raw per-path rows.
+        assert "best.dist" in cypher
+        assert "LIMIT 100" in cypher
+
 
 # ---------------------------------------------------------------------------
 # score_discoveries

--- a/tests/dashboard/test_admin_audit_filter_markup.py
+++ b/tests/dashboard/test_admin_audit_filter_markup.py
@@ -1,0 +1,90 @@
+"""Regression test for discogsography-zjg7.
+
+Pins dashboard/static/admin.html's audit-log action-filter `<select>` to being
+well-formed markup. The opening tag was previously missing its closing '>',
+which the HTML tokenizer parses as bogus attributes on the `<select>` (rather
+than a nested `<option>`), silently dropping the `value=""` ("All Actions")
+option and leaving `admin.login` as the default-selected value — hiding
+logout/extraction/dlq-purge audit events with no UI control to reset the
+filter.
+"""
+
+from html.parser import HTMLParser
+from pathlib import Path
+
+
+_ADMIN_HTML = Path(__file__).resolve().parents[2] / "dashboard" / "static" / "admin.html"
+
+
+class _SelectOptionCollector(HTMLParser):
+    """Collects the real (well-formed-HTML) child <option> values of a given <select> id."""
+
+    def __init__(self, select_id: str) -> None:
+        super().__init__()
+        self.select_id = select_id
+        self.in_target_select = False
+        self.depth = 0
+        self.option_values: list[str] = []
+        self._select_attrs: dict[str, str | None] = {}
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attrs_dict = dict(attrs)
+        if tag == "select" and attrs_dict.get("id") == self.select_id:
+            self.in_target_select = True
+            self.depth = 1
+            self._select_attrs = attrs_dict
+            return
+        if self.in_target_select:
+            if tag == "select":
+                self.depth += 1
+            elif tag == "option":
+                self.option_values.append(attrs_dict.get("value") or "")
+
+    def handle_endtag(self, tag: str) -> None:
+        if self.in_target_select and tag == "select":
+            self.depth -= 1
+            if self.depth == 0:
+                self.in_target_select = False
+
+
+def _collect_options(select_id: str) -> _SelectOptionCollector:
+    parser = _SelectOptionCollector(select_id)
+    parser.feed(_ADMIN_HTML.read_text())
+    return parser
+
+
+def test_audit_log_action_filter_select_has_closing_bracket() -> None:
+    """The <select> opening tag must be closed with '>' (not a bogus-attribute state)."""
+    content = _ADMIN_HTML.read_text()
+    idx = content.index('<select id="al-action-filter"')
+    # The next '<' after the opening tag's start must belong to a real nested
+    # element (i.e. the tag closed with '>' before any other '<').
+    close_bracket_idx = content.index(">", idx)
+    next_open_bracket_idx = content.index("<", idx + 1)
+    assert close_bracket_idx < next_open_bracket_idx, (
+        "The <select id=\"al-action-filter\"> opening tag is not closed before the next '<' — "
+        "a dropped '>' causes the HTML tokenizer to consume the following <option> as bogus "
+        "attributes of <select>, destroying the 'All Actions' option (discogsography-zjg7)."
+    )
+
+
+def test_audit_log_action_filter_has_all_actions_option() -> None:
+    """The filter must have a real, default-selected value='' ('All Actions') option."""
+    collector = _collect_options("al-action-filter")
+    assert collector.option_values, "No <option> children were parsed under #al-action-filter"
+    assert collector.option_values[0] == "", (
+        f"Expected the first option's value to be '' (All Actions, and thus the default-"
+        f"selected value), got {collector.option_values[0]!r}. Got options: {collector.option_values!r}"
+    )
+
+
+def test_audit_log_action_filter_has_all_four_named_actions() -> None:
+    """All four named audit actions must still be present alongside the 'All Actions' option."""
+    collector = _collect_options("al-action-filter")
+    assert collector.option_values == [
+        "",
+        "admin.login",
+        "admin.logout",
+        "extraction.trigger",
+        "dlq.purge",
+    ]

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -409,6 +409,61 @@ class TestDashboardAppBroadcast:
             assert mock_ws_failing not in app.websocket_connections
 
     @pytest.mark.asyncio
+    async def test_broadcast_metrics_closes_evicted_sockets(self) -> None:
+        """Regression for discogsography-lk51.
+
+        A send failure (including a timeout on a still-live, merely stalled
+        socket) used to only evict the websocket from websocket_connections
+        without ever closing it. The endpoint's keep-alive loop
+        (`while True: await websocket.receive_text()`) blocks forever on a
+        healthy connection and never notices the eviction, so the socket is
+        never closed server-side either — and the client's `ws.onclose`
+        (its ONLY reconnect trigger) never fires, leaving the dashboard
+        permanently frozen with no error. Eviction must always be
+        accompanied by an actual close so the client reconnects.
+        """
+        mock_config = Mock()
+
+        with patch("dashboard.dashboard.get_config", return_value=mock_config):
+            app = DashboardApp()
+
+            mock_ws_working = AsyncMock()
+            mock_ws_failing = AsyncMock()
+            mock_ws_failing.send_text.side_effect = Exception("Send failed")
+
+            app.websocket_connections.add(mock_ws_working)
+            app.websocket_connections.add(mock_ws_failing)
+
+            metrics = SystemMetrics(pipelines={}, databases=[], timestamp=datetime.now())
+            await app.broadcast_metrics(metrics)
+
+            mock_ws_failing.close.assert_awaited_once_with(code=1011)
+            mock_ws_working.close.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_broadcast_metrics_close_failure_does_not_raise(self) -> None:
+        """The best-effort close on an evicted socket must never propagate —
+        the socket may already be fully dead (e.g. TCP RST), in which case
+        close() itself can raise.
+        """
+        mock_config = Mock()
+
+        with patch("dashboard.dashboard.get_config", return_value=mock_config):
+            app = DashboardApp()
+
+            mock_ws_failing = AsyncMock()
+            mock_ws_failing.send_text.side_effect = Exception("Send failed")
+            mock_ws_failing.close.side_effect = Exception("Already gone")
+
+            app.websocket_connections.add(mock_ws_failing)
+
+            metrics = SystemMetrics(pipelines={}, databases=[], timestamp=datetime.now())
+            # Must not raise despite close() itself failing.
+            await app.broadcast_metrics(metrics)
+
+            assert mock_ws_failing not in app.websocket_connections
+
+    @pytest.mark.asyncio
     async def test_broadcast_metrics_stalled_client_does_not_block_others(self) -> None:
         """discogsography-cu2.62: broadcast_metrics used to hold _ws_lock while awaiting
         send_text serially, so one stalled client (e.g. a sleeping laptop applying TCP


### PR DESCRIPTION
Fixes 8 priority-2 frontend/app-logic findings from the 2026-08-10 bug hunt (run `wf_646d4b21`), one commit per bead. A 9th batch member, **discogsography-2mqt**, was verified already fixed upstream by #460's version-scoped extraction-complete latch and gets no commit.

- **discogsography-5fg0** — explore async loads carry a request sequence guard, so out-of-order responses can't render stale results.
- **discogsography-c892** — dashboard Extraction-Analysis version comparison reads the field names the API actually sends (was silently dead).
- **discogsography-zjg7** — malformed `<select>` opening tag fixed; the admin audit filter regains its 'All Actions' option.
- **discogsography-4828** — `get_person_connections` depth ≥ 2 Cypher no longer mixes a non-grouped variable into an aggregating CASE.
- **discogsography-6mvm** — explore-from-here deduplicates per node instead of returning one row per graph path.
- **discogsography-apt8** — NLQ autocomplete/find_path results propagate their real entity type instead of "unknown".
- **discogsography-bfcm** — `_classify_violation` searches JSON recursively (parity with XML), so nested dot-notation violations classify correctly.
- **discogsography-lk51** — a websocket evicted after a broadcast timeout is now closed, instead of leaving the client connected but frozen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrLwHwMcu3cuQJh8cc1SyW