### PR TITLE
fix: explore frontend UX & resilience — 7 bug-hunt findings (batch:p3-frontend)

### DIFF
--- a/dashboard/static/admin.js
+++ b/dashboard/static/admin.js
@@ -99,6 +99,8 @@ class AdminDashboard {
         this._eaVdRule = '';
         this._eaVdEntityType = '';
         this._eaVdPage = 1;
+        this._toastHideTimer = null;
+        this._toastRemoveTimer = null;
         this.bindEvents();
         if (this.token) {
             this.showPanel();
@@ -884,6 +886,18 @@ class AdminDashboard {
         const toast = document.getElementById('toast');
         if (!toast) return;
 
+        // Clear any pending hide/remove timers from a still-visible prior toast
+        // so overlapping calls don't hide this one early (each new toast resets
+        // its own 3s + 300ms window).
+        if (this._toastHideTimer) {
+            clearTimeout(this._toastHideTimer);
+            this._toastHideTimer = null;
+        }
+        if (this._toastRemoveTimer) {
+            clearTimeout(this._toastRemoveTimer);
+            this._toastRemoveTimer = null;
+        }
+
         toast.textContent = message;
         toast.style.display = 'block';
 
@@ -902,12 +916,14 @@ class AdminDashboard {
         });
 
         // Animate out after 3 seconds
-        setTimeout(() => {
+        this._toastHideTimer = setTimeout(() => {
             toast.style.opacity = '0';
             toast.style.transform = 'translateY(0.5rem)';
-            setTimeout(() => {
+            this._toastRemoveTimer = setTimeout(() => {
                 toast.style.display = 'none';
+                this._toastRemoveTimer = null;
             }, 300);
+            this._toastHideTimer = null;
         }, 3000);
     }
 

--- a/explore/__tests__/api-client.test.js
+++ b/explore/__tests__/api-client.test.js
@@ -1426,4 +1426,62 @@ describe('ApiClient', () => {
             expect(fetchSpy.mock.calls[0][1].method).toBe('DELETE');
         });
     });
+
+    describe('_checkAuthResponse (regression discogsography-ponr)', () => {
+        beforeEach(() => {
+            window.authManager = {
+                isLoggedIn: vi.fn().mockReturnValue(true),
+                clear: vi.fn(),
+                notify: vi.fn(),
+            };
+        });
+
+        it('clears and notifies authManager on a 401 response', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: false, status: 401, json: async () => ({}) }));
+
+            await window.apiClient.getUserCollection('expired-token');
+
+            expect(window.authManager.clear).toHaveBeenCalledTimes(1);
+            expect(window.authManager.notify).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not touch authManager on a non-401 error response', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: false, status: 500, json: async () => ({}) }));
+
+            await window.apiClient.getUserCollection('some-token');
+
+            expect(window.authManager.clear).not.toHaveBeenCalled();
+            expect(window.authManager.notify).not.toHaveBeenCalled();
+        });
+
+        it('does not touch authManager on a successful response', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: true, status: 200, json: async () => ({ releases: [], total: 0 }) }));
+
+            await window.apiClient.getUserCollection('valid-token');
+
+            expect(window.authManager.clear).not.toHaveBeenCalled();
+            expect(window.authManager.notify).not.toHaveBeenCalled();
+        });
+
+        it('does not throw when window.authManager is not yet set', async () => {
+            delete window.authManager;
+            vi.stubGlobal('fetch', async () => ({ ok: false, status: 401, json: async () => ({}) }));
+
+            await expect(window.apiClient.getUserCollection('expired-token')).resolves.toBeNull();
+        });
+
+        it('is applied across the other authenticated user-data/app-token methods too', async () => {
+            vi.stubGlobal('fetch', async () => ({ ok: false, status: 401, json: async () => ({}) }));
+
+            await window.apiClient.getUserWantlist('expired-token');
+            await window.apiClient.getUserRecommendations('expired-token');
+            await window.apiClient.getUserCollectionStats('expired-token');
+            await window.apiClient.listAppTokens('expired-token');
+            await window.apiClient.getMe('expired-token');
+            await window.apiClient.getSyncStatus('expired-token');
+
+            expect(window.authManager.clear).toHaveBeenCalledTimes(6);
+            expect(window.authManager.notify).toHaveBeenCalledTimes(6);
+        });
+    });
 });

--- a/explore/__tests__/app.test.js
+++ b/explore/__tests__/app.test.js
@@ -2024,6 +2024,23 @@ describe('ExploreApp helper methods', () => {
             expect(window.authManager.init).toHaveBeenCalled();
             expect(result).toBe(true);
         });
+
+        it('should still call _restoreFromUrl (not strand it) if _initAuth rejects for an unrelated reason (regression discogsography-ponr)', async () => {
+            history.replaceState(null, '', '/');
+            const restoreSpy = vi.spyOn(ExploreApp.prototype, '_restoreFromUrl').mockResolvedValue(undefined);
+            // authManager.init() itself now catches network rejections
+            // internally, but this exercises the app.js-level backstop for
+            // any other unexpected failure in the auth-init chain.
+            window.authManager.init.mockRejectedValue(new Error('unexpected failure'));
+
+            new ExploreApp();
+            // Let the unawaited constructor promise chain settle.
+            await new Promise(resolve => setTimeout(resolve, 0));
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(restoreSpy).toHaveBeenCalled();
+            restoreSpy.mockRestore();
+        });
     });
 
     describe('ExploreApp._loadExplore', () => {

--- a/explore/__tests__/app.test.js
+++ b/explore/__tests__/app.test.js
@@ -868,6 +868,80 @@ describe('ExploreApp helper methods', () => {
 
             expect(app.activePane).toBe('explore');
         });
+
+        it('should switch to explore pane when logged out on the gaps pane', () => {
+            window.authManager.isLoggedIn.mockReturnValue(false);
+            window.authManager.getUser.mockReturnValue(null);
+            window.authManager.getDiscogsStatus.mockReturnValue(null);
+
+            const app = new ExploreApp();
+            app.activePane = 'gaps';
+            app._updateAuthUI();
+
+            expect(app.activePane).toBe('explore');
+        });
+
+        it('should switch to explore pane when logged out on the settings pane', () => {
+            window.authManager.isLoggedIn.mockReturnValue(false);
+            window.authManager.getUser.mockReturnValue(null);
+            window.authManager.getDiscogsStatus.mockReturnValue(null);
+
+            const app = new ExploreApp();
+            app.activePane = 'settings';
+            app._updateAuthUI();
+
+            expect(app.activePane).toBe('explore');
+        });
+
+        it('should clear rendered settings email on logout', () => {
+            window.authManager.isLoggedIn.mockReturnValue(false);
+            window.authManager.getUser.mockReturnValue(null);
+            window.authManager.getDiscogsStatus.mockReturnValue(null);
+
+            const settingsEmailEl = document.createElement('div');
+            settingsEmailEl.id = 'settingsEmail';
+            settingsEmailEl.textContent = 'alice@example.com';
+            document.body.appendChild(settingsEmailEl);
+
+            const app = new ExploreApp();
+            app.activePane = 'settings';
+            app._updateAuthUI();
+
+            expect(document.getElementById('settingsEmail').textContent).toBe('');
+        });
+
+        it('should clear rendered gaps body content on logout', () => {
+            window.authManager.isLoggedIn.mockReturnValue(false);
+            window.authManager.getUser.mockReturnValue(null);
+            window.authManager.getDiscogsStatus.mockReturnValue(null);
+
+            const gapsBodyEl = document.createElement('div');
+            gapsBodyEl.id = 'gapsBody';
+            gapsBodyEl.innerHTML = '<p>Some personal gap analysis</p>';
+            document.body.appendChild(gapsBodyEl);
+
+            const app = new ExploreApp();
+            app.activePane = 'gaps';
+            app._updateAuthUI();
+
+            expect(document.getElementById('gapsBody').textContent).toBe('');
+        });
+
+        it('should not touch settingsEmail/gapsBody while still logged in', () => {
+            window.authManager.isLoggedIn.mockReturnValue(true);
+            window.authManager.getUser.mockReturnValue({ email: 'alice@example.com' });
+            window.authManager.getDiscogsStatus.mockReturnValue({ connected: false });
+
+            const settingsEmailEl = document.createElement('div');
+            settingsEmailEl.id = 'settingsEmail';
+            settingsEmailEl.textContent = 'alice@example.com';
+            document.body.appendChild(settingsEmailEl);
+
+            const app = new ExploreApp();
+            app._updateAuthUI();
+
+            expect(document.getElementById('settingsEmail').textContent).toBe('alice@example.com');
+        });
     });
 
     describe('ExploreApp._updateAuthUI - Discogs connected', () => {

--- a/explore/__tests__/app.test.js
+++ b/explore/__tests__/app.test.js
@@ -1822,6 +1822,18 @@ describe('ExploreApp helper methods', () => {
 
             expect(document.getElementById('loginSubmitBtn').disabled).toBe(false);
         });
+
+        it('should show network-error feedback and re-enable the button on a rejected fetch (regression discogsography-cmw0)', async () => {
+            document.getElementById('loginEmail').value = 'test@test.com';
+            document.getElementById('loginPassword').value = 'password123';
+            window.apiClient.login.mockRejectedValue(new TypeError('Failed to fetch'));
+
+            const app = new ExploreApp();
+            await expect(app._handleLogin()).resolves.toBeUndefined();
+
+            expect(document.getElementById('loginError').textContent).toContain('Could not reach the server');
+            expect(document.getElementById('loginSubmitBtn').disabled).toBe(false);
+        });
     });
 
     describe('ExploreApp._handleRegister - full flow', () => {
@@ -1856,6 +1868,18 @@ describe('ExploreApp helper methods', () => {
             const app = new ExploreApp();
             await app._handleRegister();
 
+            expect(document.getElementById('registerSubmitBtn').disabled).toBe(false);
+        });
+
+        it('should show network-error feedback and re-enable the button on a rejected fetch (regression discogsography-cmw0)', async () => {
+            document.getElementById('registerEmail').value = 'new@test.com';
+            document.getElementById('registerPassword').value = 'password123';
+            window.apiClient.register.mockRejectedValue(new TypeError('Failed to fetch'));
+
+            const app = new ExploreApp();
+            await expect(app._handleRegister()).resolves.toBeUndefined();
+
+            expect(document.getElementById('registerError').textContent).toContain('Could not reach the server');
             expect(document.getElementById('registerSubmitBtn').disabled).toBe(false);
         });
     });
@@ -2780,6 +2804,18 @@ describe('ExploreApp - password reset and 2FA UI handlers', () => {
 
             expect(document.getElementById('resetRequestError').textContent).toBeTruthy();
         });
+
+        it('should show error feedback (not throw unhandled) on a rejected fetch (regression discogsography-cmw0)', async () => {
+            new ExploreApp();
+            document.getElementById('resetEmail').value = 'user@example.com';
+            window.apiClient.resetRequest = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+
+            document.getElementById('resetRequestBtn').click();
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(document.getElementById('resetRequestError').textContent).toBeTruthy();
+            expect(document.getElementById('resetRequestSuccess').classList.contains('hidden')).toBe(true);
+        });
     });
 
     describe('login with 2FA challenge response', () => {
@@ -2894,6 +2930,21 @@ describe('ExploreApp - password reset and 2FA UI handlers', () => {
             await new Promise(resolve => setTimeout(resolve, 0));
 
             expect(document.getElementById('resetConfirmError').textContent).toContain('Token expired');
+        });
+
+        it('should show error feedback (not throw unhandled) on a rejected fetch (regression discogsography-cmw0)', async () => {
+            new ExploreApp();
+            document.getElementById('newPassword').value = 'newpassword123';
+            document.getElementById('confirmNewPassword').value = 'newpassword123';
+            delete window.location;
+            window.location = { search: '?reset_token=abc123', pathname: '/', href: '' };
+            window.apiClient.resetConfirm = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+
+            document.getElementById('resetConfirmBtn').click();
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            expect(document.getElementById('resetConfirmError').textContent).toBeTruthy();
+            expect(document.getElementById('resetConfirmSuccess').classList.contains('hidden')).toBe(true);
         });
     });
 

--- a/explore/__tests__/auth.test.js
+++ b/explore/__tests__/auth.test.js
@@ -185,5 +185,92 @@ describe('AuthManager', () => {
             expect(window.authManager.isLoggedIn()).toBe(false);
             expect(localStorage.getItem('auth_token')).toBeNull();
         });
+
+        it('should not throw and should clear state on a network-level fetch rejection (regression discogsography-ponr)', async () => {
+            localStorage.setItem('auth_token', 'stale-token');
+            loadScript('auth.js');
+
+            window.apiClient = {
+                getMe: vi.fn().mockRejectedValue(new TypeError('Failed to fetch')),
+                getDiscogsStatus: vi.fn(),
+            };
+
+            const result = await window.authManager.init();
+
+            expect(result).toBe(false);
+            expect(window.authManager.isLoggedIn()).toBe(false);
+            expect(localStorage.getItem('auth_token')).toBeNull();
+        });
+
+        it('should clear state on a network-level rejection from the second (getDiscogsStatus) call too (regression discogsography-ponr)', async () => {
+            localStorage.setItem('auth_token', 'stale-token');
+            loadScript('auth.js');
+
+            window.apiClient = {
+                getMe: vi.fn().mockResolvedValue({ id: 1, email: 'user@test.com' }),
+                getDiscogsStatus: vi.fn().mockRejectedValue(new TypeError('Failed to fetch')),
+            };
+
+            const result = await window.authManager.init();
+
+            expect(result).toBe(false);
+            expect(window.authManager.isLoggedIn()).toBe(false);
+        });
+    });
+
+    describe('cross-tab sync (regression discogsography-ponr)', () => {
+        it('clears local state and notifies listeners when another tab removes auth_token', () => {
+            localStorage.setItem('auth_token', 'shared-token');
+            loadScript('auth.js');
+            expect(window.authManager.isLoggedIn()).toBe(true);
+
+            const listener = vi.fn();
+            window.authManager.onChange(listener);
+
+            window.dispatchEvent(new StorageEvent('storage', { key: 'auth_token', newValue: null, oldValue: 'shared-token' }));
+
+            expect(window.authManager.isLoggedIn()).toBe(false);
+            expect(window.authManager.getToken()).toBeNull();
+            expect(listener).toHaveBeenCalledWith(false);
+        });
+
+        it('adopts a new token set by another tab (e.g. login there)', () => {
+            loadScript('auth.js');
+            expect(window.authManager.isLoggedIn()).toBe(false);
+
+            const listener = vi.fn();
+            window.authManager.onChange(listener);
+
+            window.dispatchEvent(new StorageEvent('storage', { key: 'auth_token', newValue: 'new-token-from-other-tab', oldValue: null }));
+
+            expect(window.authManager.isLoggedIn()).toBe(true);
+            expect(window.authManager.getToken()).toBe('new-token-from-other-tab');
+            expect(listener).toHaveBeenCalledWith(true);
+        });
+
+        it('ignores storage events for unrelated keys', () => {
+            localStorage.setItem('auth_token', 'shared-token');
+            loadScript('auth.js');
+
+            const listener = vi.fn();
+            window.authManager.onChange(listener);
+
+            window.dispatchEvent(new StorageEvent('storage', { key: 'some_other_key', newValue: 'x', oldValue: 'y' }));
+
+            expect(window.authManager.isLoggedIn()).toBe(true);
+            expect(listener).not.toHaveBeenCalled();
+        });
+
+        it('does not re-notify when the storage event reports the same token already held', () => {
+            localStorage.setItem('auth_token', 'shared-token');
+            loadScript('auth.js');
+
+            const listener = vi.fn();
+            window.authManager.onChange(listener);
+
+            window.dispatchEvent(new StorageEvent('storage', { key: 'auth_token', newValue: 'shared-token', oldValue: 'shared-token' }));
+
+            expect(listener).not.toHaveBeenCalled();
+        });
     });
 });

--- a/explore/__tests__/autocomplete.test.js
+++ b/explore/__tests__/autocomplete.test.js
@@ -294,6 +294,17 @@ describe('Autocomplete', () => {
             expect(instance.activeIndex).toBe(-1);
         });
 
+        it('should close the dropdown (not stay stuck) on a network-level fetch rejection (regression discogsography-cmw0)', async () => {
+            instance.results = [{ name: 'Stale' }];
+            instance.dropdown.classList.add('show');
+            window.apiClient.autocomplete.mockRejectedValue(new TypeError('Failed to fetch'));
+
+            await expect(instance._search('test')).resolves.toBeUndefined();
+
+            expect(instance.results).toEqual([]);
+            expect(instance.dropdown.classList.contains('show')).toBe(false);
+        });
+
         it('should discard a stale response that resolves after a newer request (discogsography-5fg0)', async () => {
             // Simulate a broad/slow query ('bea') that resolves AFTER a
             // narrower/faster query ('beatles') fired right after it — the

--- a/explore/__tests__/collaborators.test.js
+++ b/explore/__tests__/collaborators.test.js
@@ -202,7 +202,7 @@ describe('CollaboratorsPanel', () => {
             expect(container.querySelectorAll('.collaborator-item').length).toBe(2);
         });
 
-        it('should not render when API returns null', async () => {
+        it('replaces the "Loading..." placeholder with an error message when API returns null (regression discogsography-cmw0)', async () => {
             window.apiClient.getCollaborators.mockResolvedValue(null);
             const container = document.getElementById('collaboratorsContainer');
             const loadingText = document.createElement('p');
@@ -211,8 +211,24 @@ describe('CollaboratorsPanel', () => {
 
             await window.collaboratorsPanel.load('123');
 
-            // Container should remain unchanged
-            expect(container.textContent).toBe('Loading...');
+            // The stuck-forever "Loading..." placeholder must be replaced by
+            // a failure message, not left in place indefinitely.
+            expect(container.textContent).not.toBe('Loading...');
+            expect(container.textContent).toContain('Failed to load collaborators');
+        });
+
+        it('replaces the "Loading..." placeholder with an error message on a network-level fetch rejection (regression discogsography-cmw0)', async () => {
+            window.apiClient.getCollaborators.mockRejectedValue(new TypeError('Failed to fetch'));
+            const container = document.getElementById('collaboratorsContainer');
+            const loadingText = document.createElement('p');
+            loadingText.textContent = 'Loading...';
+            container.appendChild(loadingText);
+
+            // Must not throw / produce an unhandled rejection.
+            await expect(window.collaboratorsPanel.load('123')).resolves.toBeUndefined();
+
+            expect(container.textContent).not.toBe('Loading...');
+            expect(container.textContent).toContain('Failed to load collaborators');
         });
 
         it('should not crash when container is missing', async () => {

--- a/explore/__tests__/dashboard-admin-toast.test.js
+++ b/explore/__tests__/dashboard-admin-toast.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+
+/**
+ * Regression coverage for discogsography-3t37: overlapping toasts must not
+ * cancel each other early. AdminDashboard.showToast() lives in
+ * dashboard/static/admin.js, outside the explore test tree, so this suite
+ * loads it directly via the same vm-based technique explore/__tests__/helpers.js
+ * uses for explore/static/js/*.js.
+ */
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ADMIN_JS_PATH = resolve(__dirname, '..', '..', 'dashboard', 'static', 'admin.js');
+
+function loadAdminDashboardClass() {
+    const code = readFileSync(ADMIN_JS_PATH, 'utf-8');
+    // Strip the DOMContentLoaded auto-instantiation tail so loading the
+    // script doesn't try to construct AdminDashboard before the test sets
+    // up its own minimal DOM / mocks. The class declaration itself is kept.
+    const withoutAutoInit = code.replace(
+        /document\.addEventListener\(\s*['"]DOMContentLoaded['"][\s\S]*$/,
+        ''
+    );
+    const wrapped = `(function() {\n${withoutAutoInit}\nglobalThis.__AdminDashboard = AdminDashboard;\n})();`;
+    vm.runInThisContext(wrapped, { filename: ADMIN_JS_PATH });
+    return globalThis.__AdminDashboard;
+}
+
+function setupAdminDOM() {
+    document.body.textContent = '';
+
+    ['login-view', 'admin-view', 'toast'].forEach((id) => {
+        const el = document.createElement('div');
+        el.id = id;
+        document.body.appendChild(el);
+    });
+}
+
+describe('AdminDashboard.showToast (discogsography-3t37)', () => {
+    let AdminDashboard;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        setupAdminDOM();
+        localStorage.clear();
+        AdminDashboard = loadAdminDashboardClass();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('keeps a second toast visible instead of being hidden by the first toast stale timer', () => {
+        const app = new AdminDashboard();
+        const toast = document.getElementById('toast');
+
+        app.showToast('First message', 'success');
+        // Advance partway through the first toast's 3000ms window.
+        vi.advanceTimersByTime(1000);
+
+        app.showToast('Second message', 'success');
+        expect(toast.textContent).toBe('Second message');
+
+        // Advance to when the FIRST toast's original timer would have fired
+        // (2000ms after the second showToast call = 3000ms after the first).
+        vi.advanceTimersByTime(2000);
+
+        // The first toast's stale timer must not have hidden the second toast.
+        expect(toast.style.display).toBe('block');
+        expect(toast.style.opacity).not.toBe('0');
+    });
+
+    it('still hides the toast after its own full 3000ms + 300ms window elapses', () => {
+        const app = new AdminDashboard();
+        const toast = document.getElementById('toast');
+
+        app.showToast('Only message', 'success');
+        vi.advanceTimersByTime(3000);
+        expect(toast.style.opacity).toBe('0');
+
+        vi.advanceTimersByTime(300);
+        expect(toast.style.display).toBe('none');
+    });
+
+    it('clears a pending inner (300ms) remove timer from a rapid overlapping toast', () => {
+        const app = new AdminDashboard();
+        const toast = document.getElementById('toast');
+
+        app.showToast('First message', 'success');
+        // Let the first toast fully fade (opacity 0) but not yet be removed.
+        vi.advanceTimersByTime(3000);
+        expect(toast.style.opacity).toBe('0');
+
+        // A new toast arrives before the 300ms display:none timer fires.
+        app.showToast('Second message', 'success');
+        vi.advanceTimersByTime(300);
+
+        // The stale inner timer must not have hidden the second toast.
+        expect(toast.style.display).toBe('block');
+        expect(toast.textContent).toBe('Second message');
+    });
+});

--- a/explore/__tests__/search.test.js
+++ b/explore/__tests__/search.test.js
@@ -456,6 +456,7 @@ describe('search pane', () => {
                 _setSearchType: vi.fn(),
                 _switchPane: vi.fn(),
                 _loadExplore: vi.fn(),
+                _showToast: vi.fn(),
                 currentQuery: '',
             };
             window.exploreApp = mockExploreApp;
@@ -478,6 +479,72 @@ describe('search pane', () => {
             // Release type: shows toast instead of switching pane
             expect(mockExploreApp._switchPane).not.toHaveBeenCalled();
             expect(mockExploreApp._loadExplore).not.toHaveBeenCalled();
+        });
+
+        it('should call window.exploreApp._showToast (not the undefined window.app) for non-explorable types (regression discogsography-oi02)', async () => {
+            const mockExploreApp = {
+                _setSearchType: vi.fn(),
+                _switchPane: vi.fn(),
+                _loadExplore: vi.fn(),
+                _showToast: vi.fn(),
+                currentQuery: '',
+            };
+            window.exploreApp = mockExploreApp;
+            // window.app has never been assigned anywhere in explore/static/js/ —
+            // make sure it stays undefined so this test fails if the code
+            // regresses back to reading the wrong global.
+            delete window.app;
+
+            window.apiClient.search.mockResolvedValue({
+                results: [{ name: 'OK Computer', type: 'release', relevance: 0.9 }],
+                total: 1,
+                facets: {},
+                pagination: { has_more: false },
+            });
+
+            const input = document.getElementById('searchPaneInput');
+            input.value = 'ok computer';
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            await new Promise(r => setTimeout(r, 10));
+
+            const card = document.querySelector('.search-result-card');
+            card.click();
+
+            expect(mockExploreApp._showToast).toHaveBeenCalledTimes(1);
+            expect(mockExploreApp._showToast).toHaveBeenCalledWith(
+                expect.stringContaining('not explorable directly')
+            );
+        });
+
+        it('should call window.exploreApp._showToast for master type too (regression discogsography-oi02)', async () => {
+            const mockExploreApp = {
+                _setSearchType: vi.fn(),
+                _switchPane: vi.fn(),
+                _loadExplore: vi.fn(),
+                _showToast: vi.fn(),
+                currentQuery: '',
+            };
+            window.exploreApp = mockExploreApp;
+            delete window.app;
+
+            window.apiClient.search.mockResolvedValue({
+                results: [{ name: 'Master Edition', type: 'master', relevance: 0.9 }],
+                total: 1,
+                facets: {},
+                pagination: { has_more: false },
+            });
+
+            const input = document.getElementById('searchPaneInput');
+            input.value = 'master edition';
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            await new Promise(r => setTimeout(r, 10));
+
+            const card = document.querySelector('.search-result-card');
+            card.click();
+
+            expect(mockExploreApp._showToast).toHaveBeenCalledWith(
+                expect.stringContaining('master details are not explorable directly')
+            );
         });
     });
 

--- a/explore/__tests__/search.test.js
+++ b/explore/__tests__/search.test.js
@@ -170,6 +170,21 @@ describe('search pane', () => {
             expect(resultsEl.textContent).toContain('error occurred');
         });
 
+        it('should hide the loading overlay and render the error state on a network-level fetch rejection (regression discogsography-cmw0)', async () => {
+            window.apiClient.search.mockRejectedValue(new TypeError('Failed to fetch'));
+
+            const input = document.getElementById('searchPaneInput');
+            input.value = 'radiohead';
+
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            await new Promise(r => setTimeout(r, 10));
+
+            const resultsEl = document.getElementById('searchResults');
+            const loadingEl = document.getElementById('searchLoading');
+            expect(resultsEl.textContent).toContain('error occurred');
+            expect(loadingEl.classList.contains('active')).toBe(false);
+        });
+
         it('should render "no results" when results array is empty', async () => {
             window.apiClient.search.mockResolvedValue({
                 results: [],

--- a/explore/__tests__/settings-app-tokens.test.js
+++ b/explore/__tests__/settings-app-tokens.test.js
@@ -235,6 +235,29 @@ describe('SettingsPane — App Tokens card', () => {
             expect(container.querySelector('#appTokenMintBtn')).toBeTruthy();
             expect(window.apiClient.mintAppToken).not.toHaveBeenCalled();
         });
+
+        it('preserves an in-progress mint form across pane re-activation (regression discogsography-3vz8)', async () => {
+            window.settingsPane.init();
+            await flush();
+            container.querySelector('#appTokenMintBtn').click();
+
+            const nameInput = container.querySelector('#appTokenName');
+            nameInput.value = 'GRUVAX kiosk';
+
+            // Simulate the Settings pane re-activating (app.js calls init()
+            // again on every activation) while the user has an in-progress
+            // mint form open.
+            window.settingsPane.init();
+            await flush();
+
+            expect(window.apiClient.listAppTokens).toHaveBeenCalledTimes(2);
+            // The mint form must still be showing — not torn down and
+            // replaced by the token list — and the typed name preserved.
+            const nameInputAfter = container.querySelector('#appTokenName');
+            expect(nameInputAfter).toBeTruthy();
+            expect(nameInputAfter.value).toBe('GRUVAX kiosk');
+            expect(container.querySelector('#appTokenMintBtn')).toBeNull();
+        });
     });
 
     describe('reveal screen', () => {

--- a/explore/__tests__/settings-app-tokens.test.js
+++ b/explore/__tests__/settings-app-tokens.test.js
@@ -196,6 +196,20 @@ describe('SettingsPane — App Tokens card', () => {
             expect(container.querySelector('#appTokenPlaintext')).toBeNull();
         });
 
+        it('shows a network-error message on a network-level fetch rejection (regression discogsography-cmw0)', async () => {
+            window.apiClient.mintAppToken.mockRejectedValue(new TypeError('Failed to fetch'));
+            window.settingsPane.init();
+            await flush();
+            container.querySelector('#appTokenMintBtn').click();
+            container.querySelector('#appTokenName').value = 'kiosk';
+            container.querySelector('#appTokenSubmitMint').click();
+            await flush();
+
+            expect(container.querySelector('#appTokenMintError').textContent).toContain('Network error');
+            // Stayed on the mint form, not the reveal screen
+            expect(container.querySelector('#appTokenPlaintext')).toBeNull();
+        });
+
         it('rejects when no permission scope is checked', async () => {
             window.settingsPane.init();
             await flush();
@@ -390,6 +404,26 @@ describe('SettingsPane — App Tokens card', () => {
             await flush();
             expect(window.confirm).not.toHaveBeenCalled();
             expect(window.apiClient.revokeAppToken).not.toHaveBeenCalled();
+        });
+
+        it('alerts the user and still refreshes the list on a network-level fetch rejection (regression discogsography-cmw0)', async () => {
+            window.apiClient.listAppTokens.mockResolvedValue({
+                active: [{ id: 'tok-a', name: 'kiosk', scopes: ['collection:read'], created_at: null, last_used_at: null }],
+                revoked: [],
+            });
+            window.apiClient.revokeAppToken.mockRejectedValue(new TypeError('Failed to fetch'));
+            window.confirm = vi.fn().mockReturnValue(true);
+            const alertSpy = vi.fn();
+            window.alert = alertSpy;
+
+            window.settingsPane.init();
+            await flush();
+            container.querySelector('.app-token-revoke').click();
+            await flush();
+
+            expect(alertSpy).toHaveBeenCalled();
+            // Subsequent _loadAppTokens still runs, mirroring the non-ok path.
+            expect(window.apiClient.listAppTokens).toHaveBeenCalledTimes(2);
         });
 
         it('is a no-op when user is signed out at revoke time', async () => {

--- a/explore/__tests__/theme.test.js
+++ b/explore/__tests__/theme.test.js
@@ -213,3 +213,51 @@ describe('theme toggle markup', () => {
         expect(html).toContain('js/theme.js');
     });
 });
+
+describe('light palette (regression discogsography-68oe)', () => {
+    /**
+     * Extract `--name: value;` custom-property declarations out of the FIRST
+     * top-level block matching `selector`, e.g. the bare `:root { ... }`
+     * dark-default block or the `:root:not(.dark) { ... }` light override.
+     */
+    function extractCustomProps(css, selectorPattern) {
+        const blockMatch = css.match(new RegExp(`${selectorPattern}\\s*\\{([^}]*)\\}`));
+        expect(blockMatch, `expected a ${selectorPattern} block to exist in styles.css`).toBeTruthy();
+        const body = blockMatch[1];
+        const props = {};
+        for (const m of body.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/g)) {
+            props[m[1]] = m[2].trim();
+        }
+        return props;
+    }
+
+    it('defines a :root:not(.dark) light override block in styles.css', () => {
+        const css = readFileSync(resolve(__dirname, '..', 'static', 'css', 'styles.css'), 'utf-8');
+        expect(css).toMatch(/:root:not\(\.dark\)\s*\{/);
+    });
+
+    it('overrides every dark-default background/text/border token with a distinct light value', () => {
+        const css = readFileSync(resolve(__dirname, '..', 'static', 'css', 'styles.css'), 'utf-8');
+        const darkDefaults = extractCustomProps(css, ':root');
+        const lightOverrides = extractCustomProps(css, ':root:not\\(\\.dark\\)');
+
+        const criticalTokens = [
+            '--bg-void', '--bg-deep', '--card-bg', '--inner-bg',
+            '--border-color', '--inner-border', '--bg-hover',
+            '--text-high', '--text-mid', '--text-dim', '--text-muted',
+        ];
+
+        for (const token of criticalTokens) {
+            expect(darkDefaults[token], `${token} missing from base :root`).toBeTruthy();
+            expect(lightOverrides[token], `${token} missing from :root:not(.dark) override`).toBeTruthy();
+            expect(lightOverrides[token]).not.toBe(darkDefaults[token]);
+        }
+    });
+
+    it('does not hardcode a dark background on <body> via inline style (would defeat any CSS-variable light palette)', () => {
+        const html = readFileSync(resolve(__dirname, '..', 'static', 'index.html'), 'utf-8');
+        const bodyTagMatch = html.match(/<body\b[^>]*>/);
+        expect(bodyTagMatch).toBeTruthy();
+        expect(bodyTagMatch[0]).not.toMatch(/style=/);
+    });
+});

--- a/explore/__tests__/user-panes.test.js
+++ b/explore/__tests__/user-panes.test.js
@@ -197,6 +197,18 @@ describe('UserPanes', () => {
             expect(body.textContent).toContain('Second Page');
             expect(body.textContent).not.toContain('First Page');
         });
+
+        it('renders the failure state (not a blank pane) on a network-level fetch rejection (regression discogsography-cmw0)', async () => {
+            window.apiClient.getUserCollection.mockRejectedValue(new TypeError('Failed to fetch'));
+            const loading = document.getElementById('collectionLoading');
+
+            await expect(userPanes.loadCollection()).resolves.toBeUndefined();
+
+            const body = document.getElementById('collectionBody');
+            expect(body.querySelector('.user-pane-empty')).not.toBeNull();
+            expect(body.textContent).toContain('Failed to load collection.');
+            expect(loading.classList.contains('active')).toBe(false);
+        });
     });
 
     describe('loadWantlist', () => {
@@ -274,6 +286,18 @@ describe('UserPanes', () => {
             expect(body.textContent).toContain('Second Page');
             expect(body.textContent).not.toContain('First Page');
         });
+
+        it('renders the failure state (not a blank pane) on a network-level fetch rejection (regression discogsography-cmw0)', async () => {
+            window.apiClient.getUserWantlist.mockRejectedValue(new TypeError('Failed to fetch'));
+            const loading = document.getElementById('wantlistLoading');
+
+            await expect(userPanes.loadWantlist()).resolves.toBeUndefined();
+
+            const body = document.getElementById('wantlistBody');
+            expect(body.querySelector('.user-pane-empty')).not.toBeNull();
+            expect(body.textContent).toContain('Failed to load wantlist.');
+            expect(loading.classList.contains('active')).toBe(false);
+        });
     });
 
     describe('loadRecommendations', () => {
@@ -304,6 +328,17 @@ describe('UserPanes', () => {
             const body = document.getElementById('recommendationsBody');
             expect(body.textContent).toContain('Failed to load recommendations');
             expect(body.textContent).not.toContain('No recommendations yet');
+        });
+
+        it('renders the same error state on a network-level fetch rejection (regression discogsography-cmw0)', async () => {
+            window.apiClient.getUserRecommendations.mockRejectedValue(new TypeError('Failed to fetch'));
+            const loading = document.getElementById('recommendationsLoading');
+
+            await expect(userPanes.loadRecommendations()).resolves.toBeUndefined();
+
+            const body = document.getElementById('recommendationsBody');
+            expect(body.textContent).toContain('Failed to load recommendations');
+            expect(loading.classList.contains('active')).toBe(false);
         });
 
         it('should render recommendation items', async () => {
@@ -906,6 +941,12 @@ describe('UserPanes', () => {
             const el = document.getElementById('collectionStats');
             expect(el.querySelectorAll('.stat-card').length).toBe(4);
         });
+
+        it('should not throw an unhandled rejection on a network-level fetch failure (regression discogsography-cmw0)', async () => {
+            window.apiClient.getUserCollectionStats.mockRejectedValue(new TypeError('Failed to fetch'));
+
+            await expect(userPanes.loadCollectionStats()).resolves.toBeUndefined();
+        });
     });
 
     describe('startDiscogsOAuth', () => {
@@ -1392,6 +1433,18 @@ describe('UserPanes', () => {
             expect(body.textContent).toContain('Second Page Release');
             expect(body.textContent).not.toContain('First Page Release');
         });
+
+        it('renders the failure state (not a blank pane) on a network-level fetch rejection (regression discogsography-cmw0)', async () => {
+            window.apiClient.getCollectionGaps.mockRejectedValue(new TypeError('Failed to fetch'));
+            const loading = document.getElementById('gapsLoading');
+
+            await expect(userPanes.loadGapAnalysis('artist', '123')).resolves.toBeUndefined();
+
+            const body = document.getElementById('gapsBody');
+            expect(body.querySelector('.user-pane-empty')).not.toBeNull();
+            expect(body.textContent).toContain('Failed to load gap analysis.');
+            expect(loading.classList.contains('active')).toBe(false);
+        });
     });
 
     describe('_downloadTasteCard', () => {
@@ -1445,6 +1498,19 @@ describe('UserPanes', () => {
             await userPanes._downloadTasteCard(btn);
             expect(clickSpy).toHaveBeenCalled();
             document.createElement.mockRestore();
+        });
+
+        it('resets the button instead of leaving it stuck on "Downloading..." on a network-level fetch rejection (regression discogsography-cmw0)', async () => {
+            vi.useFakeTimers();
+            window.apiClient.getTasteCard.mockRejectedValue(new TypeError('Failed to fetch'));
+            const btn = document.createElement('button');
+
+            await expect(userPanes._downloadTasteCard(btn)).resolves.toBeUndefined();
+
+            expect(btn.textContent).toBe('Download failed');
+            vi.advanceTimersByTime(2000);
+            expect(btn.disabled).toBe(false);
+            vi.useRealTimers();
         });
     });
 

--- a/explore/static/css/styles.css
+++ b/explore/static/css/styles.css
@@ -63,6 +63,66 @@
 }
 
 /* ============================================================
+   Light palette — applied whenever the .dark class is absent from
+   <html> (theme.js toggles that class for 'light'/'auto' modes; see
+   explore/static/js/theme.js). :root:not(.dark) has higher specificity
+   than the bare :root block above, so it wins without needing !important.
+   ============================================================ */
+:root:not(.dark) {
+    /* Background scale */
+    --bg-void: #e7ebf0;
+    --bg-deep: #f4f6f9;
+    --card-bg: #ffffff;
+    --inner-bg: #eef1f5;
+    --border-color: #d7dce4;
+    --inner-border: #d7dce4;
+    --bg-hover: #e2e7ee;
+
+    /* Text scale */
+    --text-high: #10192b;
+    --text-mid: #45526b;
+    --text-dim: #64748b;
+    --text-muted: #94a3b8;
+
+    /* Cyan — primary accent (deepened for AA contrast on light backgrounds) */
+    --cyan-900: #b2ebf2;
+    --cyan-700: #00707d;
+    --cyan-500: #007c91;
+    --cyan-glow: #0097a7;
+    --cyan-bright: #005662;
+
+    /* Purple — secondary accent (deepened for AA contrast on light backgrounds) */
+    --purple-900: #ede7f6;
+    --purple-700: #4527a0;
+    --purple-500: #5e35b1;
+    --purple-300: #7c4dff;
+    --purple-bright: #311b92;
+
+    /* Legacy aliases (used by Tailwind classes and existing markup) */
+    --blue-accent: #007c91;
+    --purple-accent: #5e35b1;
+
+    /* Semantic status (deepened for AA contrast on light backgrounds) */
+    --accent-green: #1b8a45;
+    --accent-yellow: #b45f06;
+    --accent-red: #c62828;
+
+    /* UI tokens */
+    --card-shadow: 0 1px 3px rgba(15,23,42,0.12), 0 1px 2px rgba(15,23,42,0.08);
+    --scrollbar-thumb: #c3cbd6;
+    --glass-bg: rgba(255,255,255,0.9);
+    --label-bg: rgba(255,255,255,0.85);
+    --overlay-bg: rgba(15,23,42,0.6);
+    --gauge-track: #d7dce4;
+    --log-msg: #45526b;
+    --row-border: rgba(15,23,42,0.08);
+
+    /* Graph node colors stay the same across themes — they're drawn on the
+       graph canvas background (--bg-deep), not on card/text surfaces, and
+       already have enough contrast against both dark and light canvases. */
+}
+
+/* ============================================================
    Utility classes (matching dashboard)
    ============================================================ */
 

--- a/explore/static/index.html
+++ b/explore/static/index.html
@@ -240,7 +240,7 @@ body {
         });
     </script>
 </head>
-<body class="bg-bg-deep text-text-high overflow-hidden h-screen" style="background:#060a12;">
+<body class="bg-bg-deep text-text-high overflow-hidden h-screen">
 
     <!-- ============================================================
          Auth modal (login / register tabs)

--- a/explore/static/js/api-client.js
+++ b/explore/static/js/api-client.js
@@ -3,6 +3,21 @@
  */
 class ApiClient {
     /**
+     * Detect an expired/revoked JWT (401) on an authenticated request and
+     * reconcile client-side auth state immediately, instead of silently
+     * collapsing it into the same "return null" path as any other error —
+     * which otherwise leaves the nav showing a stale logged-in user while
+     * every authenticated feature quietly goes dead (discogsography-ponr).
+     * @param {Response} response
+     */
+    _checkAuthResponse(response) {
+        if (response && response.status === 401 && window.authManager?.isLoggedIn()) {
+            window.authManager.clear();
+            window.authManager.notify();
+        }
+    }
+
+    /**
      * Autocomplete search.
      * @param {string} query - Search query
      * @param {string} type - Entity type (artist, genre, label, style)
@@ -117,6 +132,7 @@ class ApiClient {
             headers,
             body: JSON.stringify({ nodes, center }),
         });
+        this._checkAuthResponse(response);
         if (!response.ok) return null;
         return response.json();
     }
@@ -229,6 +245,7 @@ class ApiClient {
         const response = await fetch('/api/auth/2fa/setup', {
             method: 'POST', headers: {'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json'},
         });
+        this._checkAuthResponse(response);
         return response;
     }
 
@@ -237,6 +254,7 @@ class ApiClient {
             method: 'POST', headers: {'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json'},
             body: JSON.stringify({ code }),
         });
+        this._checkAuthResponse(response);
         return response;
     }
 
@@ -261,6 +279,7 @@ class ApiClient {
             method: 'POST', headers: {'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json'},
             body: JSON.stringify({ code, password }),
         });
+        this._checkAuthResponse(response);
         return response;
     }
 
@@ -270,6 +289,7 @@ class ApiClient {
             headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
             body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
         });
+        this._checkAuthResponse(response);
         return response;
     }
 
@@ -278,6 +298,7 @@ class ApiClient {
         const response = await fetch('/api/auth/me', {
             headers: { 'Authorization': `Bearer ${token}` },
         });
+        this._checkAuthResponse(response);
         if (!response.ok) return null;
         return response.json();
     }
@@ -289,6 +310,7 @@ class ApiClient {
         const response = await fetch('/api/oauth/authorize/discogs', {
             headers: { 'Authorization': `Bearer ${token}` },
         });
+        this._checkAuthResponse(response);
         if (!response.ok) return null;
         return response.json();
     }
@@ -300,6 +322,7 @@ class ApiClient {
             headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
             body: JSON.stringify({ state, oauth_verifier: oauthVerifier }),
         });
+        this._checkAuthResponse(response);
         if (!response.ok) return null;
         return response.json();
     }
@@ -309,6 +332,7 @@ class ApiClient {
         const response = await fetch('/api/oauth/status/discogs', {
             headers: { 'Authorization': `Bearer ${token}` },
         });
+        this._checkAuthResponse(response);
         if (!response.ok) return null;
         return response.json();
     }
@@ -319,6 +343,7 @@ class ApiClient {
             method: 'DELETE',
             headers: { 'Authorization': `Bearer ${token}` },
         });
+        this._checkAuthResponse(response);
         if (!response.ok) return null;
         return response.json();
     }
@@ -334,6 +359,7 @@ class ApiClient {
         const response = await fetch('/api/user/app-tokens', {
             headers: { 'Authorization': `Bearer ${token}` },
         });
+        this._checkAuthResponse(response);
         if (!response.ok) return null;
         return response.json();
     }
@@ -349,6 +375,7 @@ class ApiClient {
             headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
             body: JSON.stringify({ name, scopes }),
         });
+        this._checkAuthResponse(response);
         let body = null;
         try { body = await response.json(); } catch { /* no-op */ }
         return { ok: response.ok, status: response.status, body };
@@ -364,6 +391,7 @@ class ApiClient {
             method: 'DELETE',
             headers: { 'Authorization': `Bearer ${token}` },
         });
+        this._checkAuthResponse(response);
         return response.status === 204;
     }
 
@@ -375,6 +403,7 @@ class ApiClient {
         const response = await fetch(`/api/user/collection?${params}`, {
             headers: { 'Authorization': `Bearer ${token}` },
         });
+        this._checkAuthResponse(response);
         if (!response.ok) return null;
         return response.json();
     }
@@ -385,6 +414,7 @@ class ApiClient {
         const response = await fetch(`/api/user/wantlist?${params}`, {
             headers: { 'Authorization': `Bearer ${token}` },
         });
+        this._checkAuthResponse(response);
         if (!response.ok) return null;
         return response.json();
     }
@@ -395,6 +425,7 @@ class ApiClient {
         const response = await fetch(`/api/user/recommendations?${params}`, {
             headers: { 'Authorization': `Bearer ${token}` },
         });
+        this._checkAuthResponse(response);
         if (!response.ok) return null;
         return response.json();
     }
@@ -404,6 +435,7 @@ class ApiClient {
         const response = await fetch('/api/user/collection/stats', {
             headers: { 'Authorization': `Bearer ${token}` },
         });
+        this._checkAuthResponse(response);
         if (!response.ok) return null;
         return response.json();
     }
@@ -413,6 +445,7 @@ class ApiClient {
         const headers = {};
         if (token) headers['Authorization'] = `Bearer ${token}`;
         const response = await fetch(`/api/user/status?${params}`, { headers });
+        if (token) this._checkAuthResponse(response);
         if (!response.ok) return null;
         return response.json();
     }
@@ -424,6 +457,7 @@ class ApiClient {
         const response = await fetch('/api/collection/formats', {
             headers: { 'Authorization': `Bearer ${token}` },
         });
+        this._checkAuthResponse(response);
         if (!response.ok) return null;
         return response.json();
     }
@@ -441,6 +475,7 @@ class ApiClient {
         const response = await fetch(`/api/collection/gaps/${entityType}/${encodeURIComponent(entityId)}?${params}`, {
             headers: { 'Authorization': `Bearer ${token}` },
         });
+        this._checkAuthResponse(response);
         if (!response.ok) return null;
         return response.json();
     }
@@ -453,6 +488,7 @@ class ApiClient {
             method: 'POST',
             headers: { 'Authorization': `Bearer ${token}` },
         });
+        this._checkAuthResponse(response);
         const body = await response.json().catch(() => null);
         return { ok: response.ok, status: response.status, body };
     }
@@ -462,6 +498,7 @@ class ApiClient {
         const response = await fetch('/api/sync/status', {
             headers: { 'Authorization': `Bearer ${token}` },
         });
+        this._checkAuthResponse(response);
         if (!response.ok) return null;
         return response.json();
     }
@@ -478,6 +515,7 @@ class ApiClient {
         const response = await fetch('/api/user/taste/fingerprint', {
             headers: { 'Authorization': `Bearer ${token}` },
         });
+        this._checkAuthResponse(response);
         if (!response.ok) return null;
         return response.json();
     }
@@ -492,6 +530,7 @@ class ApiClient {
         const response = await fetch('/api/user/taste/card', {
             headers: { 'Authorization': `Bearer ${token}` },
         });
+        this._checkAuthResponse(response);
         if (!response.ok) return null;
         return response.blob();
     }

--- a/explore/static/js/app.js
+++ b/explore/static/js/app.js
@@ -466,8 +466,17 @@ class ExploreApp {
         }
 
         // If we just logged out and were on a personal pane, switch to explore
-        if (!loggedIn && ['collection', 'wantlist', 'recommendations'].includes(this.activePane)) {
+        if (!loggedIn && ['collection', 'wantlist', 'recommendations', 'gaps', 'settings'].includes(this.activePane)) {
             this._switchPane('explore');
+        }
+
+        // Clear personal data rendered into login-gated panes so it isn't left
+        // on screen after logout (e.g. on a shared/kiosk machine).
+        if (!loggedIn) {
+            const settingsEmailEl = document.getElementById('settingsEmail');
+            if (settingsEmailEl) settingsEmailEl.textContent = '';
+            const gapsBodyEl = document.getElementById('gapsBody');
+            if (gapsBodyEl) gapsBodyEl.replaceChildren();
         }
     }
 

--- a/explore/static/js/app.js
+++ b/explore/static/js/app.js
@@ -391,7 +391,14 @@ class ExploreApp {
         window.authManager.onChange(() => this._updateAuthUI());
 
         this._bindEvents();
-        this._initAuth().then(() => this._restoreFromUrl());
+        // authManager.init() now catches its own network-level rejections
+        // (discogsography-ponr), but this .catch() is kept as a backstop so
+        // an unrelated failure in _updateAuthUI()/_initAuth() can never skip
+        // _restoreFromUrl() and strand any node/search state encoded in the URL.
+        this._initAuth().then(() => this._restoreFromUrl()).catch((err) => {
+            console.error('Auth initialisation failed:', err);
+            this._restoreFromUrl();
+        });
     }
 
     // ------------------------------------------------------------------ //

--- a/explore/static/js/app.js
+++ b/explore/static/js/app.js
@@ -633,12 +633,19 @@ class ExploreApp {
             errorEl.textContent = '';
             successEl.classList.add('hidden');
             if (!email) { errorEl.textContent = 'Please enter your email'; return; }
-            const response = await window.apiClient.resetRequest(email);
-            if (response.ok) {
-                successEl.textContent = 'If an account exists for that email, a reset link has been sent.';
-                successEl.classList.remove('hidden');
-            } else {
-                errorEl.textContent = 'Something went wrong. Please try again.';
+            try {
+                const response = await window.apiClient.resetRequest(email);
+                if (response.ok) {
+                    successEl.textContent = 'If an account exists for that email, a reset link has been sent.';
+                    successEl.classList.remove('hidden');
+                } else {
+                    errorEl.textContent = 'Something went wrong. Please try again.';
+                }
+            } catch {
+                // A network-level fetch rejection — this handler has no try
+                // at all today, so a rejected fetch skips response.ok entirely
+                // and leaves both success/error elements untouched.
+                errorEl.textContent = 'Could not reach the server. Please try again.';
             }
         });
 
@@ -654,18 +661,24 @@ class ExploreApp {
             const params = new URLSearchParams(window.location.search);
             const token = params.get('reset_token');
             if (!token) { errorEl.textContent = 'Invalid reset link'; return; }
-            const response = await window.apiClient.resetConfirm(token, password);
-            if (response.ok) {
-                successEl.textContent = 'Password has been reset! You can now log in.';
-                successEl.classList.remove('hidden');
-                history.replaceState(null, '', window.location.pathname);
-                setTimeout(() => {
-                    const modal = document.getElementById('authModal');
-                    _alpineData(modal).tab = 'login';
-                }, 2000);
-            } else {
-                const data = await response.json().catch(() => ({}));
-                errorEl.textContent = data.detail || 'Reset failed. The link may have expired.';
+            try {
+                const response = await window.apiClient.resetConfirm(token, password);
+                if (response.ok) {
+                    successEl.textContent = 'Password has been reset! You can now log in.';
+                    successEl.classList.remove('hidden');
+                    history.replaceState(null, '', window.location.pathname);
+                    setTimeout(() => {
+                        const modal = document.getElementById('authModal');
+                        _alpineData(modal).tab = 'login';
+                    }, 2000);
+                } else {
+                    const data = await response.json().catch(() => ({}));
+                    errorEl.textContent = data.detail || 'Reset failed. The link may have expired.';
+                }
+            } catch {
+                // A network-level fetch rejection — same missing-try pattern
+                // as the reset-request handler above.
+                errorEl.textContent = 'Could not reach the server. Please try again.';
             }
         });
 
@@ -807,6 +820,10 @@ class ExploreApp {
             Alpine.store('modals').authOpen = false;
             document.getElementById('loginEmail').value = '';
             document.getElementById('loginPassword').value = '';
+        } catch {
+            // A network-level fetch rejection (server restart, dropped Wi-Fi,
+            // CORS/DNS) — surface feedback instead of a silent button reset.
+            if (errorEl) errorEl.textContent = 'Could not reach the server. Please try again.';
         } finally {
             submitBtn.disabled = false;
             const loginIcon = document.createElement('span');
@@ -855,6 +872,10 @@ class ExploreApp {
             } else {
                 if (errorEl) errorEl.textContent = 'Registration failed. Please try again.';
             }
+        } catch {
+            // A network-level fetch rejection — same missing-feedback pattern
+            // as _handleLogin.
+            if (errorEl) errorEl.textContent = 'Could not reach the server. Please try again.';
         } finally {
             submitBtn.disabled = false;
             const regIcon = document.createElement('span');

--- a/explore/static/js/auth.js
+++ b/explore/static/js/auth.js
@@ -9,6 +9,29 @@ class AuthManager {
         this._discogsStatus = null;
         this._listeners = [];
         this._challengeToken = null;
+
+        // Sync auth state across tabs: a logout (or token change) in one tab
+        // only clears that tab's localStorage/memory (see clear()) — without
+        // this, a second open tab keeps its stale in-memory token and shows
+        // the user as logged in indefinitely (discogsography-ponr).
+        if (typeof window !== 'undefined' && window.addEventListener) {
+            window.addEventListener('storage', (e) => this._onStorageEvent(e));
+        }
+    }
+
+    /**
+     * Cross-tab sync: react to another tab changing/clearing `auth_token`.
+     * @param {StorageEvent} e
+     */
+    _onStorageEvent(e) {
+        if (e.key !== 'auth_token') return;
+        if (e.newValue === this._token) return;
+        this._token = e.newValue || null;
+        if (!this._token) {
+            this._user = null;
+            this._discogsStatus = null;
+        }
+        this.notify();
     }
 
     /** Whether the user is currently logged in. */
@@ -86,15 +109,26 @@ class AuthManager {
      */
     async init() {
         if (!this._token) return false;
-        const user = await window.apiClient.getMe(this._token);
-        if (!user) {
+        try {
+            const user = await window.apiClient.getMe(this._token);
+            if (!user) {
+                this.clear();
+                return false;
+            }
+            this._user = user;
+            const discogsStatus = await window.apiClient.getDiscogsStatus(this._token);
+            this._discogsStatus = discogsStatus;
+            return true;
+        } catch {
+            // A network-level fetch rejection (server unreachable, offline,
+            // DNS/CORS, server restart) — api-client only converts HTTP error
+            // statuses to null, so this is the ONLY place such a rejection
+            // would otherwise escape init() uncaught, aborting page-load auth
+            // restore (discogsography-ponr). Treat it like an invalid session
+            // rather than letting the caller's page-load chain reject.
             this.clear();
             return false;
         }
-        this._user = user;
-        const discogsStatus = await window.apiClient.getDiscogsStatus(this._token);
-        this._discogsStatus = discogsStatus;
-        return true;
     }
 }
 

--- a/explore/static/js/autocomplete.js
+++ b/explore/static/js/autocomplete.js
@@ -52,7 +52,16 @@ class Autocomplete {
     async _search(query) {
         const requestId = ++this._reqId;
         const type = window.exploreApp ? window.exploreApp.searchType : 'artist';
-        const results = await window.apiClient.autocomplete(query, type);
+        let results;
+        try {
+            results = await window.apiClient.autocomplete(query, type);
+        } catch {
+            // A network-level fetch rejection (offline, DNS, CORS) — apiClient
+            // only converts HTTP error statuses to an empty array; a thrown
+            // fetch would otherwise leave the dropdown showing stale results
+            // forever. Treat it the same as the no-results case.
+            results = [];
+        }
         if (requestId !== this._reqId) return;
         this.results = results;
         this.activeIndex = -1;

--- a/explore/static/js/collaborators.js
+++ b/explore/static/js/collaborators.js
@@ -12,11 +12,36 @@ class CollaboratorsPanel {
      * @param {string} artistId - Neo4j artist ID
      */
     async load(artistId) {
-        const data = await window.apiClient.getCollaborators(artistId);
-        if (!data) return;
         const container = document.getElementById('collaboratorsContainer');
+        let data;
+        try {
+            data = await window.apiClient.getCollaborators(artistId);
+        } catch {
+            // A network-level fetch rejection (offline, DNS, CORS) — treat
+            // exactly like the non-ok/timeout null-return path below so the
+            // placeholder "Loading..." text never sticks around forever.
+            data = null;
+        }
         if (!container) return;
+        if (!data) {
+            this._renderError(container);
+            return;
+        }
         this._renderList(container, data);
+    }
+
+    /**
+     * Replace the caller-supplied "Loading..." placeholder with an error
+     * message when collaborators fail to load (non-ok status, timeout, or
+     * network-level fetch rejection).
+     * @param {HTMLElement} container - Target container
+     */
+    _renderError(container) {
+        container.textContent = '';
+        const msg = document.createElement('p');
+        msg.className = 'text-text-mid text-sm';
+        msg.textContent = 'Failed to load collaborators.';
+        container.appendChild(msg);
     }
 
     /**

--- a/explore/static/js/search.js
+++ b/explore/static/js/search.js
@@ -132,7 +132,16 @@
         const yearMin = yearMinEl.value ? parseInt(yearMinEl.value, 10) : null;
         const yearMax = yearMaxEl.value ? parseInt(yearMaxEl.value, 10) : null;
 
-        const data = await window.apiClient.search(q, types, selectedGenres, yearMin, yearMax, PAGE_SIZE, currentOffset);
+        let data;
+        try {
+            data = await window.apiClient.search(q, types, selectedGenres, yearMin, yearMax, PAGE_SIZE, currentOffset);
+        } catch {
+            // A network-level fetch rejection (offline, DNS, connection reset,
+            // CORS) — not an HTTP error status — falls through to the same
+            // null-data error rendering below instead of leaving the loading
+            // overlay stuck on-screen forever.
+            data = null;
+        }
 
         // A newer search has since been issued — discard this stale response
         // rather than let it overwrite results/pagination for the current one.

--- a/explore/static/js/search.js
+++ b/explore/static/js/search.js
@@ -406,8 +406,8 @@
             window.exploreApp._loadExplore(name, type);
         } else if (window.exploreApp) {
             // For release/master — not directly explorable
-            if (window.app?.showToast) {
-                window.app.showToast(`${type} details are not explorable directly — try searching for the artist or label instead`, 'info');
+            if (window.exploreApp._showToast) {
+                window.exploreApp._showToast(`${type} details are not explorable directly — try searching for the artist or label instead`);
             }
         }
     }

--- a/explore/static/js/settings.js
+++ b/explore/static/js/settings.js
@@ -636,6 +636,13 @@ class SettingsPane {
         }
         this._activeTokens = (res && Array.isArray(res.active)) ? res.active : [];
         this._revokedTokens = (res && Array.isArray(res.revoked)) ? res.revoked : [];
+        if (this._appTokensView === 'minting') {
+            // Preserve the in-progress mint form (and whatever the user has
+            // typed into it) instead of tearing it down via a re-render —
+            // mirrors the 'revealing' guard below. The refreshed token list
+            // renders once minting finishes and the view returns to 'list'.
+            return;
+        }
         if (this._appTokensView !== 'revealing') {
             this._appTokensView = 'list';
         }

--- a/explore/static/js/settings.js
+++ b/explore/static/js/settings.js
@@ -978,7 +978,16 @@ class SettingsPane {
             return;
         }
 
-        const res = await window.apiClient.mintAppToken(token, name, scopes);
+        let res;
+        try {
+            res = await window.apiClient.mintAppToken(token, name, scopes);
+        } catch {
+            // A network-level fetch rejection — mirror the other settings
+            // handlers (_handleChangePassword, _confirmSetup, _handleDisable)
+            // instead of letting the rejection propagate unhandled.
+            if (errorEl) errorEl.textContent = 'Network error — please try again';
+            return;
+        }
         if (!res || !res.ok || !res.body || !res.body.token) {
             const detail = (res && res.body && res.body.detail) ? res.body.detail : 'Failed to mint token';
             if (errorEl) errorEl.textContent = detail;
@@ -1022,7 +1031,16 @@ class SettingsPane {
         const token = window.authManager && window.authManager.getToken && window.authManager.getToken();
         if (!token) return;
 
-        const ok = await window.apiClient.revokeAppToken(token, tokenId);
+        let ok;
+        try {
+            ok = await window.apiClient.revokeAppToken(token, tokenId);
+        } catch {
+            // A network-level fetch rejection — still surface feedback and
+            // refresh the list, matching the non-ok failure path below.
+            window.alert('Failed to revoke token. It may have already been revoked.');
+            this._loadAppTokens();
+            return;
+        }
         if (!ok) {
             window.alert('Failed to revoke token. It may have already been revoked.');
         }

--- a/explore/static/js/user-panes.js
+++ b/explore/static/js/user-panes.js
@@ -46,6 +46,11 @@ class UserPanes {
             }
             this._collectionTotal = data.total;
             this._renderCollectionList(body, data);
+        } catch {
+            // A network-level fetch rejection (offline, DNS, CORS) — not an
+            // HTTP error status — still needs to surface the same failure
+            // state instead of leaving the pane blank/stale.
+            if (requestId === this._collectionReqId) this._renderCollectionEmpty(body, 'Failed to load collection.');
         } finally {
             if (requestId === this._collectionReqId && loading) loading.classList.remove('active');
         }
@@ -115,6 +120,11 @@ class UserPanes {
             }
             this._wantlistTotal = data.total;
             this._renderWantlistList(body, data);
+        } catch {
+            // A network-level fetch rejection (offline, DNS, CORS) — not an
+            // HTTP error status — still needs to surface the same failure
+            // state instead of leaving the pane blank/stale.
+            if (requestId === this._wantlistReqId) this._renderWantlistEmpty(body, 'Failed to load wantlist.');
         } finally {
             if (requestId === this._wantlistReqId && loading) loading.classList.remove('active');
         }
@@ -174,6 +184,10 @@ class UserPanes {
         try {
             const data = await window.apiClient.getUserRecommendations(token, 50);
             this._renderRecommendations(body, data);
+        } catch {
+            // A network-level fetch rejection — _renderRecommendations already
+            // renders the "failed to load" state for a null/falsy data value.
+            this._renderRecommendations(body, null);
         } finally {
             if (loading) loading.classList.remove('active');
         }
@@ -266,8 +280,14 @@ class UserPanes {
     async loadCollectionStats() {
         const token = window.authManager.getToken();
         if (!token) return;
-        const stats = await window.apiClient.getUserCollectionStats(token);
-        this._renderCollectionStats(stats);
+        try {
+            const stats = await window.apiClient.getUserCollectionStats(token);
+            this._renderCollectionStats(stats);
+        } catch {
+            // A network-level fetch rejection — _renderCollectionStats already
+            // no-ops on a falsy stats value, leaving whatever was last rendered.
+            this._renderCollectionStats(null);
+        }
     }
 
     _renderCollectionStats(stats) {
@@ -771,7 +791,14 @@ class UserPanes {
         btn.disabled = true;
         btn.textContent = 'Downloading...';
 
-        const blob = await window.apiClient.getTasteCard(token);
+        let blob;
+        try {
+            blob = await window.apiClient.getTasteCard(token);
+        } catch {
+            // A network-level fetch rejection — treat exactly like the
+            // null-return failure path below so the button always recovers.
+            blob = null;
+        }
         if (!blob) {
             btn.textContent = 'Download failed';
             setTimeout(resetBtn, 2000);
@@ -853,6 +880,11 @@ class UserPanes {
             }
             this._gapTotal = data.pagination?.total || 0;
             this._renderGaps(body, data);
+        } catch {
+            // A network-level fetch rejection (offline, DNS, CORS) — not an
+            // HTTP error status — still needs to surface the same failure
+            // state instead of leaving the pane blank/stale.
+            if (requestId === this._gapReqId) this._renderGapsEmpty(body, 'Failed to load gap analysis.');
         } finally {
             if (requestId === this._gapReqId && loading) loading.classList.remove('active');
         }


### PR DESCRIPTION
Fixes 7 priority-3 explore-frontend findings from the 2026-08-10 bug hunt (run `wf_646d4b21`), one commit per bead.

- **discogsography-3c6c** — logout resets the gaps/settings panes and clears personal data from the DOM.
- **discogsography-3t37** — each toast owns its auto-hide timer; overlapping toasts no longer cancel each other early.
- **discogsography-3vz8** — an in-progress mint form survives Settings pane re-activation.
- **discogsography-68oe** — a light palette exists, so the theme toggle's light/auto modes actually render (auto follows prefers-color-scheme).
- **discogsography-cmw0** — fetch rejections across explore panes surface an error state instead of dead-ending the UI.
- **discogsography-oi02** — release/master search-result clicks call the real global (`window.exploreApp`), ending the silent no-op.
- **discogsography-ponr** — an expired/revoked JWT is cleared client-side on 401, with cross-tab logout reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrLwHwMcu3cuQJh8cc1SyW