### PR TITLE
fix: messaging & pipeline correctness — 14 bug-hunt findings (batch:p3-messaging-pipeline)

### DIFF
--- a/api/routers/admin.py
+++ b/api/routers/admin.py
@@ -335,6 +335,39 @@ async def admin_health_history(
 
 _MAX_TRACKING_ITERATIONS = 8640  # 10s * 8640 = 24 hours max tracking time
 
+# How many 10s polls a triggered run gets to actually leave the parked "waiting" state
+# before the tracker gives up on it. The extractor picks the trigger flag up within
+# 500ms and sets Running as the first statement of process_*_data, so 5 minutes is
+# enormously generous; it exists only so a slow container start is not called a failure.
+_MAX_STARTUP_POLLS = 30
+
+
+def _run_has_started(health: dict[str, Any], tracked_seconds: float) -> bool:
+    """Decide, from a health payload alone, whether THIS run actually began.
+
+    A short run (e.g. a trigger on an already-processed version) can pass through
+    running → completed → waiting entirely between two 10s polls, so "never observed
+    running" is not by itself proof that nothing happened. Two signatures distinguish
+    it from a parked extractor whose trigger was consumed but never took effect:
+
+    * ``process_*_data`` clears ``extraction_progress`` and ``last_extraction_time`` as
+      its first act, so all-zero counters mean the run started (and had nothing to do).
+      A parked extractor still carries the PREVIOUS run's counts — which is what made
+      the phantom success so convincing.
+    * Any per-type activity timestamp newer than the tracking window belongs to this
+      run.
+    """
+    progress = health.get("extraction_progress") or {}
+    total = progress.get("total")
+    if total is None:
+        total = sum(v for v in progress.values() if isinstance(v, int | float))
+    if not total:
+        return True
+
+    last_times = [v for v in (health.get("last_extraction_time") or {}).values() if isinstance(v, int | float)]
+    # +30s of slack for the tracker's own scheduling jitter.
+    return any(elapsed <= tracked_seconds + 30 for elapsed in last_times)
+
 
 async def _track_extraction(extraction_id: str) -> None:
     """Background task: poll extractor /health and update extraction record."""
@@ -345,6 +378,15 @@ async def _track_extraction(extraction_id: str) -> None:
     consecutive_failures = 0
     max_failures = 5
     iterations = 0
+    # "waiting" is overloaded: it means both "finished, back on the periodic schedule"
+    # AND "parked, the trigger has not taken effect yet". Accepting it as terminal on
+    # the first poll recorded a run that never started as a success — and since
+    # extraction_progress is only reset INSIDE process_*_data, the phantom run was
+    # stamped with the PREVIOUS run's record counts, so nothing looked wrong. Only
+    # honor a terminal "waiting"/"completed" after the run was observed running
+    # (discogsography-exnk).
+    has_seen_running = False
+    startup_polls = 0
 
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
@@ -371,6 +413,32 @@ async def _track_extraction(extraction_id: str) -> None:
                                 "UPDATE extraction_history SET record_counts = %s WHERE id = %s",
                                 (json.dumps(record_counts), extraction_id),
                             )
+
+                        if extraction_status == "running":
+                            has_seen_running = True
+
+                        # A terminal-looking status that was never preceded by "running"
+                        # is ambiguous, because "waiting" means BOTH "finished, back on
+                        # the periodic schedule" and "parked, the trigger has not taken
+                        # effect". _run_has_started disambiguates from the health payload;
+                        # when it cannot, keep polling for a bounded grace period rather
+                        # than recording a run that never started as a success.
+                        if not has_seen_running and extraction_status != "failed" and not _run_has_started(data, iterations * 10):
+                            startup_polls += 1
+                            if startup_polls > _MAX_STARTUP_POLLS:
+                                async with _pool.connection() as conn, conn.cursor(row_factory=dict_row) as cur:
+                                    await cur.execute(
+                                        "UPDATE extraction_history SET status = 'failed', completed_at = NOW(), error_message = %s WHERE id = %s",
+                                        ("Extraction never started (extractor never left the parked state)", extraction_id),
+                                    )
+                                logger.error(
+                                    "❌ Extraction never started",
+                                    extraction_id=extraction_id,
+                                    last_status=extraction_status,
+                                    polls=startup_polls,
+                                )
+                                return
+                            continue
 
                         # "completed" is the transient state set inside process_*_data at
                         # the end of a successful run. The surrounding run_*_loop immediately

--- a/brainzgraphinator/brainzgraphinator.py
+++ b/brainzgraphinator/brainzgraphinator.py
@@ -312,6 +312,20 @@ async def check_file_completion(
             data_type=data_type,
             version=data.get("version"),
         )
+
+        # extraction_complete is this type's terminal signal, so it must also
+        # (re-)mark the type complete. completed_files is otherwise written only by
+        # file_complete and ERASED by _recover_consumers for any type whose queue
+        # still holds messages — and when the only pending message IS this signal,
+        # nothing ever restored the flag: the stall check then logged at ERROR
+        # every 30s forever and check_all_consumers_idle() could never return True,
+        # so the connection and idle consumers were held open until restart. A
+        # plain restart between the file_complete ack and this delivery reaches the
+        # same terminal state (discogsography-ewvh).
+        completed_files.add(data_type)
+        if CONSUMER_CANCEL_DELAY > 0 and data_type in queues:
+            await schedule_consumer_cancellation(data_type, queues[data_type])
+
         await message.ack()
         return True
 

--- a/brainztableinator/brainztableinator.py
+++ b/brainztableinator/brainztableinator.py
@@ -515,6 +515,28 @@ async def _recover_consumers() -> None:
 _ENTITY_TYPE_ALIASES = {"release_group": "release-group"}
 
 
+def _get_or(record: dict[str, Any], key: str, default: Any) -> Any:
+    """``dict.get`` that treats a present-but-null value as absent.
+
+    The extractor's ``json!`` macro always emits every key it knows about — a source
+    field the MusicBrainz dump omits arrives as an explicit JSON ``null``, not as a
+    missing key. ``dict.get(key, default)`` therefore returns ``None`` and the default
+    is dead code, so ``ended`` landed as SQL NULL (a column DEFAULT does not apply to an
+    explicitly supplied NULL, and ``WHERE NOT ended`` silently drops those rows) and
+    ``attributes`` landed as the jsonb scalar ``null`` (on which ``jsonb_array_length``
+    errors outright). ON CONFLICT DO UPDATE then overwrote previously-correct values
+    with those nulls on reprocessing (discogsography-iud5).
+    """
+    value = record.get(key)
+    return default if value is None else value
+
+
+def _life_span(record: dict[str, Any]) -> dict[str, Any]:
+    """Return the record's ``life_span`` object, tolerating a null/absent one."""
+    life_span = record.get("life_span")
+    return life_span if isinstance(life_span, dict) else {}
+
+
 def _canonical_entity_type(entity_type: str) -> str:
     """Map a MusicBrainz entity-type spelling onto the project's canonical vocabulary."""
     return _ENTITY_TYPE_ALIASES.get(entity_type, entity_type)
@@ -563,10 +585,10 @@ async def _insert_relationships(
                 row_target_mbid,
                 row_target_type,
                 rel.get("type", ""),
-                Jsonb(rel.get("attributes", [])),
+                Jsonb(_get_or(rel, "attributes", [])),
                 rel.get("begin_date"),
                 rel.get("end_date"),
-                rel.get("ended", False),
+                _get_or(rel, "ended", False),
             )
         )
     if not params:
@@ -647,18 +669,16 @@ async def process_artist(conn: Any, record: dict[str, Any]) -> None:
                 record.get("sort_name", ""),
                 record.get("mb_type", ""),
                 record.get("gender", ""),
-                record.get("begin_date", (record.get("life_span") or {}).get("begin")),
-                record.get("end_date", (record.get("life_span") or {}).get("end")),
-                record.get(
-                    "ended", (record.get("life_span") or {}).get("ended", False)
-                ),
+                _get_or(record, "begin_date", _life_span(record).get("begin")),
+                _get_or(record, "end_date", _life_span(record).get("end")),
+                _get_or(record, "ended", _get_or(_life_span(record), "ended", False)),
                 record.get("area", ""),
                 record.get("begin_area", ""),
                 record.get("end_area", ""),
                 record.get("disambiguation", ""),
                 record.get("discogs_artist_id"),
-                Jsonb(record.get("aliases", [])),
-                Jsonb(record.get("tags", [])),
+                Jsonb(_get_or(record, "aliases", [])),
+                Jsonb(_get_or(record, "tags", [])),
                 Jsonb(record),
             ),
         )
@@ -690,11 +710,9 @@ async def process_label(conn: Any, record: dict[str, Any]) -> None:
                 record.get("name", ""),
                 record.get("mb_type", ""),
                 record.get("label_code"),
-                record.get("begin_date", (record.get("life_span") or {}).get("begin")),
-                record.get("end_date", (record.get("life_span") or {}).get("end")),
-                record.get(
-                    "ended", (record.get("life_span") or {}).get("ended", False)
-                ),
+                _get_or(record, "begin_date", _life_span(record).get("begin")),
+                _get_or(record, "end_date", _life_span(record).get("end")),
+                _get_or(record, "ended", _get_or(_life_span(record), "ended", False)),
                 record.get("area", ""),
                 record.get("disambiguation", ""),
                 record.get("discogs_label_id"),
@@ -759,7 +777,7 @@ async def process_release_group(conn: Any, record: dict[str, Any]) -> None:
                 mbid,
                 record.get("name", ""),
                 record.get("mb_type", ""),
-                Jsonb(record.get("secondary_types", [])),
+                Jsonb(_get_or(record, "secondary_types", [])),
                 record.get("first_release_date"),
                 record.get("disambiguation", ""),
                 record.get("discogs_master_id"),

--- a/brainztableinator/brainztableinator.py
+++ b/brainztableinator/brainztableinator.py
@@ -855,6 +855,20 @@ async def on_data_message(message: AbstractIncomingMessage, data_type: str) -> N
                 data_type=data_type,
                 version=data.get("version"),
             )
+
+            # extraction_complete is this type's terminal signal, so it must also
+            # (re-)mark the type complete. completed_files is otherwise written only by
+            # file_complete and ERASED by _recover_consumers for any type whose queue
+            # still holds messages — and when the only pending message IS this signal,
+            # nothing ever restored the flag: the stall check then logged at ERROR
+            # every 30s forever and check_all_consumers_idle() could never return True,
+            # so the connection and idle consumers were held open until restart. A
+            # plain restart between the file_complete ack and this delivery reaches the
+            # same terminal state (discogsography-ewvh).
+            completed_files.add(data_type)
+            if CONSUMER_CANCEL_DELAY > 0 and data_type in queues:
+                await schedule_consumer_cancellation(data_type, queues[data_type])
+
             await message.ack()
             return
 

--- a/brainztableinator/brainztableinator.py
+++ b/brainztableinator/brainztableinator.py
@@ -502,6 +502,24 @@ async def _recover_consumers() -> None:
         consumer_tags.clear()
 
 
+# MusicBrainz's ws/2 JSON serializer spells multi-word entity types with an
+# underscore ("release_group") while this project — queue names, PROCESSORS keys,
+# and the hardcoded literals at every _insert_relationships call site — uses the
+# hyphenated form. The extractor now canonicalizes on the way out
+# (extractor/src/jsonl_parser.rs::canonical_entity_type), but messages published by
+# an older extractor may still be in flight or parked in a DLQ, so normalize
+# defensively at the write boundary too. Without this, the forward row written from
+# endpoint A and the swapped backward row written from endpoint B carry different
+# target_entity_type spellings, so the natural-key ON CONFLICT never fires and the
+# same logical relationship is stored twice under two vocabularies.
+_ENTITY_TYPE_ALIASES = {"release_group": "release-group"}
+
+
+def _canonical_entity_type(entity_type: str) -> str:
+    """Map a MusicBrainz entity-type spelling onto the project's canonical vocabulary."""
+    return _ENTITY_TYPE_ALIASES.get(entity_type, entity_type)
+
+
 async def _insert_relationships(
     conn: Any, source_mbid: str, source_type: str, rels: list[dict[str, Any]]
 ) -> None:
@@ -528,12 +546,15 @@ async def _insert_relationships(
         if not (rel.get("target_mbid") and rel.get("target_type") and rel.get("type")):
             continue
 
+        rel_target_type = _canonical_entity_type(rel["target_type"])
+        canonical_source_type = _canonical_entity_type(source_type)
+
         if rel.get("direction") == "backward":
-            row_source_mbid, row_source_type = rel["target_mbid"], rel["target_type"]
-            row_target_mbid, row_target_type = source_mbid, source_type
+            row_source_mbid, row_source_type = rel["target_mbid"], rel_target_type
+            row_target_mbid, row_target_type = source_mbid, canonical_source_type
         else:
-            row_source_mbid, row_source_type = source_mbid, source_type
-            row_target_mbid, row_target_type = rel["target_mbid"], rel["target_type"]
+            row_source_mbid, row_source_type = source_mbid, canonical_source_type
+            row_target_mbid, row_target_type = rel["target_mbid"], rel_target_type
 
         params.append(
             (

--- a/brainztableinator/brainztableinator.py
+++ b/brainztableinator/brainztableinator.py
@@ -26,7 +26,7 @@ from common import (
     setup_logging,
 )
 from orjson import loads
-from psycopg.errors import DataError, InterfaceError, OperationalError
+from psycopg.errors import DataError, IntegrityError, InterfaceError, OperationalError
 from psycopg.types.json import Jsonb
 
 logger = structlog.get_logger(__name__)
@@ -948,11 +948,16 @@ async def on_data_message(message: AbstractIncomingMessage, data_type: str) -> N
         # database maintenance window (discogsography-rb05).
         await outage_backoff.wait()
         await message.nack(requeue=True)
-    except DataError as e:
-        # Malformed data that deterministically fails a column cast (e.g. a
-        # non-UUID mbid that slipped past validation above). Retrying would
-        # fail identically every time, so nack without requeue instead of
-        # churning through the quorum queue's redelivery limit.
+    except (DataError, IntegrityError) as e:
+        # Malformed data that deterministically fails a column cast (DataError, e.g. a
+        # non-UUID mbid that slipped past validation above) or a constraint
+        # (IntegrityError, e.g. NotNullViolation when the dump line carried no
+        # name/title, which the extractor forwards as "name": null). Retrying would
+        # fail identically every time, so nack without requeue instead of churning
+        # through the quorum queue's redelivery limit — 20 futile redeliveries, each
+        # opening a pooled connection and rolling back a transaction, per bad record
+        # (discogsography-yuyg). None of the musicbrainz tables declare a foreign key,
+        # so no IntegrityError here is order-dependent/transient.
         logger.error(
             "❌ Non-retryable data error, nacking without requeue",
             data_type=data_type,

--- a/common/rabbitmq_resilient.py
+++ b/common/rabbitmq_resilient.py
@@ -224,15 +224,7 @@ class AsyncResilientRabbitMQ:
 
                 logger.info("✅ Robust RabbitMQ connection established")
 
-                # Notify reconnect callbacks
-                for callback in self._reconnect_callbacks:
-                    try:
-                        if asyncio.iscoroutinefunction(callback):
-                            await callback()
-                        else:
-                            callback()
-                    except Exception as e:
-                        logger.error(f"❌ Error in reconnect callback: {e}")
+                await self._notify_reconnect_callbacks("connect")
 
                 return self._connection
 
@@ -265,8 +257,31 @@ class AsyncResilientRabbitMQ:
             self._channel = await connection.channel()
             return self._channel
 
+    async def _notify_reconnect_callbacks(self, event: str) -> None:
+        """Invoke every registered callback, isolating failures.
+
+        Must be called with ``self._lock`` NOT held: a callback that re-establishes
+        state typically calls back into :meth:`channel`, which takes the same lock.
+        """
+        for callback in self._reconnect_callbacks:
+            try:
+                if asyncio.iscoroutinefunction(callback):
+                    await callback()
+                else:
+                    callback()
+            except Exception as e:
+                logger.error(f"❌ Error in reconnect callback ({event}): {e}")
+
     async def _on_reconnect(self, *_args: Any, **_kwargs: Any) -> None:
-        """Handle reconnection event."""
+        """Handle an aio-pika auto-reconnect: reset the channel, then notify callbacks.
+
+        RobustConnection reports ``is_closed == False`` across its own internal
+        reconnects, so :meth:`connect` early-returns and never re-runs its notify
+        block. This hook is the ONLY place a caller-visible reconnect is observable,
+        so it is where ``add_reconnect_callback`` subscribers have to be fired —
+        otherwise the API is a no-op exactly when re-registration is needed
+        (discogsography-6ino).
+        """
         logger.info("🔄 RabbitMQ connection re-established")
         if self._lock is None:
             self._lock = asyncio.Lock()
@@ -274,8 +289,17 @@ class AsyncResilientRabbitMQ:
             # Reset channel so it will be recreated
             self._channel = None
 
+        # Outside the lock: callbacks commonly call channel(), which acquires it.
+        await self._notify_reconnect_callbacks("reconnect")
+
     def add_reconnect_callback(self, callback: Callable) -> None:
-        """Add a callback to be called on reconnection."""
+        """Add a callback invoked on every connection establishment.
+
+        Fires both when :meth:`connect` establishes a connection and when aio-pika's
+        RobustConnection transparently re-establishes a dropped one. Callbacks must
+        therefore be idempotent. Exceptions are logged and swallowed so one bad
+        subscriber cannot break connection recovery for the others.
+        """
         self._reconnect_callbacks.append(callback)
 
     def remove_reconnect_callback(self, callback: Callable) -> None:

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -22,6 +22,8 @@ from pydantic import BaseModel
 import uvicorn
 
 from common import (
+    DISCOGS_EXCHANGE_PREFIX,
+    MUSICBRAINZ_EXCHANGE_PREFIX,
     AsyncResilientNeo4jDriver,
     AsyncResilientPostgreSQL,
     AsyncResilientRabbitMQ,
@@ -117,6 +119,12 @@ class SystemMetrics(BaseModel):
     timestamp: datetime
 
 
+# Queue prefixes are ALWAYS env-derived (common.config reads DISCOGS_EXCHANGE_PREFIX /
+# MUSICBRAINZ_EXCHANGE_PREFIX), exactly like the extractor and all four consumers.
+# Hardcoding the defaults here made the dashboard the only component that ignored a
+# prefix override: the management-API filter matched nothing, and get_queue_info logs
+# nothing on a zero-match 200, so both pipeline panes silently showed an empty,
+# healthy-looking pipeline while queues backed up (discogsography-dvmi).
 PIPELINE_CONFIGS: dict[str, dict] = {
     "discogs": {
         "services": [
@@ -124,7 +132,7 @@ PIPELINE_CONFIGS: dict[str, dict] = {
             ("graphinator", "http://graphinator:8001/health"),
             ("tableinator", "http://tableinator:8002/health"),
         ],
-        "queue_prefix": "discogsography-discogs",
+        "queue_prefix": DISCOGS_EXCHANGE_PREFIX,
         "entity_types": ["masters", "releases", "artists", "labels"],
     },
     "musicbrainz": {
@@ -133,7 +141,7 @@ PIPELINE_CONFIGS: dict[str, dict] = {
             ("brainzgraphinator", "http://brainzgraphinator:8011/health"),
             ("brainztableinator", "http://brainztableinator:8010/health"),
         ],
-        "queue_prefix": "discogsography-musicbrainz",
+        "queue_prefix": MUSICBRAINZ_EXCHANGE_PREFIX,
         "entity_types": ["release-groups", "releases", "artists", "labels"],
     },
 }
@@ -636,6 +644,19 @@ async def get_queues() -> JSONResponse:
         if queues:
             result[pipeline_name] = [q.model_dump(mode="json") for q in queues]
     return JSONResponse(content=result)
+
+
+@app.get("/api/queue-prefixes")
+async def get_queue_prefixes() -> JSONResponse:
+    """Expose the env-derived exchange/queue prefixes to the admin frontend.
+
+    admin.js builds DLQ names it POSTs to the API, which validates them against
+    _VALID_DLQ_NAMES (itself env-derived). Its compiled-in literals are only defaults;
+    under a DISCOGS_EXCHANGE_PREFIX / MUSICBRAINZ_EXCHANGE_PREFIX override every Purge
+    button would 404 without this (discogsography-dvmi).
+    """
+    API_REQUESTS.labels(endpoint="/api/queue-prefixes", method="GET").inc()
+    return JSONResponse(content={"discogs": DISCOGS_EXCHANGE_PREFIX, "musicbrainz": MUSICBRAINZ_EXCHANGE_PREFIX})
 
 
 @app.get("/api/databases")

--- a/dashboard/static/admin.js
+++ b/dashboard/static/admin.js
@@ -6,6 +6,11 @@
 // DISCOGS_EXCHANGE_PREFIX / MUSICBRAINZ_EXCHANGE_PREFIX / DATA_TYPES /
 // MUSICBRAINZ_DATA_TYPES defaults — a drift here reproduces the "every Purge
 // button 404s" bug (discogsography-cu2.35).
+// DEFAULTS ONLY. The live values are fetched from /api/queue-prefixes (which serves
+// the dashboard's env-derived DISCOGS_EXCHANGE_PREFIX / MUSICBRAINZ_EXCHANGE_PREFIX)
+// before the DLQ list is rendered. Under a prefix override, compiled-in literals would
+// make every Purge button 404 against the backend's env-derived _VALID_DLQ_NAMES —
+// the same failure shape as discogsography-cu2.35 (discogsography-dvmi).
 const DLQ_SOURCE_PREFIXES = {
     discogs: 'discogsography-discogs',
     musicbrainz: 'discogsography-musicbrainz',
@@ -21,15 +26,34 @@ const DLQ_CONSUMER_GROUPS = [
 // Structured items (queue/service/type) generated directly — NOT parsed back
 // out of the queue name string, which is brittle against multi-segment
 // prefixes (e.g. "discogsography-discogs-graphinator-artists.dlq").
-const DLQ_ITEMS = DLQ_CONSUMER_GROUPS.flatMap(({ source, consumer, types }) =>
-    types.map(type => ({
-        queue: `${DLQ_SOURCE_PREFIXES[source]}-${consumer}-${type}.dlq`,
-        service: consumer,
-        type,
-    }))
-);
+function buildDlqItems(prefixes) {
+    return DLQ_CONSUMER_GROUPS.flatMap(({ source, consumer, types }) =>
+        types.map(type => ({
+            queue: `${prefixes[source]}-${consumer}-${type}.dlq`,
+            service: consumer,
+            type,
+        }))
+    );
+}
 
-const DLQ_NAMES = DLQ_ITEMS.map(item => item.queue);
+let DLQ_ITEMS = buildDlqItems(DLQ_SOURCE_PREFIXES);
+
+let DLQ_NAMES = DLQ_ITEMS.map(item => item.queue);
+
+// Replace the compiled-in defaults with the server's env-derived prefixes. Best effort:
+// on any failure the defaults stand, which is exactly the pre-existing behavior.
+async function loadQueuePrefixes() {
+    try {
+        const response = await fetch('/api/queue-prefixes');
+        if (!response.ok) return;
+        const prefixes = await response.json();
+        if (!prefixes || !prefixes.discogs || !prefixes.musicbrainz) return;
+        DLQ_ITEMS = buildDlqItems(prefixes);
+        DLQ_NAMES = DLQ_ITEMS.map(item => item.queue);
+    } catch {
+        // Keep the defaults — a missing endpoint must not break the admin panel.
+    }
+}
 
 const QUEUE_CHART_COLORS = [
     '#818cf8', '#34d399', '#f59e0b', '#f87171',
@@ -304,6 +328,9 @@ class AdminDashboard {
     showPanel() {
         document.getElementById('login-view').style.display = 'none';
         document.getElementById('admin-view').style.display = 'block';
+        // Refresh the prefixes first so the rendered DLQ names match the backend's
+        // env-derived _VALID_DLQ_NAMES; re-render once they land.
+        loadQueuePrefixes().then(() => this.renderDlqList());
         this.renderDlqList();
         this.loadExtractions();
         this.startAutoRefresh();

--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -228,6 +228,11 @@ pub async fn process_discogs_data(
     if pending_files.is_empty() {
         info!("✅ All files already processed");
 
+        // Tracks whether this path still owes a successful extraction_complete
+        // broadcast. Stays true when there is nothing to send (the version is
+        // already fully Completed from an earlier cycle).
+        let mut broadcast_ok = true;
+
         // Only send extraction_complete on the first completion, not on
         // subsequent periodic checks where the version is already complete.
         if state_marker.summary.overall_status != PhaseStatus::Completed {
@@ -274,12 +279,23 @@ pub async fn process_discogs_data(
                 // Leave overall_status non-Completed so should_process() returns Continue and
                 // the next cycle retries the broadcast instead of Skipping forever.
                 error!("❌ extraction_complete not sent — leaving version incomplete to retry on next cycle");
+                // ...and report the failure out of band too. Reporting Ok(true)/Completed
+                // here deferred the retry to the next PERIODIC_CHECK_DAYS sleep (15 days by
+                // default) while the health endpoint, dashboard, and logs all claimed
+                // success. The normal completion path treats the identical failure as a
+                // failure, which escalates to the cooldown-restart on the initial run and
+                // retries within minutes (discogsography-d58d).
+                broadcast_ok = false;
             }
         }
 
         let mut s = state.write().await;
-        s.extraction_status = ExtractionStatus::Completed;
-        return Ok(true);
+        s.extraction_status = if broadcast_ok {
+            ExtractionStatus::Completed
+        } else {
+            ExtractionStatus::Failed
+        };
+        return Ok(broadcast_ok);
     }
 
     info!("📋 Files to process: total={}, pending={}, completed={}", data_files.len(), pending_files.len(), data_files.len() - pending_files.len());

--- a/extractor/src/extractor.rs
+++ b/extractor/src/extractor.rs
@@ -1070,6 +1070,11 @@ pub async fn run_extraction_loop(
                     Ok(dl) => dl,
                     Err(e) => {
                         error!("❌ Failed to create downloader for periodic check: {}", e);
+                        // The run never starts, so nothing downstream would ever move the
+                        // status off Waiting. Record the failure so /health reports a
+                        // terminal, non-success state instead of a parked one that the
+                        // API's extraction tracker reads as success (discogsography-exnk).
+                        reset_status_after_failed_check(&state).await;
                         continue;
                     }
                 };
@@ -1096,6 +1101,12 @@ pub async fn run_extraction_loop(
                     Ok(dl) => dl,
                     Err(e) => {
                         error!("❌ Failed to create downloader for triggered extraction: {}", e);
+                        // wait_for_trigger already CONSUMED the trigger flag, so this run is
+                        // lost. Without a status write the extractor stays parked at Waiting
+                        // forever and the API's extraction tracker records the phantom run as
+                        // finished — with the PREVIOUS run's record counts, which makes the
+                        // false success look entirely convincing (discogsography-exnk).
+                        reset_status_after_failed_check(&state).await;
                         continue;
                     }
                 };

--- a/extractor/src/jsonl_parser.rs
+++ b/extractor/src/jsonl_parser.rs
@@ -47,6 +47,20 @@ fn extract_url_rels(relations: &[Value]) -> Vec<Value> {
     relations.iter().filter(|rel| rel["target-type"].as_str() == Some("url")).cloned().collect()
 }
 
+/// Canonicalize a MusicBrainz entity-type string to the project's vocabulary.
+///
+/// MusicBrainz spells multi-word entity types inconsistently across its
+/// serializers — `release_group` in ws/2 JSON dumps, `release-group` in the
+/// project's queue/exchange names and every consumer's hardcoded literals.
+/// Collapsing to the hyphenated form at the extractor boundary means all four
+/// consumers see exactly one spelling.
+pub fn canonical_entity_type(entity_type: &str) -> &str {
+    match entity_type {
+        "release_group" => "release-group",
+        other => other,
+    }
+}
+
 /// Extract entity-to-entity relationships from the unified `relations` array,
 /// normalizing to a flat format with `target_mbid` and `target_type` fields.
 ///
@@ -56,6 +70,14 @@ fn extract_url_rels(relations: &[Value]) -> Vec<Value> {
 /// The MusicBrainz dump stores the target entity under a key matching
 /// `target-type` (e.g., `rel["artist"]["id"]` for `target-type: "artist"`).
 /// This function normalizes that to `target_mbid` for downstream consumers.
+///
+/// The emitted `target_type` is canonicalized to the project's hyphenated
+/// vocabulary via [`canonical_entity_type`]: MusicBrainz's ws/2 JSON serializer
+/// spells release groups `release_group`, while every consumer (and
+/// [`enrich_relations`] below) keys off `release-group`. Emitting the raw
+/// spelling split the entity-type vocabulary in two and defeated the
+/// `(source_mbid, target_mbid, source_entity_type, target_entity_type,
+/// relationship_type)` dedup key in `musicbrainz.relationships`.
 fn extract_entity_rels(relations: &[Value]) -> Vec<Value> {
     relations
         .iter()
@@ -64,10 +86,13 @@ fn extract_entity_rels(relations: &[Value]) -> Vec<Value> {
             if target_type == "url" {
                 return None;
             }
-            let target_mbid = rel[target_type]["id"].as_str().unwrap_or("");
+            // The embedded entity object is keyed by the RAW target-type spelling,
+            // so look it up before canonicalizing. Dumps have been observed using
+            // both spellings for the nested key, so fall back to the alternate.
+            let target_mbid = rel[target_type]["id"].as_str().or_else(|| rel[canonical_entity_type(target_type)]["id"].as_str()).unwrap_or("");
             Some(serde_json::json!({
                 "type": rel["type"],
-                "target_type": target_type,
+                "target_type": canonical_entity_type(target_type),
                 "target_mbid": target_mbid,
                 "direction": rel["direction"],
                 "attributes": rel["attributes"],

--- a/extractor/src/state_marker.rs
+++ b/extractor/src/state_marker.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tokio::fs;
+use tokio::io::AsyncWriteExt;
 use tracing::{debug, info, warn};
 
 /// Phase status for tracking progress
@@ -230,7 +231,22 @@ impl StateMarker {
         }
     }
 
-    /// Save state marker to file
+    /// Save state marker to file.
+    ///
+    /// Durability, not just atomicity. `write(tmp)` + `rename` alone guarantees that a
+    /// READER never observes a torn file, but says nothing about what survives a power
+    /// loss or kernel panic: `tokio::fs::write` is open+write+close with no fsync, and
+    /// `rename` issues no directory fsync, so POSIX allows the rename's directory entry
+    /// to reach stable storage while the file's data blocks are still in the page cache
+    /// (dirty writeback runs every ~5-30s). The marker then comes back zero-length or
+    /// truncated, `load` treats any parse failure as "start fresh", and the extractor
+    /// re-downloads and re-publishes a whole multi-GB dump — exactly what the
+    /// tmp+rename design was meant to prevent (discogsography-mm27).
+    ///
+    /// So: fsync the temp file's contents BEFORE the rename, then fsync the parent
+    /// directory AFTER it so the rename itself is durable. The downloader already does
+    /// the equivalent for the dump files it writes (`discogs_downloader.rs`'s
+    /// `sync_data`).
     pub async fn save(&mut self, path: &Path) -> Result<()> {
         self.last_updated = Utc::now();
 
@@ -238,8 +254,29 @@ impl StateMarker {
 
         // Write to temp file then atomic rename to prevent corruption on crash
         let tmp_path = path.with_extension("json.tmp");
-        fs::write(&tmp_path, json).await.context("Failed to write state marker temp file")?;
+        {
+            let mut tmp_file = fs::File::create(&tmp_path).await.context("Failed to create state marker temp file")?;
+            tmp_file.write_all(json.as_bytes()).await.context("Failed to write state marker temp file")?;
+            // Data blocks + metadata on stable storage before anything points at them.
+            tmp_file.sync_all().await.context("Failed to fsync state marker temp file")?;
+        }
         fs::rename(&tmp_path, path).await.context("Failed to rename state marker temp file")?;
+
+        // Persist the directory entry created by the rename. Without this the file
+        // contents are durable but the name pointing at them may not be.
+        if let Some(parent) = path.parent() {
+            match fs::File::open(parent).await {
+                // Best effort: some filesystems reject fsync on a directory handle, and
+                // a marker that is merely un-fsynced is still far better than failing
+                // the extraction over it.
+                Ok(dir) => {
+                    if let Err(e) = dir.sync_all().await {
+                        debug!("⚠️ Could not fsync state marker directory {}: {}", parent.display(), e);
+                    }
+                }
+                Err(e) => debug!("⚠️ Could not open state marker directory {} for fsync: {}", parent.display(), e),
+            }
+        }
 
         debug!("💾 Saved state marker to: {}", path.display());
         Ok(())

--- a/extractor/src/tests/extractor_tests.rs
+++ b/extractor/src/tests/extractor_tests.rs
@@ -950,6 +950,25 @@ async fn test_reset_status_after_failed_check_is_not_running() {
     }
 }
 
+/// discogsography-exnk: a triggered run whose downloader cannot be constructed is LOST —
+/// `wait_for_trigger` has already consumed the trigger flag — so the loop must record the
+/// failure rather than `continue` with the status untouched. Left at `Waiting`, the
+/// extractor is indistinguishable from "parked, finished, back on schedule", and the API's
+/// extraction tracker records the phantom run as a success (stamped with the PREVIOUS
+/// run's record counts, since extraction_progress is only reset inside process_*_data).
+#[tokio::test]
+async fn test_lost_trigger_leaves_a_terminal_failed_status_not_waiting() {
+    let state = Arc::new(RwLock::new(ExtractorState::default()));
+    state.write().await.extraction_status = ExtractionStatus::Waiting;
+
+    // What the trigger arm now does when Downloader::new returns Err.
+    reset_status_after_failed_check(&state).await;
+
+    let got = state.read().await.extraction_status;
+    assert_eq!(got, ExtractionStatus::Failed);
+    assert_ne!(got, ExtractionStatus::Waiting, "a parked status is read as success by the API tracker");
+}
+
 // ── initial-run outcome tests (cu2.45) ──────────────────────────────
 
 /// Regression for cu2.45: a between-files shutdown makes `process_musicbrainz_data` return

--- a/extractor/src/tests/jsonl_parser_tests.rs
+++ b/extractor/src/tests/jsonl_parser_tests.rs
@@ -128,6 +128,68 @@ fn test_extract_entity_rels_empty() {
     assert!(entity_rels.is_empty());
 }
 
+#[test]
+fn test_extract_entity_rels_canonicalizes_underscore_release_group_target_type() {
+    // MusicBrainz's ws/2 JSON serializer spells release groups "release_group";
+    // the project's vocabulary (queues, PROCESSORS, consumer literals) is hyphenated.
+    // Emitting the raw spelling split the vocabulary and defeated the relationships
+    // natural-key dedup on the mirrored (backward-direction) row.
+    let relations = serde_json::json!([
+        {
+            "type": "tribute", "target-type": "release_group", "direction": "forward",
+            "release_group": {"id": "rg-mbid-1", "title": "Abbey Road"},
+            "attributes": [], "begin": null, "end": null, "ended": false
+        }
+    ]);
+    let entity_rels = extract_entity_rels(relations.as_array().unwrap());
+    assert_eq!(entity_rels.len(), 1);
+    assert_eq!(entity_rels[0]["target_type"], "release-group");
+    // The nested entity object is keyed by the RAW spelling; the MBID must still resolve.
+    assert_eq!(entity_rels[0]["target_mbid"], "rg-mbid-1");
+}
+
+#[test]
+fn test_extract_entity_rels_resolves_mbid_for_hyphenated_nested_release_group_key() {
+    // Dumps have been observed keying the nested object with the hyphenated spelling
+    // even when target-type uses the underscore form; the MBID must resolve either way.
+    let relations = serde_json::json!([
+        {
+            "type": "tribute", "target-type": "release_group", "direction": "forward",
+            "release-group": {"id": "rg-mbid-2", "title": "Revolver"}
+        }
+    ]);
+    let entity_rels = extract_entity_rels(relations.as_array().unwrap());
+    assert_eq!(entity_rels.len(), 1);
+    assert_eq!(entity_rels[0]["target_type"], "release-group");
+    assert_eq!(entity_rels[0]["target_mbid"], "rg-mbid-2");
+}
+
+#[test]
+fn test_canonical_entity_type_passes_through_single_word_types() {
+    assert_eq!(canonical_entity_type("artist"), "artist");
+    assert_eq!(canonical_entity_type("label"), "label");
+    assert_eq!(canonical_entity_type("release"), "release");
+    assert_eq!(canonical_entity_type("release-group"), "release-group");
+    assert_eq!(canonical_entity_type("release_group"), "release-group");
+}
+
+#[test]
+fn test_enrich_relations_matches_canonicalized_release_group_targets() {
+    // enrich_relations compares target_type against the hyphenated singular form,
+    // so canonicalization at extraction is what makes the match possible at all.
+    let relations = extract_entity_rels(
+        serde_json::json!([
+            {"type": "tribute", "target-type": "release_group", "release_group": {"id": "rg-mbid-3"}}
+        ])
+        .as_array()
+        .unwrap(),
+    );
+    let mut discogs_map = HashMap::new();
+    discogs_map.insert("rg-mbid-3".to_string(), 777i64);
+    let enriched = enrich_relations(relations, &discogs_map, "release-groups");
+    assert_eq!(enriched[0]["target_discogs_release_group_id"], 777);
+}
+
 // ─── parse_mb_artist_line ────────────────────────────────────────────────────
 
 #[test]

--- a/extractor/src/tests/state_marker_tests.rs
+++ b/extractor/src/tests/state_marker_tests.rs
@@ -638,3 +638,52 @@ fn test_legacy_marker_json_without_checksums_loads() {
     assert!(marker.download_phase.downloads_by_file["discogs_20260101_artists.xml.gz"].checksum.is_none());
     assert!(marker.processing_phase.progress_by_file["discogs_20260101_artists.xml.gz"].source_checksum.is_none());
 }
+
+// ── durable save (discogsography-mm27) ──────────────────────────────
+
+/// tmp+rename gives readers atomicity but says nothing about durability: without an
+/// fsync of the temp file and of the parent directory, POSIX allows the rename's
+/// directory entry to hit stable storage while the file's data blocks are still in the
+/// page cache. A power loss there leaves a zero-length/truncated marker, `load` treats
+/// any parse failure as "start fresh", and the extractor re-downloads and re-publishes
+/// a whole multi-GB dump.
+#[tokio::test]
+async fn test_save_leaves_a_complete_readable_marker_and_no_temp_file() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let path = StateMarker::file_path(temp.path(), "20260101");
+
+    let mut marker = StateMarker::new("20260101".to_string());
+    marker.start_processing(1);
+    marker.start_file_processing("discogs_20260101_artists.xml.gz");
+    marker.complete_file_processing("discogs_20260101_artists.xml.gz", 1234);
+    marker.save(&path).await.unwrap();
+
+    // Fully written (not zero-length) and parseable.
+    let contents = std::fs::read_to_string(&path).unwrap();
+    assert!(!contents.is_empty(), "a zero-length marker is exactly the crash artifact this guards against");
+    let loaded = StateMarker::load(&path).await.unwrap().expect("marker must parse");
+    assert_eq!(loaded.current_version, "20260101");
+    assert_eq!(loaded.processing_phase.progress_by_file["discogs_20260101_artists.xml.gz"].records_extracted, 1234);
+
+    // The temp file must not survive the rename.
+    assert!(!path.with_extension("json.tmp").exists());
+}
+
+/// Repeated saves must keep overwriting the same path cleanly — the fsync path runs on
+/// every save, including when the target already exists.
+#[tokio::test]
+async fn test_repeated_saves_overwrite_the_marker_in_place() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let path = StateMarker::file_path(temp.path(), "20260101");
+
+    let mut marker = StateMarker::new("20260101".to_string());
+    marker.save(&path).await.unwrap();
+    marker.complete_processing();
+    marker.save(&path).await.unwrap();
+    marker.complete_extraction();
+    marker.save(&path).await.unwrap();
+
+    let loaded = StateMarker::load(&path).await.unwrap().unwrap();
+    assert_eq!(loaded.summary.overall_status, PhaseStatus::Completed);
+    assert!(!path.with_extension("json.tmp").exists());
+}

--- a/extractor/tests/extractor_di_test.rs
+++ b/extractor/tests/extractor_di_test.rs
@@ -504,12 +504,26 @@ async fn test_process_discogs_data_all_files_already_processed() {
 
     let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
 
-    let result =
-        extractor::extractor::process_discogs_data(config, state, shutdown, Arc::new(AtomicBool::new(false)), true, &mut mock_dl, factory, None)
-            .await;
+    let marker_path = StateMarker::file_path(temp_dir.path(), "20260101");
+    let result = extractor::extractor::process_discogs_data(
+        config,
+        state.clone(),
+        shutdown,
+        Arc::new(AtomicBool::new(false)),
+        true,
+        &mut mock_dl,
+        factory,
+        None,
+    )
+    .await;
 
     assert!(result.is_ok());
     assert!(result.unwrap());
+    // discogsography-d58d: the success side of the same branch — a landed broadcast still
+    // reports success, marks the extraction durably complete, and sets health Completed.
+    assert_eq!(state.read().await.extraction_status, ExtractionStatus::Completed);
+    let persisted = StateMarker::load(&marker_path).await.unwrap().unwrap();
+    assert_eq!(persisted.summary.overall_status, PhaseStatus::Completed);
 }
 
 #[tokio::test]
@@ -557,13 +571,25 @@ async fn test_process_discogs_data_mq_factory_create_fails_on_all_processed() {
     }
     let factory = Arc::new(FailingMqFactory);
 
-    let result =
-        extractor::extractor::process_discogs_data(config, state, shutdown, Arc::new(AtomicBool::new(false)), true, &mut mock_dl, factory, None)
-            .await;
+    let result = extractor::extractor::process_discogs_data(
+        config,
+        state.clone(),
+        shutdown,
+        Arc::new(AtomicBool::new(false)),
+        true,
+        &mut mock_dl,
+        factory,
+        None,
+    )
+    .await;
 
-    // Should still succeed (extraction_complete failure is logged, not fatal)
+    // discogsography-d58d: an unsent extraction_complete is a FAILURE, exactly as in the
+    // normal completion path. Reporting Ok(true)/Completed here deferred the retry to the
+    // next periodic sleep (15 days by default) while health, dashboard, and logs all
+    // claimed the run had completed.
     assert!(result.is_ok());
-    assert!(result.unwrap());
+    assert!(!result.unwrap(), "a failed extraction_complete broadcast must not report success");
+    assert_eq!(state.read().await.extraction_status, ExtractionStatus::Failed);
 }
 
 /// Build a MockDataSource for the resumed all-files-already-processed Discogs path that
@@ -1550,11 +1576,15 @@ async fn test_process_discogs_data_all_processed_extraction_complete_send_fails(
 
     let factory = Arc::new(MockMqFactory { publisher: Arc::new(mock_mq) });
 
-    let result = process_discogs_data(config, state, shutdown, Arc::new(AtomicBool::new(false)), true, &mut mock_dl, factory, None).await;
+    let result = process_discogs_data(config, state.clone(), shutdown, Arc::new(AtomicBool::new(false)), true, &mut mock_dl, factory, None).await;
 
-    // Still returns Ok(true) — failure of extraction_complete is logged but not fatal in this path
+    // discogsography-d58d: the send failed, so the version still owes a broadcast. The
+    // early path must report that out of band (Ok(false) + ExtractionStatus::Failed) so the
+    // initial-run promotion to Err / cooldown-restart retries within minutes, instead of
+    // claiming success and sleeping out a whole periodic cycle.
     assert!(result.is_ok());
-    assert!(result.unwrap());
+    assert!(!result.unwrap(), "a failed extraction_complete broadcast must not report success");
+    assert_eq!(state.read().await.extraction_status, ExtractionStatus::Failed);
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/graphinator/batch_processor.py
+++ b/graphinator/batch_processor.py
@@ -789,6 +789,50 @@ class Neo4jBatchProcessor:
             await session.execute_write(batch_write)
         return nack_indices
 
+    @staticmethod
+    async def _prune_stale_edges(
+        tx: Any,
+        label: str,
+        records: list[dict[str, Any]],
+        *,
+        rel_type: str,
+        target_label: str,
+        target_key: str,
+        desired: Callable[[dict[str, Any]], list[Any]],
+        outgoing: bool = True,
+    ) -> None:
+        """Delete this record's managed edges that its NEW version no longer asserts.
+
+        Relationship writes are MERGE-only and therefore purely additive, but the
+        underlying Discogs records are mutable: a release retagged from Rock to Jazz
+        gets a new sha256, passes the hash gate, MERGEs the Jazz edge — and keeps the
+        Rock one forever. compute_genre_style_stats then counts those stale edges
+        (``MATCH (g)<-[:IS]-(r:Release) RETURN count(DISTINCT r)``), so Genre/Style/Label
+        release_count/artist_count are permanently over-stated and explore endpoints
+        list the release under a genre it no longer has (discogsography-bd0u).
+
+        Only edges of ``rel_type`` to ``target_label``, and only for the records in this
+        batch, are considered — an entity that is not being reprocessed is untouched.
+        Records whose new version asserts NO edges of the type are included too: that is
+        precisely the "all associations removed" case.
+        """
+        prune_data = [
+            {"key": record["id"], "keep": desired(record)} for record in records
+        ]
+        if not prune_data:
+            return
+
+        arrow = f"-[rel:{rel_type}]->" if outgoing else f"<-[rel:{rel_type}]-"
+        await tx.run(
+            f"""
+            UNWIND $records AS record
+            MATCH (n:{label} {{id: record.key}}){arrow}(t:{target_label})
+            WHERE NOT t.{target_key} IN record.keep
+            DELETE rel
+            """,
+            records=prune_data,
+        )
+
     async def _process_masters_batch(self, messages: list[PendingMessage]) -> set[int]:
         """Process a batch of master records.
 
@@ -847,6 +891,40 @@ class Neo4jBatchProcessor:
                         m.sha256 = master.sha256
                     """,
                     masters=masters_to_process,
+                )
+
+                # Prune managed edges the NEW version of each record no longer asserts.
+                # MERGE-only writes are additive, so without this a master retagged from
+                # Rock to Jazz keeps both edges forever and inflates every aggregate
+                # count computed off them (discogsography-bd0u).
+                await self._prune_stale_edges(
+                    tx,
+                    "Master",
+                    masters_to_process,
+                    rel_type="BY",
+                    target_label="Artist",
+                    target_key="id",
+                    desired=lambda m: [
+                        a["id"] for a in (m.get("artists") or []) if a.get("id")
+                    ],
+                )
+                await self._prune_stale_edges(
+                    tx,
+                    "Master",
+                    masters_to_process,
+                    rel_type="IS",
+                    target_label="Genre",
+                    target_key="name",
+                    desired=lambda m: [g for g in (m.get("genres") or []) if g],
+                )
+                await self._prune_stale_edges(
+                    tx,
+                    "Master",
+                    masters_to_process,
+                    rel_type="IS",
+                    target_label="Style",
+                    target_key="name",
+                    desired=lambda m: [st for st in (m.get("styles") or []) if st],
                 )
 
                 # Process artist relationships
@@ -1043,6 +1121,64 @@ class Neo4jBatchProcessor:
                         r += release.metadata
                     """,
                     releases=releases_to_process,
+                )
+
+                # Prune managed edges the NEW version of each record no longer asserts
+                # (discogsography-bd0u). MERGE-only writes never remove a dropped
+                # association, so a release corrected from genres=["Rock"] to
+                # genres=["Jazz"] kept (r)-[:IS]->(Rock) forever — permanently inflating
+                # Rock.release_count and listing the release under a genre it no longer
+                # has.
+                await self._prune_stale_edges(
+                    tx,
+                    "Release",
+                    releases_to_process,
+                    rel_type="BY",
+                    target_label="Artist",
+                    target_key="id",
+                    desired=lambda r: [
+                        a["id"] for a in (r.get("artists") or []) if a.get("id")
+                    ],
+                )
+                await self._prune_stale_edges(
+                    tx,
+                    "Release",
+                    releases_to_process,
+                    rel_type="ON",
+                    target_label="Label",
+                    target_key="id",
+                    desired=lambda r: [
+                        x["id"] for x in (r.get("labels") or []) if x.get("id")
+                    ],
+                )
+                await self._prune_stale_edges(
+                    tx,
+                    "Release",
+                    releases_to_process,
+                    rel_type="DERIVED_FROM",
+                    target_label="Master",
+                    target_key="id",
+                    desired=lambda r: (
+                        [str(r["master_id"])] if r.get("master_id") else []
+                    ),
+                )
+                await self._prune_stale_edges(
+                    tx,
+                    "Release",
+                    releases_to_process,
+                    rel_type="IS",
+                    target_label="Genre",
+                    target_key="name",
+                    desired=lambda r: [g for g in (r.get("genres") or []) if g],
+                )
+                await self._prune_stale_edges(
+                    tx,
+                    "Release",
+                    releases_to_process,
+                    rel_type="IS",
+                    target_label="Style",
+                    target_key="name",
+                    desired=lambda r: [st for st in (r.get("styles") or []) if st],
                 )
 
                 # Process artist relationships (Release)-[:BY]->(Artist)

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -676,6 +676,19 @@ async def check_file_completion(
             await message.nack(requeue=True)
             return True
 
+        # extraction_complete is this type's terminal signal, so it must also
+        # (re-)mark the type complete. completed_files is otherwise written only by
+        # file_complete and ERASED by the recovery path for any type whose queue still
+        # holds messages — and when the only pending message IS this signal, nothing
+        # ever restored the flag: "Stalled consumers detected" then logged at ERROR
+        # every 30s forever and check_all_consumers_idle() could never return True, so
+        # the connection and four idle consumers were held open until restart. A plain
+        # restart between the file_complete ack and this delivery reaches the same
+        # terminal state (discogsography-ewvh).
+        completed_files.add(data_type)
+        if CONSUMER_CANCEL_DELAY > 0 and data_type in queues:
+            await schedule_consumer_cancellation(data_type, queues[data_type])
+
         # Defer stub cleanup and stats until EVERY data type has signalled
         # extraction_complete. The four fanout queues drain at very different
         # rates (releases is by far the largest and finishes last), and every

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -779,16 +779,44 @@ async def run_post_import_maintenance() -> bool:
         try:
             maintenance_ok = True
 
+            # Drain EVERY batch queue first, not just the signalling type's. The
+            # extraction_complete branch flushes only its own data type, and a type
+            # whose signal was acked earlier can still hold pending messages:
+            # _flush_queue re-enqueues a transiently-failed batch at the front of that
+            # type's deque, so writes reappear after flush_queue already saw it empty.
+            # Cleanup then DETACH DELETEs sha256-less stubs of every label while those
+            # batches MERGE fresh stubs — the stubs survive forever with no sha256, or
+            # the sweep deletes a stub together with a just-written edge. The gate is
+            # "all four signals received"; this makes it "all four queues quiescent"
+            # too, which is the invariant the deferral comment actually claims
+            # (discogsography-fyxy). flush_all is a no-op on empty queues and waits out
+            # in-flight batches per type.
+            if batch_processor is not None and not await batch_processor.flush_all():
+                logger.error(
+                    "❌ Batch queues did not drain — deferring stub cleanup rather than "
+                    "sweeping while writers are still creating stubs",
+                )
+                maintenance_ok = False
+
             # Clean up stub nodes created by cross-type MERGE operations, across
             # EVERY entity label — not just one type's — because release batches
             # create Artist/Label/Master stubs regardless of which signal arrived
             # last.
-            if graph is not None and not await cleanup_all_stub_nodes():
+            if (
+                maintenance_ok
+                and graph is not None
+                and not await cleanup_all_stub_nodes()
+            ):
                 maintenance_ok = False
 
             # All releases are now imported — compute aggregate stats on
-            # Genre/Style/Label nodes.
-            if graph is not None and not await compute_genre_style_stats():
+            # Genre/Style/Label nodes. Skipped when the queues never drained: the
+            # counts would be computed over a graph that is still being written.
+            if (
+                maintenance_ok
+                and graph is not None
+                and not await compute_genre_style_stats()
+            ):
                 maintenance_ok = False
         except Exception as e:  # noqa: BLE001 - detached task: log and retry instead of dying silently
             logger.error(

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -1928,12 +1928,19 @@ async def main() -> None:
         active_channel = channel
 
         # Set QoS to allow concurrent batch processing for better throughput
-        # prefetch_count must be >= batch_size to allow batches to fill before flushing
+        # prefetch_count must be >= batch_size to allow batches to fill before flushing.
+        # QoS is deliberately per-consumer (aio-pika's global_=False default) so each
+        # data type can fill its own batch; the resulting channel-wide ceiling is
+        # prefetch_count x len(DATA_TYPES) and is logged so the multiplier is explicit
+        # rather than silent (discogsography-4fio). Unlike tableinator's non-batch mode,
+        # graphinator writes through the Neo4j driver's own pool, so there is no small
+        # fixed connection budget to couple the prefetch to.
         prefetch_count = max(200, BATCH_SIZE * 2) if BATCH_MODE else 200
         await channel.set_qos(prefetch_count=prefetch_count)
         logger.info(
             "🔧 QoS prefetch configured",
             prefetch_count=prefetch_count,
+            channel_wide_max=prefetch_count * len(DATA_TYPES),
             batch_size=BATCH_SIZE if BATCH_MODE else "N/A",
         )
 

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -1136,12 +1136,16 @@ async def cleanup_all_stub_nodes() -> bool:
 
 
 async def cleanup_stub_nodes(data_type: str) -> bool:
-    """Delete stub nodes that have no sha256 property.
+    """Delete ISOLATED stub nodes that have no sha256 property.
 
     During extraction, MERGE operations in relationship queries create
     skeleton nodes for cross-referenced entities (e.g., a release referencing
     an artist that hasn't been processed yet). Primary records always set
     sha256, so nodes without it are stubs that were never filled.
+
+    A stub that still has relationships is NOT collected: its edges belong to
+    fully-imported records and deleting them is unrecoverable under the
+    content-hash write-skip (discogsography-64aw).
 
     Returns:
         True if cleanup succeeded (or there is nothing to do), False if the
@@ -1176,10 +1180,21 @@ async def cleanup_stub_nodes(data_type: str) -> bool:
     # query: under transaction-memory pressure _run_maintenance_query re-runs
     # this with progressively smaller chunks. IN TRANSACTIONS commits per chunk,
     # so a retry only has to delete what the failed attempt did not.
+    # Only ISOLATED stubs are deleted. A stub that still carries relationships is a
+    # genuine dangling reference: a fully-imported release/artist MERGEd it plus a
+    # BY/ON/DERIVED_FROM/MEMBER_OF edge because the referenced entity was absent from
+    # this dump. DETACH DELETE destroyed those edges along with the stub — and the
+    # damage was permanent, because sha256 is purely content-derived: when the entity
+    # appears in a later dump the referencing record is byte-identical, the hash-skip
+    # in process_release/process_artist (and both batch processors) returns before the
+    # relationship blocks, and the edge is never rebuilt. Keeping the stub preserves
+    # both the edge and the id, and a later dump upgrades it in place — the fill-in
+    # path MERGEs on id, so the stub simply gains its properties and sha256
+    # (discogsography-64aw). Truly orphaned stubs still get collected here.
     def _build_cleanup_cypher(batch_size: int | None) -> str:
         return f"""
     MATCH (n:{label})
-    WHERE n.sha256 IS NULL
+    WHERE n.sha256 IS NULL AND NOT (n)--()
     CALL {{
         WITH n
         DETACH DELETE n

--- a/graphinator/graphinator.py
+++ b/graphinator/graphinator.py
@@ -1352,6 +1352,38 @@ async def process_label(tx: Any, record: dict[str, Any]) -> bool:
     return True  # Updated successfully
 
 
+async def _prune_stale_edges(
+    tx: Any,
+    label: str,
+    node_id: Any,
+    *,
+    rel_type: str,
+    target_label: str,
+    target_key: str,
+    keep: list[Any],
+) -> None:
+    """Delete this record's managed edges that its NEW version no longer asserts.
+
+    Relationship writes are MERGE-only and therefore purely additive, but the
+    underlying Discogs records are mutable: a release retagged from Rock to Jazz gets a
+    new sha256, passes the hash gate, MERGEs the Jazz edge — and keeps the Rock one
+    forever. compute_genre_style_stats then counts those stale edges
+    (``MATCH (g)<-[:IS]-(r:Release) RETURN count(DISTINCT r)``), so Genre/Style/Label
+    release_count/artist_count are permanently over-stated and explore endpoints list
+    the release under a genre it no longer has (discogsography-bd0u).
+
+    Called with an EMPTY ``keep`` too — that is the "all associations removed" case.
+    Mirrors Neo4jBatchProcessor._prune_stale_edges.
+    """
+    await tx.run(
+        f"MATCH (n:{label} {{id: $node_id}})-[rel:{rel_type}]->(t:{target_label}) "
+        f"WHERE NOT t.{target_key} IN $keep "
+        "DELETE rel",
+        node_id=node_id,
+        keep=keep,
+    )
+
+
 async def process_master(tx: Any, record: dict[str, Any]) -> bool:
     """Process master within a single transaction for atomicity."""
     existing_result = await tx.run(
@@ -1370,6 +1402,36 @@ async def process_master(tx: Any, record: dict[str, Any]) -> bool:
         title=record.get("title", "Unknown Master"),
         year=record.get("year"),
         sha256=record["sha256"],
+    )
+
+    # Prune managed edges this record's NEW version no longer asserts, before the
+    # additive MERGEs below re-create the current set (discogsography-bd0u).
+    await _prune_stale_edges(
+        tx,
+        "Master",
+        record["id"],
+        rel_type="BY",
+        target_label="Artist",
+        target_key="id",
+        keep=[a["id"] for a in (record.get("artists") or []) if a.get("id")],
+    )
+    await _prune_stale_edges(
+        tx,
+        "Master",
+        record["id"],
+        rel_type="IS",
+        target_label="Genre",
+        target_key="name",
+        keep=[g for g in (record.get("genres") or []) if g],
+    )
+    await _prune_stale_edges(
+        tx,
+        "Master",
+        record["id"],
+        rel_type="IS",
+        target_label="Style",
+        target_key="name",
+        keep=[st for st in (record.get("styles") or []) if st],
     )
 
     # Handle artist relationships (normalized to list of {"id": ...} dicts)
@@ -1451,6 +1513,54 @@ async def process_release(tx: Any, record: dict[str, Any]) -> bool:
         year=record.get("year"),
         formats=formats,
         sha256=record["sha256"],
+    )
+
+    # Prune managed edges this record's NEW version no longer asserts, before the
+    # additive MERGEs below re-create the current set (discogsography-bd0u).
+    await _prune_stale_edges(
+        tx,
+        "Release",
+        record["id"],
+        rel_type="BY",
+        target_label="Artist",
+        target_key="id",
+        keep=[a["id"] for a in (record.get("artists") or []) if a.get("id")],
+    )
+    await _prune_stale_edges(
+        tx,
+        "Release",
+        record["id"],
+        rel_type="ON",
+        target_label="Label",
+        target_key="id",
+        keep=[lbl["id"] for lbl in (record.get("labels") or []) if lbl.get("id")],
+    )
+    await _prune_stale_edges(
+        tx,
+        "Release",
+        record["id"],
+        rel_type="DERIVED_FROM",
+        target_label="Master",
+        target_key="id",
+        keep=[record["master_id"]] if record.get("master_id") else [],
+    )
+    await _prune_stale_edges(
+        tx,
+        "Release",
+        record["id"],
+        rel_type="IS",
+        target_label="Genre",
+        target_key="name",
+        keep=[g for g in (record.get("genres") or []) if g],
+    )
+    await _prune_stale_edges(
+        tx,
+        "Release",
+        record["id"],
+        rel_type="IS",
+        target_label="Style",
+        target_key="name",
+        keep=[st for st in (record.get("styles") or []) if st],
     )
 
     # Handle artist relationships (normalized to list of {"id": ...} dicts)

--- a/tableinator/tableinator.py
+++ b/tableinator/tableinator.py
@@ -168,6 +168,42 @@ BATCH_MODE = os.environ.get("POSTGRES_BATCH_MODE", "true").lower() == "true"
 BATCH_SIZE = int(os.environ.get("POSTGRES_BATCH_SIZE", "100"))
 BATCH_FLUSH_INTERVAL = float(os.environ.get("POSTGRES_BATCH_FLUSH_INTERVAL", "5.0"))
 
+# Fallback pool max when config is not yet loaded (matches TableinatorConfig default).
+_DEFAULT_POOL_MAX = 12
+
+
+def channel_prefetch() -> tuple[int, bool]:
+    """Resolve ``(prefetch_count, global_)`` for this channel's QoS.
+
+    Two different shapes, because the two modes hold PostgreSQL connections very
+    differently:
+
+    * **Batch mode** — handlers hand the message to :class:`PostgreSQLBatchProcessor`
+      and return immediately; only the flush task holds a pooled connection, and its
+      concurrency is bounded by the batch processor's own semaphore. Each queue needs
+      at least ``BATCH_SIZE`` unacked deliveries of its OWN data type for a batch to
+      fill, so QoS stays per-consumer (``global_=False``). The channel-wide ceiling is
+      therefore ``prefetch_count * len(DATA_TYPES)`` — logged explicitly so the 4x
+      multiplier is not a surprise.
+    * **Non-batch mode** (``POSTGRES_BATCH_MODE=false``) — every in-flight handler
+      holds a pooled connection for the duration of its upsert, exactly the shape
+      brainztableinator couples in ``_channel_prefetch``. Bound the channel's TOTAL
+      unacked deliveries (``global_=True``) to the pool max so the broker, not the
+      pool's ~15.5s exhausted-wait retry loop, applies backpressure. Without this,
+      4 x 200 = 800 concurrent handlers raced for 12 connections; the losers raised,
+      were nacked with ``requeue=True``, and burned the quorum queue's
+      ``x-delivery-limit: 20`` until the message was silently dead-lettered
+      (discogsography-4fio).
+    """
+    if BATCH_MODE:
+        # prefetch_count must be >= batch_size to allow batches to fill before flushing
+        return max(200, BATCH_SIZE * 2), False
+    pool_max = (
+        config.postgres_pool_max_size if config is not None else _DEFAULT_POOL_MAX
+    )
+    return pool_max, True
+
+
 # Global shutdown flag
 shutdown_requested = False
 
@@ -419,9 +455,12 @@ async def _recover_consumers() -> None:
             active_connection = temp_connection
             active_channel = temp_channel
 
-            # Set QoS - scale with batch_size for efficient batch processing
-            prefetch_count = max(200, BATCH_SIZE * 2) if BATCH_MODE else 200
-            await active_channel.set_qos(prefetch_count=prefetch_count)
+            # Set QoS - scale with batch_size in batch mode, couple to the PostgreSQL
+            # pool capacity in non-batch mode (see channel_prefetch).
+            prefetch_count, prefetch_global = channel_prefetch()
+            await active_channel.set_qos(
+                prefetch_count=prefetch_count, global_=prefetch_global
+            )
 
             # Declare per-data-type fanout exchanges and consumer-owned queues
             queues = {}
@@ -1183,13 +1222,18 @@ async def main() -> None:
         channel = await amqp_connection.channel()
         active_channel = channel
 
-        # Set QoS to allow concurrent batch processing for better throughput
-        # prefetch_count must be >= batch_size to allow batches to fill before flushing
-        prefetch_count = max(200, BATCH_SIZE * 2) if BATCH_MODE else 200
-        await channel.set_qos(prefetch_count=prefetch_count)
+        # Set QoS to allow concurrent batch processing for better throughput, or to
+        # couple in-flight deliveries to the PostgreSQL pool in non-batch mode.
+        prefetch_count, prefetch_global = channel_prefetch()
+        await channel.set_qos(prefetch_count=prefetch_count, global_=prefetch_global)
         logger.info(
             "🔧 QoS prefetch configured",
             prefetch_count=prefetch_count,
+            channel_global=prefetch_global,
+            # Per-consumer QoS means the real channel-wide ceiling is prefetch x consumers.
+            channel_wide_max=prefetch_count
+            if prefetch_global
+            else prefetch_count * len(DATA_TYPES),
             batch_size=BATCH_SIZE if BATCH_MODE else "N/A",
         )
 

--- a/tableinator/tableinator.py
+++ b/tableinator/tableinator.py
@@ -812,6 +812,23 @@ async def on_data_message(message: AbstractIncomingMessage, data_type: str) -> N
                     purge_ok = False
 
             if purge_ok:
+                # extraction_complete is this type's terminal signal, so it must also
+                # (re-)mark the type complete. completed_files is otherwise written
+                # only by file_complete and ERASED by _recover_consumers for any type
+                # whose queue still holds messages — and when the only pending message
+                # IS this signal, nothing ever restored the flag. The service then
+                # logged "Stalled consumers detected" at ERROR every 30s forever,
+                # check_all_consumers_idle() could never return True, and the
+                # connection plus four idle consumers were held open until restart.
+                # A plain restart between the file_complete ack and this delivery
+                # reaches the same terminal state (discogsography-ewvh).
+                completed_files.add(data_type)
+
+                # Re-arm cancellation: the file_complete that originally scheduled it
+                # was consumed in an earlier session or before recovery.
+                if CONSUMER_CANCEL_DELAY > 0 and data_type in queues:
+                    await schedule_consumer_cancellation(data_type, queues[data_type])
+
                 await message.ack()
             else:
                 await message.nack(requeue=True)

--- a/tableinator/tableinator.py
+++ b/tableinator/tableinator.py
@@ -27,7 +27,7 @@ from common import (
 )
 from orjson import loads
 from psycopg import sql
-from psycopg.errors import InterfaceError, OperationalError
+from psycopg.errors import DataError, IntegrityError, InterfaceError, OperationalError
 from psycopg.types.json import Jsonb
 
 from tableinator.batch_processor import BatchConfig, PostgreSQLBatchProcessor
@@ -943,6 +943,22 @@ async def on_data_message(message: AbstractIncomingMessage, data_type: str) -> N
         # minutes of a database outage (discogsography-rb05).
         await outage_backoff.wait()
         await message.nack(requeue=True)
+    except (DataError, IntegrityError) as e:
+        # Deterministic per-record faults: a failed column cast (DataError) or a
+        # violated constraint (IntegrityError, e.g. a NULL data_id). Retrying fails
+        # identically every time, so nack straight to the DLQ instead of spending all
+        # 20 of the quorum queue's redeliveries — each one opening a pooled connection
+        # and rolling back — before the broker dead-letters it anyway. Mirrors
+        # brainztableinator's branch (discogsography-yuyg).
+        logger.error(
+            "❌ Non-retryable data error, nacking without requeue",
+            data_type=data_type,
+            error=str(e),
+        )
+        try:
+            await message.nack(requeue=False)
+        except Exception as nack_error:  # noqa: BLE001 - the nack path itself is best-effort; the broker will redeliver
+            logger.warning("⚠️ Failed to nack message", error=str(nack_error))
     except Exception as e:  # noqa: BLE001 - per-message fault must nack rather than kill the consumer
         logger.error("❌ Failed to process message", data_type=data_type, error=str(e))
         try:

--- a/tableinator/tableinator.py
+++ b/tableinator/tableinator.py
@@ -817,8 +817,15 @@ async def on_data_message(message: AbstractIncomingMessage, data_type: str) -> N
                 await message.nack(requeue=True)
             return
 
-        # Normal message processing - require 'id' field
-        if "id" not in data:
+        # Normal message processing - require a non-empty 'id' field.
+        # Falsy (not just absent), matching every sibling site: graphinator.py's
+        # `if not record.get("id")`, both batch processors' `if not data_id`, and the
+        # brainz* consumers. Key-presence alone let `"id": null` through to an INSERT
+        # into a NOT NULL PRIMARY KEY, whose deterministic IntegrityError landed in the
+        # generic handler and was nacked with requeue=True — burning all 20 redeliveries
+        # before dead-lettering — while `"id": ""` silently wrote a junk row keyed on the
+        # empty string and acked it as success (discogsography-ria1).
+        if not data.get("id"):
             logger.error("❌ Message missing 'id' field", data=data)
             await message.nack(requeue=False)
             return

--- a/tests/api/test_admin_endpoints.py
+++ b/tests/api/test_admin_endpoints.py
@@ -649,6 +649,14 @@ class TestTrackExtraction:
             patch("api.routers.admin.asyncio.sleep", new_callable=AsyncMock),
             patch("api.routers.admin.httpx.AsyncClient") as mock_client_cls,
         ):
+            # discogsography-exnk: a run that produced records was necessarily observed
+            # running first — the tracker only accepts a terminal status after that.
+            running_response = MagicMock()
+            running_response.status_code = 200
+            running_response.json.return_value = {
+                "extraction_status": "running",
+                "extraction_progress": {"artists": 10, "labels": 0, "masters": 0, "releases": 0},
+            }
             mock_response = MagicMock()
             mock_response.status_code = 200
             mock_response.json.return_value = {
@@ -656,7 +664,7 @@ class TestTrackExtraction:
                 "extraction_progress": {"artists": 100, "labels": 50, "masters": 25, "releases": 200},
             }
             mock_client_instance = AsyncMock()
-            mock_client_instance.get = AsyncMock(return_value=mock_response)
+            mock_client_instance.get = AsyncMock(side_effect=[running_response, mock_response])
             mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
             mock_client_instance.__aexit__ = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client_instance
@@ -708,6 +716,14 @@ class TestTrackExtraction:
             patch("api.routers.admin.asyncio.sleep", new_callable=AsyncMock),
             patch("api.routers.admin.httpx.AsyncClient") as mock_client_cls,
         ):
+            # discogsography-exnk: a run that produced records was necessarily observed
+            # running first — the tracker only accepts a terminal status after that.
+            running_response = MagicMock()
+            running_response.status_code = 200
+            running_response.json.return_value = {
+                "extraction_status": "running",
+                "extraction_progress": {"artists": 10, "labels": 0, "masters": 0, "releases": 0},
+            }
             mock_response = MagicMock()
             mock_response.status_code = 200
             mock_response.json.return_value = {
@@ -715,7 +731,7 @@ class TestTrackExtraction:
                 "extraction_progress": {"artists": 100, "labels": 50, "masters": 25, "releases": 200},
             }
             mock_client_instance = AsyncMock()
-            mock_client_instance.get = AsyncMock(return_value=mock_response)
+            mock_client_instance.get = AsyncMock(side_effect=[running_response, mock_response])
             mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
             mock_client_instance.__aexit__ = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client_instance
@@ -732,6 +748,145 @@ class TestTrackExtraction:
 
         admin_mod._pool = original_pool
         admin_mod._config = original_config
+
+    @pytest.mark.asyncio
+    async def test_parked_waiting_is_not_recorded_as_success(self) -> None:
+        """discogsography-exnk: "waiting" is also the PARKED state before a trigger
+        takes effect. If the extractor consumes the trigger and then fails before the
+        run starts, status stays "waiting" forever — and because extraction_progress is
+        only reset inside process_*_data, the phantom run carries the PREVIOUS run's
+        counts, so the false success looks entirely convincing."""
+        import api.routers.admin as admin_mod
+
+        mock_pool = MagicMock()
+        mock_cur = AsyncMock()
+        mock_conn = AsyncMock()
+        cur_ctx = AsyncMock()
+        cur_ctx.__aenter__ = AsyncMock(return_value=mock_cur)
+        cur_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_conn.cursor = MagicMock(return_value=cur_ctx)
+        conn_ctx = AsyncMock()
+        conn_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+        conn_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_pool.connection = MagicMock(return_value=conn_ctx)
+
+        mock_config = MagicMock()
+        mock_config.extractor_host = "localhost"
+        mock_config.extractor_health_port = 8000
+
+        original_pool = admin_mod._pool
+        original_config = admin_mod._config
+        admin_mod._pool = mock_pool
+        admin_mod._config = mock_config
+
+        extraction_id = str(uuid4())
+
+        with (
+            patch("api.routers.admin.asyncio.sleep", new_callable=AsyncMock),
+            patch("api.routers.admin.httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "extraction_status": "waiting",
+                # A previous run's counters, never cleared because this run never started.
+                "extraction_progress": {"artists": 100, "labels": 50, "masters": 25, "releases": 200, "total": 375},
+                # ...and stale activity timestamps to match (hours old).
+                "last_extraction_time": {"artists": 7200.0, "labels": 7300.0, "masters": None, "releases": 7100.0},
+            }
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get = AsyncMock(return_value=mock_response)
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client_instance
+
+            await admin_mod._track_extraction(extraction_id)
+
+        executed = [call.args for call in mock_cur.execute.await_args_list]
+        terminal_calls = [args for args in executed if "completed_at = NOW()" in args[0]]
+        assert terminal_calls, "expected a terminal UPDATE with completed_at"
+        terminal_sql, terminal_params = terminal_calls[-1]
+        assert "status = 'failed'" in terminal_sql
+        assert "never started" in terminal_params[0]
+
+        admin_mod._pool = original_pool
+        admin_mod._config = original_config
+
+    @pytest.mark.asyncio
+    async def test_short_run_with_cleared_counters_is_still_success(self) -> None:
+        """The gate must not false-alarm on a legitimate short run. A trigger against an
+        already-processed version passes running → completed → waiting entirely between
+        two 10s polls; process_*_data cleared the counters as its first act, which is
+        what proves the run actually began."""
+        import api.routers.admin as admin_mod
+
+        mock_pool = MagicMock()
+        mock_cur = AsyncMock()
+        mock_conn = AsyncMock()
+        cur_ctx = AsyncMock()
+        cur_ctx.__aenter__ = AsyncMock(return_value=mock_cur)
+        cur_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_conn.cursor = MagicMock(return_value=cur_ctx)
+        conn_ctx = AsyncMock()
+        conn_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+        conn_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_pool.connection = MagicMock(return_value=conn_ctx)
+
+        mock_config = MagicMock()
+        mock_config.extractor_host = "localhost"
+        mock_config.extractor_health_port = 8000
+
+        original_pool = admin_mod._pool
+        original_config = admin_mod._config
+        admin_mod._pool = mock_pool
+        admin_mod._config = mock_config
+
+        extraction_id = str(uuid4())
+
+        with (
+            patch("api.routers.admin.asyncio.sleep", new_callable=AsyncMock),
+            patch("api.routers.admin.httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "extraction_status": "waiting",
+                "extraction_progress": {"artists": 0, "labels": 0, "masters": 0, "releases": 0, "total": 0},
+                "last_extraction_time": {"artists": None, "labels": None, "masters": None, "releases": None},
+            }
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get = AsyncMock(return_value=mock_response)
+            mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+            mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client_instance
+
+            await admin_mod._track_extraction(extraction_id)
+
+        executed = [call.args for call in mock_cur.execute.await_args_list]
+        terminal_calls = [args for args in executed if "completed_at = NOW()" in args[0]]
+        terminal_sql, terminal_params = terminal_calls[-1]
+        assert "SET status = %s" in terminal_sql
+        assert terminal_params[0] == "waiting"
+
+        admin_mod._pool = original_pool
+        admin_mod._config = original_config
+
+    def test_run_has_started_accepts_fresh_activity_timestamps(self) -> None:
+        """Activity newer than the tracking window belongs to THIS run, even when the
+        counters are non-zero."""
+        from api.routers.admin import _run_has_started
+
+        health = {
+            "extraction_progress": {"total": 375},
+            "last_extraction_time": {"artists": 12.0, "labels": None},
+        }
+        assert _run_has_started(health, tracked_seconds=20) is True
+        # Hours-old activity with stale counters is a parked extractor, not a run.
+        stale = {
+            "extraction_progress": {"total": 375},
+            "last_extraction_time": {"artists": 7200.0},
+        }
+        assert _run_has_started(stale, tracked_seconds=20) is False
 
     @pytest.mark.asyncio
     async def test_failed_extraction(self) -> None:

--- a/tests/brainzgraphinator/test_brainzgraphinator.py
+++ b/tests/brainzgraphinator/test_brainzgraphinator.py
@@ -561,15 +561,21 @@ class TestMessageHandling:
         """extraction_complete control message is handled and acked."""
         mock_message = AsyncMock(spec=AbstractIncomingMessage)
         mock_message.body = dumps({"type": "extraction_complete", "version": "2026-01"})
+        completed: set[str] = set()
 
         with (
             patch("brainzgraphinator.brainzgraphinator.graph", MagicMock()),
-            patch("brainzgraphinator.brainzgraphinator.completed_files", set()),
+            patch("brainzgraphinator.brainzgraphinator.completed_files", completed),
             patch("brainzgraphinator.brainzgraphinator.queues", {}),
         ):
             await on_artist_message(mock_message)
 
         mock_message.ack.assert_called_once()
+        # discogsography-ewvh: the terminal signal must also (re-)mark the type
+        # complete — completed_files is otherwise erased by the recovery path for any
+        # type whose queue still holds messages, and this signal is often the only one
+        # left, so nothing ever restored the flag.
+        assert completed == {"artists"}
 
     @pytest.mark.asyncio
     @patch("brainzgraphinator.brainzgraphinator.shutdown_requested", False)

--- a/tests/brainztableinator/test_brainztableinator.py
+++ b/tests/brainztableinator/test_brainztableinator.py
@@ -550,6 +550,137 @@ class TestInsertExternalLinks:
 
 
 # ===========================================================================
+# Present-but-null field coalescing (discogsography-iud5)
+# ===========================================================================
+
+
+class TestNullFieldCoalescing:
+    """The extractor's json! macro always emits every key it knows about, so a field
+    the MusicBrainz dump omits arrives as an explicit null rather than an absent key.
+    dict.get(key, default) then returns None and the default is dead code — NULL was
+    written where FALSE/[] was intended, and ON CONFLICT DO UPDATE overwrote
+    previously-correct values with those nulls on reprocessing."""
+
+    @pytest.mark.asyncio
+    async def test_null_relationship_ended_stores_false(self):
+        mock_conn, mock_cursor = _make_mock_conn()
+        rels = [
+            {
+                "target_mbid": "target-mbid-1",
+                "target_type": "artist",
+                "type": "member of band",
+                "ended": None,
+                "attributes": None,
+            }
+        ]
+
+        await _insert_relationships(mock_conn, "source-mbid-1", "artist", rels)
+
+        row = mock_cursor.executemany.call_args[0][1][0]
+        # ended is the last bound column; a column DEFAULT does not apply to an
+        # explicitly supplied NULL, so WHERE NOT ended would have dropped this row.
+        assert row[-1] is False
+
+    @pytest.mark.asyncio
+    async def test_null_relationship_attributes_stores_empty_array(self):
+        mock_conn, mock_cursor = _make_mock_conn()
+        rels = [
+            {
+                "target_mbid": "target-mbid-1",
+                "target_type": "artist",
+                "type": "member of band",
+                "attributes": None,
+            }
+        ]
+
+        await _insert_relationships(mock_conn, "source-mbid-1", "artist", rels)
+
+        row = mock_cursor.executemany.call_args[0][1][0]
+        # Jsonb(None) dumps the jsonb SCALAR null, on which jsonb_array_length errors.
+        assert row[5].obj == []
+
+    @pytest.mark.asyncio
+    async def test_null_artist_life_span_ended_stores_false(self):
+        mock_conn, mock_cursor = _make_mock_conn()
+        record = {
+            "mbid": "artist-mbid-1",
+            "name": "Test Artist",
+            "life_span": {"begin": None, "end": None, "ended": None},
+            "aliases": None,
+            "tags": None,
+        }
+
+        await process_artist(mock_conn, record)
+
+        params = mock_cursor.execute.call_args[0][1]
+        # (mbid, name, sort_name, mb_type, gender, begin_date, end_date, ended, ...)
+        assert params[7] is False
+        assert params[13].obj == []  # aliases
+        assert params[14].obj == []  # tags
+
+    @pytest.mark.asyncio
+    async def test_null_label_life_span_ended_stores_false(self):
+        mock_conn, mock_cursor = _make_mock_conn()
+        record = {
+            "mbid": "label-mbid-1",
+            "name": "Test Label",
+            "life_span": {"begin": None, "end": None, "ended": None},
+        }
+
+        await process_label(mock_conn, record)
+
+        params = mock_cursor.execute.call_args[0][1]
+        # (mbid, name, mb_type, label_code, begin_date, end_date, ended, ...)
+        assert params[6] is False
+
+    @pytest.mark.asyncio
+    async def test_entirely_null_life_span_is_tolerated(self):
+        """A null life_span object itself must not raise (it is emitted as a dict today,
+        but the guard is what keeps a schema change from crashing the consumer)."""
+        mock_conn, mock_cursor = _make_mock_conn()
+
+        await process_artist(mock_conn, {"mbid": "artist-mbid-2", "name": "Test", "life_span": None})
+
+        params = mock_cursor.execute.call_args[0][1]
+        assert params[5] is None  # begin_date
+        assert params[6] is None  # end_date
+        assert params[7] is False  # ended
+
+    @pytest.mark.asyncio
+    async def test_null_release_group_secondary_types_stores_empty_array(self):
+        mock_conn, mock_cursor = _make_mock_conn()
+
+        await process_release_group(
+            mock_conn,
+            {"mbid": "rg-mbid-1", "name": "Test RG", "secondary_types": None},
+        )
+
+        params = mock_cursor.execute.call_args[0][1]
+        assert params[3].obj == []
+
+    @pytest.mark.asyncio
+    async def test_real_values_are_preserved(self):
+        """Coalescing must not flatten genuine values."""
+        mock_conn, mock_cursor = _make_mock_conn()
+        record = {
+            "mbid": "artist-mbid-3",
+            "name": "Ended Artist",
+            "life_span": {"begin": "1960", "end": "1970", "ended": True},
+            "aliases": ["a"],
+            "tags": ["rock"],
+        }
+
+        await process_artist(mock_conn, record)
+
+        params = mock_cursor.execute.call_args[0][1]
+        assert params[5] == "1960"
+        assert params[6] == "1970"
+        assert params[7] is True
+        assert params[13].obj == ["a"]
+        assert params[14].obj == ["rock"]
+
+
+# ===========================================================================
 # Prefetch / pool-coupling tests
 # ===========================================================================
 

--- a/tests/brainztableinator/test_brainztableinator.py
+++ b/tests/brainztableinator/test_brainztableinator.py
@@ -759,15 +759,20 @@ class TestOnDataMessage:
         """extraction_complete message should be acked."""
         mock_message = AsyncMock()
         mock_message.body = b'{"type": "extraction_complete", "version": "2026-01-01"}'
+        completed: set[str] = set()
 
         with (
             patch("brainztableinator.brainztableinator.shutdown_requested", False),
-            patch("brainztableinator.brainztableinator.completed_files", set()),
+            patch("brainztableinator.brainztableinator.completed_files", completed),
             patch("brainztableinator.brainztableinator.connection_pool", MagicMock()),
         ):
             await on_data_message(mock_message, "artists")
 
             mock_message.ack.assert_called_once()
+            # discogsography-ewvh: the terminal signal must also (re-)mark the type
+            # complete — _recover_consumers discards it for any type whose queue still
+            # holds messages, and this signal is often the only one left.
+            assert completed == {"artists"}
 
     @pytest.mark.asyncio
     async def test_valid_data_message_calls_processor(self):

--- a/tests/brainztableinator/test_brainztableinator.py
+++ b/tests/brainztableinator/test_brainztableinator.py
@@ -436,6 +436,80 @@ class TestInsertRelationships:
         assert row[2] == "source-mbid-1"
         assert row[3] == "artist"
 
+    @pytest.mark.asyncio
+    async def test_insert_relationships_canonicalizes_release_group_entity_type(self):
+        """discogsography-06gd: MusicBrainz spells release groups 'release_group'
+        while every call site here hardcodes 'release-group'. Passing the raw
+        spelling through wrote two vocabularies into the same table, so the
+        forward row and the mirrored backward row no longer collided on the
+        natural key and the same logical relationship was stored twice."""
+        mock_conn, mock_cursor = _make_mock_conn()
+        rels = [
+            {
+                "target_mbid": "rg-mbid-1",
+                "target_type": "release_group",
+                "type": "tribute",
+            }
+        ]
+
+        await _insert_relationships(mock_conn, "source-mbid-1", "artist", rels)
+
+        row = mock_cursor.executemany.call_args[0][1][0]
+        assert row[3] == "release-group"
+
+    @pytest.mark.asyncio
+    async def test_insert_relationships_mirrored_rows_agree_on_entity_type(self):
+        """discogsography-06gd: the row written while processing endpoint A and the
+        swapped row written while processing endpoint B must be byte-identical in
+        their type columns, otherwise ON CONFLICT never fires."""
+        mock_conn_a, mock_cursor_a = _make_mock_conn()
+        # Endpoint A (the artist) sees the release group as a forward target,
+        # spelled with MusicBrainz's underscore.
+        await _insert_relationships(
+            mock_conn_a,
+            "artist-mbid-1",
+            "artist",
+            [{"target_mbid": "rg-mbid-1", "target_type": "release_group", "type": "tribute"}],
+        )
+        forward_row = mock_cursor_a.executemany.call_args[0][1][0]
+
+        mock_conn_b, mock_cursor_b = _make_mock_conn()
+        # Endpoint B (the release group) sees the mirror as a backward relation and
+        # is processed under the project's hyphenated literal.
+        await _insert_relationships(
+            mock_conn_b,
+            "rg-mbid-1",
+            "release-group",
+            [
+                {
+                    "target_mbid": "artist-mbid-1",
+                    "target_type": "artist",
+                    "type": "tribute",
+                    "direction": "backward",
+                }
+            ],
+        )
+        backward_row = mock_cursor_b.executemany.call_args[0][1][0]
+
+        # source_mbid, source_entity_type, target_mbid, target_entity_type, relationship_type
+        assert forward_row[:5] == backward_row[:5]
+
+    @pytest.mark.asyncio
+    async def test_insert_relationships_canonicalizes_the_processed_entity_type(self):
+        """discogsography-06gd: normalization must also cover source_type, so a caller
+        passing the underscore spelling cannot reintroduce the split vocabulary."""
+        mock_conn, mock_cursor = _make_mock_conn()
+
+        await _insert_relationships(
+            mock_conn,
+            "rg-mbid-1",
+            "release_group",
+            [{"target_mbid": "artist-mbid-1", "target_type": "artist", "type": "tribute"}],
+        )
+
+        row = mock_cursor.executemany.call_args[0][1][0]
+        assert row[1] == "release-group"
+
 
 class TestInsertExternalLinks:
     """Tests for _insert_external_links (batched executemany)."""

--- a/tests/brainztableinator/test_brainztableinator.py
+++ b/tests/brainztableinator/test_brainztableinator.py
@@ -953,6 +953,54 @@ class TestOnDataMessage:
             mock_message.ack.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_integrity_error_nacks_without_requeue(self):
+        """discogsography-yuyg: a NOT NULL violation is deterministic, not transient.
+
+        NotNullViolation derives from psycopg's IntegrityError, NOT DataError, so it
+        used to fall through to the generic handler and be nacked with requeue=True —
+        20 futile redeliveries per bad record, each opening a pooled connection and
+        rolling back a transaction, before the broker dead-lettered it anyway. Reached
+        whenever a dump line carries no name/title: the extractor forwards it as
+        "name": null and the four musicbrainz tables all declare name TEXT NOT NULL.
+        """
+        from psycopg.errors import NotNullViolation
+
+        mock_message = AsyncMock()
+        mock_message.body = b'{"id": "550e8400-e29b-41d4-a716-446655440000"}'
+
+        mock_pool = MagicMock()
+        mock_conn = AsyncMock()
+        mock_conn.transaction = MagicMock(return_value=AsyncMock())
+        mock_conn_cm = AsyncMock()
+        mock_conn_cm.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_pool.connection = MagicMock(return_value=mock_conn_cm)
+
+        mock_processor = AsyncMock(side_effect=NotNullViolation('null value in column "name" violates not-null constraint'))
+
+        with (
+            patch("brainztableinator.brainztableinator.shutdown_requested", False),
+            patch("brainztableinator.brainztableinator.completed_files", set()),
+            patch("brainztableinator.brainztableinator.connection_pool", mock_pool),
+            patch(
+                "brainztableinator.brainztableinator.message_counts",
+                {"artists": 0, "labels": 0, "release-groups": 0, "releases": 0},
+            ),
+            patch(
+                "brainztableinator.brainztableinator.last_message_time",
+                {"artists": 0.0, "labels": 0.0, "release-groups": 0.0, "releases": 0.0},
+            ),
+            patch.dict(
+                "brainztableinator.brainztableinator.PROCESSORS",
+                {"artists": mock_processor},
+            ),
+        ):
+            await on_data_message(mock_message, "artists")
+
+            mock_message.nack.assert_called_once_with(requeue=False)
+            mock_message.ack.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_no_processor_for_data_type_nacks(self):
         """Unknown data type with no processor should nack without requeue."""
         mock_message = AsyncMock()

--- a/tests/common/test_rabbitmq_integration.py
+++ b/tests/common/test_rabbitmq_integration.py
@@ -210,6 +210,11 @@ class TestLiveReconnect:
                 OP_TIMEOUT,
             )
 
+            # discogsography-6ino: callbacks also fire on the INITIAL connect, so the
+            # flag is already set here. Clear it before dropping the connection —
+            # otherwise the assertion below passes without a reconnect ever happening.
+            reconnected.clear()
+
             async with _mgmt() as client:
                 dropped = await _step("force-close all client connections", _drop_all_connections(client), OP_TIMEOUT + STATS_TIMEOUT)
                 assert dropped >= 1, "no connections were dropped, so nothing was tested"

--- a/tests/common/test_rabbitmq_resilient.py
+++ b/tests/common/test_rabbitmq_resilient.py
@@ -371,6 +371,75 @@ class TestAsyncResilientRabbitMQ:
         # Channel should be reset
         assert conn._channel is None
 
+    @pytest.mark.asyncio
+    async def test_on_reconnect_invokes_registered_callbacks(self, connection_url: str) -> None:
+        """discogsography-6ino: _on_reconnect is the ONLY observable reconnect event.
+
+        RobustConnection reports is_closed == False across its own reconnects, so
+        connect() early-returns and never re-runs its notify block. Subscribers to
+        add_reconnect_callback must therefore be fired from here, or the documented
+        API is a silent no-op exactly when re-registration is needed.
+        """
+        conn = AsyncResilientRabbitMQ(connection_url=connection_url)
+        sync_callback = Mock()
+        async_callback = AsyncMock()
+        conn.add_reconnect_callback(sync_callback)
+        conn.add_reconnect_callback(async_callback)
+
+        await conn._on_reconnect()
+
+        sync_callback.assert_called_once()
+        async_callback.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_on_reconnect_isolates_failing_callbacks(self, connection_url: str) -> None:
+        """One bad subscriber must not stop the others or break reconnect handling."""
+        conn = AsyncResilientRabbitMQ(connection_url=connection_url)
+        failing = Mock(side_effect=RuntimeError("callback error"))
+        failing_async = AsyncMock(side_effect=RuntimeError("async callback error"))
+        good = Mock()
+        conn.add_reconnect_callback(failing)
+        conn.add_reconnect_callback(failing_async)
+        conn.add_reconnect_callback(good)
+        conn._channel = AsyncMock()
+
+        await conn._on_reconnect()
+
+        assert conn._channel is None
+        failing.assert_called_once()
+        failing_async.assert_awaited_once()
+        good.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_on_reconnect_notifies_without_holding_the_lock(self, connection_url: str) -> None:
+        """Callbacks routinely call back into channel(), which takes the same lock —
+        firing them under it would deadlock."""
+        conn = AsyncResilientRabbitMQ(connection_url=connection_url)
+        lock_was_free: list[bool] = []
+
+        def callback() -> None:
+            assert conn._lock is not None
+            lock_was_free.append(not conn._lock.locked())
+
+        conn.add_reconnect_callback(callback)
+
+        await conn._on_reconnect()
+
+        assert lock_was_free == [True]
+
+    @pytest.mark.asyncio
+    @patch("common.rabbitmq_resilient.connect_robust", new_callable=AsyncMock)
+    async def test_reconnect_hook_is_registered_with_aio_pika(
+        self, mock_connect_robust: AsyncMock, connection_url: str, mock_async_connection: AsyncMock
+    ) -> None:
+        """The hook only fires if it is actually wired to RobustConnection."""
+        mock_connect_robust.return_value = mock_async_connection
+
+        conn = AsyncResilientRabbitMQ(connection_url=connection_url)
+        await conn.connect()
+
+        mock_async_connection.reconnect_callbacks.add.assert_called_once_with(conn._on_reconnect)
+
     def test_add_reconnect_callback(self, connection_url: str) -> None:
         """Test adding reconnect callback."""
         conn = AsyncResilientRabbitMQ(connection_url=connection_url)

--- a/tests/dashboard/test_queue_prefix_wiring.py
+++ b/tests/dashboard/test_queue_prefix_wiring.py
@@ -1,0 +1,90 @@
+"""Regression tests for discogsography-dvmi.
+
+Every component derives queue/exchange names from DISCOGS_EXCHANGE_PREFIX /
+MUSICBRAINZ_EXCHANGE_PREFIX (CLAUDE.md: "never hardcode exchange names"). The
+dashboard was the sole exception: PIPELINE_CONFIGS carried the default literals, so
+under an override its RabbitMQ management-API filter matched nothing and both
+pipeline panes silently reported an empty, healthy-looking pipeline.
+
+`get_queue_info` logs nothing on a 200 that matches zero queues, so nothing in the
+default test suite could distinguish a correct env read from a hardcoded literal —
+hence the source-level assertions below, which are the negative test that was missing.
+"""
+
+from pathlib import Path
+import re
+from typing import Any
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from common.config import DISCOGS_EXCHANGE_PREFIX, MUSICBRAINZ_EXCHANGE_PREFIX
+from dashboard.dashboard import PIPELINE_CONFIGS
+
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+DASHBOARD_PY = REPO_ROOT / "dashboard" / "dashboard.py"
+SYSTEM_MONITOR_PY = REPO_ROOT / "utilities" / "system_monitor.py"
+
+# Matches a *string literal* containing a default prefix. Comments (which legitimately
+# name the env vars and the historical literals) are stripped before matching.
+_DEFAULT_PREFIX_LITERAL = re.compile(r"""["'][^"']*discogsography-(?:discogs|musicbrainz)[^"']*["']""")
+
+
+def _code_without_comments(path: Path) -> str:
+    return "\n".join(line for line in path.read_text(encoding="utf-8").splitlines() if not line.lstrip().startswith("#"))
+
+
+class TestPipelineConfigsUseEnvPrefixes:
+    """PIPELINE_CONFIGS must carry the env-derived prefixes, not their defaults."""
+
+    def test_discogs_prefix_is_the_shared_constant(self) -> None:
+        assert PIPELINE_CONFIGS["discogs"]["queue_prefix"] == DISCOGS_EXCHANGE_PREFIX
+
+    def test_musicbrainz_prefix_is_the_shared_constant(self) -> None:
+        assert PIPELINE_CONFIGS["musicbrainz"]["queue_prefix"] == MUSICBRAINZ_EXCHANGE_PREFIX
+
+    def test_dashboard_source_has_no_hardcoded_prefix_literal(self) -> None:
+        """Equality against the constant passes trivially when the env var is unset, so
+        also assert no default-prefix literal survives in the source at all."""
+        found = _DEFAULT_PREFIX_LITERAL.findall(_code_without_comments(DASHBOARD_PY))
+        assert not found, f"dashboard.py must derive queue prefixes from the environment; found literals: {found}"
+
+    def test_system_monitor_source_has_no_hardcoded_prefix_literal(self) -> None:
+        found = _DEFAULT_PREFIX_LITERAL.findall(_code_without_comments(SYSTEM_MONITOR_PY))
+        assert not found, f"system_monitor.py must derive queue prefixes from the environment; found literals: {found}"
+
+
+class TestQueuePrefixesEndpoint:
+    """admin.js builds DLQ names the API validates against its own env-derived list,
+    so the frontend has to be told the live prefixes rather than compiling them in."""
+
+    def test_endpoint_serves_the_env_derived_prefixes(
+        self,
+        mock_dashboard_config: Any,
+        dashboard_mock_amqp_connection: Any,
+        dashboard_mock_neo4j_driver: Any,
+        dashboard_mock_psycopg_connect: Any,
+    ) -> None:
+        with (
+            patch("dashboard.dashboard.get_config", return_value=mock_dashboard_config),
+            patch("dashboard.dashboard.AsyncResilientRabbitMQ", return_value=dashboard_mock_amqp_connection),
+            patch("dashboard.dashboard.AsyncResilientNeo4jDriver", return_value=dashboard_mock_neo4j_driver),
+            patch("dashboard.dashboard.AsyncResilientPostgreSQL", return_value=dashboard_mock_psycopg_connect),
+        ):
+            from dashboard.dashboard import app
+
+            response = TestClient(app, raise_server_exceptions=False).get("/api/queue-prefixes")
+
+        assert response.status_code == 200
+        assert response.json() == {"discogs": DISCOGS_EXCHANGE_PREFIX, "musicbrainz": MUSICBRAINZ_EXCHANGE_PREFIX}
+
+
+class TestAdminJsPrefixesAreOverridable:
+    """The admin frontend may keep the defaults as a fallback, but must refresh them
+    from the server before rendering DLQ names."""
+
+    def test_admin_js_fetches_queue_prefixes(self) -> None:
+        source = (REPO_ROOT / "dashboard" / "static" / "admin.js").read_text(encoding="utf-8")
+        assert "/api/queue-prefixes" in source, "admin.js must fetch the live prefixes"
+        assert "loadQueuePrefixes()" in source, "the fetched prefixes must actually be applied before rendering"

--- a/tests/graphinator/test_batch_processor.py
+++ b/tests/graphinator/test_batch_processor.py
@@ -929,6 +929,147 @@ class TestProcessMastersBatch:
         ]
 
 
+class TestStaleEdgePruning:
+    """discogsography-bd0u: relationship writes are MERGE-only and therefore additive,
+    but Discogs records are mutable. A release corrected from genres=["Rock"] to
+    genres=["Jazz"] gets a new sha256, passes the hash gate, MERGEs the Jazz edge — and
+    used to keep the Rock one forever. compute_genre_style_stats counts those stale
+    edges, so Genre/Style/Label counts were permanently over-stated and explore
+    endpoints listed the release under a genre it no longer has.
+    """
+
+    @staticmethod
+    def _tracking_session() -> tuple[Any, Any, list[tuple[str, dict[str, Any]]]]:
+        mock_driver, mock_session = create_async_session_mock()
+        mock_session.run = AsyncMock(return_value=create_async_result_mock([{"id": "1", "hash": "oldhash"}]))
+
+        executed: list[tuple[str, dict[str, Any]]] = []
+
+        async def track_query(query: str, **params: Any) -> None:
+            executed.append((query, params))
+
+        mock_tx = AsyncMock()
+        mock_tx.run.side_effect = track_query
+
+        async def execute_write_mock(tx_func: Any) -> None:
+            await tx_func(mock_tx)
+
+        mock_session.execute_write = AsyncMock(side_effect=execute_write_mock)
+        return mock_driver, mock_session, executed
+
+    @staticmethod
+    def _prunes(executed: list[tuple[str, dict[str, Any]]], rel_type: str, target: str) -> list[dict[str, Any]]:
+        return [params for query, params in executed if "DELETE rel" in query and f"[rel:{rel_type}]" in query and f":{target})" in query]
+
+    @pytest.mark.asyncio
+    async def test_release_prunes_dropped_genre_edges(self) -> None:
+        mock_driver, _session, executed = self._tracking_session()
+        processor = Neo4jBatchProcessor(mock_driver)
+
+        await processor._process_releases_batch(
+            [
+                PendingMessage(
+                    "releases",
+                    {"id": "1", "title": "R", "sha256": "newhash", "genres": ["Jazz"], "styles": []},
+                    AsyncMock(),
+                    AsyncMock(),
+                )
+            ]
+        )
+
+        genre_prunes = self._prunes(executed, "IS", "Genre")
+        assert len(genre_prunes) == 1
+        # Only the genres the NEW version asserts are kept; "Rock" no longer matches
+        # the keep-list, so its edge is deleted.
+        assert genre_prunes[0]["records"] == [{"key": "1", "keep": ["Jazz"]}]
+
+    @pytest.mark.asyncio
+    async def test_release_prunes_every_managed_edge_type(self) -> None:
+        mock_driver, _session, executed = self._tracking_session()
+        processor = Neo4jBatchProcessor(mock_driver)
+
+        await processor._process_releases_batch(
+            [
+                PendingMessage(
+                    "releases",
+                    {
+                        "id": "1",
+                        "title": "R",
+                        "sha256": "newhash",
+                        "artists": [{"id": "A1"}],
+                        "labels": [{"id": "L1"}],
+                        "master_id": "M1",
+                        "genres": ["Jazz"],
+                        "styles": ["Bebop"],
+                    },
+                    AsyncMock(),
+                    AsyncMock(),
+                )
+            ]
+        )
+
+        assert self._prunes(executed, "BY", "Artist")[0]["records"] == [{"key": "1", "keep": ["A1"]}]
+        assert self._prunes(executed, "ON", "Label")[0]["records"] == [{"key": "1", "keep": ["L1"]}]
+        assert self._prunes(executed, "DERIVED_FROM", "Master")[0]["records"] == [{"key": "1", "keep": ["M1"]}]
+        assert self._prunes(executed, "IS", "Style")[0]["records"] == [{"key": "1", "keep": ["Bebop"]}]
+
+    @pytest.mark.asyncio
+    async def test_release_with_no_associations_prunes_them_all(self) -> None:
+        """The "every association was removed" case: an empty keep-list must still run,
+        or the old edges survive with nothing to contradict them."""
+        mock_driver, _session, executed = self._tracking_session()
+        processor = Neo4jBatchProcessor(mock_driver)
+
+        await processor._process_releases_batch(
+            [PendingMessage("releases", {"id": "1", "title": "R", "sha256": "newhash"}, AsyncMock(), AsyncMock())]
+        )
+
+        for rel_type, target in (("BY", "Artist"), ("ON", "Label"), ("DERIVED_FROM", "Master"), ("IS", "Genre"), ("IS", "Style")):
+            prunes = self._prunes(executed, rel_type, target)
+            assert len(prunes) == 1, f"{rel_type}->{target} prune must run even with nothing to keep"
+            assert prunes[0]["records"] == [{"key": "1", "keep": []}]
+
+    @pytest.mark.asyncio
+    async def test_master_prunes_dropped_genre_and_style_edges(self) -> None:
+        mock_driver, _session, executed = self._tracking_session()
+        processor = Neo4jBatchProcessor(mock_driver)
+
+        await processor._process_masters_batch(
+            [
+                PendingMessage(
+                    "masters",
+                    {"id": "1", "title": "M", "sha256": "newhash", "genres": ["Jazz"], "styles": ["Bebop"]},
+                    AsyncMock(),
+                    AsyncMock(),
+                )
+            ]
+        )
+
+        assert self._prunes(executed, "IS", "Genre")[0]["records"] == [{"key": "1", "keep": ["Jazz"]}]
+        assert self._prunes(executed, "IS", "Style")[0]["records"] == [{"key": "1", "keep": ["Bebop"]}]
+        assert self._prunes(executed, "BY", "Artist")[0]["records"] == [{"key": "1", "keep": []}]
+
+    @pytest.mark.asyncio
+    async def test_unchanged_records_are_not_pruned(self) -> None:
+        """A record whose hash matches is never reprocessed, so its edges must be left
+        strictly alone — pruning there would delete edges nothing is about to rewrite."""
+        mock_driver, _session, executed = self._tracking_session()
+        processor = Neo4jBatchProcessor(mock_driver)
+
+        await processor._process_releases_batch(
+            [
+                PendingMessage(
+                    "releases",
+                    {"id": "1", "title": "R", "sha256": "oldhash", "genres": ["Rock"]},
+                    AsyncMock(),
+                    AsyncMock(),
+                )
+            ]
+        )
+
+        assert not [q for q, _ in executed if "DELETE rel" in q]
+
+
 class TestProcessReleasesBatch:
     """Test _process_releases_batch functionality."""
 

--- a/tests/graphinator/test_graphinator.py
+++ b/tests/graphinator/test_graphinator.py
@@ -4556,6 +4556,30 @@ class TestStubCleanupBatchAndOrdering:
         assert "n.sha256 IS NULL" in cypher
 
     @pytest.mark.asyncio
+    async def test_cleanup_only_deletes_stubs_with_no_relationships(self) -> None:
+        """discogsography-64aw: a stub that still has relationships must survive.
+
+        Its edges (BY/ON/DERIVED_FROM/MEMBER_OF) were written by fully-imported records
+        that referenced an entity missing from this dump. DETACH DELETE destroyed those
+        edges with the stub, and the loss was permanent: sha256 is purely
+        content-derived, so when the entity appears in a later dump the referencing
+        record is byte-identical, the hash-skip returns before the relationship blocks,
+        and the edge is never rebuilt.
+        """
+        import graphinator.graphinator as g
+
+        graph_mock, run_calls = self._make_graph_mock()
+        with patch.object(g, "graph", graph_mock):
+            ok = await g.cleanup_stub_nodes("artists")
+
+        assert ok is True
+        cypher = run_calls[0]
+        assert "NOT (n)--()" in cypher, "connected stubs must be excluded from the sweep"
+        # ...while genuinely orphaned stubs are still collected.
+        assert "n.sha256 IS NULL" in cypher
+        assert "DETACH DELETE" in cypher
+
+    @pytest.mark.asyncio
     async def test_cleanup_failure_returns_false_for_retry(self) -> None:
         """cu2.68: a failed delete must return False so the caller nacks/retries."""
         import graphinator.graphinator as g

--- a/tests/graphinator/test_graphinator.py
+++ b/tests/graphinator/test_graphinator.py
@@ -1853,7 +1853,9 @@ class TestMasterTransactionLogic:
         # 5. Style relationships
         # No genre-style (PART_OF) connection: multiple genres make the style-belongs-to
         # -genre assertion ambiguous, so it is skipped (discogsography-sy5k).
-        assert mock_tx.run.call_count == 5
+        # Plus 3 prune queries (BY/Genre-IS/Style-IS) that drop associations the record's
+        # new version no longer asserts before the additive MERGEs (discogsography-bd0u).
+        assert mock_tx.run.call_count == 8
         mock_message.ack.assert_called_once()
 
     @pytest.mark.asyncio
@@ -1974,7 +1976,9 @@ class TestReleaseTransactionLogic:
         # 6. Genre relationships
         # 7. Style relationships
         # 8. Genre-style connections
-        assert mock_tx.run.call_count == 8
+        # ...plus 5 prune queries (BY/ON/DERIVED_FROM/Genre-IS/Style-IS) that drop
+        # associations the record's new version no longer asserts (discogsography-bd0u).
+        assert mock_tx.run.call_count == 13
         mock_message.ack.assert_called_once()
 
     @pytest.mark.asyncio
@@ -2099,7 +2103,10 @@ class TestReleaseTransactionLogic:
         # 2. Create release node
         # 3. Person CREDITED_ON relationships
         # 4. Person SAME_AS relationships (for Bob Ludwig who has artist_id)
-        assert mock_tx.run.call_count == 4
+        # ...plus the 5 release prune queries (discogsography-bd0u), which run even when
+        # the record asserts no artists/labels/master/genres/styles — that is exactly the
+        # "every association was removed" case.
+        assert mock_tx.run.call_count == 9
         mock_message.ack.assert_called_once()
 
         # Verify credits cypher was called with correct data
@@ -3243,7 +3250,8 @@ class TestProcessMasterEdgeCases:
         result = await process_master(mock_tx, record)
         assert result is True
         calls = [str(c) for c in mock_tx.run.call_args_list]
-        assert not any("BY" in c and "artist" in c for c in calls)
+        assert not any("MERGE (m)-[:BY]->" in c and "UNWIND $artists" in c for c in calls)
+        assert not any("MERGE (r)-[:BY]->" in c and "UNWIND $artists" in c for c in calls)
 
 
 class TestProcessLabelSublabelsString:
@@ -3295,7 +3303,8 @@ class TestProcessReleaseArtistNoId:
         result = await process_release(mock_tx, record)
         assert result is True
         calls = [str(c) for c in mock_tx.run.call_args_list]
-        assert not any("BY" in c and "artist" in c for c in calls)
+        assert not any("MERGE (m)-[:BY]->" in c and "UNWIND $artists" in c for c in calls)
+        assert not any("MERGE (r)-[:BY]->" in c and "UNWIND $artists" in c for c in calls)
 
 
 class TestProcessReleaseLabelNoId:
@@ -3322,7 +3331,83 @@ class TestProcessReleaseLabelNoId:
         result = await process_release(mock_tx, record)
         assert result is True
         calls = [str(c) for c in mock_tx.run.call_args_list]
-        assert not any(")-[:ON]->" in c for c in calls)
+        assert not any("MERGE (r)-[:ON]->" in c for c in calls)
+
+
+class TestNonBatchStaleEdgePruning:
+    """discogsography-bd0u (non-batch mirror): the single-record path uses the same
+    MERGE-only, additive relationship writes as the batch processor, so it needs the
+    same prune of associations the record's new version no longer asserts."""
+
+    @staticmethod
+    def _prunes(mock_tx: Any, rel_type: str, target: str) -> list[dict[str, Any]]:
+        return [
+            call.kwargs
+            for call in mock_tx.run.call_args_list
+            if "DELETE rel" in call.args[0] and f"[rel:{rel_type}]" in call.args[0] and f":{target})" in call.args[0]
+        ]
+
+    @pytest.mark.asyncio
+    async def test_release_prunes_associations_that_were_dropped(self) -> None:
+        from graphinator.graphinator import process_release
+
+        mock_tx = MagicMock()
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value={"hash": "oldhash"})
+
+        record = {
+            "id": "release-1",
+            "sha256": "newhash",
+            "title": "Retagged Release",
+            "artists": [{"id": "A1"}],
+            "labels": [{"id": "L1"}],
+            "master_id": "M1",
+            "genres": ["Jazz"],
+            "styles": ["Bebop"],
+        }
+
+        assert await process_release(mock_tx, record) is True
+
+        assert self._prunes(mock_tx, "IS", "Genre")[0]["keep"] == ["Jazz"]
+        assert self._prunes(mock_tx, "IS", "Style")[0]["keep"] == ["Bebop"]
+        assert self._prunes(mock_tx, "BY", "Artist")[0]["keep"] == ["A1"]
+        assert self._prunes(mock_tx, "ON", "Label")[0]["keep"] == ["L1"]
+        assert self._prunes(mock_tx, "DERIVED_FROM", "Master")[0]["keep"] == ["M1"]
+
+    @pytest.mark.asyncio
+    async def test_master_prunes_dropped_associations(self) -> None:
+        from graphinator.graphinator import process_master
+
+        mock_tx = MagicMock()
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value={"hash": "oldhash"})
+
+        record = {
+            "id": "master-1",
+            "sha256": "newhash",
+            "title": "Retagged Master",
+            "genres": ["Jazz"],
+            "styles": [],
+        }
+
+        assert await process_master(mock_tx, record) is True
+
+        assert self._prunes(mock_tx, "IS", "Genre")[0]["keep"] == ["Jazz"]
+        # Every style was dropped — the empty keep-list is what removes those edges.
+        assert self._prunes(mock_tx, "IS", "Style")[0]["keep"] == []
+
+    @pytest.mark.asyncio
+    async def test_unchanged_record_is_not_pruned(self) -> None:
+        """A hash match returns before any write; pruning there would delete edges
+        nothing is about to rewrite."""
+        from graphinator.graphinator import process_release
+
+        mock_tx = MagicMock()
+        mock_tx.run = AsyncMock()
+        mock_tx.run.return_value.single = AsyncMock(return_value={"hash": "samehash"})
+
+        assert await process_release(mock_tx, {"id": "r1", "sha256": "samehash", "genres": ["Rock"]}) is False
+        assert not [c for c in mock_tx.run.call_args_list if "DELETE rel" in c.args[0]]
 
 
 class TestProcessReleaseMasterNoId:
@@ -3346,7 +3431,9 @@ class TestProcessReleaseMasterNoId:
         result = await process_release(mock_tx, record)
         assert result is True
         calls = [str(c) for c in mock_tx.run.call_args_list]
-        assert not any("DERIVED_FROM" in c for c in calls)
+        # The prune query still mentions DERIVED_FROM (with an empty keep-list, which
+        # correctly removes any stale edge); only the MERGE must be absent.
+        assert not any("MERGE (r)-[:DERIVED_FROM]" in c for c in calls)
 
 
 class TestMainConfigError:

--- a/tests/graphinator/test_graphinator.py
+++ b/tests/graphinator/test_graphinator.py
@@ -951,6 +951,40 @@ class TestCheckFileCompletion:
         mock_message.ack.assert_called_once()
 
     @pytest.mark.asyncio
+    @patch("graphinator.graphinator.batch_processor", None)
+    @patch("graphinator.graphinator.graph", None)
+    async def test_extraction_complete_marks_the_type_complete(self) -> None:
+        """discogsography-ewvh: extraction_complete is the type's terminal signal.
+
+        completed_files was written only by file_complete and erased by the recovery
+        path for any type whose queue still holds messages — and when the only pending
+        message IS this signal, nothing restored the flag, so the stall check logged at
+        ERROR every 30s forever and check_all_consumers_idle() could never return True.
+        """
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        completion_data = {"type": "extraction_complete", "version": "20260101"}
+        completed: set[str] = set()
+        mock_queue = MagicMock()
+
+        from graphinator.graphinator import check_file_completion
+
+        with (
+            patch("graphinator.graphinator.completed_files", completed),
+            patch("graphinator.graphinator.queues", {"artists": mock_queue}),
+            patch("graphinator.graphinator.CONSUMER_CANCEL_DELAY", 300),
+            patch("graphinator.graphinator.schedule_consumer_cancellation", new=AsyncMock()) as mock_schedule,
+            patch("graphinator.graphinator._sync_extraction_signals", new=AsyncMock()),
+            patch("graphinator.graphinator._persist_extraction_signals", new=AsyncMock()),
+            patch("graphinator.graphinator.extraction_complete_signals", set()),
+        ):
+            result = await check_file_completion(completion_data, "artists", mock_message)
+
+        assert result is True
+        assert completed == {"artists"}
+        mock_schedule.assert_awaited_once_with("artists", mock_queue)
+        mock_message.ack.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_extraction_complete_flushes_batches(self) -> None:
         """Test extraction_complete flushes batch processor before cleanup."""
         mock_message = AsyncMock(spec=AbstractIncomingMessage)

--- a/tests/graphinator/test_post_import_maintenance_detached.py
+++ b/tests/graphinator/test_post_import_maintenance_detached.py
@@ -17,7 +17,7 @@ task own the retry the nack used to provide.
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from aio_pika.abc import AbstractIncomingMessage
 import pytest
@@ -134,6 +134,74 @@ async def test_redelivered_trigger_does_not_start_a_second_run() -> None:
     # Both deliveries are still acked — an unacked duplicate would rot on the channel.
     first.ack.assert_awaited_once()
     second.ack.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_maintenance_drains_every_queue_before_cleanup() -> None:
+    """discogsography-fyxy: cleanup DETACH DELETEs sha256-less stubs of EVERY label, so
+    every batch queue — not just the signalling type's — must be quiescent first.
+
+    The extraction_complete branch flushes only its own data type, and a type whose
+    signal was acked earlier can still hold pending messages: _flush_queue re-enqueues a
+    transiently-failed batch at the front of that type's deque, so writes reappear after
+    flush_queue already judged it empty. Those batches then MERGE fresh stubs while the
+    sweep runs.
+    """
+    order: list[str] = []
+
+    async def flush_all() -> bool:
+        order.append("flush_all")
+        return True
+
+    async def cleanup() -> bool:
+        order.append("cleanup")
+        return True
+
+    async def stats() -> bool:
+        order.append("stats")
+        return True
+
+    mock_batch = MagicMock()
+    mock_batch.flush_all = flush_all
+
+    with (
+        patch.object(g, "graph", AsyncMock()),
+        patch.object(g, "batch_processor", mock_batch),
+        patch.object(g, "cleanup_all_stub_nodes", cleanup),
+        patch.object(g, "compute_genre_style_stats", stats),
+        patch.object(g, "POST_IMPORT_MAINTENANCE_RETRY_DELAY_SECONDS", 0.0),
+    ):
+        ok = await g.run_post_import_maintenance()
+
+    assert ok is True
+    assert order == ["flush_all", "cleanup", "stats"]
+
+
+@pytest.mark.asyncio
+async def test_maintenance_skips_sweeps_when_queues_do_not_drain() -> None:
+    """A queue that will not drain means writers are still creating stubs. Sweeping
+    anyway is what strands orphan stubs; defer to the retry instead."""
+    swept = {"n": 0}
+
+    async def cleanup() -> bool:
+        swept["n"] += 1
+        return True
+
+    mock_batch = MagicMock()
+    mock_batch.flush_all = AsyncMock(return_value=False)
+
+    with (
+        patch.object(g, "graph", AsyncMock()),
+        patch.object(g, "batch_processor", mock_batch),
+        patch.object(g, "cleanup_all_stub_nodes", cleanup),
+        patch.object(g, "compute_genre_style_stats", AsyncMock(return_value=True)),
+        patch.object(g, "POST_IMPORT_MAINTENANCE_RETRY_DELAY_SECONDS", 0.0),
+    ):
+        ok = await g.run_post_import_maintenance()
+
+    assert ok is False
+    assert swept["n"] == 0, "stub cleanup must not run over queues that are still writing"
+    assert mock_batch.flush_all.await_count == g.POST_IMPORT_MAINTENANCE_MAX_ATTEMPTS
 
 
 @pytest.mark.asyncio

--- a/tests/tableinator/test_tableinator.py
+++ b/tests/tableinator/test_tableinator.py
@@ -977,6 +977,33 @@ class TestOnDataMessageExtended:
         mock_message.nack.assert_called_once_with(requeue=False)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_id", [None, ""])
+    @patch("tableinator.tableinator.shutdown_requested", False)
+    async def test_handles_falsy_id_field(self, bad_id: str | None) -> None:
+        """discogsography-ria1: a present-but-falsy id is just as invalid as a missing one.
+
+        Key-presence-only validation let `"id": null` reach an INSERT into a NOT NULL
+        PRIMARY KEY; the resulting deterministic IntegrityError fell to the generic
+        handler and was nacked with requeue=True, burning all 20 redeliveries before the
+        DLQ. `"id": ""` was worse — it upserted a junk row keyed on the empty string and
+        was acked as a success. Every sibling consumer already rejects falsy ids.
+        """
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        mock_message.body = json.dumps({"id": bad_id, "name": "Test Artist"}).encode()
+        mock_message.routing_key = "artists"
+
+        with (
+            patch("tableinator.tableinator.logger"),
+            patch("tableinator.tableinator.BATCH_MODE", False),
+            patch("tableinator.tableinator.connection_pool", MagicMock()),
+        ):
+            await on_data_message(mock_message, "artists")
+
+        # Deterministic poison -> straight to the DLQ, no redelivery cycling, no write.
+        mock_message.nack.assert_called_once_with(requeue=False)
+        mock_message.ack.assert_not_called()
+
+    @pytest.mark.asyncio
     @patch("tableinator.tableinator.shutdown_requested", False)
     async def test_handles_no_connection_pool(self) -> None:
         """Test handling when connection pool is not initialized."""

--- a/tests/tableinator/test_tableinator.py
+++ b/tests/tableinator/test_tableinator.py
@@ -880,6 +880,80 @@ class TestOnDataMessageExtended:
 
     @pytest.mark.asyncio
     @patch("tableinator.tableinator.shutdown_requested", False)
+    async def test_extraction_complete_marks_the_type_complete(self) -> None:
+        """discogsography-ewvh: extraction_complete is the type's terminal signal.
+
+        completed_files was written only by file_complete and erased by
+        _recover_consumers for any type whose queue still holds messages — and when the
+        only pending message IS this signal, nothing restored the flag. The service then
+        logged "Stalled consumers detected" at ERROR every 30s forever and
+        check_all_consumers_idle() could never return True, holding the connection and
+        four idle consumers open until restart.
+        """
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        mock_message.body = json.dumps({"type": "extraction_complete", "version": "20260101", "started_at": "2026-01-01T00:00:00Z"}).encode()
+        completed: set[str] = set()  # as left by _recover_consumers' discard
+
+        with (
+            patch("tableinator.tableinator.logger"),
+            patch("tableinator.tableinator.batch_processor", None),
+            patch("tableinator.tableinator.connection_pool", None),
+            patch("tableinator.tableinator.completed_files", completed),
+            patch("tableinator.tableinator.queues", {}),
+        ):
+            await on_data_message(mock_message, "artists")
+
+        assert completed == {"artists"}
+        mock_message.ack.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("tableinator.tableinator.shutdown_requested", False)
+    async def test_extraction_complete_rearms_consumer_cancellation(self) -> None:
+        """The file_complete that originally scheduled cancellation was consumed in an
+        earlier session, so the terminal signal has to re-arm it or the consumer is
+        never released."""
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        mock_message.body = json.dumps({"type": "extraction_complete", "version": "20260101", "started_at": "2026-01-01T00:00:00Z"}).encode()
+        mock_queue = MagicMock()
+
+        with (
+            patch("tableinator.tableinator.logger"),
+            patch("tableinator.tableinator.batch_processor", None),
+            patch("tableinator.tableinator.connection_pool", None),
+            patch("tableinator.tableinator.completed_files", set()),
+            patch("tableinator.tableinator.queues", {"artists": mock_queue}),
+            patch("tableinator.tableinator.CONSUMER_CANCEL_DELAY", 300),
+            patch("tableinator.tableinator.schedule_consumer_cancellation", new=AsyncMock()) as mock_schedule,
+        ):
+            await on_data_message(mock_message, "artists")
+
+        mock_schedule.assert_awaited_once_with("artists", mock_queue)
+
+    @pytest.mark.asyncio
+    @patch("tableinator.tableinator.shutdown_requested", False)
+    async def test_extraction_complete_does_not_mark_complete_on_failed_purge(self) -> None:
+        """A requeued signal must not leave the type marked complete — the purge still
+        owes a retry."""
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        mock_message.body = json.dumps({"type": "extraction_complete", "version": "20260101", "started_at": "2026-01-01T00:00:00Z"}).encode()
+        completed: set[str] = set()
+
+        with (
+            patch("tableinator.tableinator.logger"),
+            patch("tableinator.tableinator.batch_processor", None),
+            patch("tableinator.tableinator.connection_pool", MagicMock()),
+            patch("tableinator.tableinator.completed_files", completed),
+            patch("tableinator.tableinator.queues", {}),
+            patch("tableinator.tableinator.purge_stale_rows", side_effect=Exception("purge boom")),
+        ):
+            await on_data_message(mock_message, "artists")
+
+        assert completed == set()
+        mock_message.nack.assert_called_once_with(requeue=True)
+        mock_message.ack.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("tableinator.tableinator.shutdown_requested", False)
     async def test_extraction_complete_flushes_batches(self) -> None:
         """Test extraction_complete flushes batch processor."""
         mock_message = AsyncMock(spec=AbstractIncomingMessage)

--- a/tests/tableinator/test_tableinator.py
+++ b/tests/tableinator/test_tableinator.py
@@ -1979,6 +1979,57 @@ class TestOnDataMessageDatabaseOperations:
 
     @pytest.mark.asyncio
     @patch("tableinator.tableinator.shutdown_requested", False)
+    @patch("tableinator.tableinator.BATCH_MODE", False)
+    async def test_handles_integrity_error_without_requeue(self, sample_artist_data: dict[str, Any]) -> None:
+        """discogsography-yuyg (mirror): a constraint violation is deterministic.
+
+        IntegrityError (e.g. NotNullViolation) is not a subclass of DataError, so it
+        used to reach the generic handler and be nacked with requeue=True, spending all
+        20 of the quorum queue's redeliveries — each opening a pooled connection and
+        rolling back — before the broker dead-lettered it anyway."""
+        from psycopg.errors import NotNullViolation
+
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        mock_message.body = json.dumps(sample_artist_data).encode()
+        mock_message.routing_key = "artists"
+
+        mock_pool = MagicMock()
+        mock_pool.connection.side_effect = NotNullViolation('null value in column "data_id"')
+
+        with (
+            patch("tableinator.tableinator.connection_pool", mock_pool),
+            patch("tableinator.tableinator.logger"),
+        ):
+            await on_data_message(mock_message, "artists")
+
+        mock_message.nack.assert_called_once_with(requeue=False)
+        mock_message.ack.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("tableinator.tableinator.shutdown_requested", False)
+    @patch("tableinator.tableinator.BATCH_MODE", False)
+    async def test_handles_data_error_without_requeue(self, sample_artist_data: dict[str, Any]) -> None:
+        """The cast-failure half of the same classification."""
+        from psycopg.errors import DataError
+
+        mock_message = AsyncMock(spec=AbstractIncomingMessage)
+        mock_message.body = json.dumps(sample_artist_data).encode()
+        mock_message.routing_key = "artists"
+
+        mock_pool = MagicMock()
+        mock_pool.connection.side_effect = DataError("invalid input syntax")
+
+        with (
+            patch("tableinator.tableinator.connection_pool", mock_pool),
+            patch("tableinator.tableinator.logger"),
+        ):
+            await on_data_message(mock_message, "artists")
+
+        mock_message.nack.assert_called_once_with(requeue=False)
+        mock_message.ack.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("tableinator.tableinator.shutdown_requested", False)
     async def test_handles_nack_failure(self, sample_artist_data: dict[str, Any]) -> None:
         """Test handling failure during nack operation."""
         mock_message = AsyncMock(spec=AbstractIncomingMessage)

--- a/tests/tableinator/test_tableinator.py
+++ b/tests/tableinator/test_tableinator.py
@@ -13,6 +13,7 @@ from aio_pika.abc import AbstractIncomingMessage
 import pytest
 
 from tableinator.tableinator import (
+    channel_prefetch,
     check_all_consumers_idle,
     close_rabbitmq_connection,
     get_connection,
@@ -48,6 +49,65 @@ class TestGetConnection:
             pytest.raises(RuntimeError, match="Connection pool not initialized"),
         ):
             get_connection()
+
+
+class TestChannelPrefetch:
+    """discogsography-4fio: QoS must be coupled to the PostgreSQL pool in non-batch mode.
+
+    In non-batch mode every in-flight handler holds a pooled connection for its upsert.
+    Per-consumer QoS of 200 across 4 consumers put 800 handlers in flight against a
+    12-connection pool; losers of that race raised out of the pool's bounded
+    exhausted-wait, were nacked with requeue=True, and burned the quorum queue's
+    x-delivery-limit until the message was silently dead-lettered.
+    """
+
+    def test_non_batch_prefetch_is_channel_global_and_matches_pool_max(self) -> None:
+        mock_config = MagicMock()
+        mock_config.postgres_pool_max_size = 12
+
+        with (
+            patch("tableinator.tableinator.BATCH_MODE", False),
+            patch("tableinator.tableinator.config", mock_config),
+        ):
+            prefetch, global_ = channel_prefetch()
+
+        assert prefetch == 12
+        # global_=True bounds the CHANNEL's total unacked deliveries, not each consumer's.
+        assert global_ is True
+
+    def test_non_batch_prefetch_falls_back_when_config_unset(self) -> None:
+        from tableinator.tableinator import _DEFAULT_POOL_MAX
+
+        with (
+            patch("tableinator.tableinator.BATCH_MODE", False),
+            patch("tableinator.tableinator.config", None),
+        ):
+            prefetch, global_ = channel_prefetch()
+
+        assert prefetch == _DEFAULT_POOL_MAX
+        assert global_ is True
+
+    def test_batch_prefetch_stays_per_consumer_and_scales_with_batch_size(self) -> None:
+        """Batch mode hands off to the batch processor rather than holding a connection
+        per message, and each queue needs BATCH_SIZE unacked deliveries of its OWN data
+        type for a batch to fill — so QoS deliberately stays per-consumer there."""
+        with (
+            patch("tableinator.tableinator.BATCH_MODE", True),
+            patch("tableinator.tableinator.BATCH_SIZE", 500),
+        ):
+            prefetch, global_ = channel_prefetch()
+
+        assert prefetch == 1000
+        assert global_ is False
+
+    def test_batch_prefetch_has_a_floor_of_200(self) -> None:
+        with (
+            patch("tableinator.tableinator.BATCH_MODE", True),
+            patch("tableinator.tableinator.BATCH_SIZE", 10),
+        ):
+            prefetch, _ = channel_prefetch()
+
+        assert prefetch == 200
 
 
 class TestMakeDataHandler:

--- a/tests/utilities/test_system_monitor.py
+++ b/tests/utilities/test_system_monitor.py
@@ -142,6 +142,33 @@ def test_monitor_system_all_healthy(capsys) -> None:
     assert "No recent errors found" in out
 
 
+def test_monitor_system_honors_overridden_queue_prefixes(capsys) -> None:
+    """discogsography-dvmi: the queue filter and the display shortening must both follow
+    DISCOGS_EXCHANGE_PREFIX / MUSICBRAINZ_EXCHANGE_PREFIX. With the prefixes hardcoded,
+    an override made the filter match nothing and the monitor reported an empty broker."""
+    queues = [
+        {"name": "staging-discogs-graphinator-artists", "messages_ready": 2, "messages_unacknowledged": 1, "messages": 3},
+        {"name": "staging-musicbrainz-brainztableinator-releases", "messages_ready": 0, "messages_unacknowledged": 0, "messages": 4},
+    ]
+    with (
+        patch.object(system_monitor, "DISCOGS_EXCHANGE_PREFIX", "staging-discogs"),
+        patch.object(system_monitor, "MUSICBRAINZ_EXCHANGE_PREFIX", "staging-musicbrainz"),
+        patch.object(system_monitor, "get_docker_stats", return_value=[]),
+        patch.object(system_monitor, "get_queue_stats", return_value=queues),
+        patch.object(system_monitor, "check_neo4j_status", return_value="neo4j ok"),
+        patch.object(system_monitor, "check_postgres_status", return_value="pg ok"),
+        patch.object(system_monitor, "get_service_logs", return_value="INFO all good"),
+    ):
+        system_monitor.monitor_system()
+
+    out = capsys.readouterr().out
+    assert "Total messages: 7" in out
+    # Labels are shortened using the overridden prefixes, not left fully qualified.
+    assert "graphinator-artists" in out
+    assert "mb-brainztableinator-releases" in out
+    assert "staging-discogs-graphinator-artists" not in out
+
+
 def test_monitor_system_all_unavailable(capsys) -> None:
     def fake_logs(service: str, _lines: int = 20) -> str:
         return "ERROR something Failed badly" if service == "graphinator" else ""

--- a/utilities/system_monitor.py
+++ b/utilities/system_monitor.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import requests
 
-from common.config import get_secret
+from common.config import DISCOGS_EXCHANGE_PREFIX, MUSICBRAINZ_EXCHANGE_PREFIX, get_secret
 
 
 def get_docker_stats() -> list[dict[str, Any]]:
@@ -153,8 +153,11 @@ def monitor_system() -> None:
     else:
         total_messages = 0
         for queue in queues:
-            if "discogsography" in queue["name"] or "musicbrainz" in queue["name"]:
-                name = queue["name"].replace("discogsography-discogs-", "").replace("discogsography-musicbrainz-", "mb-")
+            if queue["name"].startswith((DISCOGS_EXCHANGE_PREFIX, MUSICBRAINZ_EXCHANGE_PREFIX)):
+                # Shorten for display using the env-derived prefixes, not hardcoded
+                # literals — under a prefix override the labels stayed fully qualified
+                # and the filter above matched nothing at all (discogsography-dvmi).
+                name = queue["name"].replace(f"{DISCOGS_EXCHANGE_PREFIX}-", "").replace(f"{MUSICBRAINZ_EXCHANGE_PREFIX}-", "mb-")
                 ready = queue.get("messages_ready", 0)
                 unacked = queue.get("messages_unacknowledged", 0)
                 total = queue.get("messages", 0)


### PR DESCRIPTION
Fixes 14 priority-3 messaging/pipeline findings from the 2026-08-10 bug hunt (run `wf_646d4b21`), one commit per bead.

## Message handling & consumers
- **discogsography-06gd** — 'release-group' entity type canonicalized at the extractor boundary (ends the musicbrainz.relationships vocabulary drift).
- **discogsography-4fio** — tableinator non-batch prefetch coupled to the PostgreSQL pool size.
- **discogsography-ria1** — falsy record ids dead-lettered in non-batch mode instead of churning 20 redeliveries.
- **discogsography-iud5** — present-but-null 'ended'/'attributes' fields coalesced instead of trusting .get() defaults.
- **discogsography-yuyg** — deterministic NOT NULL violations dead-lettered instead of requeue-churning.
- **discogsography-6ino** — AsyncResilientRabbitMQ reconnect callbacks fire on aio-pika auto-reconnects.

## Extraction-complete pipeline
- **discogsography-d58d** — extractor reports a failed extraction_complete broadcast as failure, not Completed.
- **discogsography-ewvh** — a recovered data type is re-marked complete on extraction_complete.
- **discogsography-exnk** — pre-existing 'waiting' status no longer read as terminal success.
- **discogsography-fyxy** — every data type's batch queue drains before post-import maintenance.
- **discogsography-64aw** — stub cleanup collects only isolated stub nodes; relationships from fully-imported releases survive.

## Durability & reprocessing
- **discogsography-mm27** — state-marker saves fsync the temp file and parent directory (rebased onto #467's fsync work; both test suites kept).
- **discogsography-bd0u** — hash-changed records prune relationships they no longer assert.
- **discogsography-dvmi** — dashboard derives queue prefixes from the exchange-prefix env vars.

Validation: cargo fmt/clippy/test green after conflict resolution; ruff/mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrLwHwMcu3cuQJh8cc1SyW