### PR TITLE
fix: security & auth hardening — 11 bug-hunt findings (batch:p3-security-auth)

### DIFF
--- a/api/admin_setup.py
+++ b/api/admin_setup.py
@@ -1,13 +1,21 @@
 """CLI tool for managing admin accounts.
 
 Usage:
-    admin-setup --email admin@example.com --password mysecretpw
+    admin-setup --email admin@example.com          # prompts for the password
     admin-setup --list
+
+The password may also come from the ADMIN_PASSWORD (or ADMIN_PASSWORD_FILE)
+environment variable for non-interactive/scripted use. A bare --password
+CLI argument is intentionally NOT offered: command-line arguments are
+world-readable via /proc/*/cmdline for the life of the process and land
+verbatim in shell history, leaking the highest-privilege credential in the
+system (discogsography-dir0).
 """
 
 from __future__ import annotations
 
 import argparse
+import getpass
 from os import getenv
 import sys
 
@@ -64,6 +72,21 @@ def list_admins(conninfo: str) -> None:
         print(f"{email:<40} {status:<8} {created_at}")
 
 
+def _resolve_password() -> str:
+    """Resolve the admin password WITHOUT ever accepting it as a CLI argument.
+
+    Command-line arguments are world-readable via /proc/*/cmdline for the life
+    of the process (`ps aux`, `docker container top`) and land verbatim in
+    shell history — for the highest-privilege account in the system, that is
+    an unconditional credential leak on every invocation (discogsography-dir0).
+    ADMIN_PASSWORD / ADMIN_PASSWORD_FILE (via the repo's standard `get_secret`
+    Docker-secrets convention) covers scripted/non-interactive use; an
+    interactive getpass prompt (never echoed, never in argv or history)
+    covers everything else.
+    """
+    return get_secret("ADMIN_PASSWORD") or getpass.getpass("Admin password (min 8 chars): ")
+
+
 def main() -> None:
     """Entry point for the admin-setup CLI tool."""
     parser = argparse.ArgumentParser(
@@ -71,25 +94,26 @@ def main() -> None:
         description="Manage admin accounts for the dashboard.",
     )
     parser.add_argument("--email", metavar="EMAIL", help="Admin email address")
-    parser.add_argument("--password", metavar="PW", help="Admin password (min 8 chars)")
     parser.add_argument("--list", action="store_true", help="List existing admin accounts")
 
     args = parser.parse_args()
 
-    if not args.list and not (args.email and args.password):
+    if not args.list and not args.email:
         parser.print_help()
-        sys.exit(1)
-
-    if args.password and len(args.password) < 8:
-        print("❌ Password must be at least 8 characters.")
         sys.exit(1)
 
     conninfo = _build_conninfo()
 
     if args.list:
         list_admins(conninfo)
-    else:
-        add_admin(conninfo, args.email, args.password)
+        return
+
+    password = _resolve_password()
+    if len(password) < 8:
+        print("❌ Password must be at least 8 characters.")
+        sys.exit(1)
+
+    add_admin(conninfo, args.email, password)
 
 
 if __name__ == "__main__":

--- a/api/api.py
+++ b/api/api.py
@@ -375,13 +375,25 @@ async def security_headers(request: Request, call_next: Any) -> Any:
 
 @app.middleware("http")
 async def metrics_middleware(request: Request, call_next: Any) -> Any:
-    """Record per-request timing for endpoint performance metrics."""
+    """Record per-request timing for endpoint performance metrics.
+
+    Keys on the matched route's path TEMPLATE (e.g. ``/api/artists/{id}``),
+    not the raw request URL. Requests that never matched a route (unknown
+    paths — attacker-controlled cardinality, wrong HTTP method) collapse into
+    a single ``<unmatched>`` bucket instead of each becoming a distinct key.
+    Previously this keyed on ``normalize_path(request.url.path)``, a regex
+    reconstruction that only collapses pure-integer/UUID segments — an
+    unauthenticated flood of distinct junk paths (``/a1``, ``/a2``, ...) could
+    fill the whole 10k-entry MetricsBuffer and evict every real endpoint's
+    samples (discogsography-jlei).
+    """
     import time as _time  # noqa: PLC0415
 
-    path = normalize_path(request.url.path)
     start = _time.monotonic()
     response = await call_next(request)
     elapsed_ms = (_time.monotonic() - start) * 1000
+    route = request.scope.get("route")
+    path = normalize_path(route.path) if route is not None else "<unmatched>"
     if hasattr(app.state, "metrics_buffer"):
         app.state.metrics_buffer.record(path, response.status_code, elapsed_ms)
     return response

--- a/api/app_tokens.py
+++ b/api/app_tokens.py
@@ -172,7 +172,15 @@ def _parse_bearer(credentials: HTTPAuthorizationCredentials | None) -> str:
 
 
 async def _lookup_active_token(token_hash: str) -> dict[str, Any] | None:
-    """Fetch the active row for a token_hash, or None if missing/revoked."""
+    """Fetch the active row for a token_hash, or None if missing/revoked/for a deactivated user.
+
+    Joins `users` so a deactivated account's app tokens stop authenticating —
+    mirroring the `is_active` check every JWT-based admin/user path already
+    enforces (discogsography-ci4a). Also projects the row's own `token_hash`
+    so callers can do a real defense-in-depth comparison against it, instead
+    of recomputing the same value they already used for the WHERE clause and
+    comparing it to itself (discogsography-osoc).
+    """
     if _pool is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -181,9 +189,10 @@ async def _lookup_active_token(token_hash: str) -> dict[str, Any] | None:
     async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
         await cur.execute(
             """
-            SELECT id, user_id, name, scope
-            FROM app_tokens
-            WHERE token_hash = %s AND revoked_at IS NULL
+            SELECT t.id, t.user_id, t.name, t.scope, t.token_hash
+            FROM app_tokens t
+            JOIN users u ON u.id = t.user_id
+            WHERE t.token_hash = %s AND t.revoked_at IS NULL AND u.is_active = TRUE
             """,
             (token_hash,),
         )
@@ -222,11 +231,14 @@ def require_app_token(scopes: list[str]) -> Any:
                 headers={"WWW-Authenticate": "Bearer"},
             )
 
-        # Defense in depth: hmac.compare_digest on the canonical hash even though
-        # the WHERE clause already filtered. Guards against any future fast-path
-        # that bypasses the index (e.g. column rename, query restructure).
-        stored_hash = hash_token(plaintext)
-        if not hmac.compare_digest(stored_hash, token_hash):
+        # Defense in depth: compare the row's OWN persisted token_hash (now
+        # projected by _lookup_active_token) against the hash we looked up
+        # with. Previously this recomputed hash_token(plaintext) on both
+        # sides of compare_digest — comparing a value to itself, an
+        # unreachable guard (discogsography-osoc). Comparing against the
+        # stored column actually catches a future fast-path query that
+        # bypasses the WHERE clause (e.g. column rename, query restructure).
+        if not hmac.compare_digest(row["token_hash"], token_hash):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid app token",

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from dataclasses import dataclass
+import hmac
 from typing import Annotated, Any, Literal
 
 from fastapi import Depends, HTTPException, status
@@ -132,11 +133,22 @@ def require_user_or_app_token(scopes: list[str]) -> Any:
         # so the JWT path's 503/401 ordering and revocation checks are preserved
         # byte-for-byte for existing clients.
         if credentials is not None and credentials.credentials.startswith(_APP_TOKEN_PREFIX):
-            row = await _lookup_active_token(hash_token(credentials.credentials))
+            token_hash = hash_token(credentials.credentials)
+            row = await _lookup_active_token(token_hash)
             if row is None:
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
                     detail="Invalid or revoked app token",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+            # Defense in depth: mirrors require_app_token's check against the
+            # row's own persisted token_hash, so the two app-token entry
+            # points stay in lockstep instead of silently diverging
+            # (discogsography-osoc).
+            if not hmac.compare_digest(row["token_hash"], token_hash):
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Invalid app token",
                     headers={"WWW-Authenticate": "Bearer"},
                 )
             granted = list(row.get("scope") or [])

--- a/api/notifications.py
+++ b/api/notifications.py
@@ -24,9 +24,9 @@ class NotificationChannel(Protocol):
 class LogNotificationChannel:
     """Notification channel that logs messages (development/MVP use)."""
 
-    async def send_password_reset(self, email: str, reset_url: str) -> None:  # noqa: ARG002  # reset_url unused in log channel
-        """Log a password reset link (URL intentionally not logged for security)."""
-        logger.info("🔑 Password reset link generated", email=email)
+    async def send_password_reset(self, email: str, reset_url: str) -> None:  # noqa: ARG002  # email/reset_url unused in log channel
+        """Log a password reset link (email and URL intentionally not logged — PII)."""
+        logger.info("🔑 Password reset link generated")
 
 
 class ResendNotificationChannel:
@@ -58,7 +58,7 @@ class ResendNotificationChannel:
             "</body></html>"
         )
 
-        logger.debug("🔑 Sending password reset email", email=email)
+        logger.debug("🔑 Sending password reset email")
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
                 response = await client.post(
@@ -72,6 +72,6 @@ class ResendNotificationChannel:
                     },
                 )
                 response.raise_for_status()
-            logger.info("📧 Password reset email sent", email=email)
+            logger.info("📧 Password reset email sent")
         except Exception:
-            logger.exception("❌ Failed to send password reset email", email=email)
+            logger.exception("❌ Failed to send password reset email")

--- a/api/routers/admin.py
+++ b/api/routers/admin.py
@@ -118,7 +118,7 @@ async def admin_login(request: Request, body: AdminLoginRequest) -> JSONResponse
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
 
     access_token, expires_in = create_admin_token(str(admin["id"]), admin["email"], _config.jwt_secret_key)
-    logger.info("✅ Admin logged in", email=body.email)
+    logger.info("✅ Admin logged in", user_id=str(admin["id"]))
     await record_audit_entry(pool=_pool, admin_id=str(admin["id"]), action="admin.login", target=body.email, details={"success": True})
 
     return JSONResponse(
@@ -593,8 +593,8 @@ async def purge_dlq(
             detail="RabbitMQ management API unreachable",
         ) from exc
 
-    admin_email = current_admin.get("email", "unknown")
-    logger.info("🗑️ DLQ purged", queue=queue, messages_purged=messages_purged, admin_email=admin_email)
+    admin_id = current_admin.get("sub", "unknown")
+    logger.info("🗑️ DLQ purged", queue=queue, messages_purged=messages_purged, admin_id=admin_id)
     if _pool is not None:
         await record_audit_entry(
             pool=_pool, admin_id=current_admin["sub"], action="dlq.purge", target=queue, details={"purged_count": messages_purged}

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -783,7 +783,15 @@ async def twofa_recovery(request: Request, body: TwoFactorRecoveryModel) -> JSON
     )
 
     # Recovery code redeemed — now consume the challenge so it cannot be replayed.
-    await _redis.getdel(challenge_key)
+    # getdel is atomic, so concurrent requests replaying the same challenge
+    # (with different recovery codes) race here and exactly one wins; the
+    # loser must be rejected — mirrors twofa_verify's identical check
+    # (discogsography-kqw4). The recovery code redeemed above is *not*
+    # un-spent on this path; that's an accepted, bounded trade (same one
+    # twofa_verify's loser already takes on its TOTP code).
+    consumed = await _redis.getdel(challenge_key)
+    if not consumed:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Challenge expired or already used")
 
     # Issue access token, stamped with the CHALLENGE's iat (see twofa_verify).
     access_token, expires_in = _create_access_token_fn(user_id, email, issued_at=payload.get("iat"))

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -750,12 +750,22 @@ async def twofa_recovery(request: Request, body: TwoFactorRecoveryModel) -> JSON
     # row locking, concurrent redemptions serialize and the WHERE qual is
     # re-evaluated against the committed row, so only one redemption of a given
     # code can ever match (rowcount 1); the rest match nothing (rowcount 0).
+    # Recovery is an equally strong proof of account control as a correct TOTP
+    # code (password + a one-time recovery code), so its success path must
+    # reset the failed-attempt/lockout columns exactly like twofa_verify's
+    # success path does — folded into this same guarded UPDATE so it only
+    # fires when the code actually matched (discogsography-cflq). Without
+    # this, stale lockout state from before the recovery login survives it
+    # and can 429 a CORRECT TOTP code on the very next login.
     async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
         await execute_sql(
             cur,
             """
             UPDATE users
-            SET totp_recovery_codes = totp_recovery_codes - %s, updated_at = NOW()
+            SET totp_recovery_codes = totp_recovery_codes - %s,
+                totp_failed_attempts = 0,
+                totp_locked_until = NULL,
+                updated_at = NOW()
             WHERE id = %s::uuid
               AND totp_recovery_codes IS NOT NULL
               AND totp_recovery_codes ? %s

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -542,13 +542,26 @@ async def twofa_confirm(
     if not verify_totp_code(secret, body.code):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid TOTP code")
 
-    # Enable TOTP
+    # Enable TOTP — guarded on the EXACT secret whose code was just verified
+    # (bound as `row["totp_secret"]`, read above), not a blind write. Without
+    # this guard, a concurrent twofa_disable committing between our SELECT and
+    # this UPDATE would land as totp_enabled=TRUE with totp_secret/
+    # totp_recovery_codes NULLed — login demands 2FA but neither twofa_verify
+    # nor twofa_recovery can ever satisfy it, a permanent lockout
+    # (discogsography-8vlp). rowcount 0 means the setup state changed
+    # underneath us (disabled, or re-setup with a new secret) — treat that as
+    # a conflict rather than silently reporting success.
     async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
         await execute_sql(
             cur,
-            "UPDATE users SET totp_enabled = TRUE, updated_at = NOW() WHERE id = %s::uuid",
-            (user_id,),
+            "UPDATE users SET totp_enabled = TRUE, updated_at = NOW() WHERE id = %s::uuid AND totp_secret = %s",
+            (user_id, row["totp_secret"]),
         )
+        if cur.rowcount == 0:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="2FA setup state changed — restart 2FA setup",
+            )
 
     logger.info("✅ 2FA enabled", user_id=user_id)
     return JSONResponse(content={"message": "2FA has been enabled"})

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -366,6 +366,16 @@ async def reset_confirm(request: Request, body: ResetConfirmModel) -> JSONRespon
             "UPDATE users SET hashed_password = %s, password_changed_at = NOW(), updated_at = NOW() WHERE id = %s::uuid",
             (hashed_password, user_id),
         )
+        # Bulk-revoke third-party app tokens too. password_changed:{user_id} only
+        # gates JWT validation and TTLs out after jwt_expire_minutes, so it can
+        # never durably revoke app tokens (which carry no expiry by design) —
+        # revoking the rows themselves is the only correct fix
+        # (discogsography-ci4a).
+        await execute_sql(
+            cur,
+            "UPDATE app_tokens SET revoked_at = NOW() WHERE user_id = %s::uuid AND revoked_at IS NULL",
+            (user_id,),
+        )
 
     # Invalidate all existing sessions
     await _redis.setex(f"password_changed:{user_id}", _config.jwt_expire_minutes * 60, str(now_ts))
@@ -409,6 +419,14 @@ async def change_password(
             cur,
             "UPDATE users SET hashed_password = %s, password_changed_at = NOW(), updated_at = NOW() WHERE id = %s::uuid",
             (hashed_password, user_id),
+        )
+        # Bulk-revoke third-party app tokens too (same pattern as reset-confirm;
+        # see discogsography-ci4a for why the Redis password_changed marker
+        # alone cannot cover app tokens).
+        await execute_sql(
+            cur,
+            "UPDATE app_tokens SET revoked_at = NOW() WHERE user_id = %s::uuid AND revoked_at IS NULL",
+            (user_id,),
         )
 
     # Invalidate all existing sessions (same pattern as reset-confirm)

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -156,7 +156,7 @@ async def register(request: Request, body: RegisterRequest) -> JSONResponse:  # 
             detail="Registration failed",
         )
 
-    logger.info("✅ User registered", email=body.email)
+    logger.info("✅ User registered", user_id=str(row["id"]))
     return JSONResponse(
         content={"message": "Registration processed"},
         status_code=status.HTTP_201_CREATED,
@@ -226,7 +226,7 @@ async def login(request: Request, body: LoginRequest) -> JSONResponse:  # noqa: 
         )
 
     access_token, expires_in = _create_access_token_fn(str(user["id"]), user["email"], issued_at=credential_issued_at)
-    logger.info("✅ User logged in", email=body.email)
+    logger.info("✅ User logged in", user_id=str(user["id"]))
 
     return JSONResponse(
         content={

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -586,70 +586,94 @@ async def twofa_verify(request: Request, body: TwoFactorVerifyModel) -> JSONResp
     user_id = payload["sub"]
     email = payload.get("email", "")
 
-    # Fetch user TOTP data
-    async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
-        await execute_sql(
-            cur,
-            "SELECT totp_secret, totp_failed_attempts, totp_locked_until FROM users WHERE id = %s::uuid",
-            (user_id,),
-        )
-        user = await cur.fetchone()
+    # The lockout GATE and the failed-attempt INCREMENT must be atomic with
+    # each other — not just internally consistent. Previously the lockout
+    # check read a plain SELECT (no lock held past that statement, per this
+    # repo's autocommit=True pool contract), so N concurrent requests could
+    # all read "not locked" before any of them committed the lock, each
+    # getting a free TOTP guess (discogsography-vjod). `SELECT ... FOR UPDATE`
+    # inside an explicit transaction takes a row lock that concurrent verify
+    # attempts for the SAME user serialize on: the second request's SELECT
+    # blocks until the first request's transaction (lock check + increment)
+    # commits, so it always observes the POST-increment state.
+    configured = False
+    locked = False
+    encryption_missing = False
+    code_ok = False
+    failed_attempts: int | None = None
+    async with _pool.connection() as conn:
+        await conn.set_autocommit(False)
+        async with conn.transaction(), conn.cursor(row_factory=dict_row) as cur:
+            await execute_sql(
+                cur,
+                "SELECT totp_secret, totp_failed_attempts, totp_locked_until FROM users WHERE id = %s::uuid FOR UPDATE",
+                (user_id,),
+            )
+            user = await cur.fetchone()
 
-    if not user or not user.get("totp_secret"):
+            if user and user.get("totp_secret"):
+                configured = True
+                locked_until = user.get("totp_locked_until")
+                if locked_until and locked_until.tzinfo is None:
+                    locked_until = locked_until.replace(tzinfo=UTC)
+                locked = bool(locked_until and locked_until > datetime.now(UTC))
+
+            totp_key = get_totp_encryption_key(_config.encryption_master_key) if configured and not locked else None
+            if configured and not locked and not totp_key:
+                encryption_missing = True
+
+            if totp_key:
+                secret = decrypt_totp_secret(user["totp_secret"], totp_key)
+                # NOTE: the challenge is intentionally NOT consumed until AFTER a
+                # successful verification (see success branch below). Consuming it
+                # here would burn the challenge on a single mistyped digit, forcing
+                # a full re-login for every typo.
+                code_ok = verify_totp_code(secret, body.code)
+                if not code_ok:
+                    # Derive the lock from the freshly-computed value in the SAME
+                    # statement, still holding the row lock taken above. When a
+                    # previous lock window has already elapsed (totp_locked_until
+                    # is set but in the past — the gate above let us through), the
+                    # counter resets so each post-expiry window starts fresh
+                    # instead of instantly re-locking at 5+1.
+                    lock_sql = """
+                        UPDATE users
+                        SET totp_failed_attempts = CASE
+                                WHEN totp_locked_until IS NOT NULL AND totp_locked_until <= NOW() THEN 1
+                                ELSE COALESCE(totp_failed_attempts, 0) + 1
+                            END,
+                            totp_locked_until = CASE
+                                WHEN (CASE
+                                        WHEN totp_locked_until IS NOT NULL AND totp_locked_until <= NOW() THEN 1
+                                        ELSE COALESCE(totp_failed_attempts, 0) + 1
+                                      END) >= 5
+                                    THEN NOW() + INTERVAL '15 minutes'
+                                WHEN totp_locked_until IS NOT NULL AND totp_locked_until <= NOW()
+                                    THEN NULL
+                                ELSE totp_locked_until
+                            END,
+                            updated_at = NOW()
+                        WHERE id = %s::uuid
+                        RETURNING totp_failed_attempts
+                    """
+                    await execute_sql(cur, lock_sql, (user_id,))
+                    updated = await cur.fetchone()
+                    failed_attempts = updated["totp_failed_attempts"] if updated else None
+        # Transaction commits here (releasing the row lock) before we raise —
+        # a locked-out or failed attempt must still be durably recorded even
+        # though the HTTP response is an error.
+
+    if not configured:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="2FA not configured")
 
-    # Check lockout BEFORE consuming the challenge — locked-out users keep their token
-    locked_until = user.get("totp_locked_until")
-    if locked_until and locked_until.tzinfo is None:
-        locked_until = locked_until.replace(tzinfo=UTC)
-    if locked_until and locked_until > datetime.now(UTC):
+    if locked:
         raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Account temporarily locked due to failed 2FA attempts")
 
-    totp_key = get_totp_encryption_key(_config.encryption_master_key)
-    if not totp_key:
+    if encryption_missing:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Encryption not configured")
 
-    secret = decrypt_totp_secret(user["totp_secret"], totp_key)
-
-    # NOTE: the challenge is intentionally NOT consumed until AFTER a successful
-    # verification (see success branch below). Consuming it here would burn the
-    # challenge on a single mistyped digit, forcing a full re-login for every typo.
-    if not verify_totp_code(secret, body.code):
-        # Increment the failed-attempt counter ATOMICALLY in SQL and derive the
-        # lock from the freshly-computed value. Parallel wrong-code submissions
-        # must each advance the counter — a Python read-then-blind-write lets K
-        # concurrent requests all write value+1, defeating the 5-strike lock.
-        #
-        # When a previous lock window has already elapsed (totp_locked_until is
-        # set but in the past — the gate above let us through), the counter is
-        # reset so each post-expiry window starts fresh instead of instantly
-        # re-locking at 5+1.
-        lock_sql = """
-            UPDATE users
-            SET totp_failed_attempts = CASE
-                    WHEN totp_locked_until IS NOT NULL AND totp_locked_until <= NOW() THEN 1
-                    ELSE COALESCE(totp_failed_attempts, 0) + 1
-                END,
-                totp_locked_until = CASE
-                    WHEN (CASE
-                            WHEN totp_locked_until IS NOT NULL AND totp_locked_until <= NOW() THEN 1
-                            ELSE COALESCE(totp_failed_attempts, 0) + 1
-                          END) >= 5
-                        THEN NOW() + INTERVAL '15 minutes'
-                    WHEN totp_locked_until IS NOT NULL AND totp_locked_until <= NOW()
-                        THEN NULL
-                    ELSE totp_locked_until
-                END,
-                updated_at = NOW()
-            WHERE id = %s::uuid
-            RETURNING totp_failed_attempts
-        """
-        async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
-            await execute_sql(cur, lock_sql, (user_id,))
-            updated = await cur.fetchone()
-
-        failed = updated["totp_failed_attempts"] if updated else None
-        logger.warning("⚠️ Failed 2FA attempt", user_id=user_id, attempts=failed)
+    if not code_ok:
+        logger.warning("⚠️ Failed 2FA attempt", user_id=user_id, attempts=failed_attempts)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid TOTP code")
 
     # Success — consume the challenge NOW (only after a correct code) to prevent

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -5,7 +5,7 @@ import json
 import secrets
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from psycopg.rows import dict_row
@@ -300,9 +300,35 @@ async def get_me(
 # ---------------------------------------------------------------------------
 
 
+async def _process_reset_request(user: dict[str, Any] | None) -> None:
+    """Mint the reset token, write it to Redis, and send the email — OFF the request path.
+
+    Scheduled unconditionally by the caller (whether or not the account
+    exists) and only does real work when ``user`` is truthy. This means the
+    HTTP response for reset-request returns after nothing but the initial
+    SELECT on both branches, so response timing carries no signal about
+    account existence — the Redis `setex` and the outbound Resend HTTP call
+    (the actual timing oracle) both happen after the client already has the
+    response (discogsography-0lof).
+    """
+    if not user or _redis is None or _config is None:
+        return
+    token = secrets.token_urlsafe(32)
+    await _redis.setex(
+        f"reset:{token}",
+        900,  # 15 min TTL
+        json.dumps({"user_id": str(user["id"]), "email": user["email"]}),
+    )
+    # Must be absolute: this link is emailed, and a mail client has no base
+    # URL to resolve a relative href against.
+    reset_url = f"{_config.app_base_url}/?reset_token={token}"
+    if _notification_channel:
+        await _notification_channel.send_password_reset(user["email"], reset_url)
+
+
 @router.post("/api/auth/reset-request")
 @limiter.limit("3/minute")
-async def reset_request(request: Request, body: ResetRequestModel) -> JSONResponse:  # noqa: ARG001
+async def reset_request(request: Request, body: ResetRequestModel, background_tasks: BackgroundTasks) -> JSONResponse:  # noqa: ARG001
     """Request a password reset. Same response whether email exists or not."""
     if _pool is None or _redis is None or _config is None:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service not ready")
@@ -311,18 +337,8 @@ async def reset_request(request: Request, body: ResetRequestModel) -> JSONRespon
         await execute_sql(cur, "SELECT id, email FROM users WHERE email = %s", (body.email,))
         user = await cur.fetchone()
 
-    if user:
-        token = secrets.token_urlsafe(32)
-        await _redis.setex(
-            f"reset:{token}",
-            900,  # 15 min TTL
-            json.dumps({"user_id": str(user["id"]), "email": user["email"]}),
-        )
-        # Must be absolute: this link is emailed, and a mail client has no base
-        # URL to resolve a relative href against.
-        reset_url = f"{_config.app_base_url}/?reset_token={token}"
-        if _notification_channel:
-            await _notification_channel.send_password_reset(user["email"], reset_url)
+    # Scheduled on BOTH branches — see _process_reset_request docstring.
+    background_tasks.add_task(_process_reset_request, user)
 
     return JSONResponse(content={"message": "If an account exists for that email, a reset link has been sent"})
 

--- a/api/snapshot_store.py
+++ b/api/snapshot_store.py
@@ -93,16 +93,34 @@ class SnapshotStore:
         if user_id:
             count_key = f"{self._USER_COUNT_KEY_PREFIX}{user_id}"
             count = await self._redis.incr(count_key)
-            if count == 1:
-                # First snapshot in this window starts the count's own TTL so
-                # it decays alongside the snapshots it's counting (approximate
-                # sliding window — bounded exactly by max_per_user regardless).
-                await self._redis.expire(count_key, self._ttl_seconds)
+            # Self-healing TTL: `nx=True` means "set the TTL only if the key
+            # doesn't already have one." Normally a no-op after the first
+            # save. Previously this was gated on `count == 1` — a ONE-SHOT
+            # opportunity per key generation — so if that single EXPIRE call
+            # failed or the process died between incr and expire, the counter
+            # was left permanent (no TTL, never re-armed by any later save),
+            # silently converting "live snapshots in a 28-day window" into
+            # "lifetime saves, forever" and eventually locking the user out
+            # permanently (discogsography-7639). `nx=True` makes every save a
+            # chance to arm a missing TTL, not just the first.
+            await self._redis.expire(count_key, self._ttl_seconds, nx=True)
             if count > self._max_per_user:
                 await self._redis.decr(count_key)
                 raise SnapshotQuotaExceededError(f"User already has {count - 1} snapshots, maximum is {self._max_per_user}")
 
-        await self._redis.set(f"{self._KEY_PREFIX}{token}", payload, ex=self._ttl_seconds)
+            try:
+                await self._redis.set(f"{self._KEY_PREFIX}{token}", payload, ex=self._ttl_seconds)
+            except Exception:
+                # Compensate: the save didn't happen, so the quota slot it
+                # reserved above must be freed — mirrors the decrement on the
+                # quota-exceeded path. Without this, a transient Redis/network
+                # failure on this specific call permanently burns the user's
+                # quota with zero live snapshots to show for it.
+                await self._redis.decr(count_key)
+                raise
+        else:
+            await self._redis.set(f"{self._KEY_PREFIX}{token}", payload, ex=self._ttl_seconds)
+
         return token, expires_at
 
     async def load(self, token: str) -> dict[str, Any] | None:

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -5,9 +5,15 @@
 Admin accounts are created via the `admin-setup` CLI tool inside the API container:
 
 ```
-docker exec -it discogsography-api admin-setup \
-  --email admin@example.com --password <password>
+docker exec -it discogsography-api admin-setup --email admin@example.com
 ```
+
+`admin-setup` never accepts the password as a CLI argument (command-line
+arguments are world-readable via `/proc/*/cmdline` and land in shell
+history). The command above prompts interactively (input hidden, not
+echoed). For scripted/non-interactive use, set `ADMIN_PASSWORD` (or
+`ADMIN_PASSWORD_FILE`, pointing at a Docker secret) in the container's
+environment instead.
 
 Passwords must be at least 8 characters. If the email already exists, the password is updated.
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -95,9 +95,9 @@ The dashboard includes a login-gated admin panel at `/admin` for managing extrac
 #### Accessing the Admin Panel
 
 ```bash
-# Create an admin account (one-time setup)
-docker exec -it discogsography-api admin-setup \
-  --email admin@example.com --password <min-8-chars>
+# Create an admin account (one-time setup) — prompts for the password
+# interactively; never pass it as a CLI argument (see docs/admin-guide.md).
+docker exec -it discogsography-api admin-setup --email admin@example.com
 
 # Access admin panel
 open http://localhost:8003/admin

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -76,6 +76,15 @@ def mock_conn(mock_cur: AsyncMock) -> AsyncMock:
     cur_ctx.__aenter__ = AsyncMock(return_value=mock_cur)
     cur_ctx.__aexit__ = AsyncMock(return_value=False)
     conn.cursor = MagicMock(return_value=cur_ctx)
+    conn.set_autocommit = AsyncMock()
+    # `async with conn.transaction():` — a no-op async context manager so
+    # code that opens an explicit transaction (e.g. twofa_verify's atomic
+    # lockout check, discogsography-vjod) round-trips through the same
+    # mock_cur without a real Postgres transaction.
+    tx_ctx = AsyncMock()
+    tx_ctx.__aenter__ = AsyncMock(return_value=None)
+    tx_ctx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=tx_ctx)
     return conn
 
 

--- a/tests/api/test_admin_endpoints.py
+++ b/tests/api/test_admin_endpoints.py
@@ -140,6 +140,26 @@ class TestAdminLogin:
         )
         assert resp.status_code == 403
 
+    def test_success_does_not_log_email(self, test_client: TestClient, mock_cur: AsyncMock) -> None:
+        """discogsography-1385: admin login success log must carry user_id, not email."""
+        from structlog.testing import capture_logs
+
+        admin_row = _make_admin_row()
+        mock_cur.fetchone = AsyncMock(return_value=admin_row)
+
+        with capture_logs() as captured:
+            resp = test_client.post(
+                "/api/admin/auth/login",
+                json={"email": TEST_ADMIN_EMAIL, "password": "adminpassword123"},
+            )
+        assert resp.status_code == 200
+
+        success_events = [entry for entry in captured if "logged in" in entry.get("event", "")]
+        assert success_events, "expected an admin-login-success log entry"
+        for entry in success_events:
+            assert entry.get("user_id") == TEST_ADMIN_ID
+            assert TEST_ADMIN_EMAIL not in str(entry.values())
+
 
 class TestAdminLogout:
     def test_success(self, test_client: TestClient, mock_redis: AsyncMock) -> None:
@@ -325,6 +345,34 @@ class TestDlqPurge:
             headers=_admin_auth_headers(),
         )
         assert resp.status_code == 502
+
+    @patch("api.routers.admin.httpx.AsyncClient")
+    def test_purge_success_does_not_log_email(self, mock_client_cls: Any, test_client: TestClient) -> None:
+        """discogsography-1385: DLQ-purge audit log must carry admin_id, not
+        the admin's email address (PII)."""
+        from structlog.testing import capture_logs
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 204
+        mock_client_instance = AsyncMock()
+        mock_client_instance.delete = AsyncMock(return_value=mock_response)
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client_instance
+
+        with capture_logs() as captured:
+            resp = test_client.post(
+                "/api/admin/dlq/purge/discogsography-discogs-graphinator-artists.dlq",
+                headers=_admin_auth_headers(),
+            )
+        assert resp.status_code == 200
+
+        purge_events = [entry for entry in captured if "purged" in entry.get("event", "")]
+        assert purge_events, "expected a DLQ-purge log entry"
+        for entry in purge_events:
+            assert entry.get("admin_id") == TEST_ADMIN_ID
+            assert "admin_email" not in entry
+            assert TEST_ADMIN_EMAIL not in str(entry.values())
 
     @patch("api.routers.admin.httpx.AsyncClient")
     def test_purge_read_timeout_returns_502(self, mock_client_cls: Any, test_client: TestClient) -> None:

--- a/tests/api/test_admin_setup.py
+++ b/tests/api/test_admin_setup.py
@@ -143,8 +143,18 @@ def test_main_no_args_prints_help_and_exits(monkeypatch: pytest.MonkeyPatch) -> 
     assert exc.value.code == 1
 
 
-def test_main_short_password_exits(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
-    _run_main(monkeypatch, ["--email", "a@example.com", "--password", "short"])
+def test_main_rejects_password_as_cli_argument(monkeypatch: pytest.MonkeyPatch) -> None:
+    """discogsography-dir0: --password must not exist as a CLI flag at all —
+    argparse must reject it rather than silently accepting a leaky argument."""
+    _run_main(monkeypatch, ["--email", "a@example.com", "--password", "longenoughpw"])
+    with pytest.raises(SystemExit) as exc:
+        admin_setup.main()
+    assert exc.value.code == 2  # argparse's "unrecognized arguments" exit code
+
+
+def test_main_short_password_from_env_exits(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _run_main(monkeypatch, ["--email", "a@example.com"])
+    monkeypatch.setattr(admin_setup, "get_secret", lambda name: "short" if name == "ADMIN_PASSWORD" else None)
     with pytest.raises(SystemExit) as exc:
         admin_setup.main()
     assert exc.value.code == 1
@@ -158,8 +168,29 @@ def test_main_list_calls_list_admins(monkeypatch: pytest.MonkeyPatch) -> None:
     list_admins.assert_called_once_with("fake-conninfo")
 
 
-def test_main_add_calls_add_admin(monkeypatch: pytest.MonkeyPatch) -> None:
-    _run_main(monkeypatch, ["--email", "a@example.com", "--password", "longenoughpw"])
-    with patch.object(admin_setup, "add_admin") as add_admin:
+def test_main_add_calls_add_admin_using_env_password(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ADMIN_PASSWORD (the get_secret convention) is honored without ever
+    prompting — the scripted/non-interactive path."""
+    _run_main(monkeypatch, ["--email", "a@example.com"])
+    monkeypatch.setattr(admin_setup, "get_secret", lambda name: "longenoughpw" if name == "ADMIN_PASSWORD" else None)
+    with (
+        patch.object(admin_setup, "add_admin") as add_admin,
+        patch.object(admin_setup.getpass, "getpass") as mock_getpass,
+    ):
         admin_setup.main()
+    add_admin.assert_called_once_with("fake-conninfo", "a@example.com", "longenoughpw")
+    mock_getpass.assert_not_called()
+
+
+def test_main_add_prompts_interactively_when_no_env_password(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No ADMIN_PASSWORD set → falls back to an interactive, non-echoed prompt —
+    never a CLI argument, never in shell history (discogsography-dir0)."""
+    _run_main(monkeypatch, ["--email", "a@example.com"])
+    monkeypatch.setattr(admin_setup, "get_secret", lambda _name: None)
+    with (
+        patch.object(admin_setup, "add_admin") as add_admin,
+        patch.object(admin_setup.getpass, "getpass", return_value="longenoughpw") as mock_getpass,
+    ):
+        admin_setup.main()
+    mock_getpass.assert_called_once()
     add_admin.assert_called_once_with("fake-conninfo", "a@example.com", "longenoughpw")

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -282,6 +282,35 @@ class TestRegisterEndpoint:
         )
         assert response.status_code == 500
 
+    def test_register_success_avoids_logging_email(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+    ) -> None:
+        """discogsography-1385: the success log must carry user_id, never the
+        registrant's email (PII) — no ad-hoc emoji/log rule bypass."""
+        from structlog.testing import capture_logs
+
+        mock_cur.fetchone.return_value = {
+            "id": TEST_USER_ID,
+            "email": TEST_USER_EMAIL,
+            "is_active": True,
+            "created_at": datetime.now(UTC),
+        }
+
+        with capture_logs() as captured:
+            response = test_client.post(
+                "/api/auth/register",
+                json={"email": TEST_USER_EMAIL, "password": "Password123!"},
+            )
+        assert response.status_code == 201
+
+        success_events = [entry for entry in captured if "registered" in entry.get("event", "")]
+        assert success_events, "expected a registration-success log entry"
+        for entry in success_events:
+            assert entry.get("user_id") == TEST_USER_ID
+            assert TEST_USER_EMAIL not in str(entry.values())
+
 
 class TestLoginEndpoint:
     """Tests for POST /api/auth/login."""
@@ -364,6 +393,38 @@ class TestLoginEndpoint:
             json={"email": TEST_USER_EMAIL, "password": "password"},
         )
         assert response.status_code == 401
+
+    def test_login_success_does_not_log_email(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+    ) -> None:
+        """discogsography-1385: sibling of the registration leak — the
+        high-volume per-session login log must also carry user_id, not email."""
+        from structlog.testing import capture_logs
+
+        from api.auth import _hash_password
+
+        hashed = _hash_password("correctpassword")
+        mock_cur.fetchone.return_value = {
+            "id": TEST_USER_ID,
+            "email": TEST_USER_EMAIL,
+            "is_active": True,
+            "hashed_password": hashed,
+        }
+
+        with capture_logs() as captured:
+            response = test_client.post(
+                "/api/auth/login",
+                json={"email": TEST_USER_EMAIL, "password": "correctpassword"},
+            )
+        assert response.status_code == 200
+
+        success_events = [entry for entry in captured if "logged in" in entry.get("event", "")]
+        assert success_events, "expected a login-success log entry"
+        for entry in success_events:
+            assert entry.get("user_id") == TEST_USER_ID
+            assert TEST_USER_EMAIL not in str(entry.values())
 
 
 class TestMeEndpoint:

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -184,6 +184,37 @@ class TestHealthEndpoint:
         assert data["service"] == "api"
 
 
+class TestMetricsMiddlewareCardinality:
+    """discogsography-jlei: metrics_middleware must key on the matched route's
+    path TEMPLATE, so path cardinality is bounded by the number of registered
+    routes — not by attacker-controlled URL segments."""
+
+    def test_unmatched_paths_collapse_to_a_single_bucket(self, test_client: TestClient) -> None:
+        from api.api import app
+
+        test_client.get("/totally-made-up-path-one")
+        test_client.get("/another-made-up-path-two")
+        test_client.get("/yet-a-third-bogus-path")
+
+        stats = app.state.metrics_buffer.flush()
+        assert "<unmatched>" in stats
+        assert stats["<unmatched>"]["count"] >= 3
+        # None of the raw junk paths became their own distinct key.
+        assert "/totally-made-up-path-one" not in stats
+        assert "/another-made-up-path-two" not in stats
+
+    def test_matched_route_uses_its_path_template(self, test_client: TestClient) -> None:
+        from api.api import app
+
+        # Unauthenticated DELETE — rejected by the require_user dependency
+        # (401) before the handler body runs, so no backend I/O is needed.
+        test_client.delete("/api/user/app-tokens/some-token-id")
+
+        stats = app.state.metrics_buffer.flush()
+        assert "/api/user/app-tokens/{token_id}" in stats
+        assert "/api/user/app-tokens/some-token-id" not in stats
+
+
 class TestRegisterEndpoint:
     """Tests for POST /api/auth/register."""
 

--- a/tests/api/test_app_token_auth.py
+++ b/tests/api/test_app_token_auth.py
@@ -30,13 +30,34 @@ from api.app_tokens import (
 
 
 def _make_pool_with_row(row: dict[str, Any] | None) -> MagicMock:
-    """Build a mock pool whose cursor.fetchone() returns `row`."""
+    """Build a mock pool whose cursor.fetchone() returns `row`.
+
+    If `row` doesn't set its own "token_hash", it's auto-filled with whatever
+    token_hash the query was actually invoked with, so the defense-in-depth
+    `hmac.compare_digest(row["token_hash"], token_hash)` check
+    (discogsography-osoc) naturally passes for tests that aren't specifically
+    exercising a hash mismatch.
+    """
     pool = MagicMock()
     cur = AsyncMock()
     cur.__aenter__ = AsyncMock(return_value=cur)
     cur.__aexit__ = AsyncMock(return_value=False)
-    cur.execute = AsyncMock()
-    cur.fetchone = AsyncMock(return_value=row)
+    captured_params: dict[str, Any] = {}
+
+    async def _execute(_query: str, params: tuple[Any, ...] = ()) -> None:
+        if params:
+            captured_params["token_hash"] = params[0]
+
+    cur.execute = AsyncMock(side_effect=_execute)
+
+    async def _fetchone() -> dict[str, Any] | None:
+        if row is None:
+            return None
+        if "token_hash" not in row and "token_hash" in captured_params:
+            return {**row, "token_hash": captured_params["token_hash"]}
+        return row
+
+    cur.fetchone = AsyncMock(side_effect=_fetchone)
     cur.fetchall = AsyncMock(return_value=[])
     cur.rowcount = 1 if row is not None else 0
     conn = AsyncMock()
@@ -100,6 +121,37 @@ class TestHashToken:
 
     def test_different_inputs_different_hashes(self) -> None:
         assert hash_token("dscg_a") != hash_token("dscg_b")
+
+
+class TestLookupActiveTokenQuery:
+    """discogsography-ci4a: a deactivated user's app tokens must stop authenticating.
+
+    _lookup_active_token now joins `users` and filters `is_active = TRUE`
+    instead of a bare token_hash/revoked_at lookup on app_tokens alone.
+    """
+
+    @pytest.mark.asyncio
+    async def test_query_joins_users_and_filters_is_active(self) -> None:
+        pool = _make_pool_with_row(None)
+        configure(pool)
+        await app_tokens._lookup_active_token("deadbeef")
+
+        query = pool._cur.execute.call_args.args[0]
+        assert "JOIN users" in query
+        assert "is_active = TRUE" in query
+        assert "revoked_at IS NULL" in query
+
+    @pytest.mark.asyncio
+    async def test_selects_token_hash_for_defense_in_depth(self) -> None:
+        """The row must project its own token_hash so callers can do a real
+        compare_digest check instead of comparing a value to itself
+        (discogsography-osoc)."""
+        pool = _make_pool_with_row(None)
+        configure(pool)
+        await app_tokens._lookup_active_token("deadbeef")
+
+        query = pool._cur.execute.call_args.args[0]
+        assert "token_hash" in query
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -170,6 +222,26 @@ class TestRequireAppTokenFailureModes:
         This test asserts the contract — the partial-index predicate is verified in P2 schema tests.
         """
         configure(_make_pool_with_row(None))  # None simulates "WHERE revoked_at IS NULL" filtering
+        dep = require_app_token(["collection:read"])
+        with pytest.raises(HTTPException) as exc:
+            await dep(credentials=_make_credentials(generate_plaintext_token()))  # type: ignore[arg-type]
+        assert exc.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_defense_in_depth_rejects_row_hash_mismatch(self) -> None:
+        """discogsography-osoc: the compare_digest guard must be a REAL check
+        against the row's own persisted token_hash, not a self-comparison of
+        hash_token(plaintext) against itself. Forcing the row's token_hash to
+        diverge from the lookup hash must make the guard fire (401) — the
+        pre-fix code could never reach this branch."""
+        row = {
+            "id": UUID("00000000-0000-0000-0000-000000000001"),
+            "user_id": UUID("00000000-0000-0000-0000-000000000002"),
+            "name": "GRUVAX kiosk",
+            "scope": ["collection:read"],
+            "token_hash": "0" * 64,  # deliberately wrong — never matches the real lookup hash
+        }
+        configure(_make_pool_with_row(row))
         dep = require_app_token(["collection:read"])
         with pytest.raises(HTTPException) as exc:
             await dep(credentials=_make_credentials(generate_plaintext_token()))  # type: ignore[arg-type]

--- a/tests/api/test_auth_router.py
+++ b/tests/api/test_auth_router.py
@@ -891,6 +891,34 @@ class TestTwoFactorRecoveryFull:
         assert "totp_failed_attempts = 0" in executed
         assert "totp_locked_until = NULL" in executed
 
+    def test_recovery_getdel_race_returns_401(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """discogsography-kqw4: a concurrent request that already consumed the
+        challenge (getdel -> None) must reject this one with 401, mirroring
+        twofa_verify's identical check. Previously the getdel return value was
+        discarded entirely, so a single challenge token backed by two
+        recovery codes could mint two independent access tokens."""
+        plaintext_codes, hashed_codes = self._make_recovery_setup()
+        challenge_token = _make_challenge_token()
+
+        mock_redis.get = _challenge_only_get()
+        # getdel returns None — another concurrent request already consumed
+        # this challenge (e.g. via a parallel twofa_verify or twofa_recovery
+        # call) between the existence check and this consume.
+        mock_redis.getdel = AsyncMock(return_value=None)
+        mock_cur.fetchone = AsyncMock(return_value={"totp_recovery_codes": json.dumps(hashed_codes)})
+
+        response = test_client.post(
+            "/api/auth/2fa/recovery",
+            json={"challenge_token": challenge_token, "code": plaintext_codes[0]},
+        )
+        assert response.status_code == 401
+        assert "Challenge expired or already used" in response.json()["detail"]
+
     def test_recovery_invalid_code_returns_401(
         self,
         test_client: TestClient,

--- a/tests/api/test_auth_router.py
+++ b/tests/api/test_auth_router.py
@@ -1426,6 +1426,40 @@ class TestTwoFactorStateMachineRegressions:
         assert "COALESCE(totp_failed_attempts, 0) + 1" in executed
         assert "RETURNING totp_failed_attempts" in executed
 
+    def test_verify_lockout_gate_is_atomic_with_increment(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+        mock_conn: AsyncMock,
+    ) -> None:
+        """discogsography-vjod: the lockout SELECT must take a row lock (FOR
+        UPDATE) inside an explicit transaction, so concurrent verify attempts
+        for the same user serialize instead of all reading a stale
+        pre-increment snapshot."""
+        _secret, encrypted_secret = _make_encrypted_totp_secret()
+        challenge_token = _make_challenge_token()
+
+        mock_redis.get = _challenge_only_get()
+        mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
+        mock_cur.fetchone = AsyncMock(return_value={"totp_secret": encrypted_secret, "totp_failed_attempts": 0, "totp_locked_until": None})
+
+        original_config = auth_router._config
+        auth_router._config = replace(original_config, encryption_master_key=_TEST_MASTER_KEY)
+        try:
+            response = test_client.post(
+                "/api/auth/2fa/verify",
+                json={"challenge_token": challenge_token, "code": "000000"},
+            )
+        finally:
+            auth_router._config = original_config
+
+        assert response.status_code == 401
+        executed = " ".join(self._executed_sql(mock_cur))
+        assert "FOR UPDATE" in executed
+        mock_conn.set_autocommit.assert_any_call(False)
+        mock_conn.transaction.assert_called()
+
     def test_verify_failure_resets_counter_after_lock_expiry(
         self,
         test_client: TestClient,

--- a/tests/api/test_auth_router.py
+++ b/tests/api/test_auth_router.py
@@ -640,6 +640,76 @@ class TestTwoFactorConfirm:
 
         assert response.status_code == 503
 
+    def test_confirm_refuses_on_concurrent_disable_race(
+        self,
+        test_client: TestClient,
+        auth_headers: dict[str, str],
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """discogsography-8vlp: if a concurrent twofa_disable commits between
+        confirm's SELECT and its enable UPDATE, the guarded
+        `AND totp_secret = %s` matches zero rows — confirm must reject with
+        409 rather than landing totp_enabled=TRUE against a NULLed secret
+        (which would permanently lock the account out: login demands 2FA but
+        neither twofa_verify nor twofa_recovery could ever satisfy it)."""
+        secret, encrypted_secret = _make_encrypted_totp_secret()
+        mock_cur.fetchone = AsyncMock(return_value={"totp_secret": encrypted_secret})
+        mock_redis.get = AsyncMock(return_value=None)
+        # The code is verified against the secret read above, but a concurrent
+        # disable clears totp_secret before the enable UPDATE runs, so the
+        # guarded WHERE matches no row.
+        mock_cur.rowcount = 0
+
+        valid_code = pyotp.TOTP(secret).now()
+
+        original_config = auth_router._config
+        auth_router._config = replace(original_config, encryption_master_key=_TEST_MASTER_KEY)
+        try:
+            response = test_client.post(
+                "/api/auth/2fa/confirm",
+                headers=auth_headers,
+                json={"code": valid_code},
+            )
+        finally:
+            auth_router._config = original_config
+
+        assert response.status_code == 409
+
+    def test_confirm_enable_update_is_guarded_on_secret(
+        self,
+        test_client: TestClient,
+        auth_headers: dict[str, str],
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """The enable UPDATE must bind the exact secret read at the top of the
+        handler, not perform a blind write."""
+        secret, encrypted_secret = _make_encrypted_totp_secret()
+        mock_cur.fetchone = AsyncMock(return_value={"totp_secret": encrypted_secret})
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_cur.rowcount = 1
+
+        valid_code = pyotp.TOTP(secret).now()
+
+        original_config = auth_router._config
+        auth_router._config = replace(original_config, encryption_master_key=_TEST_MASTER_KEY)
+        try:
+            response = test_client.post(
+                "/api/auth/2fa/confirm",
+                headers=auth_headers,
+                json={"code": valid_code},
+            )
+        finally:
+            auth_router._config = original_config
+
+        assert response.status_code == 200
+        enable_calls = [call for call in mock_cur.execute.call_args_list if "totp_enabled = TRUE" in call.args[0]]
+        assert len(enable_calls) == 1
+        query, params = enable_calls[0].args
+        assert "AND totp_secret = %s" in query
+        assert params == (TEST_USER_ID, encrypted_secret)
+
 
 # ---------------------------------------------------------------------------
 # 2FA Verify — TOTP login verification (lines 433-499)

--- a/tests/api/test_auth_router.py
+++ b/tests/api/test_auth_router.py
@@ -86,6 +86,54 @@ class TestResetRequest:
         response = test_client.post("/api/auth/reset-request", json={"email": " Test@Example.COM "})
         assert response.status_code == 200
 
+    def test_reset_request_defers_redis_and_email_off_the_request_path(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """discogsography-0lof: the SELECT must be the only DB/network work done
+        BEFORE the response is built. `_process_reset_request` (Redis setex +
+        notification send) is scheduled as a FastAPI background task so its
+        cost never leaks into response timing and never diverges between the
+        known-email and unknown-email branches."""
+        mock_cur.fetchone = AsyncMock(return_value=make_sample_user_row())
+        channel = AsyncMock()
+        original_channel = auth_router._notification_channel
+        auth_router._notification_channel = channel
+        try:
+            response = test_client.post("/api/auth/reset-request", json={"email": TEST_USER_EMAIL})
+        finally:
+            auth_router._notification_channel = original_channel
+
+        assert response.status_code == 200
+        # Background task must have actually run (TestClient awaits background
+        # tasks before returning) and performed the Redis + notification work.
+        mock_redis.setex.assert_called_once()
+        channel.send_password_reset.assert_called_once()
+
+    def test_reset_request_unknown_email_does_not_touch_redis_or_notify(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """The no-op branch for a nonexistent email must genuinely do nothing —
+        confirms the background task is a no-op rather than a disguised no-op
+        that still leaks timing via a dummy Redis round-trip."""
+        mock_cur.fetchone = AsyncMock(return_value=None)
+        channel = AsyncMock()
+        original_channel = auth_router._notification_channel
+        auth_router._notification_channel = channel
+        try:
+            response = test_client.post("/api/auth/reset-request", json={"email": "unknown@example.com"})
+        finally:
+            auth_router._notification_channel = original_channel
+
+        assert response.status_code == 200
+        mock_redis.setex.assert_not_called()
+        channel.send_password_reset.assert_not_called()
+
     def test_reset_link_is_absolute_and_uses_app_base_url(
         self,
         test_client: TestClient,

--- a/tests/api/test_auth_router.py
+++ b/tests/api/test_auth_router.py
@@ -233,6 +233,37 @@ class TestResetConfirm:
         )
         assert response.status_code == 422  # Pydantic validation
 
+    def test_reset_confirm_revokes_app_tokens(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """discogsography-ci4a: a password reset must bulk-revoke the user's
+        app tokens — the password_changed Redis marker alone never covers
+        them (it only gates JWTs and it TTLs out; app tokens carry no
+        expiry)."""
+        mock_redis.getdel = AsyncMock(
+            return_value=json.dumps(
+                {
+                    "user_id": TEST_USER_ID,
+                    "email": TEST_USER_EMAIL,
+                }
+            )
+        )
+        response = test_client.post(
+            "/api/auth/reset-confirm",
+            json={"token": "valid-token", "new_password": "newpassword123"},
+        )
+        assert response.status_code == 200
+
+        revoke_calls = [call for call in mock_cur.execute.call_args_list if "UPDATE app_tokens" in call.args[0]]
+        assert len(revoke_calls) == 1
+        query, params = revoke_calls[0].args
+        assert "revoked_at = NOW()" in query
+        assert "revoked_at IS NULL" in query
+        assert params == (TEST_USER_ID,)
+
 
 class TestTwoFactorSetup:
     """Tests for POST /api/auth/2fa/setup."""
@@ -1476,6 +1507,29 @@ class TestChangePassword:
         mock_redis.setex.assert_called()
         redis_call_args = mock_redis.setex.call_args
         assert redis_call_args[0][0].startswith("password_changed:")
+
+    def test_change_password_revokes_app_tokens(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,  # noqa: ARG002  # required so setex is stubbed
+        auth_headers: dict[str, str],
+    ) -> None:
+        """discogsography-ci4a: same bulk-revoke contract as reset-confirm."""
+        mock_cur.fetchone = AsyncMock(return_value=make_sample_user_row())
+        response = test_client.post(
+            "/api/auth/change-password",
+            json={"current_password": "testpassword", "new_password": "newpassword123"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+
+        revoke_calls = [call for call in mock_cur.execute.call_args_list if "UPDATE app_tokens" in call.args[0]]
+        assert len(revoke_calls) == 1
+        query, params = revoke_calls[0].args
+        assert "revoked_at = NOW()" in query
+        assert "revoked_at IS NULL" in query
+        assert params == (TEST_USER_ID,)
 
     def test_change_password_wrong_current(
         self,

--- a/tests/api/test_auth_router.py
+++ b/tests/api/test_auth_router.py
@@ -863,6 +863,34 @@ class TestTwoFactorRecoveryFull:
         assert "access_token" in data
         assert data["token_type"] == "bearer"
 
+    def test_recovery_success_resets_totp_lockout_state(
+        self,
+        test_client: TestClient,
+        mock_cur: AsyncMock,
+        mock_redis: AsyncMock,
+    ) -> None:
+        """discogsography-cflq: a successful recovery must reset
+        totp_failed_attempts/totp_locked_until in the same UPDATE that redeems
+        the code — otherwise stale lockout state survives the recovery login
+        and can 429 a subsequent CORRECT TOTP code."""
+        plaintext_codes, hashed_codes = self._make_recovery_setup()
+        challenge_token = _make_challenge_token()
+
+        mock_redis.get = _challenge_only_get()
+        mock_redis.getdel = AsyncMock(return_value=TEST_USER_ID)
+        mock_redis.delete = AsyncMock()
+        mock_cur.fetchone = AsyncMock(return_value={"totp_recovery_codes": json.dumps(hashed_codes)})
+
+        response = test_client.post(
+            "/api/auth/2fa/recovery",
+            json={"challenge_token": challenge_token, "code": plaintext_codes[0]},
+        )
+        assert response.status_code == 200
+
+        executed = " ".join(str(call) for call in mock_cur.execute.call_args_list)
+        assert "totp_failed_attempts = 0" in executed
+        assert "totp_locked_until = NULL" in executed
+
     def test_recovery_invalid_code_returns_401(
         self,
         test_client: TestClient,

--- a/tests/api/test_collection_app_token_auth.py
+++ b/tests/api/test_collection_app_token_auth.py
@@ -20,28 +20,31 @@ _APP_USER_ID = "99999999-9999-9999-9999-999999999999"
 _APP_TOKEN_ID = "11111111-1111-1111-1111-111111111111"
 
 
-def _make_active_row(scopes: list[str] | None = None, token_id: str = _APP_TOKEN_ID) -> dict[str, Any]:
+def _make_active_row(scopes: list[str] | None = None, token_id: str = _APP_TOKEN_ID, token_hash: str | None = None) -> dict[str, Any]:
     """A typical active `app_tokens` row as returned by `_lookup_active_token`."""
     return {
         "id": UUID(token_id),
         "user_id": UUID(_APP_USER_ID),
         "name": "GRUVAX kiosk",
         "scope": scopes if scopes is not None else ["collection:read"],
+        "token_hash": token_hash,
     }
 
 
 @pytest.fixture
 def app_token_headers(mock_cur: AsyncMock) -> dict[str, str]:
     """Authorization header whose lookup yields a valid active app token row."""
-    mock_cur.fetchone = AsyncMock(return_value=_make_active_row())
-    return {"Authorization": f"Bearer {generate_plaintext_token()}"}
+    plaintext = generate_plaintext_token()
+    mock_cur.fetchone = AsyncMock(return_value=_make_active_row(token_hash=hash_token(plaintext)))
+    return {"Authorization": f"Bearer {plaintext}"}
 
 
 @pytest.fixture
 def app_token_headers_wrong_scope(mock_cur: AsyncMock) -> dict[str, str]:
     """Active token but lacks `collection:read`."""
-    mock_cur.fetchone = AsyncMock(return_value=_make_active_row(scopes=["other:scope"]))
-    return {"Authorization": f"Bearer {generate_plaintext_token()}"}
+    plaintext = generate_plaintext_token()
+    mock_cur.fetchone = AsyncMock(return_value=_make_active_row(scopes=["other:scope"], token_hash=hash_token(plaintext)))
+    return {"Authorization": f"Bearer {plaintext}"}
 
 
 @pytest.fixture
@@ -211,8 +214,9 @@ class TestRateLimits:
         monkeypatch.setattr(user_router, "get_user_collection", AsyncMock(return_value=([], 0)))
 
         # Token A → drive to 429
-        mock_cur.fetchone = AsyncMock(return_value=_make_active_row())
-        headers_a = {"Authorization": f"Bearer {generate_plaintext_token()}"}
+        plaintext_a = generate_plaintext_token()
+        mock_cur.fetchone = AsyncMock(return_value=_make_active_row(token_hash=hash_token(plaintext_a)))
+        headers_a = {"Authorization": f"Bearer {plaintext_a}"}
         seen_429 = False
         for _ in range(65):
             r = test_client.get("/api/user/collection", headers=headers_a)
@@ -222,8 +226,14 @@ class TestRateLimits:
         assert seen_429, "Test setup failed: did not reach 429 on token A"
 
         # Token B → brand-new plaintext → different hash → fresh bucket
-        mock_cur.fetchone = AsyncMock(return_value=_make_active_row(token_id="22222222-2222-2222-2222-222222222222"))  # noqa: S106
-        headers_b = {"Authorization": f"Bearer {generate_plaintext_token()}"}
+        plaintext_b = generate_plaintext_token()
+        mock_cur.fetchone = AsyncMock(
+            return_value=_make_active_row(
+                token_id="22222222-2222-2222-2222-222222222222",  # noqa: S106
+                token_hash=hash_token(plaintext_b),
+            )
+        )
+        headers_b = {"Authorization": f"Bearer {plaintext_b}"}
         r_b = test_client.get("/api/user/collection", headers=headers_b)
         assert r_b.status_code == 200
 

--- a/tests/api/test_dependencies.py
+++ b/tests/api/test_dependencies.py
@@ -641,14 +641,17 @@ class TestUnifiedAuthTouchesLastUsedAt:
         from uuid import UUID
 
         from api import dependencies as deps
+        from api.app_tokens import hash_token
         from api.dependencies import require_user_or_app_token
 
         token_id = "11111111-1111-1111-1111-111111111111"
+        plaintext_token = "dscg_sometokenplaintext"
         row = {
             "id": UUID(token_id),
             "user_id": UUID("99999999-9999-9999-9999-999999999999"),
             "name": "GRUVAX kiosk",
             "scope": ["collection:read"],
+            "token_hash": hash_token(plaintext_token),
         }
         monkeypatch.setattr(deps, "_lookup_active_token", AsyncMock(return_value=row))
 
@@ -660,7 +663,7 @@ class TestUnifiedAuthTouchesLastUsedAt:
         monkeypatch.setattr(deps, "_touch_last_used_at", fake_touch)
 
         dependency = require_user_or_app_token(["collection:read"])
-        creds = _make_credentials("dscg_sometokenplaintext")
+        creds = _make_credentials(plaintext_token)
         auth = await dependency(creds)
 
         assert auth.via == "app_token"
@@ -668,3 +671,33 @@ class TestUnifiedAuthTouchesLastUsedAt:
         # Fire-and-forget task — let the loop run it, then assert bookkeeping fired.
         await asyncio.sleep(0)
         assert touched == [token_id]
+
+
+class TestUnifiedAuthDefenseInDepth:
+    """discogsography-osoc: require_user_or_app_token's app-token branch must
+    perform the same compare_digest defense-in-depth check as require_app_token,
+    against the row's own persisted token_hash — not a self-comparison."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_row_hash_mismatch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from uuid import UUID
+
+        from fastapi import HTTPException
+
+        from api import dependencies as deps
+        from api.dependencies import require_user_or_app_token
+
+        row = {
+            "id": UUID("11111111-1111-1111-1111-111111111111"),
+            "user_id": UUID("99999999-9999-9999-9999-999999999999"),
+            "name": "GRUVAX kiosk",
+            "scope": ["collection:read"],
+            "token_hash": "0" * 64,  # deliberately wrong
+        }
+        monkeypatch.setattr(deps, "_lookup_active_token", AsyncMock(return_value=row))
+
+        dependency = require_user_or_app_token(["collection:read"])
+        creds = _make_credentials("dscg_sometokenplaintext")
+        with pytest.raises(HTTPException) as exc:
+            await dependency(creds)
+        assert exc.value.status_code == 401

--- a/tests/api/test_notifications.py
+++ b/tests/api/test_notifications.py
@@ -23,6 +23,23 @@ class TestLogNotificationChannel:
         channel = LogNotificationChannel()
         assert isinstance(channel, NotificationChannel)
 
+    @pytest.mark.asyncio
+    async def test_send_password_reset_does_not_log_email(self) -> None:
+        """discogsography-1385: the fallback log channel must never bind the
+        recipient's email address into a structlog event (PII)."""
+        from structlog.testing import capture_logs
+
+        from api.notifications import LogNotificationChannel
+
+        channel = LogNotificationChannel()
+        with capture_logs() as captured:
+            await channel.send_password_reset("user@example.com", "https://example.com/reset?token=abc123")
+
+        assert captured
+        for entry in captured:
+            assert "email" not in entry
+            assert "user@example.com" not in str(entry.values())
+
 
 def _mock_async_client(mock_response: MagicMock) -> MagicMock:
     """Build a mock httpx.AsyncClient whose `.post()` returns `mock_response`."""
@@ -179,3 +196,27 @@ class TestResendNotificationChannel:
             )
 
             await channel.send_password_reset("user@example.com", "https://example.com/reset")
+
+    @pytest.mark.asyncio
+    async def test_send_password_reset_success_does_not_log_email(self) -> None:
+        """discogsography-1385: success-path log must not bind email either."""
+        from structlog.testing import capture_logs
+
+        from api.notifications import ResendNotificationChannel
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_client = _mock_async_client(mock_response)
+
+        with patch("api.notifications.httpx.AsyncClient", return_value=mock_client), capture_logs() as captured:
+            channel = ResendNotificationChannel(
+                api_key="test-key",
+                sender_email="noreply@test.com",
+                sender_name="Test",
+            )
+            await channel.send_password_reset("user@example.com", "https://example.com/reset")
+
+        assert captured
+        for entry in captured:
+            assert "email" not in entry
+            assert "user@example.com" not in str(entry.values())

--- a/tests/api/test_snapshot_store.py
+++ b/tests/api/test_snapshot_store.py
@@ -6,10 +6,12 @@ enforced the cap. Any direct caller of SnapshotStore bypassing the router
 (scripts, future reuse) could persist arbitrarily large payloads to Redis.
 """
 
+from unittest.mock import AsyncMock, patch
+
 import fakeredis.aioredis as aioredis_fake
 import pytest
 
-from api.snapshot_store import SnapshotStore
+from api.snapshot_store import SnapshotQuotaExceededError, SnapshotStore
 
 
 class TestSnapshotStoreMaxNodes:
@@ -50,3 +52,97 @@ class TestSnapshotStoreMaxNodes:
         nodes = [{"id": str(i), "type": "artist"} for i in range(3)]
         token, _ = await store.save(nodes, {"id": "0", "type": "artist"})
         assert token
+
+
+class TestSnapshotStoreQuotaCounterAtomicity:
+    """discogsography-7639: the per-user quota counter must self-heal a
+    missing TTL and must not be permanently consumed by a failed save."""
+
+    @pytest.mark.asyncio
+    async def test_expire_self_heals_a_ttl_less_counter(self) -> None:
+        """If a prior save's EXPIRE call was lost (crash/timeout right after
+        INCR), the counter key would be left with NO TTL — permanent, never
+        re-armed under the old `if count == 1` one-shot gate. The next save
+        must notice the missing TTL and arm it via `EXPIRE ... NX`."""
+        redis_client = aioredis_fake.FakeRedis()
+        store = SnapshotStore(redis_client, ttl_days=1, max_per_user=50)
+        count_key = f"{store._USER_COUNT_KEY_PREFIX}user-1"
+
+        # Simulate the lost-EXPIRE failure mode directly: a counter that
+        # exists but carries no TTL at all.
+        await redis_client.set(count_key, 1)
+        assert await redis_client.ttl(count_key) == -1  # no TTL
+
+        await store.save([{"id": "1", "type": "artist"}], {"id": "1", "type": "artist"}, user_id="user-1")
+
+        assert await redis_client.ttl(count_key) > 0
+
+    @pytest.mark.asyncio
+    async def test_expire_nx_does_not_reset_an_existing_ttl(self) -> None:
+        """`NX` must be a no-op once a TTL is already armed — otherwise every
+        save would keep sliding the window forward indefinitely."""
+        redis_client = aioredis_fake.FakeRedis()
+        store = SnapshotStore(redis_client, ttl_days=1, max_per_user=50)
+        count_key = f"{store._USER_COUNT_KEY_PREFIX}user-1"
+
+        await store.save([{"id": "1", "type": "artist"}], {"id": "1", "type": "artist"}, user_id="user-1")
+        first_ttl = await redis_client.ttl(count_key)
+        assert first_ttl > 0
+
+        await store.save([{"id": "2", "type": "artist"}], {"id": "2", "type": "artist"}, user_id="user-1")
+        second_ttl = await redis_client.ttl(count_key)
+        assert second_ttl <= first_ttl
+
+    @pytest.mark.asyncio
+    async def test_failed_save_decrements_the_quota_counter(self) -> None:
+        """A Redis error on the final `set()` must not permanently consume the
+        user's quota slot for a snapshot that was never actually written."""
+        redis_client = aioredis_fake.FakeRedis()
+        store = SnapshotStore(redis_client, ttl_days=1, max_per_user=50)
+        count_key = f"{store._USER_COUNT_KEY_PREFIX}user-1"
+
+        with (
+            patch.object(redis_client, "set", AsyncMock(side_effect=ConnectionError("boom"))),
+            pytest.raises(ConnectionError),
+        ):
+            await store.save([{"id": "1", "type": "artist"}], {"id": "1", "type": "artist"}, user_id="user-1")
+
+        # The incr was rolled back — the counter must not remain elevated.
+        remaining = await redis_client.get(count_key)
+        assert remaining in (None, b"0", "0")
+
+    @pytest.mark.asyncio
+    async def test_repeated_failed_saves_never_exhaust_the_quota(self) -> None:
+        """Repeated transient failures on the final write must not accumulate
+        into a quota lockout with zero live snapshots to show for it."""
+        redis_client = aioredis_fake.FakeRedis()
+        store = SnapshotStore(redis_client, ttl_days=1, max_per_user=3)
+        count_key = f"{store._USER_COUNT_KEY_PREFIX}user-1"
+
+        with patch.object(redis_client, "set", AsyncMock(side_effect=ConnectionError("boom"))):
+            for _ in range(10):
+                with pytest.raises(ConnectionError):
+                    await store.save([{"id": "1", "type": "artist"}], {"id": "1", "type": "artist"}, user_id="user-1")
+
+        remaining = await redis_client.get(count_key)
+        assert remaining in (None, b"0", "0")
+
+        # Quota must still be available for a real, successful save.
+        token, _ = await store.save([{"id": "1", "type": "artist"}], {"id": "1", "type": "artist"}, user_id="user-1")
+        assert token
+
+    @pytest.mark.asyncio
+    async def test_quota_exceeded_still_decrements(self) -> None:
+        """Existing behavior preserved: exceeding the quota still decrements
+        the over-count and raises, without ever calling the final set()."""
+        redis_client = aioredis_fake.FakeRedis()
+        store = SnapshotStore(redis_client, ttl_days=1, max_per_user=1)
+
+        token, _ = await store.save([{"id": "1", "type": "artist"}], {"id": "1", "type": "artist"}, user_id="user-1")
+        assert token
+
+        with pytest.raises(SnapshotQuotaExceededError):
+            await store.save([{"id": "2", "type": "artist"}], {"id": "2", "type": "artist"}, user_id="user-1")
+
+        count_key = f"{store._USER_COUNT_KEY_PREFIX}user-1"
+        assert (await redis_client.get(count_key)) in (b"1", "1")


### PR DESCRIPTION
Fixes 11 priority-3 security/auth findings from the 2026-08-10 bug hunt (run `wf_646d4b21`), one commit per bead.

## Auth & 2FA
- **discogsography-0lof** — /api/auth/reset-request timing no longer reveals account existence (side-channel closed).
- **discogsography-ci4a** — password reset/change bulk-revokes app tokens, not just JWT sessions.
- **discogsography-vjod** — 2FA verify lockout gate is atomic with the attempt increment; concurrent requests can't bypass it.
- **discogsography-cflq** — successful 2FA recovery resets totp_failed_attempts/totp_locked_until.
- **discogsography-kqw4** — 2FA recovery honors the atomic GETDEL result; a challenge token can't be consumed twice.
- **discogsography-8vlp** — twofa_confirm's enable UPDATE is guarded on the verified secret still existing (race with twofa_disable).
- **discogsography-osoc** — app-token defense-in-depth check compares against the real stored hash (was self-comparison, guard inert).

## API hygiene
- **discogsography-1385** — registrant/admin emails no longer logged at INFO.
- **discogsography-dir0** — admin-setup takes the password via env/stdin/prompt instead of argv.
- **discogsography-jlei** — request metrics key on the matched route template, so unauthenticated 404 floods can't evict legitimate endpoint metrics.
- **discogsography-7639** — snapshot quota counter self-heals TTL and refunds on failed save; Redis error paths no longer leak quota.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrLwHwMcu3cuQJh8cc1SyW