### PR TITLE
fix: concurrency races & resource leaks — 13 bug-hunt findings (batch:p3-concurrency-resource)

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -67,6 +67,7 @@ from api.services.discogs import (
     fetch_discogs_identity,
     request_oauth_token,
 )
+from api.syncer import reconcile_stale_sync_history
 from common import AsyncPostgreSQLPool, AsyncResilientNeo4jDriver, HealthServer, neo4j_security_kwargs, parse_postgres_host_port, setup_logging
 from common.config import ApiConfig
 from common.query_debug import execute_sql
@@ -225,6 +226,11 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:  # pragma: no cover
     )
     await _pool.initialize()
     logger.info("💾 Database pool initialized")
+
+    # Reconcile sync_history rows abandoned by a hard process death (SIGKILL/
+    # OOM) between the INSERT and run_full_sync's terminal UPDATE — no
+    # in-process handler survives that to fix them itself (discogsography-pxqw).
+    await reconcile_stale_sync_history(_pool)
 
     # Initialize Redis for OAuth state storage and token blacklist
     _redis = await aioredis.from_url(_config.redis_host, decode_responses=True)

--- a/api/api.py
+++ b/api/api.py
@@ -341,6 +341,12 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:  # pragma: no cover
         await _pool.close()
     if _redis:
         await _redis.aclose()
+    if anthropic_client is not None:
+        # AsyncAnthropic owns an internal httpx.AsyncClient whose connection
+        # pool/keep-alive sockets are never drained unless explicitly
+        # closed — it has no context-manager/finalizer wired up here, so
+        # without this the client just leaks on shutdown (discogsography-8nle).
+        await anthropic_client.close()
     health_srv.stop()
     logger.info("✅ API service stopped")
 

--- a/api/metrics_collector.py
+++ b/api/metrics_collector.py
@@ -86,22 +86,15 @@ class MetricsBuffer:
             self._entries.popleft()
         self._entries.append(_Entry(path=path, status_code=status_code, duration_ms=duration_ms))
 
-    def flush(self) -> dict[str, dict[str, Any]]:
-        """Group buffered entries by path and compute stats, WITHOUT clearing the buffer.
-
-        Non-destructive on purpose: the caller is responsible for calling
-        :meth:`clear` only after the returned stats have been durably persisted.
-        This keeps a failed persist from silently discarding the window's
-        samples — they simply stay buffered (growth still bounded by
-        ``max_size`` via ``record()``'s eviction) and are folded into the next
-        cycle's stats until a persist finally succeeds.
-        """
-        if not self._entries:
+    @staticmethod
+    def _compute_stats(entries: deque[_Entry] | list[_Entry]) -> dict[str, dict[str, Any]]:
+        """Group entries by path and compute count/percentile/error-count stats."""
+        if not entries:
             return {}
 
         groups: dict[str, list[float]] = {}
         error_counts: dict[str, int] = {}
-        for entry in self._entries:
+        for entry in entries:
             groups.setdefault(entry.path, []).append(entry.duration_ms)
             if entry.status_code >= 500:
                 error_counts[entry.path] = error_counts.get(entry.path, 0) + 1
@@ -119,9 +112,69 @@ class MetricsBuffer:
             }
         return result
 
+    def flush(self) -> dict[str, dict[str, Any]]:
+        """Group buffered entries by path and compute stats, WITHOUT clearing the buffer.
+
+        Non-destructive on purpose: the caller is responsible for calling
+        :meth:`clear` only after the returned stats have been durably persisted.
+        This keeps a failed persist from silently discarding the window's
+        samples — they simply stay buffered (growth still bounded by
+        ``max_size`` via ``record()``'s eviction) and are folded into the next
+        cycle's stats until a persist finally succeeds.
+
+        NOTE: pairing this with :meth:`clear` after an ``await`` (e.g. a
+        persist call) is a TOCTOU — any entry ``record()``ed during that
+        ``await`` is silently dropped by ``clear()``'s wholesale replacement,
+        because it was never part of the snapshot ``flush()`` returned
+        (discogsography-qtts). Callers that persist across an await should
+        use :meth:`drain` / :meth:`restore` instead, which swap the buffer
+        out atomically so newly-arrived entries can never be in the
+        snapshot that gets dropped.
+        """
+        return self._compute_stats(self._entries)
+
     def clear(self) -> None:
         """Drop all buffered entries.  Call only after a successful persist of ``flush()``'s result."""
         self._entries = deque()
+
+    def drain(self) -> tuple[dict[str, dict[str, Any]], deque[_Entry]]:
+        """Atomically swap out the buffer and compute stats from the swapped-out copy.
+
+        Returns ``(stats, samples)``. The swap (``samples = self._entries;
+        self._entries = deque()``) is a single, non-yielding assignment, so
+        any entry ``record()``ed after this call returns lands in the FRESH
+        deque — never in ``samples`` — regardless of how long the caller then
+        spends ``await``ing a persist. This is what makes drain/restore safe
+        across an await where ``flush``/``clear`` is not: on persist failure,
+        pass ``samples`` to :meth:`restore` to put them back ahead of
+        whatever arrived in the meantime, instead of ``clear()`` wiping both
+        the persisted snapshot AND everything recorded during the persist
+        window (discogsography-qtts).
+        """
+        samples = self._entries
+        self._entries = deque()
+        try:
+            stats = self._compute_stats(samples)
+        except Exception:
+            # Stats computation blew up on this batch — put the raw samples
+            # back rather than losing them silently.
+            self.restore(samples)
+            raise
+        return stats, samples
+
+    def restore(self, samples: deque[_Entry]) -> None:
+        """Re-prepend entries a failed persist could not durably store.
+
+        Placed AHEAD of anything recorded since the matching :meth:`drain`
+        call, then trimmed from the left (oldest-first) to ``max_size`` —
+        the same eviction order :meth:`record` uses — so a restore can never
+        transiently exceed the bound record() otherwise enforces.
+        """
+        if not samples:
+            return
+        self._entries.extendleft(reversed(samples))
+        while len(self._entries) > self.max_size:
+            self._entries.popleft()
 
 
 # ---------------------------------------------------------------------------
@@ -299,10 +352,15 @@ async def run_collector(
         except Exception:
             logger.error("❌ Error collecting service health")
 
-        # 3. Flush metrics buffer (non-destructive) and attach endpoint_stats to API row
+        # 3. Drain metrics buffer — an ATOMIC swap (not the non-destructive
+        # flush()), so any request recorded during the persist `await` below
+        # lands in the buffer's fresh deque and is never part of the samples
+        # a failed persist has to restore or a successful one discards
+        # (discogsography-qtts). Attach endpoint_stats to the API health row.
         endpoint_stats: dict[str, dict[str, Any]] = {}
+        buffer_samples: deque[Any] = deque()
         try:
-            endpoint_stats = metrics_buffer.flush()
+            endpoint_stats, buffer_samples = metrics_buffer.drain()
             if endpoint_stats:
                 # Find existing API row or create synthetic one
                 api_row = next((r for r in health_rows if r["service_name"] == "api"), None)
@@ -321,18 +379,21 @@ async def run_collector(
         except Exception:
             logger.error("❌ Error flushing metrics buffer")
 
-        # 4. Persist — only drop the buffered endpoint stats once they're durably
-        # written; on failure they stay buffered (bounded by max_size) and are
-        # retried as part of the next cycle's stats instead of being lost.
+        # 4. Persist — only drop the drained endpoint stats once they're durably
+        # written. On failure (including cancellation) they are restored
+        # AHEAD of anything recorded during this await, instead of being lost
+        # (drain() already removed them from the live buffer, so a `clear()`-
+        # style "leave them buffered" is no longer available — restore() is
+        # the equivalent for the atomic-swap design).
         try:
             await persist_metrics(pool, queue_rows, health_rows)
             logger.info("📊 Persisted metrics", queues=len(queue_rows), health=len(health_rows))
-            if endpoint_stats:
-                metrics_buffer.clear()
         except asyncio.CancelledError:
+            metrics_buffer.restore(buffer_samples)
             raise
         except Exception:
             logger.error("❌ Error persisting metrics")
+            metrics_buffer.restore(buffer_samples)
 
         # 5. Prune
         try:

--- a/api/routers/extraction_analysis.py
+++ b/api/routers/extraction_analysis.py
@@ -1,6 +1,7 @@
 """Extraction Analysis router — versions, summary, violations, and parsing errors for flagged records."""
 
 import asyncio
+from collections.abc import Callable, Coroutine
 import json
 import math
 from pathlib import Path
@@ -31,9 +32,64 @@ _anthropic_model: str = "claude-sonnet-4-20250514"
 _SAFE_VERSION = re.compile(r"^[a-zA-Z0-9._-]+$")
 _SAFE_RECORD_ID = re.compile(r"^[a-zA-Z0-9._-]+$")
 
-# Parsing-error classification cache: version → (expiry_timestamp, result_dict)
-_parsing_error_cache: dict[str, tuple[float, dict[str, Any]]] = {}
+
+class _SingleFlightTTLCache[T]:
+    """A read-through TTL memo that collapses concurrent misses for the same key.
+
+    A plain ``dict``-backed TTL cache is a check-then-act race: the miss
+    check and the cache store are separated by an ``await`` (the scan
+    itself), so every request arriving during that window also misses and
+    launches its own duplicate scan. For this router that means N concurrent
+    admin requests for the same cold version each run their own full-corpus
+    JSONL scan (or classification pass) in parallel, each holding its own
+    near-cap parsed corpus in memory simultaneously — multiplying exactly the
+    peak-memory bound the size caps exist to enforce (discogsography-jrm3).
+
+    The in-flight ``asyncio.Task`` registry is a plain ``dict``; the `Task`
+    objects it holds are only ever created inside the running event loop
+    (never at import time), so this is safe to instantiate at module scope
+    per the repo's asyncio-primitive rule.
+    """
+
+    def __init__(self, ttl_seconds: float) -> None:
+        self._ttl_seconds = ttl_seconds
+        self._cache: dict[str, tuple[float, T]] = {}
+        self._inflight: dict[str, asyncio.Task[T]] = {}
+
+    async def get_or_compute(self, key: str, compute: Callable[[], Coroutine[Any, Any, T]]) -> T:
+        """Return the cached value for *key*, computing it at most once per TTL window."""
+        now = time.monotonic()
+        cached = self._cache.get(key)
+        if cached is not None and now < cached[0]:
+            return cached[1]
+
+        # Join an in-flight computation for this key instead of starting a
+        # second one — the single-flight collapse.
+        task = self._inflight.get(key)
+        if task is not None:
+            return await task
+
+        task = asyncio.create_task(compute())
+        self._inflight[key] = task
+        try:
+            result = await task
+        finally:
+            # Always drop the in-flight entry, success or failure, so a
+            # failed scan doesn't wedge every subsequent caller behind a
+            # dead task forever.
+            self._inflight.pop(key, None)
+        self._cache[key] = (time.monotonic() + self._ttl_seconds, result)
+        return result
+
+    def clear(self) -> None:
+        """Drop every cached and in-flight entry (test/ops reset hook)."""
+        self._cache.clear()
+        self._inflight.clear()
+
+
+# Parsing-error classification cache: version → result_dict
 _PARSING_ERROR_CACHE_TTL: float = 300.0  # 5 minutes
+_parsing_error_cache: _SingleFlightTTLCache[dict[str, Any]] = _SingleFlightTTLCache(_PARSING_ERROR_CACHE_TTL)
 
 
 # ---------------------------------------------------------------------------
@@ -227,12 +283,13 @@ def _read_skipped(flagged_version_dir: Path) -> list[dict[str, Any]]:
     return skipped
 
 
-# version-dir path → (expiry_timestamp, cached result). Shared by every endpoint
+# version-dir path → cached violation/skipped set. Shared by every endpoint
 # that needs a version's full violation/skipped set, so the aggregate JSONL scan
-# runs at most once per version per TTL window instead of once per request.
-_violations_cache: dict[str, tuple[float, list[dict[str, Any]]]] = {}
-_skipped_cache: dict[str, tuple[float, list[dict[str, Any]]]] = {}
+# runs at most once per version per TTL window instead of once per request —
+# AND at most once per cold miss even under concurrent requests.
 _JSONL_CACHE_TTL: float = 300.0  # 5 minutes — matches _PARSING_ERROR_CACHE_TTL
+_violations_cache: _SingleFlightTTLCache[list[dict[str, Any]]] = _SingleFlightTTLCache(_JSONL_CACHE_TTL)
+_skipped_cache: _SingleFlightTTLCache[list[dict[str, Any]]] = _SingleFlightTTLCache(_JSONL_CACHE_TTL)
 
 
 async def _get_violations(flagged_version_dir: Path) -> list[dict[str, Any]]:
@@ -244,25 +301,13 @@ async def _get_violations(flagged_version_dir: Path) -> list[dict[str, Any]]:
     requests for the cache TTL instead of re-scanning the corpus each time.
     """
     cache_key = str(flagged_version_dir)
-    now = time.monotonic()
-    cached = _violations_cache.get(cache_key)
-    if cached is not None and now < cached[0]:
-        return cached[1]
-    violations = await asyncio.to_thread(_read_violations, flagged_version_dir)
-    _violations_cache[cache_key] = (now + _JSONL_CACHE_TTL, violations)
-    return violations
+    return await _violations_cache.get_or_compute(cache_key, lambda: asyncio.to_thread(_read_violations, flagged_version_dir))
 
 
 async def _get_skipped(flagged_version_dir: Path) -> list[dict[str, Any]]:
     """Cached, off-event-loop accessor for a version's full skipped-record set. See `_get_violations`."""
     cache_key = str(flagged_version_dir)
-    now = time.monotonic()
-    cached = _skipped_cache.get(cache_key)
-    if cached is not None and now < cached[0]:
-        return cached[1]
-    skipped = await asyncio.to_thread(_read_skipped, flagged_version_dir)
-    _skipped_cache[cache_key] = (now + _JSONL_CACHE_TTL, skipped)
-    return skipped
+    return await _skipped_cache.get_or_compute(cache_key, lambda: asyncio.to_thread(_read_skipped, flagged_version_dir))
 
 
 def _load_state_marker(data_root: Path, version: str, source: str) -> dict[str, Any] | None:
@@ -744,32 +789,25 @@ async def get_parsing_errors(
     if location is None:
         raise HTTPException(status_code=404, detail=f"Version not found: {version!r}")
 
-    cache_key = version
-    now = time.monotonic()
-    if cache_key in _parsing_error_cache:
-        expiry, cached_result = _parsing_error_cache[cache_key]
-        if now < expiry:
-            return JSONResponse(content=cached_result)
-
     data_root, _source = location
     flagged_version_dir = data_root / "flagged" / version
 
-    violations = await _get_violations(flagged_version_dir)
-    parsing_errors, source_issues, indeterminate = await asyncio.to_thread(_classify_all_violations, violations, flagged_version_dir)
+    async def _compute() -> dict[str, Any]:
+        violations = await _get_violations(flagged_version_dir)
+        parsing_errors, source_issues, indeterminate = await asyncio.to_thread(_classify_all_violations, violations, flagged_version_dir)
+        return {
+            "parsing_errors": parsing_errors,
+            "source_issues": source_issues,
+            "indeterminate": indeterminate,
+            "stats": {
+                "total_analyzed": len(violations),
+                "parsing_errors": len(parsing_errors),
+                "source_issues": len(source_issues),
+                "indeterminate": len(indeterminate),
+            },
+        }
 
-    result: dict[str, Any] = {
-        "parsing_errors": parsing_errors,
-        "source_issues": source_issues,
-        "indeterminate": indeterminate,
-        "stats": {
-            "total_analyzed": len(violations),
-            "parsing_errors": len(parsing_errors),
-            "source_issues": len(source_issues),
-            "indeterminate": len(indeterminate),
-        },
-    }
-
-    _parsing_error_cache[cache_key] = (now + _PARSING_ERROR_CACHE_TTL, result)
+    result = await _parsing_error_cache.get_or_compute(version, _compute)
     return JSONResponse(content=result)
 
 

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -585,6 +585,7 @@ async def run_full_sync(
     error_message = None
     collection_count = 0
     wantlist_count = 0
+    cancelled = False
 
     try:
         # Fetch OAuth tokens for the user
@@ -646,6 +647,17 @@ async def run_full_sync(
             neo4j_driver=neo4j_driver,
         )
 
+    except asyncio.CancelledError:
+        # CancelledError is a BaseException, not an Exception — the `except
+        # Exception` below never sees it. Shutdown/restart cancels this task
+        # via api/api.py's lifespan (task.cancel() + gather(...,
+        # return_exceptions=True)), so this path is routinely reachable, not
+        # exceptional. Record a terminal status in `finally` below and
+        # re-raise so cancellation still propagates normally
+        # (discogsography-pxqw).
+        cancelled = True
+        error_message = "Sync cancelled (service shutdown or restart)"
+        raise
     except Exception as exc:
         error_message = str(exc)
         logger.error("❌ Sync failed", user_id=str(user_uuid), error=error_message)
@@ -664,24 +676,28 @@ async def run_full_sync(
             await rec_cache.invalidate_user(str(user_uuid))
             logger.info("🔄 Recommendation cache invalidated", user_id=str(user_uuid))
 
-    # Update sync_history record
-    final_status = "failed" if error_message else "completed"
-    try:
-        async with pg_pool.connection() as conn, conn.cursor() as cur:
-            await execute_sql(
-                cur,
-                """
-                    UPDATE sync_history
-                    SET status = %s,
-                        items_synced = %s,
-                        error_message = %s,
-                        completed_at = NOW()
-                    WHERE id = %s::uuid
-                    """,
-                (final_status, collection_count + wantlist_count, error_message, sync_id),
-            )
-    except Exception as update_exc:
-        logger.error("❌ Failed to update sync_history", sync_id=sync_id, error=str(update_exc))
+        # Update sync_history record — moved INTO `finally` so it runs even
+        # when CancelledError is propagating (the previous plain-code
+        # placement after the try/except/finally never executed on
+        # cancellation, leaving the row stuck at status='running' forever —
+        # discogsography-pxqw).
+        final_status = "cancelled" if cancelled else ("failed" if error_message else "completed")
+        try:
+            async with pg_pool.connection() as conn, conn.cursor() as cur:
+                await execute_sql(
+                    cur,
+                    """
+                        UPDATE sync_history
+                        SET status = %s,
+                            items_synced = %s,
+                            error_message = %s,
+                            completed_at = NOW()
+                        WHERE id = %s::uuid
+                        """,
+                    (final_status, collection_count + wantlist_count, error_message, sync_id),
+                )
+        except Exception as update_exc:
+            logger.error("❌ Failed to update sync_history", sync_id=sync_id, error=str(update_exc))
 
     return {
         "sync_id": sync_id,
@@ -690,3 +706,29 @@ async def run_full_sync(
         "wantlist_count": wantlist_count,
         "error": error_message,
     }
+
+
+async def reconcile_stale_sync_history(pg_pool: AsyncPostgreSQLPool) -> None:
+    """Flip any sync_history row stuck at status='running' to 'failed' at startup.
+
+    run_full_sync's own CancelledError/Exception handling (see above) covers
+    an in-process cancellation or crash, but it can do nothing about a hard
+    process death (SIGKILL/OOM) between the INSERT in
+    api/routers/sync.py:trigger_sync and run_full_sync's terminal UPDATE —
+    the row is simply abandoned with no in-process handler left to run.
+    Call this once at service startup, before traffic is accepted, so a
+    restart after a crash mid-sync doesn't leave GET /api/sync/status
+    reporting a phantom running sync forever (discogsography-pxqw).
+    """
+    async with pg_pool.connection() as conn, conn.cursor() as cur:
+        await execute_sql(
+            cur,
+            """
+                UPDATE sync_history
+                SET status = 'failed', error_message = 'Interrupted by service restart', completed_at = NOW()
+                WHERE status = 'running'
+                """,
+        )
+        reconciled = cur.rowcount
+    if reconciled:
+        logger.warning("⚠️ Reconciled stale sync_history rows stuck at 'running'", count=reconciled)

--- a/common/health_server.py
+++ b/common/health_server.py
@@ -100,7 +100,19 @@ class HealthServer(ThreadingHTTPServer):
         self.thread.start()
 
     def stop(self) -> None:
-        """Stop the health server."""
-        self.shutdown()
-        if self.thread:
-            self.thread.join(timeout=5)
+        """Stop the health server and release its listening socket.
+
+        socketserver.BaseServer.shutdown() only signals serve_forever() to
+        exit and blocks until it does — it does NOT close the bound
+        listening socket. Only server_close() releases that file
+        descriptor. Without it, stop()'s 'Stop the health server' contract
+        is only half kept: the accept loop stops, but the socket FD stays
+        open for the rest of the process (discogsography-c4ag). Guarded in
+        a finally so a join() timeout still lets the socket close.
+        """
+        try:
+            self.shutdown()
+            if self.thread:
+                self.thread.join(timeout=5)
+        finally:
+            self.server_close()

--- a/common/postgres_resilient.py
+++ b/common/postgres_resilient.py
@@ -90,10 +90,20 @@ class ResilientPostgreSQLPool:
 
         def create() -> psycopg.Connection[Any]:
             conn = psycopg.connect(**self.connection_params)
-            conn.autocommit = True  # Enable autocommit by default
-            # Test the connection
-            with conn.cursor() as cursor:
-                cursor.execute("SELECT 1")
+            # Once connect() returns, a real backend is live. If setting
+            # autocommit or the SELECT 1 probe below raises, close it before
+            # re-raising — otherwise the connection is orphaned and only
+            # reclaimed by unreliable/delayed __del__ GC, pinning a backend
+            # against the shared PgBouncer session-mode cap (discogsography-n1s8).
+            try:
+                conn.autocommit = True  # Enable autocommit by default
+                # Test the connection
+                with conn.cursor() as cursor:
+                    cursor.execute("SELECT 1")
+            except BaseException:
+                with contextlib.suppress(Exception):
+                    conn.close()
+                raise
             return conn
 
         return self.circuit_breaker.call(create)
@@ -331,7 +341,15 @@ class AsyncResilientPostgreSQL(AsyncResilientConnection[Any]):
         """Create a new async PostgreSQL connection."""
         logger.info("🐘 Creating new async PostgreSQL connection")
         conn = await psycopg.AsyncConnection.connect(**self.connection_params)
-        await conn.set_autocommit(True)
+        # connect() returning means a real backend is live. If set_autocommit
+        # raises, close it before re-raising rather than orphaning it to
+        # unreliable/delayed GC (discogsography-n1s8).
+        try:
+            await conn.set_autocommit(True)
+        except BaseException:
+            with contextlib.suppress(Exception):
+                await conn.close()
+            raise
         return conn
 
     async def _test_connection(self, conn: Any) -> bool:
@@ -458,10 +476,22 @@ class AsyncPostgreSQLPool:
         """Open and validate a new async PostgreSQL connection (no breaker wrapping)."""
         logger.info("🐘 Creating new async PostgreSQL connection")
         conn = await psycopg.AsyncConnection.connect(**self.connection_params)
-        await conn.set_autocommit(True)
-        # Test the connection
-        async with conn.cursor() as cursor:
-            await cursor.execute("SELECT 1")
+        # connect() returning means a real backend is live. If set_autocommit
+        # or the SELECT 1 probe raises, close it before re-raising — otherwise
+        # the connection is orphaned and only reclaimed by unreliable/delayed
+        # __del__ GC, pinning a backend against the shared PgBouncer
+        # session-mode cap for the GC-delay window (discogsography-n1s8).
+        # active_connections itself is already rolled back by every caller of
+        # this method on failure; this closes the underlying OS resource too.
+        try:
+            await conn.set_autocommit(True)
+            # Test the connection
+            async with conn.cursor() as cursor:
+                await cursor.execute("SELECT 1")
+        except BaseException:
+            with contextlib.suppress(Exception):
+                await conn.close()
+            raise
         return conn
 
     async def _test_connection(self, conn: psycopg.AsyncConnection[Any]) -> bool:

--- a/common/postgres_resilient.py
+++ b/common/postgres_resilient.py
@@ -8,7 +8,7 @@ import logging
 from queue import Empty, Full, Queue
 import threading
 import time
-from typing import Any
+from typing import Any, cast
 
 import psycopg
 from psycopg.errors import DatabaseError, InterfaceError, OperationalError
@@ -441,7 +441,21 @@ class AsyncPostgreSQLPool:
         self._initialized = True
 
     async def _create_connection(self) -> psycopg.AsyncConnection[Any]:
-        """Create a new async PostgreSQL connection with retry logic."""
+        """Create a new async PostgreSQL connection, routed through the circuit breaker.
+
+        Every checkout path (initialize, the checkout retry loop, and the
+        health-loop replenish) calls this method directly, so routing it
+        through ``circuit_breaker.call_async`` here — instead of each caller
+        wrapping its own call — makes the breaker actually participate in
+        every connection attempt. Previously the breaker was constructed but
+        never invoked: during a sustained outage every caller independently
+        walked the full 5-attempt retry ladder instead of fast-failing after
+        3 failures (discogsography-4q2s).
+        """
+        return cast("psycopg.AsyncConnection[Any]", await self.circuit_breaker.call_async(self._raw_create_connection))
+
+    async def _raw_create_connection(self) -> psycopg.AsyncConnection[Any]:
+        """Open and validate a new async PostgreSQL connection (no breaker wrapping)."""
         logger.info("🐘 Creating new async PostgreSQL connection")
         conn = await psycopg.AsyncConnection.connect(**self.connection_params)
         await conn.set_autocommit(True)

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -212,9 +212,27 @@ class DashboardApp:
             if self.postgres_conn:
                 await self.postgres_conn.close()
 
-            # Close all websocket connections
-            for ws in self.websocket_connections:
-                await ws.close()
+            # Close all websocket connections. Every OTHER access to
+            # websocket_connections (add in websocket_endpoint, discard() on
+            # disconnect, broadcast_metrics' snapshot) holds `_ws_lock` per
+            # the repo's lock-scope-discipline rule — this loop is the one
+            # site that used to iterate the live set directly. `await
+            # ws.close()` yields on every iteration, and a still-alive
+            # websocket_endpoint coroutine that wakes with a
+            # WebSocketDisconnect during that window runs `discard()` under
+            # the lock concurrently, mutating the set mid-iteration
+            # (`RuntimeError: Set changed size during iteration`), which the
+            # broad `except Exception` below swallows — leaving the
+            # remaining sockets never closed (discogsography-ip9y).
+            if self._ws_lock is None:
+                self._ws_lock = asyncio.Lock()
+            async with self._ws_lock:
+                targets = list(self.websocket_connections)
+                self.websocket_connections.clear()
+                WEBSOCKET_CONNECTIONS.set(0)
+            for ws in targets:
+                with contextlib.suppress(Exception):
+                    await ws.close()
 
             logger.info("✅ Shutdown complete")
 

--- a/graphinator/batch_processor.py
+++ b/graphinator/batch_processor.py
@@ -326,7 +326,24 @@ class Neo4jBatchProcessor:
             self._flush_semaphore = asyncio.Semaphore(
                 self.config.max_concurrent_flushes
             )
-        async with self._flush_semaphore:
+
+        # Acquire manually (not `async with`) so a cancellation delivered
+        # WHILE BLOCKED on the acquire itself — routine under load, since
+        # max_concurrent_flushes is small relative to potential concurrent
+        # flush callers — is caught here and re-enqueues `messages` before
+        # propagating. Semaphore.__aenter__ raises CancelledError straight out
+        # with no permit held and no enclosing handler, so `messages` (already
+        # popped off the deque above) would otherwise vanish: never written,
+        # never acked, never nacked, and invisible to the next flush
+        # (discogsography-r8hr).
+        try:
+            await self._flush_semaphore.acquire()
+        except asyncio.CancelledError:
+            for msg in reversed(messages):
+                queue.appendleft(msg)
+            raise
+
+        try:
             try:
                 # Process batch based on data type.
                 # _process_*_batch returns a set of indices that should be
@@ -481,6 +498,8 @@ class Neo4jBatchProcessor:
                 self._backoff_until[data_type] = time.time() + delay
                 # Messages are back on deque for retry — do NOT nack them
                 return
+        finally:
+            self._flush_semaphore.release()
 
         batch_duration = time.time() - batch_start
 

--- a/insights/insights.py
+++ b/insights/insights.py
@@ -151,6 +151,16 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
         logger.info("✅ Redis cache initialized", ttl_hours=_config.schedule_hours)
     except Exception:
         logger.warning("⚠️ Redis unavailable — caching disabled, falling back to PostgreSQL")
+        # from_url() is lazy — ping() is what actually opens the socket, so a
+        # failure here (e.g. requirepass with a missing/wrong REDIS_PASSWORD)
+        # still leaves a live client + pooled connection to close. Without
+        # this, the reference is dropped with no deterministic cleanup and
+        # the module's own shutdown convention (line 179: `if _redis: await
+        # _redis.aclose()`) becomes a no-op here since _redis is already None
+        # (discogsography-v1g8).
+        if _redis is not None:
+            with contextlib.suppress(Exception):
+                await _redis.aclose()
         _redis = None
         _cache = None
 

--- a/schema-init/schema_init.py
+++ b/schema-init/schema_init.py
@@ -55,6 +55,18 @@ def _postgres_connection_params() -> dict[str, Any]:
         "dbname": POSTGRES_DATABASE,
         "user": POSTGRES_USERNAME,
         "password": POSTGRES_PASSWORD,
+        # Bound the TCP+startup-packet+auth handshake. libpq's own default is
+        # 0 (infinite) — a pooler (POSTGRES_HOST "may embed a port, e.g. a
+        # pooler") that accepts the TCP connection but never completes the
+        # handshake would otherwise block psycopg.connect() forever. This is
+        # the FIRST thing main() does, synchronously, before any other
+        # service can start (module docstring) — an infinite block here never
+        # raises, so it bypasses the top-level exit(1) guard entirely and
+        # wedges every dependent service's `depends_on:
+        # service_completed_successfully` (discogsography-4vnh). Shared by
+        # both the admin CREATE DATABASE connect and the async pool built
+        # from this same dict.
+        "connect_timeout": 10,
     }
 
 

--- a/tableinator/batch_processor.py
+++ b/tableinator/batch_processor.py
@@ -349,7 +349,22 @@ class PostgreSQLBatchProcessor:
             self._flush_semaphore = asyncio.Semaphore(
                 self.config.max_concurrent_flushes
             )
-        async with self._flush_semaphore:
+
+        # Acquire manually (not `async with`) so a cancellation delivered
+        # WHILE BLOCKED on the acquire itself is caught here and re-enqueues
+        # `messages` before propagating. Semaphore.__aenter__ raises
+        # CancelledError straight out with no permit held and no enclosing
+        # handler, so `messages` (already popped off the deque above) would
+        # otherwise vanish: never written, never acked, never nacked, and
+        # invisible to the next flush (discogsography-r8hr).
+        try:
+            await self._flush_semaphore.acquire()
+        except asyncio.CancelledError:
+            for msg in reversed(messages):
+                queue.appendleft(msg)
+            raise
+
+        try:
             try:
                 await self._process_batch(data_type, messages)
                 success = True
@@ -484,6 +499,8 @@ class PostgreSQLBatchProcessor:
                 self._backoff_until[data_type] = time.time() + delay
                 # Messages are back on deque for retry — do NOT nack them
                 return
+        finally:
+            self._flush_semaphore.release()
 
         batch_duration = time.time() - batch_start
 

--- a/tableinator/tableinator.py
+++ b/tableinator/tableinator.py
@@ -626,14 +626,21 @@ async def purge_stale_rows(
                     )
                     return
 
+                # No RETURNING/fetchall here — the only past use of the
+                # deleted rows was len(), a count already known exactly from
+                # cursor.rowcount (the DELETE's own affected-row count,
+                # available with O(1) memory regardless of table size).
+                # RETURNING data_id would stream every deleted id back over
+                # the wire and buffer it into one Python list purely to
+                # discard it after counting — a multi-GB allocation on a
+                # large purge (discogsography-6u1o).
                 await cursor.execute(  # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query  # safe: psycopg2 sql.Identifier parameterizes the identifier, not user input
-                    sql.SQL(
-                        "DELETE FROM {table} WHERE updated_at < %s RETURNING data_id"
-                    ).format(table=sql.Identifier(data_type)),
+                    sql.SQL("DELETE FROM {table} WHERE updated_at < %s").format(
+                        table=sql.Identifier(data_type)
+                    ),
                     (started_at_dt,),
                 )
-                deleted_rows = await cursor.fetchall()
-                deleted_count = len(deleted_rows)
+                deleted_count = cursor.rowcount
 
                 logger.info(
                     f"🧹 Purged {deleted_count} stale {data_type} rows "

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1,11 +1,12 @@
 """Tests for the API service (api/api.py)."""
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 import pytest
 
+from common.config import ApiConfig
 from tests.api.conftest import (
     TEST_USER_EMAIL,
     TEST_USER_ID,
@@ -1379,3 +1380,115 @@ class TestVerifyDiscogsOAuthStateBinding:
         assert response.status_code == 200
         data = response.json()
         assert data["connected"] is True
+
+
+class TestLifespanShutdownClosesAnthropicClient:
+    """discogsography-8nle: the lifespan-created AsyncAnthropic client must be
+    closed on shutdown, mirroring the existing _neo4j/_pool/_redis cleanup."""
+
+    @staticmethod
+    def _make_config() -> ApiConfig:
+        return ApiConfig(
+            postgres_host="localhost:5432",
+            postgres_username="u",
+            postgres_password="p",  # nosec B106  # noqa: S106  # test fixture value, not a real credential
+            postgres_database="db",
+            jwt_secret_key="x" * 32,
+            neo4j_host="bolt://localhost:7687",
+            neo4j_username="neo4j",
+            neo4j_password="pw",  # nosec B106  # noqa: S106  # test fixture value, not a real credential
+            resend_api_key=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_shutdown_closes_anthropic_client_when_nlq_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import api.api as api_module
+        from api.api import lifespan
+
+        monkeypatch.setenv("NLQ_ENABLED", "true")
+        monkeypatch.setenv("NLQ_API_KEY", "test-anthropic-key")
+
+        mock_health = MagicMock()
+        mock_health.start_background = MagicMock()
+        mock_health.stop = MagicMock()
+
+        mock_pool = MagicMock()
+        mock_pool.initialize = AsyncMock()
+        mock_pool.close = AsyncMock()
+
+        mock_redis = AsyncMock()
+        mock_redis.aclose = AsyncMock()
+
+        mock_neo4j = MagicMock()
+        mock_neo4j.close = AsyncMock()
+
+        mock_anthropic_client = AsyncMock()
+        mock_anthropic_client.close = AsyncMock()
+
+        with (
+            patch("api.api.ApiConfig.from_env", return_value=self._make_config()),
+            patch("api.api.HealthServer", return_value=mock_health),
+            patch("api.api.AsyncPostgreSQLPool", return_value=mock_pool),
+            patch("api.api.reconcile_stale_sync_history", new_callable=AsyncMock),
+            patch("api.api.aioredis.from_url", new_callable=AsyncMock, return_value=mock_redis),
+            patch("api.api.AsyncResilientNeo4jDriver", return_value=mock_neo4j),
+            patch("anthropic.AsyncAnthropic", return_value=mock_anthropic_client),
+            patch("api.api.run_collector", new_callable=AsyncMock),
+            patch("api.api._prewarm_search_cache", new_callable=AsyncMock),
+        ):
+            async with lifespan(MagicMock()):
+                pass  # trigger shutdown on exit
+
+        mock_anthropic_client.close.assert_awaited_once()
+        # The other lifespan-owned clients must still be closed too.
+        mock_neo4j.close.assert_awaited_once()
+        mock_pool.close.assert_awaited_once()
+        mock_redis.aclose.assert_awaited_once()
+
+        # Restore module globals lifespan mutated, so later tests in this
+        # file see the fixture-provisioned state again.
+        api_module._pool = None
+        api_module._config = None
+        api_module._redis = None
+        api_module._neo4j = None
+
+    @pytest.mark.asyncio
+    async def test_shutdown_skips_anthropic_close_when_nlq_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No client was ever created — shutdown must not error trying to close one."""
+        import api.api as api_module
+        from api.api import lifespan
+
+        monkeypatch.setenv("NLQ_ENABLED", "false")
+        monkeypatch.delenv("NLQ_API_KEY", raising=False)
+
+        mock_health = MagicMock()
+        mock_health.start_background = MagicMock()
+        mock_health.stop = MagicMock()
+
+        mock_pool = MagicMock()
+        mock_pool.initialize = AsyncMock()
+        mock_pool.close = AsyncMock()
+
+        mock_redis = AsyncMock()
+        mock_redis.aclose = AsyncMock()
+
+        mock_neo4j = MagicMock()
+        mock_neo4j.close = AsyncMock()
+
+        with (
+            patch("api.api.ApiConfig.from_env", return_value=self._make_config()),
+            patch("api.api.HealthServer", return_value=mock_health),
+            patch("api.api.AsyncPostgreSQLPool", return_value=mock_pool),
+            patch("api.api.reconcile_stale_sync_history", new_callable=AsyncMock),
+            patch("api.api.aioredis.from_url", new_callable=AsyncMock, return_value=mock_redis),
+            patch("api.api.AsyncResilientNeo4jDriver", return_value=mock_neo4j),
+            patch("api.api.run_collector", new_callable=AsyncMock),
+            patch("api.api._prewarm_search_cache", new_callable=AsyncMock),
+        ):
+            async with lifespan(MagicMock()):
+                pass  # Should not raise
+
+        api_module._pool = None
+        api_module._config = None
+        api_module._redis = None
+        api_module._neo4j = None

--- a/tests/api/test_extraction_analysis.py
+++ b/tests/api/test_extraction_analysis.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+import time
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1250,6 +1251,102 @@ class TestViolationsReadBoundedAndOffloaded:
         assert resp1.status_code == 200
         assert resp2.status_code == 200
         spy.assert_called_once()
+
+
+class TestCacheStampedeSingleFlight:
+    """Regression for discogsography-jrm3: concurrent misses for the same key
+    must collapse into a single computation, not one duplicate scan per
+    concurrent caller."""
+
+    def setup_method(self) -> None:
+        import api.routers.extraction_analysis as ea
+
+        ea._violations_cache.clear()
+        ea._skipped_cache.clear()
+        ea._parsing_error_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_get_violations_single_flight_collapses_concurrent_misses(self, tmp_path: Path) -> None:
+        """N concurrent callers missing the cache for the SAME key must
+        trigger exactly one filesystem scan — not N duplicate scans each
+        holding its own parsed corpus in memory simultaneously."""
+        import api.routers.extraction_analysis as ea
+
+        entity_dir = tmp_path / "flagged" / "20260101" / "artists"
+        entity_dir.mkdir(parents=True)
+        (entity_dir / "violations.jsonl").write_text(json.dumps({"record_id": "1", "rule": "x", "severity": "warning"}) + "\n")
+        flagged_version_dir = entity_dir.parent
+
+        call_count = 0
+        real_read = ea._read_violations
+
+        def slow_read(*args: object, **kwargs: object) -> list[dict]:
+            nonlocal call_count
+            call_count += 1
+            time.sleep(0.05)  # widen the window so concurrent callers definitely overlap
+            return real_read(*args, **kwargs)  # type: ignore[arg-type]
+
+        with patch.object(ea, "_read_violations", side_effect=slow_read):
+            results = await asyncio.gather(*[ea._get_violations(flagged_version_dir) for _ in range(5)])
+
+        assert call_count == 1
+        assert all(r == results[0] for r in results)
+
+    @pytest.mark.asyncio
+    async def test_get_skipped_single_flight_collapses_concurrent_misses(self, tmp_path: Path) -> None:
+        """Same guarantee as violations, for the skipped-records cache."""
+        import api.routers.extraction_analysis as ea
+
+        entity_dir = tmp_path / "flagged" / "20260101" / "artists"
+        entity_dir.mkdir(parents=True)
+        (entity_dir / "skipped.jsonl").write_text(json.dumps({"record_id": "1", "reason": "x"}) + "\n")
+        flagged_version_dir = entity_dir.parent
+
+        call_count = 0
+        real_read = ea._read_skipped
+
+        def slow_read(*args: object, **kwargs: object) -> list[dict]:
+            nonlocal call_count
+            call_count += 1
+            time.sleep(0.05)
+            return real_read(*args, **kwargs)  # type: ignore[arg-type]
+
+        with patch.object(ea, "_read_skipped", side_effect=slow_read):
+            results = await asyncio.gather(*[ea._get_skipped(flagged_version_dir) for _ in range(5)])
+
+        assert call_count == 1
+        assert all(r == results[0] for r in results)
+
+    @pytest.mark.asyncio
+    async def test_parsing_errors_concurrent_calls_single_flight(self, tmp_path: Path) -> None:
+        """The heaviest cache (parsing-errors, wrapping classification) must
+        also collapse concurrent misses — this is the exact Promise.all
+        fan-out pattern the admin dashboard uses (summary + parsing-errors
+        fired together for the same version). Calls the handler directly
+        (bypassing the ASGI/TestClient layer, which serializes requests) so
+        the concurrency is real."""
+        import api.routers.extraction_analysis as ea
+
+        _make_flagged_version(tmp_path)
+
+        call_count = 0
+        real_classify = ea._classify_all_violations
+
+        def slow_classify(*args: object, **kwargs: object) -> tuple[list, list, list]:
+            nonlocal call_count
+            call_count += 1
+            time.sleep(0.05)
+            return real_classify(*args, **kwargs)  # type: ignore[arg-type]
+
+        with (
+            patch.object(ea, "_discogs_data_root", tmp_path),
+            patch.object(ea, "_musicbrainz_data_root", None),
+            patch.object(ea, "_classify_all_violations", side_effect=slow_classify),
+        ):
+            responses = await asyncio.gather(*[ea.get_parsing_errors("20260101", {"sub": "admin-1"}) for _ in range(3)])
+
+        assert all(r.status_code == 200 for r in responses)
+        assert call_count == 1
 
 
 class TestLoadStateMarkerCorrupt:

--- a/tests/api/test_metrics_collector.py
+++ b/tests/api/test_metrics_collector.py
@@ -154,6 +154,109 @@ class TestMetricsBuffer:
         assert result == {}
 
 
+class TestMetricsBufferDrainRestore:
+    """discogsography-qtts: drain()/restore() must be safe to pair across an
+    await, unlike flush()/clear() which race with concurrent record()."""
+
+    def test_drain_removes_entries_and_returns_stats_and_samples(self) -> None:
+        from api.metrics_collector import MetricsBuffer
+
+        buf = MetricsBuffer(max_size=100)
+        buf.record("/api/search", 200, 10.0)
+        buf.record("/api/search", 200, 20.0)
+
+        stats, samples = buf.drain()
+
+        assert stats["/api/search"]["count"] == 2
+        assert len(samples) == 2
+        # Unlike flush(), drain() actually empties the live buffer.
+        assert buf.flush() == {}
+
+    def test_entries_recorded_after_drain_are_not_in_the_snapshot(self) -> None:
+        """The whole point of the atomic swap: anything record()ed AFTER
+        drain() returns must land in the fresh buffer, never in the
+        snapshot drain() already computed stats from."""
+        from api.metrics_collector import MetricsBuffer
+
+        buf = MetricsBuffer(max_size=100)
+        buf.record("/api/before", 200, 5.0)
+
+        stats, samples = buf.drain()
+        buf.record("/api/after", 200, 7.0)
+
+        assert "/api/before" in stats
+        assert "/api/after" not in stats
+        assert all(s.path == "/api/before" for s in samples)
+        # The post-drain record must be visible in a fresh flush.
+        assert buf.flush() == {"/api/after": {"count": 1, "p50": 7.0, "p95": 7.0, "p99": 7.0, "error_count": 0}}
+
+    def test_restore_puts_samples_back_ahead_of_newer_entries(self) -> None:
+        """restore() must re-prepend the failed batch AHEAD of (i.e. older
+        than) anything recorded since the matching drain() — samples arrived
+        first in wall-clock terms and eviction order must reflect that."""
+        from api.metrics_collector import MetricsBuffer
+
+        buf = MetricsBuffer(max_size=100)
+        buf.record("/api/before", 200, 5.0)
+        _stats, samples = buf.drain()
+        buf.record("/api/after", 200, 7.0)
+
+        buf.restore(samples)
+
+        result = buf.flush()
+        assert result["/api/before"]["count"] == 1
+        assert result["/api/after"]["count"] == 1
+        # "before" was recorded first and restored ahead of "after" — it must
+        # be the entry evicted first once the buffer fills.
+        buf2 = MetricsBuffer(max_size=1)
+        buf2.restore(samples)
+        buf2.record("/api/after", 200, 7.0)
+        assert buf2.flush() == {"/api/after": {"count": 1, "p50": 7.0, "p95": 7.0, "p99": 7.0, "error_count": 0}}
+
+    def test_restore_trims_to_max_size_from_the_left(self) -> None:
+        """A restore that would push the buffer over max_size must evict the
+        OLDEST entries first — the same order record()'s own eviction uses."""
+        from api.metrics_collector import MetricsBuffer
+
+        buf = MetricsBuffer(max_size=3)
+        buf.record("/a", 200, 1.0)
+        buf.record("/b", 200, 2.0)
+        _stats, samples = buf.drain()  # samples = [/a, /b]
+        buf.record("/c", 200, 3.0)
+        buf.record("/d", 200, 4.0)
+
+        buf.restore(samples)  # would be [/a, /b, /c, /d] — over max_size=3
+
+        result = buf.flush()
+        assert len(buf._entries) == 3
+        assert "/a" not in result  # oldest, evicted first
+        assert "/b" in result
+        assert "/c" in result
+        assert "/d" in result
+
+    def test_restore_with_empty_samples_is_a_no_op(self) -> None:
+        from api.metrics_collector import MetricsBuffer
+
+        buf = MetricsBuffer(max_size=100)
+        buf.record("/api/x", 200, 1.0)
+        buf.drain()  # empties the buffer
+        _stats, empty_samples = buf.drain()  # nothing left to drain this time
+        assert len(empty_samples) == 0
+
+        buf.restore(empty_samples)  # nothing to restore
+
+        assert buf.flush() == {}
+
+    def test_drain_on_empty_buffer_returns_empty_stats_and_samples(self) -> None:
+        from api.metrics_collector import MetricsBuffer
+
+        buf = MetricsBuffer(max_size=100)
+        stats, samples = buf.drain()
+
+        assert stats == {}
+        assert len(samples) == 0
+
+
 # ---------------------------------------------------------------------------
 # Task 3: _percentile_index helper
 # ---------------------------------------------------------------------------
@@ -717,6 +820,84 @@ class TestRunCollector:
         assert buf.flush() == {}
 
     @pytest.mark.anyio
+    async def test_collector_persist_success_does_not_drop_entries_recorded_during_await(self) -> None:
+        """discogsography-qtts: a successful persist must only discard the
+        exact batch it persisted — not entries record()ed WHILE
+        persist_metrics is awaiting. The old flush()-then-clear() design
+        clear()ed the whole live buffer, silently dropping anything that
+        arrived during the await; drain()/restore() only ever remove the
+        atomically-swapped-out snapshot."""
+        from api.metrics_collector import MetricsBuffer, run_collector
+
+        mock_pool = MagicMock()
+        config = MagicMock()
+        config.rabbitmq_management_host = "localhost"
+        config.rabbitmq_management_port = 15672
+        config.rabbitmq_username = "guest"
+        config.rabbitmq_password = "guest"
+        config.metrics_retention_days = 30
+        config.metrics_collection_interval = 1
+
+        buf = MetricsBuffer(max_size=100)
+        buf.record("/api/before", 200, 5.0)
+
+        async def persist_and_record_concurrently(_pool: Any, _q: Any, _h: list[dict[str, Any]]) -> None:
+            # Simulate a request landing in the SAME buffer while this
+            # persist call is in flight.
+            buf.record("/api/during-persist", 200, 7.0)
+
+        with (
+            patch("api.metrics_collector.collect_queue_metrics", new_callable=AsyncMock, return_value=[]),
+            patch("api.metrics_collector.collect_service_health", new_callable=AsyncMock, return_value=[]),
+            patch("api.metrics_collector.persist_metrics", side_effect=persist_and_record_concurrently),
+            patch("api.metrics_collector.prune_old_metrics", new_callable=AsyncMock),
+            patch("asyncio.sleep", side_effect=asyncio.CancelledError),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await run_collector(mock_pool, config, buf)
+
+        result = buf.flush()
+        assert "/api/before" not in result  # the persisted batch is gone
+        assert result["/api/during-persist"]["count"] == 1  # survives, not dropped
+
+    @pytest.mark.anyio
+    async def test_collector_persist_failure_preserves_entries_recorded_during_await(self) -> None:
+        """discogsography-qtts: entries record()ed WHILE persist_metrics is
+        awaiting must survive a FAILED persist too — restore() must put the
+        failed batch back ahead of them rather than discarding either set."""
+        from api.metrics_collector import MetricsBuffer, run_collector
+
+        mock_pool = MagicMock()
+        config = MagicMock()
+        config.rabbitmq_management_host = "localhost"
+        config.rabbitmq_management_port = 15672
+        config.rabbitmq_username = "guest"
+        config.rabbitmq_password = "guest"
+        config.metrics_retention_days = 30
+        config.metrics_collection_interval = 1
+
+        buf = MetricsBuffer(max_size=100)
+        buf.record("/api/before", 200, 5.0)
+
+        async def persist_and_record_concurrently(_pool: Any, _q: Any, _h: list[dict[str, Any]]) -> None:
+            buf.record("/api/during-persist", 200, 7.0)
+            raise RuntimeError("db error")
+
+        with (
+            patch("api.metrics_collector.collect_queue_metrics", new_callable=AsyncMock, return_value=[]),
+            patch("api.metrics_collector.collect_service_health", new_callable=AsyncMock, return_value=[]),
+            patch("api.metrics_collector.persist_metrics", side_effect=persist_and_record_concurrently),
+            patch("api.metrics_collector.prune_old_metrics", new_callable=AsyncMock),
+            patch("asyncio.sleep", side_effect=asyncio.CancelledError),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await run_collector(mock_pool, config, buf)
+
+        result = buf.flush()
+        assert result["/api/before"]["count"] == 1
+        assert result["/api/during-persist"]["count"] == 1
+
+    @pytest.mark.anyio
     async def test_collector_handles_prune_error(self) -> None:
         """run_collector continues when prune_old_metrics raises."""
         from api.metrics_collector import MetricsBuffer, run_collector
@@ -744,7 +925,7 @@ class TestRunCollector:
 
     @pytest.mark.anyio
     async def test_collector_handles_flush_error(self) -> None:
-        """run_collector continues when metrics_buffer.flush() raises."""
+        """run_collector continues when metrics_buffer.drain() raises."""
         from api.metrics_collector import MetricsBuffer, run_collector
 
         mock_pool = MagicMock()
@@ -762,7 +943,7 @@ class TestRunCollector:
         with (
             patch("api.metrics_collector.collect_queue_metrics", new_callable=AsyncMock, return_value=[]),
             patch("api.metrics_collector.collect_service_health", new_callable=AsyncMock, return_value=[]),
-            patch.object(buf, "flush", side_effect=RuntimeError("flush error")),
+            patch.object(buf, "drain", side_effect=RuntimeError("drain error")),
             patch("api.metrics_collector.persist_metrics", new_callable=AsyncMock),
             patch("api.metrics_collector.prune_old_metrics", new_callable=AsyncMock),
             patch("asyncio.sleep", side_effect=asyncio.CancelledError),

--- a/tests/api/test_syncer.py
+++ b/tests/api/test_syncer.py
@@ -1,5 +1,6 @@
 """Tests for api/syncer.py — collection and wantlist sync logic."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
@@ -9,6 +10,7 @@ from api.syncer import (
     MAX_RATE_LIMIT_RETRIES,
     DiscogsSyncError,
     _auth_header,
+    reconcile_stale_sync_history,
     run_full_sync,
     sync_collection,
     sync_wantlist,
@@ -1167,6 +1169,92 @@ class TestRunFullSync:
         )
 
         assert set(result.keys()) == {"sync_id", "status", "collection_count", "wantlist_count", "error"}
+
+    @pytest.mark.asyncio
+    async def test_cancelled_mid_sync_marks_row_cancelled_and_reraises(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """discogsography-pxqw: asyncio.CancelledError is a BaseException, not
+        an Exception — it must still result in a terminal sync_history write
+        (previously the UPDATE sat after the try/except/finally and never ran
+        on cancellation, leaving the row stuck at status='running' forever),
+        AND the cancellation must still propagate to the caller."""
+        mock_pg_pool._mock_cur.fetchone.return_value = {
+            "access_token": "at",
+            "access_secret": "as",
+            "provider_username": "user",
+        }
+        mock_pg_pool._mock_cur.fetchall.return_value = [
+            {"key": "discogs_consumer_key", "value": "ck"},
+            {"key": "discogs_consumer_secret", "value": "cs"},
+        ]
+
+        with (
+            patch("api.syncer.sync_collection", new_callable=AsyncMock, side_effect=asyncio.CancelledError),
+            patch("api.syncer.decrypt_oauth_token", side_effect=lambda val, _key: val),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await run_full_sync(
+                TEST_USER_UUID,
+                "sync-cancel",
+                mock_pg_pool,
+                mock_neo4j,
+                TEST_USER_AGENT,
+            )
+
+        update_calls = [c for c in mock_pg_pool._mock_cur.execute.call_args_list if "UPDATE sync_history" in c.args[0]]
+        assert len(update_calls) == 1
+        query, params = update_calls[0].args
+        assert "SET status = %s" in query
+        assert params[0] == "cancelled"
+        assert params[3] == "sync-cancel"
+
+    @pytest.mark.asyncio
+    async def test_cancelled_before_sync_still_invalidates_cache(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """The finally block's cache-invalidation step must still run on the
+        cancellation path, exactly as it does on the exception path."""
+        mock_pg_pool._mock_cur.fetchone.side_effect = asyncio.CancelledError
+        mock_redis = MagicMock()
+
+        with patch("api.syncer.RecommendCache") as mock_cache_cls:
+            mock_cache_cls.return_value.invalidate_user = AsyncMock()
+            with pytest.raises(asyncio.CancelledError):
+                await run_full_sync(
+                    TEST_USER_UUID,
+                    "sync-cancel-2",
+                    mock_pg_pool,
+                    mock_neo4j,
+                    TEST_USER_AGENT,
+                    redis_client=mock_redis,
+                )
+
+        mock_cache_cls.return_value.invalidate_user.assert_awaited_once_with(str(TEST_USER_UUID))
+
+
+class TestReconcileStaleSyncHistory:
+    """Tests for reconcile_stale_sync_history — the startup reconciliation
+    pass for discogsography-pxqw's case (b): a hard process crash (SIGKILL/
+    OOM) between the INSERT and run_full_sync's terminal UPDATE, which no
+    in-process handler can ever cover."""
+
+    @pytest.mark.asyncio
+    async def test_flips_running_rows_to_failed(self, mock_pg_pool: MagicMock) -> None:
+        mock_pg_pool._mock_cur.rowcount = 3
+
+        await reconcile_stale_sync_history(mock_pg_pool)
+
+        mock_pg_pool._mock_cur.execute.assert_awaited_once()
+        query = mock_pg_pool._mock_cur.execute.call_args.args[0]
+        assert "UPDATE sync_history" in query
+        assert "SET status = 'failed'" in query
+        assert "WHERE status = 'running'" in query
+
+    @pytest.mark.asyncio
+    async def test_no_stale_rows_is_a_no_op_beyond_the_update(self, mock_pg_pool: MagicMock) -> None:
+        mock_pg_pool._mock_cur.rowcount = 0
+
+        # Must not raise even when nothing needed reconciling.
+        await reconcile_stale_sync_history(mock_pg_pool)
+
+        mock_pg_pool._mock_cur.execute.assert_awaited_once()
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/common/test_health_server.py
+++ b/tests/common/test_health_server.py
@@ -170,6 +170,49 @@ class TestHealthServerStop:
         finally:
             server.server_close()
 
+    def test_stop_releases_the_listening_socket(self) -> None:
+        """discogsography-c4ag: stop() must call server_close(), not just
+        shutdown() — socketserver.BaseServer.shutdown() only stops the
+        serve_forever() accept loop; it does NOT close the bound listening
+        socket. Only server_close() releases that file descriptor."""
+        health_func = Mock(return_value={"status": "healthy"})
+
+        server = HealthServer(0, health_func)
+        server.start_background()
+
+        server.stop()
+
+        # The socket is closed — fileno() returns -1 once the underlying
+        # socket object has been closed.
+        assert server.socket.fileno() == -1
+
+    def test_stop_calls_server_close_even_when_thread_is_none(self) -> None:
+        """The finally-guard must still release the socket on the
+        skip-the-join path (no thread was ever started)."""
+        health_func = Mock(return_value={"status": "healthy"})
+
+        server = HealthServer(0, health_func)
+        with patch.object(server, "shutdown"):
+            server.stop()
+
+        assert server.socket.fileno() == -1
+
+    def test_stop_calls_server_close_even_when_join_raises(self) -> None:
+        """server_close() must still run (via finally) if shutdown()/join()
+        itself raises — a failure mid-stop must not leak the socket FD."""
+        health_func = Mock(return_value={"status": "healthy"})
+
+        server = HealthServer(0, health_func)
+        server.start_background()
+
+        with (
+            patch.object(server, "shutdown", side_effect=RuntimeError("boom")),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            server.stop()
+
+        assert server.socket.fileno() == -1
+
 
 class TestHealthHandlerHTTP:
     """Integration tests for the HTTP request handler."""

--- a/tests/common/test_neo4j_resilient.py
+++ b/tests/common/test_neo4j_resilient.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from neo4j.exceptions import ServiceUnavailable, SessionExpired
 import pytest
 
-from common.db_resilience import ExponentialBackoff
+from common.db_resilience import CircuitState, ConnectionEstablishmentError, ExponentialBackoff
 from common.neo4j_resilient import (
     AsyncResilientNeo4jDriver,
     ResilientNeo4jDriver,
@@ -128,6 +128,27 @@ class TestResilientNeo4jDriver:
 
         assert resilient_driver._connection is None
 
+    @patch("common.neo4j_resilient.GraphDatabase")
+    def test_repeated_connection_test_failures_open_the_breaker(self, mock_graph_db: Mock, mock_driver: Mock) -> None:
+        """discogsography-4utz: a failed health-test must count as a circuit-
+        breaker failure. _test_driver swallows real exceptions to a bare
+        `False`, and the connection-establishment wrapper turns that into a
+        typed `ConnectionEstablishmentError` (a `DatabaseUnavailableError`),
+        which IS in this breaker's `expected_exception` tuple — so 3
+        consecutive failed health checks must open the circuit, not leave it
+        stuck CLOSED forever."""
+        # Real driver.session() raises — the ORIGINAL (unpatched) _test_driver
+        # swallows it and returns False, exactly like a live outage would.
+        mock_driver.session = Mock(side_effect=ServiceUnavailable("Neo4j is down"))
+        mock_graph_db.driver = Mock(return_value=mock_driver)
+        resilient_driver = ResilientNeo4jDriver("neo4j://localhost:7687", ("neo4j", "password"), max_retries=5)
+
+        with pytest.raises(ConnectionEstablishmentError):
+            resilient_driver.get_connection()
+
+        assert resilient_driver.circuit_breaker.state == CircuitState.OPEN
+        assert resilient_driver.circuit_breaker.failure_count >= resilient_driver.circuit_breaker.config.failure_threshold
+
 
 class TestAsyncResilientNeo4jDriver:
     """Tests for AsyncResilientNeo4jDriver class."""
@@ -234,6 +255,23 @@ class TestAsyncResilientNeo4jDriver:
         await resilient_driver.close()
 
         assert resilient_driver._connection is None
+
+    @pytest.mark.asyncio
+    @patch("common.neo4j_resilient.AsyncGraphDatabase")
+    async def test_repeated_connection_test_failures_open_the_breaker(self, mock_async_graph_db: Mock, mock_async_driver: AsyncMock) -> None:
+        """discogsography-4utz (async twin): same guarantee as the sync driver —
+        repeated failed health checks must open the circuit."""
+        # Real driver.session() raises — the ORIGINAL (unpatched) _test_driver
+        # swallows it and returns False, exactly like a live outage would.
+        mock_async_driver.session = Mock(side_effect=ServiceUnavailable("Neo4j is down"))
+        mock_async_graph_db.driver = Mock(return_value=mock_async_driver)
+        resilient_driver = AsyncResilientNeo4jDriver("neo4j://localhost:7687", ("neo4j", "password"), max_retries=5)
+
+        with pytest.raises(ConnectionEstablishmentError):
+            await resilient_driver.get_connection()
+
+        assert resilient_driver.circuit_breaker.state == CircuitState.OPEN
+        assert resilient_driver.circuit_breaker.failure_count >= resilient_driver.circuit_breaker.config.failure_threshold
 
 
 class TestNeo4jRetryDecorator:

--- a/tests/common/test_postgres_resilient.py
+++ b/tests/common/test_postgres_resilient.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, Mock, patch
 from psycopg.errors import InterfaceError, OperationalError
 import pytest
 
+from common.db_resilience import CircuitState
 from common.postgres_resilient import AsyncPostgreSQLPool, AsyncResilientPostgreSQL, ResilientPostgreSQLPool
 
 
@@ -784,6 +785,35 @@ class TestAsyncPostgreSQLPool:
         assert conn == mock_async_connection
         mock_connect.assert_called_with(**connection_params)
         mock_async_connection.set_autocommit.assert_called_once_with(True)
+
+        # Cleanup
+        await pool.close()
+
+    @pytest.mark.asyncio
+    @patch("common.postgres_resilient.psycopg.AsyncConnection.connect")
+    async def test_create_connection_routes_through_circuit_breaker(self, mock_connect: Mock, connection_params: dict) -> None:
+        """discogsography-4q2s: _create_connection must actually invoke the
+        breaker constructed in __init__, not bypass it. 3 consecutive
+        connect() failures must open the circuit so subsequent callers
+        fast-fail (CircuitOpenError) instead of each walking the full
+        connect+backoff ladder during a sustained outage."""
+        mock_connect.side_effect = OperationalError("Postgres is down")
+
+        pool = AsyncPostgreSQLPool(connection_params=connection_params, max_retries=1)
+        assert pool.circuit_breaker.state == CircuitState.CLOSED
+
+        for _ in range(pool.circuit_breaker.config.failure_threshold):
+            with pytest.raises(OperationalError):
+                await pool._create_connection()
+
+        assert pool.circuit_breaker.state == CircuitState.OPEN
+
+        # The breaker itself now rejects the call BEFORE a new connect()
+        # attempt is even made — the fast-fail this bead is about.
+        mock_connect.reset_mock()
+        with pytest.raises(Exception, match="Circuit breaker is OPEN"):
+            await pool._create_connection()
+        mock_connect.assert_not_called()
 
         # Cleanup
         await pool.close()

--- a/tests/common/test_postgres_resilient.py
+++ b/tests/common/test_postgres_resilient.py
@@ -82,6 +82,25 @@ class TestResilientPostgreSQLPool:
 
     @patch("common.postgres_resilient.psycopg.connect")
     @patch("common.postgres_resilient.threading.Thread")
+    def test_create_connection_closes_conn_when_validation_fails(
+        self, _mock_thread: Mock, mock_connect: Mock, connection_params: dict, mock_connection: Mock
+    ) -> None:
+        """discogsography-n1s8: once psycopg.connect() returns, a real backend
+        is live. If the SELECT 1 probe raises, the just-opened connection must
+        be closed before the exception propagates — otherwise it is orphaned
+        and only reclaimed by unreliable/delayed __del__ GC, pinning a
+        backend against the shared PgBouncer session-mode cap."""
+        mock_connection.cursor.return_value.execute.side_effect = OperationalError("probe failed")
+        mock_connect.return_value = mock_connection
+
+        pool = ResilientPostgreSQLPool(connection_params=connection_params, min_connections=0)
+        with pytest.raises(Exception):  # noqa: B017  # circuit_breaker.call re-raises the probe error
+            pool._create_connection()
+
+        mock_connection.close.assert_called_once()
+
+    @patch("common.postgres_resilient.psycopg.connect")
+    @patch("common.postgres_resilient.threading.Thread")
     def test_test_connection_healthy(self, _mock_thread: Mock, mock_connect: Mock, connection_params: dict, mock_connection: Mock) -> None:
         """Test connection health check on healthy connection."""
         mock_connect.return_value = mock_connection
@@ -578,6 +597,23 @@ class TestAsyncResilientPostgreSQL:
 
     @pytest.mark.asyncio
     @patch("common.postgres_resilient.psycopg.AsyncConnection.connect")
+    async def test_create_connection_closes_conn_when_set_autocommit_fails(
+        self, mock_connect: Mock, connection_params: dict, mock_async_connection: AsyncMock
+    ) -> None:
+        """discogsography-n1s8: connect() returning means a real backend is
+        live. If set_autocommit raises, the connection must be closed before
+        the exception propagates rather than orphaned to GC."""
+        mock_async_connection.set_autocommit.side_effect = OperationalError("autocommit failed")
+        mock_connect.return_value = mock_async_connection
+
+        async_conn = AsyncResilientPostgreSQL(connection_params=connection_params)
+        with pytest.raises(OperationalError):
+            await async_conn._create_connection()
+
+        mock_async_connection.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("common.postgres_resilient.psycopg.AsyncConnection.connect")
     async def test_test_connection_healthy(self, _mock_connect: Mock, connection_params: dict, mock_async_connection: AsyncMock) -> None:
         """Test async connection health check on healthy connection."""
         async_conn = AsyncResilientPostgreSQL(connection_params=connection_params)
@@ -832,6 +868,29 @@ class TestAsyncPostgreSQLPool:
         # Verify health check query was executed
         cursor = mock_async_connection.cursor.return_value
         cursor.execute.assert_called_with("SELECT 1")
+
+        # Cleanup
+        await pool.close()
+
+    @pytest.mark.asyncio
+    @patch("common.postgres_resilient.psycopg.AsyncConnection.connect")
+    async def test_create_connection_closes_conn_when_validation_fails(
+        self, mock_connect: Mock, connection_params: dict, mock_async_connection: AsyncMock
+    ) -> None:
+        """discogsography-n1s8: psycopg.AsyncConnection.connect() returning
+        means a real backend is live. If the post-connect SELECT 1 probe
+        raises, the just-opened connection must be closed before the
+        exception propagates — otherwise it is orphaned and only reclaimed by
+        unreliable/delayed __del__ GC, pinning a backend against the shared
+        PgBouncer session-mode cap under DB instability."""
+        mock_async_connection.cursor.return_value.execute.side_effect = OperationalError("probe failed")
+        mock_connect.return_value = mock_async_connection
+
+        pool = AsyncPostgreSQLPool(connection_params=connection_params, max_retries=1)
+        with pytest.raises(OperationalError):
+            await pool._create_connection()
+
+        mock_async_connection.close.assert_called_once()
 
         # Cleanup
         await pool.close()

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -199,6 +199,48 @@ class TestDashboardAppShutdown:
             # Verify error was logged
             mock_logger.error.assert_called()
 
+    @pytest.mark.asyncio
+    async def test_shutdown_survives_concurrent_disconnect_mutating_the_set(self) -> None:
+        """discogsography-ip9y: shutdown() must snapshot websocket_connections
+        under _ws_lock before iterating — not iterate the live set directly.
+        Simulates the exact race: another coroutine's disconnect handler
+        (discard() under the lock) mutates the set WHILE shutdown is closing
+        sockets. Previously this could raise 'RuntimeError: Set changed size
+        during iteration', silently caught by the broad except and leaving
+        the remaining sockets never closed."""
+        mock_config = Mock()
+
+        with patch("dashboard.dashboard.get_config", return_value=mock_config):
+            app = DashboardApp()
+
+            mock_ws1 = AsyncMock()
+            mock_ws2 = AsyncMock()
+            mock_ws3 = AsyncMock()
+            app.websocket_connections.add(mock_ws1)
+            app.websocket_connections.add(mock_ws2)
+            app.websocket_connections.add(mock_ws3)
+
+            async def close_and_mutate() -> None:
+                # Simulate a concurrent websocket_endpoint coroutine's
+                # disconnect handler discarding a DIFFERENT socket from the
+                # live set while shutdown's own loop is mid-iteration.
+                async with app._ws_lock:  # type: ignore[union-attr]
+                    app.websocket_connections.discard(mock_ws3)
+
+            mock_ws1.close = AsyncMock(side_effect=close_and_mutate)
+
+            with patch("dashboard.dashboard.logger") as mock_logger:
+                await app.shutdown()
+
+            # All three sockets must still have been closed — the snapshot
+            # was taken before the live set was mutated out from under it.
+            mock_ws1.close.assert_called_once()
+            mock_ws2.close.assert_called_once()
+            mock_ws3.close.assert_called_once()
+            # No "Set changed size during iteration" (or any other) error
+            # swallowed by shutdown()'s broad except.
+            mock_logger.error.assert_not_called()
+
 
 class TestDashboardAppMetrics:
     """Test DashboardApp metrics collection."""

--- a/tests/graphinator/test_batch_processor.py
+++ b/tests/graphinator/test_batch_processor.py
@@ -557,6 +557,34 @@ class TestFlushQueue:
         nack.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_flush_cancelled_while_acquiring_semaphore_re_enqueues(self) -> None:
+        """discogsography-r8hr: cancellation delivered WHILE BLOCKED on the
+        concurrency-limiter semaphore acquire — BEFORE the inner try block
+        that handles cancellation during the Neo4j write is ever entered —
+        must still re-enqueue the popped messages instead of losing them."""
+        mock_driver, mock_session = create_async_session_mock()
+
+        processor = Neo4jBatchProcessor(mock_driver)
+        processor._flush_semaphore = asyncio.Semaphore(1)
+        processor._flush_semaphore.acquire = AsyncMock(side_effect=asyncio.CancelledError())
+
+        ack = AsyncMock()
+        nack = AsyncMock()
+        msg1 = PendingMessage("artists", {"id": "1", "name": "Artist 1", "sha256": "hash1"}, ack, nack)
+        msg2 = PendingMessage("artists", {"id": "2", "name": "Artist 2", "sha256": "hash2"}, AsyncMock(), AsyncMock())
+        processor.queues["artists"].append(msg1)
+        processor.queues["artists"].append(msg2)
+
+        with pytest.raises(asyncio.CancelledError):
+            await processor._flush_queue("artists")
+
+        # Messages should be re-enqueued, not lost
+        assert len(processor.queues["artists"]) == 2
+        ack.assert_not_called()
+        nack.assert_not_called()
+        mock_session.execute_write.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_flush_respects_batch_size_limit(self) -> None:
         """Test that flush respects batch size limit."""
         mock_driver, _mock_session = create_async_session_mock()

--- a/tests/insights/test_insights.py
+++ b/tests/insights/test_insights.py
@@ -571,6 +571,121 @@ class TestLifespan:
 
             mock_health_srv.stop.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_lifespan_closes_redis_client_when_ping_fails(self) -> None:
+        """discogsography-v1g8: from_url() is lazy — ping() is what actually
+        opens the socket. If ping() raises (e.g. requirepass with a missing/
+        wrong REDIS_PASSWORD), the client built by from_url() must still be
+        closed before the reference is dropped — otherwise the connection
+        pool and the socket ping() opened are never released."""
+        from fastapi import FastAPI
+
+        import insights.insights as _module
+
+        mock_pool = AsyncMock()
+        mock_pool.initialize = AsyncMock()
+        mock_pool.close = AsyncMock()
+
+        mock_http_client = AsyncMock()
+        mock_http_client.aclose = AsyncMock()
+
+        mock_health_srv = MagicMock()
+        mock_health_srv.start_background = MagicMock()
+        mock_health_srv.stop = MagicMock()
+
+        mock_config = MagicMock()
+        mock_config.postgres_host = "localhost:5432"
+        mock_config.postgres_database = "test"
+        mock_config.postgres_username = "user"
+        mock_config.postgres_password = "pass"
+        mock_config.api_base_url = "http://localhost:8004"
+        mock_config.redis_host = "redis://localhost"
+        mock_config.schedule_hours = 24
+        mock_config.milestone_years = [25, 50]
+
+        # from_url() succeeds (lazy) but the socket-opening ping() fails —
+        # the exact AUTH-failure-under-requirepass scenario.
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock(side_effect=ConnectionError("NOAUTH Authentication required"))
+        mock_redis.aclose = AsyncMock()
+
+        async def fake_scheduler(*_args: object, **_kwargs: object) -> None:
+            await asyncio.sleep(100)
+
+        fake_app = FastAPI()
+
+        with (
+            patch.object(_module, "setup_logging"),
+            patch.object(_module.InsightsConfig, "from_env", return_value=mock_config),
+            patch.object(_module, "HealthServer", return_value=mock_health_srv),
+            patch.object(_module, "AsyncPostgreSQLPool", return_value=mock_pool),
+            patch("httpx.AsyncClient", return_value=mock_http_client),
+            patch("redis.asyncio.from_url", new_callable=AsyncMock, return_value=mock_redis),
+            patch.object(_module, "_scheduler_loop", side_effect=fake_scheduler),
+        ):
+            async with _module.lifespan(fake_app):
+                # Falls back to no caching, exactly like the from_url()-raises case.
+                assert _module._redis is None
+                assert _module._cache is None
+
+            mock_health_srv.stop.assert_called_once()
+
+        # The orphaned client (from the successful from_url()) must have
+        # been closed before _redis was set to None.
+        mock_redis.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_lifespan_redis_close_failure_on_ping_error_is_swallowed(self) -> None:
+        """A failure while cleaning up the orphaned client (aclose() itself
+        raising) must not prevent the graceful PostgreSQL-fallback path."""
+        from fastapi import FastAPI
+
+        import insights.insights as _module
+
+        mock_pool = AsyncMock()
+        mock_pool.initialize = AsyncMock()
+        mock_pool.close = AsyncMock()
+
+        mock_http_client = AsyncMock()
+        mock_http_client.aclose = AsyncMock()
+
+        mock_health_srv = MagicMock()
+        mock_health_srv.start_background = MagicMock()
+        mock_health_srv.stop = MagicMock()
+
+        mock_config = MagicMock()
+        mock_config.postgres_host = "localhost:5432"
+        mock_config.postgres_database = "test"
+        mock_config.postgres_username = "user"
+        mock_config.postgres_password = "pass"
+        mock_config.api_base_url = "http://localhost:8004"
+        mock_config.redis_host = "redis://localhost"
+        mock_config.schedule_hours = 24
+        mock_config.milestone_years = [25, 50]
+
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock(side_effect=ConnectionError("Redis down"))
+        mock_redis.aclose = AsyncMock(side_effect=RuntimeError("close also failed"))
+
+        async def fake_scheduler(*_args: object, **_kwargs: object) -> None:
+            await asyncio.sleep(100)
+
+        fake_app = FastAPI()
+
+        with (
+            patch.object(_module, "setup_logging"),
+            patch.object(_module.InsightsConfig, "from_env", return_value=mock_config),
+            patch.object(_module, "HealthServer", return_value=mock_health_srv),
+            patch.object(_module, "AsyncPostgreSQLPool", return_value=mock_pool),
+            patch("httpx.AsyncClient", return_value=mock_http_client),
+            patch("redis.asyncio.from_url", new_callable=AsyncMock, return_value=mock_redis),
+            patch.object(_module, "_scheduler_loop", side_effect=fake_scheduler),
+        ):
+            async with _module.lifespan(fake_app):
+                # Must not raise — the service still falls back cleanly.
+                assert _module._redis is None
+                assert _module._cache is None
+
 
 # ============================================================
 # 503 "not ready" responses when _pool is None

--- a/tests/schema-init/test_schema_init.py
+++ b/tests/schema-init/test_schema_init.py
@@ -39,6 +39,7 @@ class TestPostgresConnectionParams:
             "dbname": "testdb",
             "user": "testuser",
             "password": "testpass",
+            "connect_timeout": 10,
         }
 
     def test_host_only_defaults_to_port_5432(self) -> None:
@@ -72,6 +73,24 @@ class TestPostgresConnectionParams:
             result = _postgres_connection_params()
         assert isinstance(result["port"], int)
         assert result["port"] == 9999
+
+    def test_connect_timeout_is_bounded(self) -> None:
+        """discogsography-4vnh: libpq's own connect_timeout default is 0
+        (infinite). Without an explicit bound here, a pooler that accepts the
+        TCP connection but never completes the startup handshake blocks
+        psycopg.connect() forever — this is the first thing main() does,
+        synchronously, before any other service can start, so an infinite
+        block here wedges the entire stack with no error, only a hang."""
+        with (
+            patch("schema_init.POSTGRES_HOST", "localhost:5432"),
+            patch("schema_init.POSTGRES_DATABASE", "db"),
+            patch("schema_init.POSTGRES_USERNAME", "u"),
+            patch("schema_init.POSTGRES_PASSWORD", "p"),
+        ):
+            result = _postgres_connection_params()
+        assert "connect_timeout" in result
+        assert isinstance(result["connect_timeout"], int)
+        assert 0 < result["connect_timeout"] <= 30
 
 
 class TestEnsurePostgresDatabase:
@@ -125,6 +144,20 @@ class TestEnsurePostgresDatabase:
         # Must connect to "postgres" admin db, not the target db
         call_kwargs = mock_connect.call_args[1]
         assert call_kwargs.get("dbname") == "postgres"
+
+    def test_propagates_connect_timeout_to_admin_connect(self) -> None:
+        """discogsography-4vnh: whatever connect_timeout is present in the
+        params dict built by _postgres_connection_params() must reach the
+        admin psycopg.connect() call unchanged — _ensure_postgres_database
+        must not drop it while building admin_params."""
+        mock_conn = self._make_mock_conn(fetchone_result=(1,))
+        params = {"host": "myhost", "port": 5432, "dbname": "target_db", "user": "u", "password": "p", "connect_timeout": 10}
+
+        with patch("schema_init.psycopg.connect", return_value=mock_conn) as mock_connect, patch("schema_init.POSTGRES_DATABASE", "target_db"):
+            _ensure_postgres_database(params)
+
+        call_kwargs = mock_connect.call_args[1]
+        assert call_kwargs.get("connect_timeout") == 10
 
     def test_sets_autocommit(self) -> None:
         mock_conn = self._make_mock_conn(fetchone_result=(1,))

--- a/tests/tableinator/test_batch_processor.py
+++ b/tests/tableinator/test_batch_processor.py
@@ -970,6 +970,27 @@ class TestPostgreSQLBatchProcessor:
         assert [m.data_id for m in processor.queues["artists"]] == ["0", "1"]
 
     @pytest.mark.asyncio
+    async def test_flush_cancelled_while_acquiring_semaphore_re_enqueues(self) -> None:
+        """discogsography-r8hr: cancellation delivered WHILE BLOCKED on the
+        concurrency-limiter semaphore acquire — BEFORE the inner try block
+        that handles cancellation during _process_batch is ever entered —
+        must still re-enqueue the popped messages instead of losing them."""
+        processor = PostgreSQLBatchProcessor(MagicMock())
+        processor._flush_semaphore = asyncio.Semaphore(1)
+        processor._flush_semaphore.acquire = AsyncMock(side_effect=asyncio.CancelledError())
+        processor._process_batch = AsyncMock()  # type: ignore[method-assign]
+
+        for i in range(2):
+            processor.queues["artists"].append(PendingMessage("artists", str(i), {"id": str(i)}, "h", AsyncMock(), AsyncMock()))
+
+        with pytest.raises(asyncio.CancelledError):
+            await processor._flush_queue("artists")
+
+        assert len(processor.queues["artists"]) == 2
+        assert [m.data_id for m in processor.queues["artists"]] == ["0", "1"]
+        processor._process_batch.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_periodic_flush(self) -> None:
         """Test periodic flush background task."""
         mock_connection_pool = MagicMock()

--- a/tests/tableinator/test_tableinator.py
+++ b/tests/tableinator/test_tableinator.py
@@ -231,13 +231,15 @@ class TestOnDataMessage:
 def _make_purge_connection(total_count: int, stale_count: int) -> tuple[MagicMock, AsyncMock]:
     """Build a mock connection wired for purge_stale_rows.
 
-    fetchone yields the total-row count then the would-be-deleted count; fetchall
-    (only reached if the purge is not vetoed) returns stale_count data_id rows.
+    fetchone yields the total-row count then the would-be-deleted count;
+    rowcount (only meaningful once the DELETE itself runs) reports the actual
+    affected-row count purge_stale_rows now reads directly — no RETURNING/
+    fetchall (discogsography-6u1o).
     """
     mock_cursor = AsyncMock()
     mock_cursor.execute = AsyncMock()
     mock_cursor.fetchone = AsyncMock(side_effect=[(total_count,), (stale_count,)])
-    mock_cursor.fetchall = AsyncMock(return_value=[(f"id-{i}",) for i in range(stale_count)])
+    mock_cursor.rowcount = stale_count
 
     cursor_cm = AsyncMock()
     cursor_cm.__aenter__ = AsyncMock(return_value=mock_cursor)
@@ -274,7 +276,10 @@ class TestPurgeStaleRowsGuards:
 
         # 2 count queries + 1 DELETE = 3 executes; the DELETE actually ran.
         assert mock_cursor.execute.call_count == 3
-        mock_cursor.fetchall.assert_awaited_once()
+        delete_sql = mock_cursor.execute.call_args_list[-1].args[0]
+        assert "DELETE FROM" in str(delete_sql)
+        assert "RETURNING" not in str(delete_sql)
+        mock_cursor.fetchall.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_vetoes_full_table_wipe(self, mock_async_pool: Any) -> None:
@@ -315,7 +320,9 @@ class TestPurgeStaleRowsGuards:
             await purge_stale_rows("artists", "2026-07-20T00:00:00+00:00", record_count=11)
 
         assert mock_cursor.execute.call_count == 3
-        mock_cursor.fetchall.assert_awaited_once()
+        delete_sql = mock_cursor.execute.call_args_list[-1].args[0]
+        assert "DELETE FROM" in str(delete_sql)
+        mock_cursor.fetchall.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_skips_when_zero_records_this_session(self, mock_async_pool: Any) -> None:
@@ -367,6 +374,58 @@ class TestPurgeStaleRowsGuards:
         # Both count queries ran, but the stale count was 0 so no DELETE followed.
         assert mock_cursor.execute.call_count == 2
         mock_cursor.fetchall.assert_not_awaited()
+
+
+class TestPurgeStaleRowsDeleteIsO1Memory:
+    """discogsography-6u1o: the DELETE must never stream every deleted data_id
+    back over the wire and buffer it into a Python list purely to len() a
+    count already known — that is an O(n) allocation (potentially multi-GB
+    on a large purge) where O(1) suffices via cursor.rowcount."""
+
+    @pytest.mark.asyncio
+    async def test_delete_statement_has_no_returning_clause(self, mock_async_pool: Any) -> None:
+        mock_conn, mock_cursor = _make_purge_connection(total_count=100, stale_count=5)
+        pool = mock_async_pool(mock_conn)
+
+        with patch("tableinator.tableinator.connection_pool", pool):
+            await purge_stale_rows("artists", "2026-07-20T00:00:00+00:00", record_count=95)
+
+        delete_sql = str(mock_cursor.execute.call_args_list[-1].args[0])
+        assert "DELETE FROM" in delete_sql
+        assert "RETURNING" not in delete_sql
+
+    @pytest.mark.asyncio
+    async def test_delete_never_calls_fetchall(self, mock_async_pool: Any) -> None:
+        """Even on a real (non-vetoed) delete, fetchall must never be awaited —
+        the deleted-row count comes from cursor.rowcount alone."""
+        mock_conn, mock_cursor = _make_purge_connection(total_count=100, stale_count=5)
+        pool = mock_async_pool(mock_conn)
+
+        with patch("tableinator.tableinator.connection_pool", pool):
+            await purge_stale_rows("artists", "2026-07-20T00:00:00+00:00", record_count=95)
+
+        mock_cursor.fetchall.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_deleted_count_uses_rowcount(self, mock_async_pool: Any) -> None:
+        """The logged deleted count must reflect cursor.rowcount, not a
+        materialized row list — proven by rowcount and the (unused) stale
+        count diverging and the log using rowcount's value."""
+        mock_conn, mock_cursor = _make_purge_connection(total_count=100, stale_count=5)
+        # Simulate the DELETE's actual affected-row count differing from the
+        # pre-count (e.g. a row deleted by a concurrent process in between) —
+        # rowcount is the authority, not the earlier SELECT count(*).
+        mock_cursor.rowcount = 3
+
+        pool = mock_async_pool(mock_conn)
+        with (
+            patch("tableinator.tableinator.connection_pool", pool),
+            patch("tableinator.tableinator.logger") as mock_logger,
+        ):
+            await purge_stale_rows("artists", "2026-07-20T00:00:00+00:00", record_count=95)
+
+        info_calls = [str(call) for call in mock_logger.info.call_args_list]
+        assert any("Purged 3 stale" in call for call in info_calls)
 
 
 class TestMain:


### PR DESCRIPTION
Fixes 13 priority-3 concurrency/resource findings from the 2026-08-10 bug hunt (run `wf_646d4b21`), one commit per bead.

## Circuit breakers & pools (common/)
- **discogsography-4q2s** — AsyncPostgreSQLPool connection creation actually routes through its circuit breaker (fast-fail during outages).
- **discogsography-4utz** — regression test confirming the Neo4j breaker opens on repeated health-check failures (behavior fixed by #460's rework; test locks it in).
- **discogsography-n1s8** — a backend that fails post-connect validation is closed, not leaked.

## API races
- **discogsography-jrm3** — violations/skipped/parsing-error caches are single-flighted (no cache-stampede TOCTOU).
- **discogsography-pxqw** — a cancelled/crashed sync can no longer leave sync_history stuck at 'running'.
- **discogsography-qtts** — metrics recorded during the persist await window are kept, not silently discarded.

## Consumers & dashboard
- **discogsography-r8hr** — flush-semaphore acquire is cancellation-safe; a popped batch can't be dropped (both batch processors).
- **discogsography-6u1o** — purge_stale_rows uses rowcount instead of DELETE…RETURNING+fetchall (no unbounded memory).
- **discogsography-ip9y** — dashboard shutdown snapshots websocket_connections under _ws_lock.

## Shutdown/startup resource leaks
- **discogsography-4vnh** — schema-init admin CREATE DATABASE connect is bounded by a timeout.
- **discogsography-8nle** — the AsyncAnthropic client closes on lifespan shutdown.
- **discogsography-c4ag** — HealthServer.stop() releases its listening socket (all services).
- **discogsography-v1g8** — insights closes the orphaned Redis client when the startup ping fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrLwHwMcu3cuQJh8cc1SyW