### PR TITLE
fix: extractor resilience & observability — 8 bug-hunt findings (batch:p3-extractor)

### DIFF
--- a/docs/state-marker-system.md
+++ b/docs/state-marker-system.md
@@ -31,6 +31,15 @@ Each marker tracks:
     "files_downloaded": 4,
     "files_total": 4,
     "bytes_downloaded": 5234567890,
+    "downloads_by_file": {
+      "discogs_20260101_artists.xml.gz": {
+        "status": "completed",
+        "bytes_downloaded": 1234567890,
+        "started_at": "2026-01-31T12:00:00.000Z",
+        "completed_at": "2026-01-31T12:05:00.000Z",
+        "checksum": "a1b2c3..."
+      }
+    },
     "errors": []
   },
 
@@ -48,7 +57,8 @@ Each marker tracks:
         "records_extracted": 500000,
         "messages_published": 5000,
         "started_at": "2026-01-31T12:15:00.000Z",
-        "completed_at": "2026-01-31T12:20:00.000Z"
+        "completed_at": "2026-01-31T12:20:00.000Z",
+        "source_checksum": "a1b2c3..."
       },
       "discogs_20260101_labels.xml.gz": {
         "status": "completed",
@@ -129,6 +139,32 @@ When the extractor restarts, it checks the state marker and makes one of three d
 - Skip completed files
 - Resume processing unfinished files
 - Continue from last checkpoint
+
+### Byte-image provenance (re-download invalidation)
+
+The download and processing phases are independent state machines keyed by the same
+filename, so they need one explicit invariant linking them: **a processing status is
+valid only for the byte-image it was computed from.**
+
+- `download_phase.downloads_by_file[file].checksum` — SHA-256 of the bytes currently on
+  disk, recorded once they are verified.
+- `processing_phase.progress_by_file[file].source_checksum` — the checksum that was in
+  effect when this file's processing started.
+
+When the downloader materializes bytes for a file (whether freshly downloaded or already
+present), it calls `file_bytes_verified()`. If that file has a `completed` processing
+status whose `source_checksum` differs from the new checksum, the entry is dropped:
+`pending_files()` then re-queues the file, `files_processed` and the record counts are
+corrected, and a `completed` version is reopened so it is not skipped.
+
+This matters when the downloader forces a re-download because the locally trusted
+checksum disagrees with the Discogs-published `CHECKSUM`: without invalidation, the
+corrected bytes would be skipped by resume and never published for that version.
+
+Invalidation is deliberately narrow — it fires only when both checksums are known and
+they differ. Re-downloading identical bytes (e.g. an operator deleted a processed
+`.xml.gz` to reclaim disk) does not force a reparse, and markers written before these
+fields existed have unknown provenance and are left untouched.
 
 ### 3. Skip (Already Complete)
 

--- a/extractor/src/discogs_downloader.rs
+++ b/extractor/src/discogs_downloader.rs
@@ -214,9 +214,18 @@ impl Downloader {
                             warn!("⚠️ Failed to persist metadata after downloading {}: {}", filename, e);
                         }
 
-                        // Track file download in state marker with actual downloaded size
+                        // Track file download in state marker with actual downloaded size, and
+                        // bind the marker to the byte-image now on disk. If these bytes differ
+                        // from the ones an earlier session already processed (the whole point of
+                        // a forced re-download), that stale Completed processing status is
+                        // dropped so pending_files() re-queues the file — otherwise the
+                        // corrected data would never be parsed or published.
+                        let verified_checksum = self.metadata.get(filename).map(|info| info.checksum.clone());
                         if let Some(ref mut marker) = self.state_marker {
                             marker.file_downloaded(filename, downloaded_size);
+                            if let Some(ref checksum) = verified_checksum {
+                                marker.file_bytes_verified(filename, checksum);
+                            }
                         }
                         self.save_state_marker().await;
 
@@ -230,11 +239,17 @@ impl Downloader {
             } else {
                 info!("✅ Already have latest version of: {}", filename);
 
-                // Track existing file in state marker with actual file size
+                // Track existing file in state marker with actual file size. The locally
+                // trusted checksum is recorded too, so the first run after this change
+                // establishes the provenance that later re-downloads are compared against.
+                let local_path = self.output_directory.join(filename);
+                let file_size = tokio::fs::metadata(&local_path).await.map(|m| m.len()).unwrap_or(0);
+                let local_checksum = self.metadata.get(filename).map(|info| info.checksum.clone());
                 if let Some(ref mut marker) = self.state_marker {
-                    let local_path = self.output_directory.join(filename);
-                    let file_size = tokio::fs::metadata(&local_path).await.map(|m| m.len()).unwrap_or(0);
                     marker.file_downloaded(filename, file_size);
+                    if let Some(ref checksum) = local_checksum {
+                        marker.file_bytes_verified(filename, checksum);
+                    }
                 }
                 self.save_state_marker().await;
 

--- a/extractor/src/discogs_downloader.rs
+++ b/extractor/src/discogs_downloader.rs
@@ -284,12 +284,31 @@ impl Downloader {
         // Pattern matches: ?download=data%2F2026%2Fdiscogs_20260101_artists.xml.gz
         let file_pattern = Regex::new(r#"\?download=data%2F\d{4}%2F(discogs_(\d{8})_[^"]+)"#).context("Failed to compile file regex")?;
 
+        // Per-year outcome accounting. Without it there is no baseline against which the
+        // final version count can be judged, so a year silently contributing nothing is
+        // indistinguishable from a year that genuinely has nothing.
+        let mut years_checked = 0usize;
+        let mut years_contributing = 0usize;
+
         for year in years.iter().take(2) {
             let year_url = format!("{}?prefix=data%2F{}%2F", self.base_url, year);
+            years_checked += 1;
 
             match self.client.get(&year_url).await {
                 Ok(year_response) if year_response.status().is_success() => {
-                    if let Ok(year_html) = year_response.text().await {
+                    // A body read can fail independently of the response (connection reset or
+                    // truncation after headers), and PoliteClient never retries body reads.
+                    // Dropping the year silently here was the one traceless failure arm in this
+                    // function — the newest dump would vanish with nothing in the logs.
+                    let year_html = match year_response.text().await {
+                        Ok(html) => html,
+                        Err(e) => {
+                            warn!("⚠️ Failed to read year {} directory body: {}", year, e);
+                            continue;
+                        }
+                    };
+
+                    {
                         let mut file_count = 0;
                         for cap in file_pattern.captures_iter(&year_html) {
                             if let (Some(filename_match), Some(version_match)) = (cap.get(1), cap.get(2)) {
@@ -310,6 +329,16 @@ impl Downloader {
 
                         if file_count > 0 {
                             info!("📋 Found {} files in year {} directory", file_count, year);
+                            years_contributing += 1;
+                        } else {
+                            // A readable page that matches nothing is the other silent path:
+                            // a Discogs markup change would drop years just as invisibly, and
+                            // unlike a transport error it would not self-heal on the next check.
+                            warn!(
+                                "⚠️ No dump files matched in the year {} directory ({} bytes of HTML) — the Discogs listing markup may have changed",
+                                year,
+                                year_html.len()
+                            );
                         }
                     }
                 }
@@ -325,10 +354,17 @@ impl Downloader {
         }
 
         if ids.is_empty() {
-            return Err(anyhow::anyhow!("No files found on Discogs website"));
+            return Err(anyhow::anyhow!(
+                "No files found on Discogs website (none of the {} recent year directories contributed files)",
+                years_checked
+            ));
         }
 
-        info!("📊 Found {} unique versions from website", ids.len());
+        if years_contributing < years_checked {
+            warn!("⚠️ Only {}/{} recent year directories contributed files — the newest dump may be missing", years_contributing, years_checked);
+        }
+
+        info!("📊 Found {} unique versions from website ({}/{} year directories contributed)", ids.len(), years_contributing, years_checked);
 
         Ok(ids)
     }

--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -856,8 +856,16 @@ async fn progress_reporter(state: Arc<RwLock<ExtractorState>>, shutdown: Arc<tok
 
         // Log progress
         info!(
-            "📊 Extraction Progress: {} total records (Artists: {}, Labels: {}, Masters: {}, Releases: {})",
-            total, s.extraction_progress.artists, s.extraction_progress.labels, s.extraction_progress.masters, s.extraction_progress.releases
+            // Every type total() sums over must be listed, otherwise the parts do not add
+            // up to the printed total on the MusicBrainz instance (release_groups) and the
+            // type that is actually moving is hidden behind an always-zero Masters.
+            "📊 Extraction Progress: {} total records (Artists: {}, Labels: {}, Masters: {}, Release Groups: {}, Releases: {})",
+            total,
+            s.extraction_progress.artists,
+            s.extraction_progress.labels,
+            s.extraction_progress.masters,
+            s.extraction_progress.release_groups,
+            s.extraction_progress.releases
         );
 
         if !s.completed_files.is_empty() {

--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -480,149 +480,166 @@ pub async fn process_single_file(
         s.active_connections.insert(data_type, file_name.to_string());
     }
 
-    // Create channels for processing pipeline
-    let (parse_sender, parse_receiver) = mpsc::channel::<DataMessage>(config.queue_size);
-    let (batch_sender, batch_receiver) = mpsc::channel::<Vec<DataMessage>>(100);
+    // The pipeline below is wrapped so that the two pieces of non-RAII state acquired above
+    // — the `active_connections` entry and the per-file AMQP connection — are released on
+    // EVERY exit path, not just the success tail. Straight-line `?` propagation used to skip
+    // both on any error, leaving a phantom active connection in /metrics until the next run's
+    // state reset (periodic_check_days away) and tearing the broker connection down abruptly.
+    // The MusicBrainz loop already removes its entry unconditionally; this matches it.
+    let pipeline_result: Result<u64> = async {
+        // Create channels for processing pipeline
+        let (parse_sender, parse_receiver) = mpsc::channel::<DataMessage>(config.queue_size);
+        let (batch_sender, batch_receiver) = mpsc::channel::<Vec<DataMessage>>(100);
 
-    // Start workers — with optional validator stage between parser and batcher
-    let file_base_name = Path::new(file_name).file_name().and_then(|n| n.to_str()).unwrap_or(file_name); // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
-    let version = extract_version_from_filename(file_base_name).unwrap_or_else(|| "unknown".to_string());
+        // Start workers — with optional validator stage between parser and batcher
+        let file_base_name = Path::new(file_name).file_name().and_then(|n| n.to_str()).unwrap_or(file_name); // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
+        let version = extract_version_from_filename(file_base_name).unwrap_or_else(|| "unknown".to_string());
 
-    // Always-on normalization/hashing stage sits between the (optional) validator / parser and
-    // the batcher, so published records carry the normalized shape and a real sha256 in BOTH the
-    // rules and no-rules pipelines. (cu2.43)
-    let (normalized_sender, normalized_receiver) = mpsc::channel::<DataMessage>(config.queue_size);
+        // Always-on normalization/hashing stage sits between the (optional) validator / parser and
+        // the batcher, so published records carry the normalized shape and a real sha256 in BOTH the
+        // rules and no-rules pipelines. (cu2.43)
+        let (normalized_sender, normalized_receiver) = mpsc::channel::<DataMessage>(config.queue_size);
 
-    let validator_handle = if let Some(rules) = compiled_rules {
-        let (validated_sender, validated_receiver) = mpsc::channel::<DataMessage>(config.queue_size);
-        let rules = rules.clone();
-        let discogs_root = config.discogs_root.clone();
-        let version_clone = version.clone();
-        let data_type_str = data_type.as_str().to_string();
+        let validator_handle = if let Some(rules) = compiled_rules {
+            let (validated_sender, validated_receiver) = mpsc::channel::<DataMessage>(config.queue_size);
+            let rules = rules.clone();
+            let discogs_root = config.discogs_root.clone();
+            let version_clone = version.clone();
+            let data_type_str = data_type.as_str().to_string();
 
-        let handle =
-            tokio::spawn(
-                async move { message_validator(parse_receiver, validated_sender, rules, &data_type_str, &discogs_root, &version_clone).await },
-            );
+            let handle = tokio::spawn(async move {
+                message_validator(parse_receiver, validated_sender, rules, &data_type_str, &discogs_root, &version_clone).await
+            });
 
-        // parser -> validator (skip/filter/rules) -> normalizer (normalize + hash) -> batcher
-        let normalizer_handle = tokio::spawn(async move { message_normalizer(validated_receiver, normalized_sender, data_type).await });
+            // parser -> validator (skip/filter/rules) -> normalizer (normalize + hash) -> batcher
+            let normalizer_handle = tokio::spawn(async move { message_normalizer(validated_receiver, normalized_sender, data_type).await });
 
-        let batcher_config = BatcherConfig {
-            batch_size: config.batch_size,
-            data_type,
-            state: state.clone(),
-            state_marker: state_marker.clone(),
-            marker_path: marker_path.clone(),
-            file_name: file_name.to_string(),
-            state_save_interval: config.state_save_interval,
-        };
-        let batcher_handle = tokio::spawn(async move { message_batcher(normalized_receiver, batch_sender, batcher_config).await });
+            let batcher_config = BatcherConfig {
+                batch_size: config.batch_size,
+                data_type,
+                state: state.clone(),
+                state_marker: state_marker.clone(),
+                marker_path: marker_path.clone(),
+                file_name: file_name.to_string(),
+                state_save_interval: config.state_save_interval,
+            };
+            let batcher_handle = tokio::spawn(async move { message_batcher(normalized_receiver, batch_sender, batcher_config).await });
 
-        let parser_handle = tokio::spawn({
-            let file_path = config.discogs_root.join(file_name); // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
-            async move {
-                let parser = XmlParser::with_options(data_type, parse_sender, true);
-                parser.parse_file(&file_path).await
+            let parser_handle = tokio::spawn({
+                let file_path = config.discogs_root.join(file_name); // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
+                async move {
+                    let parser = XmlParser::with_options(data_type, parse_sender, true);
+                    parser.parse_file(&file_path).await
+                }
+            });
+
+            let publisher_handle = tokio::spawn({
+                let mq = mq.clone();
+                let state = state.clone();
+                async move { message_publisher(batch_receiver, mq, data_type, state).await }
+            });
+
+            let (parser_result, validator_result, normalizer_result, batcher_result, publisher_result) =
+                tokio::try_join!(parser_handle, handle, normalizer_handle, batcher_handle, publisher_handle)?;
+            let total_count = parser_result?;
+            let report: QualityReport = validator_result?;
+            normalizer_result?;
+            batcher_result?;
+            publisher_result?;
+
+            if report.has_violations() {
+                // file_name comes from S3 file listing (operator-controlled, not user input)
+                let version_for_report = extract_version_from_filename(
+                    Path::new(file_name).file_name().and_then(|n| n.to_str()).unwrap_or(""), // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
+                )
+                .unwrap_or_default();
+                info!("{}", report.format_summary(&version_for_report));
             }
-        });
 
-        let publisher_handle = tokio::spawn({
-            let mq = mq.clone();
-            let state = state.clone();
-            async move { message_publisher(batch_receiver, mq, data_type, state).await }
-        });
+            Some(total_count)
+        } else {
+            // parser -> normalizer (normalize + hash) -> batcher — no validator, but normalization
+            // and hashing still happen so consumers receive the same shape as the rules path. (cu2.43)
+            let parser_handle = tokio::spawn({
+                let file_path = config.discogs_root.join(file_name);
+                async move {
+                    let parser = XmlParser::new(data_type, parse_sender);
+                    parser.parse_file(&file_path).await
+                }
+            });
 
-        let (parser_result, validator_result, normalizer_result, batcher_result, publisher_result) =
-            tokio::try_join!(parser_handle, handle, normalizer_handle, batcher_handle, publisher_handle)?;
-        let total_count = parser_result?;
-        let report: QualityReport = validator_result?;
-        normalizer_result?;
-        batcher_result?;
-        publisher_result?;
+            let normalizer_handle = tokio::spawn(async move { message_normalizer(parse_receiver, normalized_sender, data_type).await });
 
-        if report.has_violations() {
-            // file_name comes from S3 file listing (operator-controlled, not user input)
-            let version_for_report = extract_version_from_filename(
-                Path::new(file_name).file_name().and_then(|n| n.to_str()).unwrap_or(""), // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
-            )
-            .unwrap_or_default();
-            info!("{}", report.format_summary(&version_for_report));
+            let batcher_config = BatcherConfig {
+                batch_size: config.batch_size,
+                data_type,
+                state: state.clone(),
+                state_marker: state_marker.clone(),
+                marker_path: marker_path.clone(),
+                file_name: file_name.to_string(),
+                state_save_interval: config.state_save_interval,
+            };
+            let batcher_handle = tokio::spawn(async move { message_batcher(normalized_receiver, batch_sender, batcher_config).await });
+
+            let publisher_handle = tokio::spawn({
+                let mq = mq.clone();
+                let state = state.clone();
+                async move { message_publisher(batch_receiver, mq, data_type, state).await }
+            });
+
+            let total_count = parser_handle.await??;
+            normalizer_handle.await??;
+            batcher_handle.await??;
+            publisher_handle.await??;
+
+            Some(total_count)
+        };
+
+        let total_count = validator_handle.unwrap_or(0);
+
+        // Send the file completion message BEFORE marking the file Completed in
+        // the state marker. If this AMQP send fails, the marker stays NOT
+        // Completed, so pending_files() on the next run still includes this file
+        // and send_file_complete is retried — instead of the signal being
+        // silently and permanently dropped (the previous "marker first" ordering
+        // let an AMQP failure land in the window after the marker was already
+        // durably Completed, so a retry would skip the file and never resend).
+        mq.send_file_complete(data_type, file_name, total_count).await?;
+
+        // Now that the completion signal has been durably handed off to the
+        // broker, mark the file as completed in the state marker.
+        {
+            let mut marker = state_marker.lock().await;
+            marker.complete_file_processing(file_name, total_count);
+            marker.save(&marker_path).await?;
+            info!("✅ Completed file processing in state marker: {} ({} records)", file_name, total_count);
         }
 
-        Some(total_count)
-    } else {
-        // parser -> normalizer (normalize + hash) -> batcher — no validator, but normalization
-        // and hashing still happen so consumers receive the same shape as the rules path. (cu2.43)
-        let parser_handle = tokio::spawn({
-            let file_path = config.discogs_root.join(file_name);
-            async move {
-                let parser = XmlParser::new(data_type, parse_sender);
-                parser.parse_file(&file_path).await
-            }
-        });
-
-        let normalizer_handle = tokio::spawn(async move { message_normalizer(parse_receiver, normalized_sender, data_type).await });
-
-        let batcher_config = BatcherConfig {
-            batch_size: config.batch_size,
-            data_type,
-            state: state.clone(),
-            state_marker: state_marker.clone(),
-            marker_path: marker_path.clone(),
-            file_name: file_name.to_string(),
-            state_save_interval: config.state_save_interval,
-        };
-        let batcher_handle = tokio::spawn(async move { message_batcher(normalized_receiver, batch_sender, batcher_config).await });
-
-        let publisher_handle = tokio::spawn({
-            let mq = mq.clone();
-            let state = state.clone();
-            async move { message_publisher(batch_receiver, mq, data_type, state).await }
-        });
-
-        let total_count = parser_handle.await??;
-        normalizer_handle.await??;
-        batcher_handle.await??;
-        publisher_handle.await??;
-
-        Some(total_count)
-    };
-
-    let total_count = validator_handle.unwrap_or(0);
-
-    // Send the file completion message BEFORE marking the file Completed in
-    // the state marker. If this AMQP send fails, the marker stays NOT
-    // Completed, so pending_files() on the next run still includes this file
-    // and send_file_complete is retried — instead of the signal being
-    // silently and permanently dropped (the previous "marker first" ordering
-    // let an AMQP failure land in the window after the marker was already
-    // durably Completed, so a retry would skip the file and never resend).
-    mq.send_file_complete(data_type, file_name, total_count).await?;
-
-    // Now that the completion signal has been durably handed off to the
-    // broker, mark the file as completed in the state marker.
-    {
-        let mut marker = state_marker.lock().await;
-        marker.complete_file_processing(file_name, total_count);
-        marker.save(&marker_path).await?;
-        info!("✅ Completed file processing in state marker: {} ({} records)", file_name, total_count);
+        Ok(total_count)
     }
+    .await;
 
-    // Update state
+    // Update state. Only `completed_files` is success-conditional; the active-connection
+    // entry must be dropped whether the pipeline succeeded or failed.
     {
         let mut s = state.write().await;
-        s.completed_files.insert(file_name.to_string());
+        if pipeline_result.is_ok() {
+            s.completed_files.insert(file_name.to_string());
+        }
         s.active_connections.remove(&data_type);
     }
 
-    // Clean up — best-effort. A cleanup failure here is purely cosmetic (the
-    // completion signal was already sent and the marker already committed
-    // above), so it must not flip an otherwise fully-successful file to
-    // Failed and trigger the failure cooldown.
+    // Clean up — best-effort, and unconditional. On the success path a cleanup failure is
+    // purely cosmetic (the completion signal was already sent and the marker already
+    // committed above), so it must not flip an otherwise fully-successful file to Failed
+    // and trigger the failure cooldown. On the failure path this replaces an abrupt
+    // connection drop (which RabbitMQ logs as 'client unexpectedly closed TCP connection')
+    // with a graceful close.
     if let Err(e) = mq.close().await {
         warn!("⚠️ Failed to cleanly close per-file MQ connection for {}: {}", file_name, e);
     }
+
+    let total_count = pipeline_result?;
 
     info!("✅ Completed processing {} with {} records", file_name, total_count);
     Ok(())

--- a/extractor/src/health.rs
+++ b/extractor/src/health.rs
@@ -93,6 +93,9 @@ async fn metrics_handler(State((state, _)): State<AppState>) -> (StatusCode, Jso
         "extraction_progress_artists": state.extraction_progress.artists,
         "extraction_progress_labels": state.extraction_progress.labels,
         "extraction_progress_masters": state.extraction_progress.masters,
+        // MusicBrainz-only type — omitting it made the per-type counters sum to less
+        // than extraction_progress_total on the extractor-musicbrainz instance.
+        "extraction_progress_release_groups": state.extraction_progress.release_groups,
         "extraction_progress_releases": state.extraction_progress.releases,
         "extraction_progress_total": state.extraction_progress.total(),
         "completed_files": state.completed_files.len(),

--- a/extractor/src/musicbrainz_downloader.rs
+++ b/extractor/src/musicbrainz_downloader.rs
@@ -337,6 +337,12 @@ impl MbDownloader {
         // only after SHA256 passes. A hard crash (OOM/SIGKILL/power loss) mid-extraction then
         // leaves only a `{entity}.jsonl.xz.tmp` — which is_version_complete does NOT accept —
         // instead of a truncated `{entity}.jsonl.xz` that would be forever trusted as complete.
+        //
+        // Extending that guarantee from process kills to actual power loss needs two fsyncs,
+        // because ordering between the data blocks and the directory entry is otherwise not
+        // guaranteed: the `.tmp` file's data is fsynced before the rename (in
+        // `extract_entity_from_reader`), and the parent directory is fsynced after it
+        // (`sync_parent_dir`).
         let tmp_path = tmp_download_path(out_path);
         let mut last_error: Option<anyhow::Error> = None;
 
@@ -417,6 +423,12 @@ impl MbDownloader {
                         last_error = Some(anyhow::anyhow!(msg));
                         let _ = fs::remove_file(&tmp_path).await;
                         continue;
+                    }
+                    // Make the new directory entry itself durable; the file's own data was
+                    // fsynced before the rename inside extract_entity_from_reader.
+                    {
+                        let out_path_for_sync = out_path.to_path_buf();
+                        let _ = tokio::task::spawn_blocking(move || sync_parent_dir(&out_path_for_sync)).await;
                     }
                     let elapsed = attempt_start.elapsed().as_secs_f64();
                     let speed = if elapsed > 0.0 { (total_bytes as f64 / 1_048_576.0) / elapsed } else { 0.0 };
@@ -519,6 +531,32 @@ fn tmp_download_path(out_path: &Path) -> PathBuf {
     PathBuf::from(name)
 }
 
+/// fsync the directory that contains `path` so a rename into it survives power loss.
+///
+/// `rename(2)` is atomic with respect to what a running system observes, but on journaling
+/// file systems the *new directory entry* only becomes durable once the parent directory is
+/// itself fsynced. Without this, the rename can be persisted while the renamed file's data
+/// blocks are not — the exact shape that leaves a truncated `{entity}.jsonl.xz` at a path
+/// `is_version_complete` trusts forever.
+///
+/// Best-effort: on platforms where a directory cannot be opened for sync this warns rather
+/// than failing an otherwise complete, checksum-verified download.
+pub(crate) fn sync_parent_dir(path: &Path) {
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    // `parent` is derived from operator-controlled config, not HTTP input.
+    match std::fs::File::open(parent) {
+        // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
+        Ok(dir) => {
+            if let Err(e) = dir.sync_all() {
+                warn!("⚠️ Failed to fsync directory {:?}: {}", parent, e);
+            }
+        }
+        Err(e) => warn!("⚠️ Failed to open directory {:?} for fsync: {}", parent, e),
+    }
+}
+
 /// Extract `mbdump/<entity>` from a `.tar.xz` file on disk into a compressed `.jsonl.xz`
 /// output file. Thin wrapper around [`extract_entity_from_reader`] — kept as a stable public
 /// entry point so existing disk-based tests and any standalone callers keep working.
@@ -533,6 +571,7 @@ pub fn extract_entity_from_tarball(tar_path: &Path, entity: &str, out_path: &Pat
     let tmp_path = tmp_download_path(out_path);
     extract_entity_from_reader(file, entity, &tmp_path).map(|_| ())?;
     std::fs::rename(&tmp_path, out_path).with_context(|| format!("Failed to rename {:?} -> {:?}", tmp_path, out_path))?;
+    sync_parent_dir(out_path);
     Ok(())
 }
 
@@ -593,7 +632,13 @@ fn extract_entity_from_reader<R: Read>(reader: R, entity: &str, out_path: &Path)
                     last_progress_log = now;
                 }
             }
-            encoder.finish().context("Failed to finalize XZ compression")?;
+            // Flush the XZ footer, then force the data to stable storage BEFORE the caller
+            // renames this file into its final path. Without the fsync the rename can be
+            // journaled while the data blocks are not, and a power loss leaves a truncated
+            // `{entity}.jsonl.xz` at the final path — which `is_version_complete` trusts
+            // forever, wedging extraction until an operator deletes the file by hand.
+            let finished = encoder.finish().context("Failed to finalize XZ compression")?;
+            finished.sync_all().with_context(|| format!("Failed to fsync {:?}", out_path))?;
             Ok(())
         })();
 

--- a/extractor/src/musicbrainz_downloader.rs
+++ b/extractor/src/musicbrainz_downloader.rs
@@ -37,11 +37,41 @@ pub fn discover_mb_dump_files(root: &Path) -> Result<HashMap<DataType, PathBuf>>
 
     // `root` comes from operator-controlled config (CLI/env var), not HTTP input.
     let read_dir_result = std::fs::read_dir(root); // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
+
+    // A listing failure that is NOT "directory missing" is a genuine I/O error and must not
+    // be reported to the caller as "no dump files" — process_musicbrainz_data treats an empty
+    // map as a benign Completed run, so an EACCES/EIO/EMFILE would be durably misreported as
+    // success on every cycle. It is remembered here rather than returned immediately because
+    // the exact-name probing below needs no directory listing at all and still succeeds when
+    // the directory is traversable but not listable.
+    let mut listing_error: Option<std::io::Error> = None;
+
     let entries: Vec<_> = match read_dir_result {
-        Ok(rd) => rd.filter_map(|e| e.ok()).filter(|e| e.file_type().map(|ft| ft.is_file()).unwrap_or(false)).collect(),
+        Ok(rd) => rd
+            .filter_map(|entry| match entry {
+                Ok(entry) => Some(entry),
+                Err(e) => {
+                    warn!("⚠️ Skipping unreadable entry in MusicBrainz dump directory {:?}: {}", root, e);
+                    None
+                }
+            })
+            .filter(|entry| match entry.file_type() {
+                Ok(ft) => ft.is_file(),
+                Err(e) => {
+                    warn!("⚠️ Cannot stat {:?} in MusicBrainz dump directory: {}", entry.path(), e);
+                    false
+                }
+            })
+            .collect(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Genuinely absent directory — nothing has been downloaded yet. Benign.
+            warn!("⚠️ MusicBrainz dump directory {:?} does not exist: {}", root, e);
+            Vec::new()
+        }
         Err(e) => {
-            warn!("⚠️ Cannot read MusicBrainz dump directory {:?}: {}", root, e);
-            return Ok(found);
+            warn!("⚠️ Cannot list MusicBrainz dump directory {:?}: {} — falling back to exact-name probing", root, e);
+            listing_error = Some(e);
+            Vec::new()
         }
     };
 
@@ -76,6 +106,11 @@ pub fn discover_mb_dump_files(root: &Path) -> Result<HashMap<DataType, PathBuf>>
     }
 
     if found.is_empty() {
+        // Exact-name probing recovered nothing, so the listing failure is the reason we
+        // found no files. Surface it as an error instead of an empty (success) result.
+        if let Some(e) = listing_error {
+            return Err(e).context(format!("Failed to read MusicBrainz dump directory {root:?}"));
+        }
         warn!("⚠️ No MusicBrainz dump files found in {:?}", root);
     } else {
         info!("📋 Discovered {} MusicBrainz dump file(s) in {:?}", found.len(), root);

--- a/extractor/src/musicbrainz_downloader.rs
+++ b/extractor/src/musicbrainz_downloader.rs
@@ -271,13 +271,29 @@ impl MbDownloader {
         // tar extractor, and xz encoder, landing on disk only as {entity}.jsonl.xz.
         // SHA256 is computed on the raw compressed bytes as they flow past.
         for entity in MB_ENTITIES {
+            let out_path = version_dir.join(format!("{}.jsonl.xz", entity)); // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
+
+            // Per-entity resume. A final `{entity}.jsonl(.xz)` can only exist because a previous
+            // run fully extracted and SHA256-verified it (see `is_version_complete` — the download
+            // path renames into place only after verification), so trusting it here is no weaker
+            // an assumption than the version-level gate already makes for all four entities.
+            // Without this skip, a run that dies on entity N re-downloads and re-extracts the
+            // multi-GB tarballs of entities 1..N-1 on every retry. Both the compressed and bare
+            // variants are honored, matching `is_version_complete` and `discover_mb_dump_files`.
+            let plain_path = version_dir.join(format!("{}.jsonl", entity)); // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
+            if out_path.exists() || plain_path.exists() {
+                info!("⏭️ MusicBrainz {} dump already extracted, skipping re-download", entity);
+                continue;
+            }
+
+            // Looked up after the skip so an already-materialized entity does not fail the whole
+            // run when its checksum line is absent from SHA256SUMS.
             let tarball_name = format!("{}.tar.xz", entity);
             let expected_hash = checksums
                 .get(&tarball_name)
                 .ok_or_else(|| anyhow::anyhow!("No SHA256 checksum found for {} in SHA256SUMS", tarball_name))?;
 
             let download_url = format!("{}{}/{}", self.base_url, version, tarball_name);
-            let out_path = version_dir.join(format!("{}.jsonl.xz", entity)); // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
 
             self.stream_download_verify_extract(&download_url, entity, expected_hash, &out_path).await?;
 

--- a/extractor/src/parser.rs
+++ b/extractor/src/parser.rs
@@ -20,6 +20,14 @@ use crate::types::{DataMessage, DataType};
 /// file is genuinely unusable (wrong file, truncated download), so parsing aborts.
 const MAX_MALFORMED_RECORDS_PER_FILE: u64 = 100;
 
+/// Maximum number of per-chunk UTF-8 decode warnings emitted while parsing one file.
+///
+/// The crate is built without quick-xml's `encoding` feature, so `decode()` is exactly
+/// `str::from_utf8` and a dump that is not actually UTF-8 would fail on *every* text
+/// chunk. Warn about the first few (enough for an operator to notice and diagnose) and
+/// summarize the rest once at end-of-file instead of flooding the log.
+const MAX_DECODE_WARNINGS_PER_FILE: u64 = 10;
+
 /// Represents an element being parsed with its attributes and children
 #[derive(Debug)]
 struct ElementContext {
@@ -162,6 +170,10 @@ impl XmlParser {
         let mut malformed_records = 0u64;
         let mut resyncing = false;
         let mut last_error_position = u64::MAX;
+
+        // Count of text/entity chunks that failed a strict UTF-8 decode and were preserved
+        // lossily instead of being dropped.
+        let mut decode_failures = 0u64;
 
         // Determine the target element based on data type
         let target_element = match self.data_type {
@@ -338,11 +350,25 @@ impl XmlParser {
                 }
 
                 Event::Text(e) => {
-                    if in_target_element
-                        && let Some(context) = element_stack.last_mut()
-                        && let Ok(text) = e.decode()
-                    {
-                        context.text_content.push_str(&text);
+                    if in_target_element && let Some(context) = element_stack.last_mut() {
+                        match e.decode() {
+                            Ok(text) => context.text_content.push_str(&text),
+                            Err(err) => {
+                                // Degrade lossily rather than dropping the chunk: a silent drop
+                                // publishes the record with the field's text missing, and the
+                                // sha256 computed over that corrupted shape becomes the canonical
+                                // value downstream, so the loss is never re-detected.
+                                let position = reader.buffer_position();
+                                decode_failures += 1;
+                                if decode_failures <= MAX_DECODE_WARNINGS_PER_FILE {
+                                    warn!(
+                                        "⚠️ Failed to decode XML text at position {} ({}), preserving it lossily: {}",
+                                        position, self.data_type, err
+                                    );
+                                }
+                                context.text_content.push_str(&String::from_utf8_lossy(e.as_ref()));
+                            }
+                        }
                     }
                 }
 
@@ -362,8 +388,21 @@ impl XmlParser {
                                     context.text_content.push('\u{FFFD}');
                                 }
                             }
-                        } else if let Ok(name) = e.decode() {
-                            match name.as_ref() {
+                        } else {
+                            // Same lossy-degradation contract as Event::Text: an undecodable
+                            // entity name is preserved verbatim rather than dropped silently.
+                            let name = e.decode().map(|n| n.into_owned()).unwrap_or_else(|err| {
+                                let position = reader.buffer_position();
+                                decode_failures += 1;
+                                if decode_failures <= MAX_DECODE_WARNINGS_PER_FILE {
+                                    warn!(
+                                        "⚠️ Failed to decode XML entity reference at position {} ({}), preserving it lossily: {}",
+                                        position, self.data_type, err
+                                    );
+                                }
+                                String::from_utf8_lossy(e.as_ref()).into_owned()
+                            });
+                            match name.as_str() {
                                 "amp" => context.text_content.push('&'),
                                 "lt" => context.text_content.push('<'),
                                 "gt" => context.text_content.push('>'),
@@ -391,6 +430,13 @@ impl XmlParser {
 
         if malformed_records > 0 {
             warn!("⚠️ Skipped {} malformed XML record(s) while parsing {:?} ({} records parsed)", malformed_records, file_path, record_count);
+        }
+
+        if decode_failures > 0 {
+            warn!(
+                "⚠️ Recovered {} non-UTF-8 text chunk(s) lossily while parsing {:?} — the source dump is not valid UTF-8 and affected fields contain replacement characters",
+                decode_failures, file_path
+            );
         }
 
         debug!("✅ Finished parsing {} records from {:?}", record_count, file_path);

--- a/extractor/src/state_marker.rs
+++ b/extractor/src/state_marker.rs
@@ -23,11 +23,18 @@ pub struct FileDownloadStatus {
     pub bytes_downloaded: u64,
     pub started_at: Option<DateTime<Utc>>,
     pub completed_at: Option<DateTime<Utc>>,
+    /// SHA-256 of the bytes currently on disk for this file, once verified.
+    ///
+    /// This is what links the two otherwise-independent phase machines: a processing
+    /// status is only valid for the byte-image it was computed from, and that image is
+    /// identified here. Defaulted so markers written before this field existed still load.
+    #[serde(default)]
+    pub checksum: Option<String>,
 }
 
 impl Default for FileDownloadStatus {
     fn default() -> Self {
-        Self { status: PhaseStatus::Pending, bytes_downloaded: 0, started_at: None, completed_at: None }
+        Self { status: PhaseStatus::Pending, bytes_downloaded: 0, started_at: None, completed_at: None, checksum: None }
     }
 }
 
@@ -68,11 +75,25 @@ pub struct FileProcessingStatus {
     pub batches_sent: u64,
     pub started_at: Option<DateTime<Utc>>,
     pub completed_at: Option<DateTime<Utc>>,
+    /// Checksum of the downloaded byte-image this processing status was computed from.
+    ///
+    /// `None` means the provenance is unknown (a marker written before this field existed),
+    /// in which case the status is left alone rather than speculatively invalidated.
+    #[serde(default)]
+    pub source_checksum: Option<String>,
 }
 
 impl Default for FileProcessingStatus {
     fn default() -> Self {
-        Self { status: PhaseStatus::Pending, records_extracted: 0, messages_published: 0, batches_sent: 0, started_at: None, completed_at: None }
+        Self {
+            status: PhaseStatus::Pending,
+            records_extracted: 0,
+            messages_published: 0,
+            batches_sent: 0,
+            started_at: None,
+            completed_at: None,
+            source_checksum: None,
+        }
     }
 }
 
@@ -331,6 +352,7 @@ impl StateMarker {
                     bytes_downloaded: bytes,
                     started_at: Some(Utc::now()),
                     completed_at: Some(Utc::now()),
+                    checksum: None,
                 },
             );
         }
@@ -340,6 +362,61 @@ impl StateMarker {
         }
         // Recalculate total bytes from all files
         self.download_phase.bytes_downloaded = self.download_phase.downloads_by_file.values().map(|s| s.bytes_downloaded).sum();
+    }
+
+    /// Record the checksum of the bytes now on disk for `filename` and, if a completed
+    /// processing status was derived from *different* bytes, invalidate it so the file is
+    /// processed again.
+    ///
+    /// The download and processing phases are otherwise independent state machines keyed by
+    /// the same filename, with no invariant linking them. That let a file whose bytes had
+    /// just been declared untrustworthy — and re-downloaded to replace them — keep a
+    /// `Completed` processing status computed from the old, bad bytes: `pending_files()`
+    /// filters purely on processing status, so the corrected file was never re-parsed and
+    /// the run still finalized as Completed, permanently for that version.
+    ///
+    /// Invalidation is deliberately narrow. It fires only when both checksums are known and
+    /// they differ, so the common case of an operator deleting a processed `.xml.gz` to
+    /// reclaim disk (re-downloaded → identical bytes) does not force a needless reparse, and
+    /// markers predating the checksum field are left untouched.
+    ///
+    /// Returns `true` when a completed processing status was invalidated.
+    pub fn file_bytes_verified(&mut self, filename: &str, checksum: &str) -> bool {
+        let previous_checksum = match self.processing_phase.progress_by_file.get(filename) {
+            Some(status) if status.status == PhaseStatus::Completed => status.source_checksum.clone(),
+            _ => None,
+        };
+
+        if let Some(status) = self.download_phase.downloads_by_file.get_mut(filename) {
+            status.checksum = Some(checksum.to_string());
+        }
+
+        let stale = previous_checksum.is_some_and(|previous| previous != checksum);
+        if !stale {
+            return false;
+        }
+
+        warn!("⚠️ {} was re-downloaded with different bytes than the ones already processed — re-queuing it for processing", filename);
+
+        self.processing_phase.progress_by_file.remove(filename);
+        self.processing_phase.files_processed = self.processing_phase.files_processed.saturating_sub(1);
+        if let Some(data_type) = extract_data_type(filename) {
+            self.summary.files_by_type.insert(data_type, PhaseStatus::Pending);
+        }
+        // Drop the stale record/message counts too — they feed /health totals and the
+        // extraction_complete record_counts broadcast.
+        self.sync_phase_totals();
+
+        // The version is no longer fully processed, so it must not be skipped on a later cycle.
+        if self.summary.overall_status == PhaseStatus::Completed {
+            self.summary.overall_status = PhaseStatus::InProgress;
+        }
+        if self.processing_phase.status == PhaseStatus::Completed {
+            self.processing_phase.status = PhaseStatus::InProgress;
+            self.processing_phase.completed_at = None;
+        }
+
+        true
     }
 
     /// Mark download phase as completed
@@ -364,7 +441,11 @@ impl StateMarker {
     pub fn start_file_processing(&mut self, filename: &str) {
         self.processing_phase.current_file = Some(filename.to_string());
 
-        let status = FileProcessingStatus { status: PhaseStatus::InProgress, started_at: Some(Utc::now()), ..Default::default() };
+        // Bind this processing attempt to the byte-image it is about to read, so a later
+        // re-download of different bytes can tell that the resulting status is stale.
+        let source_checksum = self.download_phase.downloads_by_file.get(filename).and_then(|s| s.checksum.clone());
+
+        let status = FileProcessingStatus { status: PhaseStatus::InProgress, started_at: Some(Utc::now()), source_checksum, ..Default::default() };
 
         self.processing_phase.progress_by_file.insert(filename.to_string(), status);
 

--- a/extractor/src/tests/downloader_tests.rs
+++ b/extractor/src/tests/downloader_tests.rs
@@ -1092,3 +1092,104 @@ async fn test_download_metadata_persisted_incrementally_on_mid_batch_failure() {
     let completed = S3FileInfo { name: "discogs_20260101_artists.xml.gz".to_string(), size: "fake artists data".len() as u64 };
     assert!(!reloaded.should_download(&completed).await.unwrap(), "a completed, persisted file must not be re-downloaded");
 }
+
+/// Collects formatted log output so a test can assert that a failure was actually reported.
+#[derive(Clone, Default)]
+struct LogCapture(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+impl LogCapture {
+    fn contents(&self) -> String {
+        String::from_utf8_lossy(&self.0.lock().unwrap()).to_string()
+    }
+}
+
+impl std::io::Write for LogCapture {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for LogCapture {
+    type Writer = LogCapture;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+#[tokio::test]
+async fn test_year_body_read_failure_is_logged() {
+    // discogsography-xgyb regression: the year-page body read was the one traceless failure
+    // arm in scrape_file_list_from_discogs — `if let Ok(year_html)` with no else. A body that
+    // fails post-headers (proxy reset / truncation) dropped the whole year's listing, so the
+    // newest dump became invisible while the run still reported success with nothing logged.
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    let capture = LogCapture::default();
+    let subscriber = tracing_subscriber::fmt().with_max_level(tracing::Level::WARN).with_writer(capture.clone()).finish();
+    let _log_guard = tracing::subscriber::set_default(subscriber);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let _server = tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                return;
+            };
+            tokio::spawn(async move {
+                loop {
+                    let mut buf = vec![0u8; 4096];
+                    let n = match sock.read(&mut buf).await {
+                        Ok(0) | Err(_) => return,
+                        Ok(n) => n,
+                    };
+                    let request = String::from_utf8_lossy(&buf[..n]).to_string();
+
+                    if request.contains("prefix=data%2F2026%2F") {
+                        // Headers promise a full body; send a fragment and close the socket —
+                        // reqwest surfaces this as an Err from .text(), not from .get().
+                        let _ = sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 4096\r\n\r\n<html><body>").await;
+                        let _ = sock.flush().await;
+                        return;
+                    }
+
+                    let body = if request.contains("prefix=data%2F2025%2F") {
+                        r#"<html><body>
+                        <a href="?download=data%2F2025%2Fdiscogs_20251201_artists.xml.gz">a</a>
+                        <a href="?download=data%2F2025%2Fdiscogs_20251201_labels.xml.gz">l</a>
+                        <a href="?download=data%2F2025%2Fdiscogs_20251201_masters.xml.gz">m</a>
+                        <a href="?download=data%2F2025%2Fdiscogs_20251201_releases.xml.gz">r</a>
+                        </body></html>"#
+                    } else {
+                        r#"<html><body>
+                        <a href="?prefix=data%2F2026%2F">2026/</a>
+                        <a href="?prefix=data%2F2025%2F">2025/</a>
+                        </body></html>"#
+                    };
+                    let response = format!("HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\n\r\n{}", body.len(), body);
+                    if sock.write_all(response.as_bytes()).await.is_err() {
+                        return;
+                    }
+                    let _ = sock.flush().await;
+                }
+            });
+        }
+    });
+
+    let temp_dir = TempDir::new().unwrap();
+    let base_url = format!("http://{}/", addr);
+    let mut downloader = Downloader::new_with_base_url(temp_dir.path().to_path_buf(), base_url).await.unwrap();
+
+    let files = downloader.list_s3_files().await.expect("a lost year must not fail the whole listing");
+    assert!(files.iter().all(|f| f.name.contains("2025")), "only the readable year can contribute files; got {:?}", files);
+
+    let logs = capture.contents();
+    assert!(logs.contains("Failed to read year 2026 directory body"), "the lost year must be logged, not silently dropped; logs were:\n{logs}");
+}

--- a/extractor/src/tests/downloader_tests.rs
+++ b/extractor/src/tests/downloader_tests.rs
@@ -1193,3 +1193,191 @@ async fn test_year_body_read_failure_is_logged() {
     let logs = capture.contents();
     assert!(logs.contains("Failed to read year 2026 directory body"), "the lost year must be logged, not silently dropped; logs were:\n{logs}");
 }
+
+#[tokio::test]
+async fn test_forced_redownload_requeues_processed_file() {
+    // discogsography-qhel regression: cu2.106 revokes trust in bad bytes on the download
+    // side, but the processing status computed from those bytes used to survive — so
+    // pending_files() skipped the corrected file, the run finalized Completed, and the
+    // corrected data was never parsed or published for the whole monthly version.
+    use sha2::{Digest, Sha256};
+
+    let temp_dir = TempDir::new().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let base_url = format!("{}/", server.url());
+
+    let main_page_html = r#"<html><body>
+        <a href="?prefix=data%2F2026%2F">2026/</a>
+    </body></html>"#;
+    let _main_mock = server.mock("GET", "/").with_status(200).with_body(main_page_html).create_async().await;
+
+    let year_page_html = r#"<html><body>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_artists.xml.gz">artists</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_labels.xml.gz">labels</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_masters.xml.gz">masters</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_releases.xml.gz">releases</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_CHECKSUM.txt">checksum</a>
+    </body></html>"#;
+    let _year_mock = server.mock("GET", "/?prefix=data%2F2026%2F").with_status(200).with_body(year_page_html).create_async().await;
+
+    let _checksum_mock = server
+        .mock("GET", "/?download=data%2F2026%2Fdiscogs_20260101_CHECKSUM.txt")
+        .with_status(200)
+        .with_body(fake_data_checksums_txt())
+        .create_async()
+        .await;
+
+    let file_types = ["artists", "labels", "masters", "releases"];
+    let mut downloader = Downloader::new_with_base_url(temp_dir.path().to_path_buf(), base_url).await.unwrap();
+
+    // Session 1's world: locally trusted bytes that do NOT match the published CHECKSUM.
+    let mut trusted_checksums = std::collections::HashMap::new();
+    for file_type in &file_types {
+        let filename = format!("discogs_20260101_{}.xml.gz", file_type);
+        let content = format!("previously trusted bad {} data", file_type);
+        let local_path = temp_dir.path().join(&filename);
+        fs::write(&local_path, content.as_bytes()).await.unwrap();
+
+        let mut hasher = Sha256::new();
+        hasher.update(content.as_bytes());
+        let checksum = hex::encode(hasher.finalize());
+        trusted_checksums.insert(filename.clone(), checksum.clone());
+
+        downloader.metadata.insert(
+            filename,
+            LocalFileInfo { path: local_path.to_string_lossy().to_string(), checksum, version: "202601".to_string(), size: content.len() as u64 },
+        );
+    }
+
+    // Session 1's marker: artists was parsed from the bad bytes and marked Completed.
+    let artists = "discogs_20260101_artists.xml.gz".to_string();
+    let mut marker = StateMarker::new("20260101".to_string());
+    marker.start_download(4);
+    marker.start_file_download(&artists);
+    marker.file_downloaded(&artists, 42);
+    marker.file_bytes_verified(&artists, &trusted_checksums[&artists]);
+    marker.complete_download();
+    marker.start_processing(4);
+    marker.start_file_processing(&artists);
+    marker.complete_file_processing(&artists, 500);
+
+    let all_files: Vec<String> = file_types.iter().map(|t| format!("discogs_20260101_{}.xml.gz", t)).collect();
+    assert!(!marker.pending_files(&all_files).contains(&artists), "precondition: artists starts out completed");
+
+    downloader.set_state_marker(marker, temp_dir.path().join("marker.json"));
+
+    let mut _download_mocks = Vec::new();
+    for file_type in &file_types {
+        let download_path = format!("/?download=data%2F2026%2Fdiscogs_20260101_{}.xml.gz", file_type);
+        let mock = server
+            .mock("GET", download_path.as_str())
+            .with_status(200)
+            .with_body(format!("fake {} data", file_type))
+            .create_async()
+            .await;
+        _download_mocks.push(mock);
+    }
+
+    downloader.download_discogs_data().await.unwrap();
+
+    let marker = downloader.take_state_marker().expect("marker returns from the downloader");
+    assert!(
+        marker.pending_files(&all_files).contains(&artists),
+        "a file re-downloaded with different bytes must be re-queued, not skipped as already processed"
+    );
+    assert_eq!(marker.processing_phase.files_processed, 0, "the stale completion must not still be counted");
+}
+
+#[tokio::test]
+async fn test_unchanged_redownload_keeps_file_processed() {
+    // The counterpart: an operator deleting a processed .xml.gz to reclaim disk gets the
+    // same bytes back, which must not force a needless multi-GB reparse.
+    use sha2::{Digest, Sha256};
+
+    let temp_dir = TempDir::new().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let base_url = format!("{}/", server.url());
+
+    let main_page_html = r#"<html><body>
+        <a href="?prefix=data%2F2026%2F">2026/</a>
+    </body></html>"#;
+    let _main_mock = server.mock("GET", "/").with_status(200).with_body(main_page_html).create_async().await;
+
+    let year_page_html = r#"<html><body>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_artists.xml.gz">artists</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_labels.xml.gz">labels</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_masters.xml.gz">masters</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_releases.xml.gz">releases</a>
+        <a href="?download=data%2F2026%2Fdiscogs_20260101_CHECKSUM.txt">checksum</a>
+    </body></html>"#;
+    let _year_mock = server.mock("GET", "/?prefix=data%2F2026%2F").with_status(200).with_body(year_page_html).create_async().await;
+
+    let _checksum_mock = server
+        .mock("GET", "/?download=data%2F2026%2Fdiscogs_20260101_CHECKSUM.txt")
+        .with_status(200)
+        .with_body(fake_data_checksums_txt())
+        .create_async()
+        .await;
+
+    let file_types = ["artists", "labels", "masters", "releases"];
+    let mut downloader = Downloader::new_with_base_url(temp_dir.path().to_path_buf(), base_url).await.unwrap();
+
+    // The good bytes the server will serve, hashed exactly as download_file would.
+    let artists = "discogs_20260101_artists.xml.gz".to_string();
+    let mut hasher = Sha256::new();
+    hasher.update(b"fake artists data");
+    let good_checksum = hex::encode(hasher.finalize());
+
+    // artists is absent from disk (deleted to reclaim disk) but already processed.
+    for file_type in &file_types {
+        if *file_type == "artists" {
+            continue;
+        }
+        let filename = format!("discogs_20260101_{}.xml.gz", file_type);
+        let content = format!("fake {} data", file_type);
+        let local_path = temp_dir.path().join(&filename);
+        fs::write(&local_path, content.as_bytes()).await.unwrap();
+
+        let mut hasher = Sha256::new();
+        hasher.update(content.as_bytes());
+        downloader.metadata.insert(
+            filename,
+            LocalFileInfo {
+                path: local_path.to_string_lossy().to_string(),
+                checksum: hex::encode(hasher.finalize()),
+                version: "202601".to_string(),
+                size: content.len() as u64,
+            },
+        );
+    }
+
+    let mut marker = StateMarker::new("20260101".to_string());
+    marker.start_download(4);
+    marker.start_file_download(&artists);
+    marker.file_downloaded(&artists, 17);
+    marker.file_bytes_verified(&artists, &good_checksum);
+    marker.complete_download();
+    marker.start_processing(4);
+    marker.start_file_processing(&artists);
+    marker.complete_file_processing(&artists, 500);
+    downloader.set_state_marker(marker, temp_dir.path().join("marker.json"));
+
+    let mut _download_mocks = Vec::new();
+    for file_type in &file_types {
+        let download_path = format!("/?download=data%2F2026%2Fdiscogs_20260101_{}.xml.gz", file_type);
+        let mock = server
+            .mock("GET", download_path.as_str())
+            .with_status(200)
+            .with_body(format!("fake {} data", file_type))
+            .create_async()
+            .await;
+        _download_mocks.push(mock);
+    }
+
+    downloader.download_discogs_data().await.unwrap();
+
+    let marker = downloader.take_state_marker().unwrap();
+    let all_files: Vec<String> = file_types.iter().map(|t| format!("discogs_20260101_{}.xml.gz", t)).collect();
+    assert!(!marker.pending_files(&all_files).contains(&artists), "identical bytes must not force a reparse of an already-processed file");
+    assert_eq!(marker.processing_phase.records_extracted, 500);
+}

--- a/extractor/src/tests/health_tests.rs
+++ b/extractor/src/tests/health_tests.rs
@@ -235,6 +235,7 @@ async fn test_metrics_json_format() {
     assert!(value.get("extraction_progress_artists").is_some());
     assert!(value.get("extraction_progress_labels").is_some());
     assert!(value.get("extraction_progress_masters").is_some());
+    assert!(value.get("extraction_progress_release_groups").is_some());
     assert!(value.get("extraction_progress_releases").is_some());
     assert!(value.get("extraction_progress_total").is_some());
     assert!(value.get("completed_files").is_some());
@@ -321,4 +322,48 @@ async fn test_health_extraction_status_completed() {
     let trigger = Arc::new(Mutex::new(None::<bool>));
     let (_, json) = health_handler(State((state, trigger))).await;
     assert_eq!(json.0["extraction_status"], "completed");
+}
+
+#[tokio::test]
+async fn test_metrics_parts_sum_to_published_total() {
+    // On the extractor-musicbrainz instance release_groups is nonzero; the published
+    // per-type counters must sum to extraction_progress_total, and release-group
+    // throughput must be observable at all.
+    let state = Arc::new(RwLock::new(ExtractorState::default()));
+    {
+        let mut s = state.write().await;
+        s.extraction_progress.artists = 1000;
+        s.extraction_progress.labels = 500;
+        s.extraction_progress.release_groups = 700;
+        s.extraction_progress.releases = 2000;
+    }
+
+    let trigger = Arc::new(Mutex::new(None::<bool>));
+    let (status, json) = metrics_handler(State((state, trigger))).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let value = json.0;
+    assert_eq!(value["extraction_progress_release_groups"], 700);
+    assert_eq!(value["extraction_progress_total"], 4200);
+
+    let parts: u64 = ["artists", "labels", "masters", "release_groups", "releases"]
+        .iter()
+        .map(|t| value[format!("extraction_progress_{t}")].as_u64().unwrap_or_else(|| panic!("missing extraction_progress_{t}")))
+        .sum();
+    assert_eq!(parts, value["extraction_progress_total"].as_u64().unwrap(), "per-type metrics must sum to the published total");
+}
+
+#[tokio::test]
+async fn test_metrics_and_health_report_same_types() {
+    // /metrics and /health must not disagree about which data types exist.
+    let state = Arc::new(RwLock::new(ExtractorState::default()));
+    let trigger = Arc::new(Mutex::new(None::<bool>));
+    let (_, health_json) = health_handler(State((state.clone(), trigger.clone()))).await;
+    let (_, metrics_json) = metrics_handler(State((state, trigger))).await;
+
+    let health_progress = health_json.0["extraction_progress"].clone();
+    for data_type in ["artists", "labels", "masters", "release_groups", "releases", "total"] {
+        assert!(health_progress.get(data_type).is_some(), "/health is missing {data_type}");
+        assert!(metrics_json.0.get(format!("extraction_progress_{data_type}")).is_some(), "/metrics is missing {data_type}");
+    }
 }

--- a/extractor/src/tests/musicbrainz_downloader_tests.rs
+++ b/extractor/src/tests/musicbrainz_downloader_tests.rs
@@ -1283,3 +1283,60 @@ async fn test_download_latest_resumes_per_entity() {
     assert_eq!(std::fs::read(version_dir.join("release-group.jsonl.xz")).unwrap(), b"previous-run-release-group");
     assert!(version_dir.join("release.jsonl.xz").exists(), "the missing entity must still be downloaded");
 }
+
+#[test]
+fn test_sync_parent_dir_on_existing_file() {
+    // The durability helper must succeed quietly for a normal file in a real directory.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("artist.jsonl.xz");
+    std::fs::write(&file, b"payload").unwrap();
+
+    sync_parent_dir(&file);
+
+    assert_eq!(std::fs::read(&file).unwrap(), b"payload");
+}
+
+#[test]
+fn test_sync_parent_dir_missing_parent_is_best_effort() {
+    // A missing/unopenable parent must warn rather than panic — a durability nicety must
+    // never fail an otherwise complete, checksum-verified download.
+    sync_parent_dir(Path::new("/nonexistent/path/to/mb/dumps/artist.jsonl.xz"));
+    sync_parent_dir(Path::new("artist.jsonl.xz"));
+}
+
+#[test]
+fn test_extract_entity_from_tarball_output_is_durable() {
+    // discogsography-ug9f regression: the output must be fsynced before it is renamed into
+    // place, so a power loss cannot leave a truncated file at the final path that
+    // is_version_complete then trusts forever. The observable surface is that the published
+    // file is complete and decompresses fully.
+    let dir = TempDir::new().unwrap();
+    let tar_path = dir.path().join("artist.tar.xz");
+    let out_path = dir.path().join("artist.jsonl.xz");
+
+    let payload: String = (0..500).map(|i| format!("{{\"id\":\"artist-{i}\"}}\n")).collect();
+    let mut tar_data = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_data);
+        let bytes = payload.as_bytes();
+        let mut header = tar::Header::new_gnu();
+        header.set_path("artist/mbdump/artist").unwrap();
+        header.set_size(bytes.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append(&header, bytes).unwrap();
+        builder.finish().unwrap();
+    }
+    let mut encoder = xz2::write::XzEncoder::new(Vec::new(), 1);
+    encoder.write_all(&tar_data).unwrap();
+    std::fs::write(&tar_path, encoder.finish().unwrap()).unwrap();
+
+    extract_entity_from_tarball(&tar_path, "artist", &out_path).unwrap();
+
+    assert!(out_path.exists());
+    assert!(!tmp_download_path(&out_path).exists(), "the .tmp staging file must be gone after the rename");
+
+    let mut round_tripped = String::new();
+    xz2::read::XzDecoder::new(std::fs::File::open(&out_path).unwrap()).read_to_string(&mut round_tripped).unwrap();
+    assert_eq!(round_tripped, payload, "the published file must contain the complete XZ stream");
+}

--- a/extractor/src/tests/musicbrainz_downloader_tests.rs
+++ b/extractor/src/tests/musicbrainz_downloader_tests.rs
@@ -1151,3 +1151,58 @@ fn test_extract_entity_from_tarball_success_leaves_no_tmp() {
     decoder.read_to_string(&mut decompressed).unwrap();
     assert_eq!(decompressed, original_content);
 }
+
+/// Make `dir` traversable but not listable and return false when the process can still
+/// list it anyway (i.e. running as root), so the caller can skip the assertion.
+#[cfg(unix)]
+fn make_unlistable(dir: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o111)).unwrap();
+    std::fs::read_dir(dir).is_err()
+}
+
+#[cfg(unix)]
+fn restore_listable(dir: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o755));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_discover_unlistable_dir_errors() {
+    // A real I/O failure (EACCES/EIO/EMFILE) must NOT be flattened into Ok(empty):
+    // process_musicbrainz_data reads an empty map as a benign run and reports
+    // Completed/success, wedging the service in a silent no-op loop for the whole
+    // periodic-check window.
+    let dir = TempDir::new().unwrap();
+    if !make_unlistable(dir.path()) {
+        return; // running as root — the permission bit is not enforced
+    }
+
+    let result = discover_mb_dump_files(dir.path());
+    restore_listable(dir.path());
+
+    let err = result.expect_err("an unreadable dump directory must surface as an error, not Ok(empty)");
+    assert!(format!("{err:#}").contains("Failed to read MusicBrainz dump directory"), "unexpected error: {err:#}");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_discover_unlistable_dir_probes_exact_names() {
+    // Traversable-but-not-listable (x without r) still supports exact-name probing, so
+    // discovery must fall through to it instead of bailing out of the whole function.
+    let dir = TempDir::new().unwrap();
+    std::fs::write(dir.path().join("artist.jsonl.xz"), b"fake").unwrap();
+    std::fs::write(dir.path().join("label.jsonl.xz"), b"fake").unwrap();
+    if !make_unlistable(dir.path()) {
+        return; // running as root — the permission bit is not enforced
+    }
+
+    let result = discover_mb_dump_files(dir.path());
+    restore_listable(dir.path());
+
+    let found = result.expect("exact-name probing needs no directory listing and must still succeed");
+    assert_eq!(found.len(), 2);
+    assert!(found.contains_key(&DataType::Artists));
+    assert!(found.contains_key(&DataType::Labels));
+}

--- a/extractor/src/tests/musicbrainz_downloader_tests.rs
+++ b/extractor/src/tests/musicbrainz_downloader_tests.rs
@@ -1206,3 +1206,80 @@ fn test_discover_unlistable_dir_probes_exact_names() {
     assert!(found.contains_key(&DataType::Artists));
     assert!(found.contains_key(&DataType::Labels));
 }
+
+/// Build a tiny `{entity}.tar.xz` body containing one JSONL record.
+fn build_entity_tarball(entity: &str) -> Vec<u8> {
+    let content = format!("{{\"id\":\"test-{}\"}}\n", entity);
+    let mut tar_data = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_data);
+        let bytes = content.as_bytes();
+        let mut header = tar::Header::new_gnu();
+        header.set_path(format!("{}/mbdump/{}", entity, entity)).unwrap();
+        header.set_size(bytes.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append(&header, bytes).unwrap();
+        builder.finish().unwrap();
+    }
+    let mut encoder = xz2::write::XzEncoder::new(Vec::new(), 1);
+    encoder.write_all(&tar_data).unwrap();
+    encoder.finish().unwrap()
+}
+
+#[tokio::test]
+async fn test_download_latest_resumes_per_entity() {
+    // discogsography-ov20 regression: a run that died partway through the entity loop must
+    // not re-download and re-extract the entities it already materialized. Only `release`
+    // is missing here, so only `release.tar.xz` may be fetched.
+    let dir = TempDir::new().unwrap();
+
+    let mut server = mockito::Server::new_async().await;
+    let base_url = format!("{}/", server.url());
+
+    let index_html = r#"<html><body>
+        <a href="20260325-001001/">20260325-001001/</a>
+    </body></html>"#;
+    let _index_mock = server.mock("GET", "/").with_status(200).with_body(index_html).create_async().await;
+
+    // Three entities already on disk from the previous run — one bare `.jsonl`, to prove the
+    // skip honors both variants that is_version_complete accepts.
+    let version_dir = dir.path().join("20260325-001001");
+    std::fs::create_dir(&version_dir).unwrap();
+    std::fs::write(version_dir.join("artist.jsonl.xz"), b"previous-run-artist").unwrap();
+    std::fs::write(version_dir.join("label.jsonl"), b"previous-run-label").unwrap();
+    std::fs::write(version_dir.join("release-group.jsonl.xz"), b"previous-run-release-group").unwrap();
+
+    let release_body = build_entity_tarball("release");
+    // SHA256SUMS deliberately carries ONLY the missing entity's line: an already-materialized
+    // entity must not fail the run on an absent checksum line either.
+    let sha256_lines = format!("{} *release.tar.xz\n", hex::encode(sha2::Sha256::digest(&release_body)));
+    let _sha_mock = server.mock("GET", "/20260325-001001/SHA256SUMS").with_status(200).with_body(&sha256_lines).create_async().await;
+
+    let release_mock = server
+        .mock("GET", "/20260325-001001/release.tar.xz")
+        .with_status(200)
+        .with_body(release_body)
+        .expect(1)
+        .create_async()
+        .await;
+    let artist_mock = server.mock("GET", "/20260325-001001/artist.tar.xz").with_status(200).expect(0).create_async().await;
+    let label_mock = server.mock("GET", "/20260325-001001/label.tar.xz").with_status(200).expect(0).create_async().await;
+    let rg_mock = server.mock("GET", "/20260325-001001/release-group.tar.xz").with_status(200).expect(0).create_async().await;
+
+    let downloader = MbDownloader::new(dir.path().to_path_buf(), base_url);
+    let result = downloader.download_latest().await.unwrap();
+
+    assert!(matches!(result, MbDownloadResult::Downloaded(v) if v == "20260325-001001"));
+
+    release_mock.assert_async().await;
+    artist_mock.assert_async().await;
+    label_mock.assert_async().await;
+    rg_mock.assert_async().await;
+
+    // Already-present outputs must be left byte-for-byte alone.
+    assert_eq!(std::fs::read(version_dir.join("artist.jsonl.xz")).unwrap(), b"previous-run-artist");
+    assert_eq!(std::fs::read(version_dir.join("label.jsonl")).unwrap(), b"previous-run-label");
+    assert_eq!(std::fs::read(version_dir.join("release-group.jsonl.xz")).unwrap(), b"previous-run-release-group");
+    assert!(version_dir.join("release.jsonl.xz").exists(), "the missing entity must still be downloaded");
+}

--- a/extractor/src/tests/parser_tests.rs
+++ b/extractor/src/tests/parser_tests.rs
@@ -880,3 +880,63 @@ async fn test_reconstruct_xml_id_without_at_id_is_kept() {
     assert!(raw.contains("<id>"), "reconstructed XML should retain <id> child when no @id attribute");
     assert!(raw.contains("77"), "reconstructed XML should contain the id value");
 }
+
+/// Compress raw (possibly non-UTF-8) XML bytes into a temp gzip file.
+fn gzip_bytes_to_temp(raw: &[u8]) -> NamedTempFile {
+    let mut temp_file = NamedTempFile::new().unwrap();
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(raw).unwrap();
+    let compressed = encoder.finish().unwrap();
+    temp_file.write_all(&compressed).unwrap();
+    temp_file.flush().unwrap();
+    temp_file
+}
+
+#[tokio::test]
+async fn test_invalid_utf8_text_kept_lossily() {
+    // A stray latin-1 byte (0xE9) inside a text node makes `e.decode()` fail.
+    // The chunk must degrade to a lossy decode, NOT vanish from the record — a silent
+    // drop would publish an empty field and lock the corrupted shape in via sha256.
+    let mut raw: Vec<u8> = Vec::new();
+    raw.extend_from_slice(b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<artists>\n<artist id=\"1\">\n<name>Beyonc");
+    raw.push(0xE9);
+    raw.extend_from_slice(b"</name>\n<profile>Intact profile</profile>\n</artist>\n</artists>");
+
+    let temp_file = gzip_bytes_to_temp(&raw);
+    let (sender, mut receiver) = mpsc::channel(10);
+    let parser = XmlParser::new(DataType::Artists, sender);
+    let count = parser.parse_file(temp_file.path()).await.unwrap();
+
+    assert_eq!(count, 1);
+    let message = receiver.recv().await.unwrap();
+    let name = message.data["name"].as_str().expect("name must be present");
+    assert!(!name.is_empty(), "undecodable text must not be dropped: {message:?}");
+    assert!(name.starts_with("Beyonc"), "decodable prefix must survive, got {name:?}");
+    assert!(name.contains('\u{FFFD}'), "the bad byte must surface as U+FFFD, got {name:?}");
+    assert_eq!(message.data["profile"], json!("Intact profile"));
+}
+
+#[tokio::test]
+async fn test_invalid_utf8_in_multiple_fields_all_preserved() {
+    // Simulates a whole dump that is not actually UTF-8: every affected chunk must be
+    // recovered lossily rather than the record being published with empty fields.
+    let mut raw: Vec<u8> = Vec::new();
+    raw.extend_from_slice(b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<artists>\n<artist id=\"7\">\n<name>Caf");
+    raw.push(0xE9);
+    raw.extend_from_slice(b"</name>\n<profile>Se");
+    raw.push(0xF1);
+    raw.extend_from_slice(b"or</profile>\n</artist>\n</artists>");
+
+    let temp_file = gzip_bytes_to_temp(&raw);
+    let (sender, mut receiver) = mpsc::channel(10);
+    let parser = XmlParser::new(DataType::Artists, sender);
+    let count = parser.parse_file(temp_file.path()).await.unwrap();
+
+    assert_eq!(count, 1);
+    let message = receiver.recv().await.unwrap();
+    for field in ["name", "profile"] {
+        let value = message.data[field].as_str().unwrap_or_default();
+        assert!(!value.is_empty(), "{field} must not be dropped: {message:?}");
+        assert!(value.contains('\u{FFFD}'), "{field} should carry U+FFFD, got {value:?}");
+    }
+}

--- a/extractor/src/tests/state_marker_tests.rs
+++ b/extractor/src/tests/state_marker_tests.rs
@@ -500,3 +500,141 @@ fn test_interrupted_download_no_progress() {
     assert_eq!(marker.completed_file_count(), 0);
     assert_eq!(marker.should_process(), ProcessingDecision::Reprocess);
 }
+
+/// Drive one file through download → process, recording the checksum it was derived from.
+fn marker_with_processed_file(filename: &str, checksum: &str, records: u64) -> StateMarker {
+    let mut marker = StateMarker::new("20260101".to_string());
+    marker.start_download(1);
+    marker.start_file_download(filename);
+    marker.file_downloaded(filename, 1024);
+    marker.file_bytes_verified(filename, checksum);
+    marker.complete_download();
+
+    marker.start_processing(1);
+    marker.start_file_processing(filename);
+    marker.complete_file_processing(filename, records);
+    marker
+}
+
+#[test]
+fn test_redownloaded_bytes_requeue_that_file() {
+    // discogsography-qhel regression: when a file is re-downloaded because its previously
+    // trusted bytes were wrong, the Completed processing status computed from those bad
+    // bytes must not survive — otherwise pending_files() skips the corrected file, the run
+    // finalizes Completed, and the corrected data is never parsed or published.
+    let file = "discogs_20260101_artists.xml.gz";
+    let mut marker = marker_with_processed_file(file, "checksum-of-corrupt-bytes", 500);
+
+    let all_files = vec![file.to_string(), "discogs_20260101_labels.xml.gz".to_string()];
+    assert!(!marker.pending_files(&all_files).contains(&file.to_string()), "precondition: the file starts out completed");
+
+    let invalidated = marker.file_bytes_verified(file, "checksum-of-corrected-bytes");
+
+    assert!(invalidated, "different bytes must invalidate the processing status");
+    assert!(marker.pending_files(&all_files).contains(&file.to_string()), "the re-downloaded file must be re-queued for processing");
+    assert_eq!(marker.processing_phase.files_processed, 0, "the stale completion must not still be counted");
+    assert_eq!(marker.processing_phase.records_extracted, 0, "stale record counts must not be reported as authoritative");
+    assert_eq!(marker.summary.files_by_type.get("artists"), Some(&PhaseStatus::Pending));
+}
+
+#[test]
+fn test_identical_redownload_keeps_completion() {
+    // The narrow counterpart: an operator deleting a processed .xml.gz to reclaim disk gets
+    // the same bytes back, which must NOT force a needless multi-GB reparse.
+    let file = "discogs_20260101_artists.xml.gz";
+    let mut marker = marker_with_processed_file(file, "same-checksum", 500);
+
+    let invalidated = marker.file_bytes_verified(file, "same-checksum");
+
+    assert!(!invalidated, "identical bytes must not invalidate a completed file");
+    assert!(!marker.pending_files(&[file.to_string()]).contains(&file.to_string()));
+    assert_eq!(marker.processing_phase.files_processed, 1);
+    assert_eq!(marker.processing_phase.records_extracted, 500);
+}
+
+#[test]
+fn test_unknown_provenance_keeps_completed() {
+    // A marker written before source_checksum existed has unknown provenance; leave it alone
+    // rather than speculatively re-processing every file on the next run.
+    let file = "discogs_20260101_artists.xml.gz";
+    let mut marker = StateMarker::new("20260101".to_string());
+    marker.start_processing(1);
+    marker.start_file_processing(file);
+    marker.complete_file_processing(file, 500);
+    assert!(marker.processing_phase.progress_by_file[file].source_checksum.is_none());
+
+    let invalidated = marker.file_bytes_verified(file, "some-new-checksum");
+
+    assert!(!invalidated, "unknown provenance must not trigger invalidation");
+    assert!(!marker.pending_files(&[file.to_string()]).contains(&file.to_string()));
+}
+
+#[test]
+fn test_invalidation_reopens_completed_version() {
+    // A version already finalized as Completed would otherwise take the Skip path forever,
+    // so re-queuing a file has to reopen the summary too.
+    let file = "discogs_20260101_artists.xml.gz";
+    let mut marker = marker_with_processed_file(file, "old-bytes", 500);
+    marker.complete_processing();
+    marker.complete_extraction();
+    assert_eq!(marker.should_process(), ProcessingDecision::Skip);
+
+    assert!(marker.file_bytes_verified(file, "new-bytes"));
+
+    assert_ne!(marker.summary.overall_status, PhaseStatus::Completed);
+    assert_eq!(marker.should_process(), ProcessingDecision::Continue, "the version must be re-entered, not skipped");
+    assert!(marker.pending_files(&[file.to_string()]).contains(&file.to_string()));
+}
+
+#[test]
+fn test_checksum_fields_survive_serde_round_trip() {
+    let file = "discogs_20260101_artists.xml.gz";
+    let marker = marker_with_processed_file(file, "checksum-abc", 500);
+
+    let json = serde_json::to_string(&marker).unwrap();
+    let loaded: StateMarker = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(loaded.download_phase.downloads_by_file[file].checksum.as_deref(), Some("checksum-abc"));
+    assert_eq!(loaded.processing_phase.progress_by_file[file].source_checksum.as_deref(), Some("checksum-abc"));
+}
+
+#[test]
+fn test_legacy_marker_json_without_checksums_loads() {
+    // Markers on disk predate both new fields; #[serde(default)] must keep them loadable.
+    let json = r#"{
+        "metadata_version": "1.0",
+        "last_updated": "2026-01-31T12:34:56.789Z",
+        "current_version": "20260101",
+        "download_phase": {
+            "status": "completed", "started_at": null, "completed_at": null,
+            "files_downloaded": 1, "files_total": 1, "bytes_downloaded": 10,
+            "downloads_by_file": {
+                "discogs_20260101_artists.xml.gz": {
+                    "status": "completed", "bytes_downloaded": 10, "started_at": null, "completed_at": null
+                }
+            },
+            "errors": []
+        },
+        "processing_phase": {
+            "status": "completed", "started_at": null, "completed_at": null,
+            "files_processed": 1, "files_total": 1, "records_extracted": 5, "current_file": null,
+            "progress_by_file": {
+                "discogs_20260101_artists.xml.gz": {
+                    "status": "completed", "records_extracted": 5, "messages_published": 5,
+                    "batches_sent": 1, "started_at": null, "completed_at": null
+                }
+            },
+            "errors": []
+        },
+        "publishing_phase": {
+            "status": "completed", "messages_published": 5, "batches_sent": 1,
+            "errors": [], "last_amqp_heartbeat": null
+        },
+        "summary": {"overall_status": "completed", "total_duration_seconds": null, "files_by_type": {}}
+    }"#;
+
+    let marker: StateMarker = serde_json::from_str(json).unwrap();
+
+    assert!(marker.download_phase.downloads_by_file["discogs_20260101_artists.xml.gz"].checksum.is_none());
+    assert!(marker.processing_phase.progress_by_file["discogs_20260101_artists.xml.gz"].source_checksum.is_none());
+}

--- a/extractor/tests/extractor_di_test.rs
+++ b/extractor/tests/extractor_di_test.rs
@@ -144,6 +144,63 @@ async fn test_process_single_file_close_failure_does_not_fail_the_run() {
 }
 
 #[tokio::test]
+async fn test_single_file_amqp_failure_clears_active_connection() {
+    // discogsography-b09b regression: every error exit of process_single_file must drop
+    // the active_connections entry and gracefully close the per-file AMQP connection.
+    // Previously both sat on the success tail only, so a failed file left a phantom
+    // connection in /metrics until the next run's state reset — periodic_check_days away.
+    let temp_dir = TempDir::new().unwrap();
+    let file_name = "discogs_20260101_artists.xml.gz";
+    write_empty_artists_gz(&temp_dir.path().join(file_name));
+
+    let config = Arc::new(test_config(temp_dir.path()));
+    let state = Arc::new(RwLock::new(ExtractorState::default()));
+    let state_marker = Arc::new(Mutex::new(StateMarker::new("20260101".to_string())));
+    let marker_path = temp_dir.path().join("marker.json");
+
+    let mut mock_mq = MockMessagePublisher::new();
+    mock_mq.expect_setup_exchange().returning(|_| Ok(()));
+    mock_mq.expect_publish_batch().returning(|_, _| Ok(()));
+    mock_mq.expect_send_file_complete().times(1).returning(|_, _, _| Err(anyhow::anyhow!("AMQP connection dropped")));
+    // close() must still be called exactly once on the failure path.
+    mock_mq.expect_close().times(1).returning(|| Ok(()));
+
+    let mq: Arc<dyn extractor::message_queue::MessagePublisher> = Arc::new(mock_mq);
+
+    let result = process_single_file(file_name, config, state.clone(), state_marker, marker_path, mq, None).await;
+    assert!(result.is_err(), "a send_file_complete failure must propagate as an error");
+
+    let s = state.read().await;
+    assert!(s.active_connections.is_empty(), "failed file must not leave a phantom active connection: {:?}", s.active_connections);
+    assert!(!s.completed_files.contains(file_name), "a failed file must not be recorded as completed");
+}
+
+#[tokio::test]
+async fn test_single_file_parse_failure_clears_active_connection() {
+    // Same contract for a failure raised inside the pipeline itself (missing dump file)
+    // rather than at the AMQP handoff.
+    let temp_dir = TempDir::new().unwrap();
+    let config = Arc::new(test_config(temp_dir.path()));
+    let state = Arc::new(RwLock::new(ExtractorState::default()));
+    let state_marker = Arc::new(Mutex::new(StateMarker::new("20260101".to_string())));
+    let marker_path = temp_dir.path().join("marker.json");
+
+    let mut mock_mq = MockMessagePublisher::new();
+    mock_mq.expect_setup_exchange().returning(|_| Ok(()));
+    mock_mq.expect_publish_batch().returning(|_, _| Ok(()));
+    mock_mq.expect_send_file_complete().times(0).returning(|_, _, _| Ok(()));
+    mock_mq.expect_close().times(1).returning(|| Ok(()));
+
+    let mq: Arc<dyn extractor::message_queue::MessagePublisher> = Arc::new(mock_mq);
+
+    let result = process_single_file("discogs_20260101_artists.xml.gz", config, state.clone(), state_marker, marker_path, mq, None).await;
+    assert!(result.is_err(), "a missing dump file must fail the pipeline");
+
+    let s = state.read().await;
+    assert!(s.active_connections.is_empty(), "failed file must not leave a phantom active connection: {:?}", s.active_connections);
+}
+
+#[tokio::test]
 async fn test_message_publisher_increments_error_count_on_failure() {
     let state = Arc::new(RwLock::new(ExtractorState::default()));
 


### PR DESCRIPTION
Fixes 8 priority-3 Rust extractor findings from the 2026-08-10 bug hunt (run `wf_646d4b21`), one commit per bead.

- **discogsography-7ehd** — non-UTF-8 XML text is preserved lossily instead of silently dropped (no more silent data corruption).
- **discogsography-8qtz** — `/metrics` reports the release_groups progress counter (parity with extraction_progress).
- **discogsography-b09b** — every `process_single_file` exit path releases its active_connections entry and closes the message queue.
- **discogsography-h0ib** — a `read_dir` I/O error in MusicBrainz dump discovery is surfaced instead of becoming Ok(empty).
- **discogsography-ov20** — MusicBrainz downloads resume per entity; a crash after N of 4 entities no longer forces full re-download.
- **discogsography-qhel** — a file whose bytes were re-downloaded to replace corruption is re-queued for processing instead of being resume-skipped.
- **discogsography-ug9f** — entity output and its parent directory are fsynced before the atomic rename, so resume can trust what it finds after power loss.
- **discogsography-xgyb** — year-page body read failures during Discogs scraping are logged instead of silently swallowed (newest dumps no longer silently missed).

Validation: cargo fmt/clippy (-D warnings)/test green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrLwHwMcu3cuQJh8cc1SyW