### PR TITLE
fix: API & insights correctness — 12 bug-hunt findings (batch:p3-api-insights)

### DIFF
--- a/api/nlq/engine.py
+++ b/api/nlq/engine.py
@@ -133,7 +133,18 @@ class NLQEngine:
         if context.user_id is not None:
             tools.extend(get_authenticated_tool_schemas())
 
-        messages: list[dict[str, Any]] = [{"role": "user", "content": query}]
+        # Resolve references like "this artist"/"tell me more about them" to the
+        # entity the user is currently viewing in the Explore pane. Prepended to
+        # the user message (not appended to the static system prompt) so it reads
+        # naturally as query context. See discogsography-xcsx.
+        user_content = query
+        if context.current_entity_id is not None and context.current_entity_type is not None:
+            user_content = (
+                f'[Context: the user is currently viewing {context.current_entity_type} "{context.current_entity_id}" '
+                f'in the Explore pane. Resolve references like "this artist" or "them" to it.]\n\n{query}'
+            )
+
+        messages: list[dict[str, Any]] = [{"role": "user", "content": user_content}]
         tools_used: list[str] = []
         entities: list[dict[str, Any]] = []
         actions: list[Action] = []

--- a/api/queries/neo4j_queries.py
+++ b/api/queries/neo4j_queries.py
@@ -169,15 +169,31 @@ async def autocomplete_style(driver: AsyncResilientNeo4jDriver, query: str, limi
 
 
 async def explore_artist(driver: AsyncResilientNeo4jDriver, name: str) -> dict[str, Any] | None:
-    """Get artist center node with category counts."""
+    """Get artist center node with category counts.
+
+    alias_count dedups across ALIAS_OF/MEMBER_OF categories the same way
+    count_artist_aliases and expand_artist_aliases do, so an artist reachable
+    through more than one category still contributes exactly one
+    (discogsography-1wiu).
+    """
     cypher = """
     MATCH (a:Artist {name: $name})
+    CALL {
+        WITH a
+        OPTIONAL MATCH (a)-[:ALIAS_OF]->(alias:Artist)
+        WITH a, collect(DISTINCT alias.id) AS alias_ids
+        OPTIONAL MATCH (a)-[:MEMBER_OF]->(grp:Artist)
+        WITH a, alias_ids, collect(DISTINCT grp.id) AS group_ids
+        OPTIONAL MATCH (m:Artist)-[:MEMBER_OF]->(a)
+        WITH alias_ids, group_ids, collect(DISTINCT m.id) AS member_ids
+        UNWIND (alias_ids + group_ids + member_ids) AS related_id
+        WITH DISTINCT related_id WHERE related_id IS NOT NULL
+        RETURN count(related_id) AS alias_count
+    }
     RETURN a.id AS id, a.name AS name,
            COUNT { MATCH (r:Release)-[:BY]->(a) RETURN DISTINCT r } AS release_count,
            COUNT { MATCH (r:Release)-[:BY]->(a), (r)-[:ON]->(l:Label) RETURN DISTINCT l } AS label_count,
-           COUNT { (a)-[:ALIAS_OF]->(:Artist) }
-               + COUNT { (a)-[:MEMBER_OF]->(:Artist) }
-               + COUNT { (:Artist)-[:MEMBER_OF]->(a) } AS alias_count
+           alias_count
     """
     return await run_single(driver, cypher, name=name)
 
@@ -556,16 +572,25 @@ async def count_artist_labels(driver: AsyncResilientNeo4jDriver, artist_name: st
 
 
 async def count_artist_aliases(driver: AsyncResilientNeo4jDriver, artist_name: str, *, before_year: int | None = None) -> int:  # noqa: ARG001
-    """Count total aliases, group memberships, and members for an artist."""
+    """Count total distinct aliases, group memberships, and members for an artist.
+
+    Mirrors expand_artist_aliases's dedup: an artist reachable through more
+    than one category (e.g. both ALIAS_OF and MEMBER_OF the same node) must
+    contribute exactly one to this total, matching the one row expand_artist_aliases
+    returns for it — otherwise pagination's `total` disagrees with the
+    enumerable row count (discogsography-1wiu).
+    """
     cypher = """
     MATCH (a:Artist {name: $name})
     OPTIONAL MATCH (a)-[:ALIAS_OF]->(alias:Artist)
-    WITH a, count(DISTINCT alias) AS alias_count
+    WITH a, collect(DISTINCT alias.id) AS alias_ids
     OPTIONAL MATCH (a)-[:MEMBER_OF]->(grp:Artist)
-    WITH a, alias_count, count(DISTINCT grp) AS group_count
+    WITH a, alias_ids, collect(DISTINCT grp.id) AS group_ids
     OPTIONAL MATCH (m:Artist)-[:MEMBER_OF]->(a)
-    WITH alias_count, group_count, count(DISTINCT m) AS member_count
-    RETURN alias_count + group_count + member_count AS total
+    WITH alias_ids, group_ids, collect(DISTINCT m.id) AS member_ids
+    UNWIND (alias_ids + group_ids + member_ids) AS related_id
+    WITH DISTINCT related_id WHERE related_id IS NOT NULL
+    RETURN count(related_id) AS total
     """
     return await run_count(driver, cypher, name=artist_name)
 

--- a/api/queries/neo4j_queries.py
+++ b/api/queries/neo4j_queries.py
@@ -303,6 +303,17 @@ async def explore_style(driver: AsyncResilientNeo4jDriver, name: str) -> dict[st
 
 
 # --- Expand (populate category children) ---
+#
+# Every ORDER BY below carries `id` (or, for _expand_releases, `id` after the
+# year sort) as a unique, index-backed tiebreaker. SKIP/LIMIT pagination
+# requires a TOTAL order to stay stable across separate query executions —
+# without one, Neo4j's ordering of a tied group (e.g. many artists all with
+# release_count=1) is not guaranteed identical between the offset=0 and
+# offset=50 requests, so pages can duplicate and drop rows even though
+# count_* reports the correct total. Same tiebreaker discipline the SQL side
+# already applies (search_queries.py's `data_id`, rarity_queries.py's
+# `release_id`) — expand_artist_aliases (ORDER BY id on unique item.id) was
+# already safe; these were not (discogsography-ypkc).
 
 
 async def _expand_releases(
@@ -314,7 +325,7 @@ async def _expand_releases(
     MATCH {match_clause}{year_filter}
     RETURN r.id AS id, r.title AS name, 'release' AS type,
            CASE WHEN r.year > 0 THEN r.year ELSE null END AS year
-    ORDER BY year IS NULL ASC, year DESC
+    ORDER BY year IS NULL ASC, year DESC, id
     SKIP $offset
     LIMIT $limit
     """
@@ -339,7 +350,7 @@ async def expand_artist_labels(
     cypher = f"""
     MATCH (r:Release)-[:BY]->(a:Artist {{name: $name}}), (r)-[:ON]->(l:Label){year_filter}
     RETURN l.id AS id, l.name AS name, 'label' AS type, count(DISTINCT r) AS release_count
-    ORDER BY release_count DESC
+    ORDER BY release_count DESC, id
     SKIP $offset
     LIMIT $limit
     """
@@ -395,7 +406,7 @@ async def expand_genre_artists(
     cypher = f"""
     MATCH (r:Release)-[:IS]->(g:Genre {{name: $name}}), (r)-[:BY]->(a:Artist){year_filter}
     RETURN a.id AS id, a.name AS name, 'artist' AS type, count(r) AS release_count
-    ORDER BY release_count DESC
+    ORDER BY release_count DESC, id
     SKIP $offset
     LIMIT $limit
     """
@@ -413,7 +424,7 @@ async def expand_genre_labels(
     cypher = f"""
     MATCH (r:Release)-[:IS]->(g:Genre {{name: $name}}), (r)-[:ON]->(l:Label){year_filter}
     RETURN l.id AS id, l.name AS name, 'label' AS type, count(DISTINCT r) AS release_count
-    ORDER BY release_count DESC
+    ORDER BY release_count DESC, id
     SKIP $offset
     LIMIT $limit
     """
@@ -431,7 +442,7 @@ async def expand_genre_styles(
     cypher = f"""
     MATCH (r:Release)-[:IS]->(g:Genre {{name: $name}}), (r)-[:IS]->(s:Style){year_filter}
     RETURN s.name AS id, s.name AS name, 'style' AS type, count(DISTINCT r) AS release_count
-    ORDER BY release_count DESC
+    ORDER BY release_count DESC, id
     SKIP $offset
     LIMIT $limit
     """
@@ -456,7 +467,7 @@ async def expand_label_artists(
     cypher = f"""
     MATCH (r:Release)-[:ON]->(l:Label {{name: $name}}), (r)-[:BY]->(a:Artist){year_filter}
     RETURN a.id AS id, a.name AS name, 'artist' AS type, count(DISTINCT r) AS release_count
-    ORDER BY release_count DESC
+    ORDER BY release_count DESC, id
     SKIP $offset
     LIMIT $limit
     """
@@ -474,7 +485,7 @@ async def expand_label_genres(
     cypher = f"""
     MATCH (r:Release)-[:ON]->(l:Label {{name: $name}}), (r)-[:IS]->(g:Genre){year_filter}
     RETURN g.name AS id, g.name AS name, 'genre' AS type, count(DISTINCT r) AS release_count
-    ORDER BY release_count DESC
+    ORDER BY release_count DESC, id
     SKIP $offset
     LIMIT $limit
     """
@@ -499,7 +510,7 @@ async def expand_style_artists(
     cypher = f"""
     MATCH (r:Release)-[:IS]->(s:Style {{name: $name}}), (r)-[:BY]->(a:Artist){year_filter}
     RETURN a.id AS id, a.name AS name, 'artist' AS type, count(r) AS release_count
-    ORDER BY release_count DESC
+    ORDER BY release_count DESC, id
     SKIP $offset
     LIMIT $limit
     """
@@ -517,7 +528,7 @@ async def expand_style_labels(
     cypher = f"""
     MATCH (r:Release)-[:IS]->(s:Style {{name: $name}}), (r)-[:ON]->(l:Label){year_filter}
     RETURN l.id AS id, l.name AS name, 'label' AS type, count(DISTINCT r) AS release_count
-    ORDER BY release_count DESC
+    ORDER BY release_count DESC, id
     SKIP $offset
     LIMIT $limit
     """
@@ -535,7 +546,7 @@ async def expand_style_genres(
     cypher = f"""
     MATCH (r:Release)-[:IS]->(s:Style {{name: $name}}), (r)-[:IS]->(g:Genre){year_filter}
     RETURN g.name AS id, g.name AS name, 'genre' AS type, count(DISTINCT r) AS release_count
-    ORDER BY release_count DESC
+    ORDER BY release_count DESC, id
     SKIP $offset
     LIMIT $limit
     """

--- a/api/queries/taste_queries.py
+++ b/api/queries/taste_queries.py
@@ -65,14 +65,7 @@ async def get_obscurity_score(
     RETURN collectors
     ORDER BY collectors
     """
-    count_cypher = """
-    MATCH (u:User {id: $user_id})-[:COLLECTED]->(r:Release)
-    RETURN count(r) AS total
-    """
-    rows, total = await asyncio.gather(
-        run_query(driver, cypher, timeout=120, user_id=user_id),
-        run_count(driver, count_cypher, timeout=120, user_id=user_id),
-    )
+    rows = await run_query(driver, cypher, timeout=120, user_id=user_id)
 
     if not rows:
         return {"score": 1.0, "median_collectors": 0.0, "total_releases": 0}
@@ -85,7 +78,15 @@ async def get_obscurity_score(
     max_collectors = max(collector_counts) if collector_counts else 0
     score = 1.0 if max_collectors == 0 else max(0.0, min(1.0, 1.0 - (median / max_collectors)))
 
-    return {"score": round(score, 4), "median_collectors": median, "total_releases": total}
+    # total_releases MUST match the distinct-release basis the score/median are
+    # computed on. `rows` is already one row per distinct release (the main
+    # query dedups via `WITH DISTINCT u, r`), so len(rows) is the correct
+    # count. A separate `count(r)` query (no DISTINCT) would count COLLECTED
+    # *edges* instead — inflated for any release owned in multiple physical
+    # copies (syncer.py keys the edge on instance_id) and internally
+    # inconsistent with the distinct-release score/median in the same
+    # response (discogsography-omrb).
+    return {"score": round(score, 4), "median_collectors": median, "total_releases": n}
 
 
 async def get_taste_drift(

--- a/api/routers/extraction_analysis.py
+++ b/api/routers/extraction_analysis.py
@@ -945,7 +945,10 @@ def _build_prompt_contexts(all_violations: list[dict[str, Any]], flagged_version
             sample_records.append(
                 {
                     "record_id": rid,
-                    "violations": [{"rule": m.get("rule", ""), "message": m.get("message", m.get("field", ""))} for m in record_violations],
+                    "violations": [
+                        {"rule": m.get("rule", ""), "field": m.get("field", ""), "field_value": m.get("field_value", m.get("value", ""))}
+                        for m in record_violations
+                    ],
                     "raw_xml": raw_xml,
                     "parsed_json": parsed_json,
                 }
@@ -1014,7 +1017,7 @@ def _build_rule_sections(all_violations: list[dict[str, Any]], flagged_version_d
         # Collect unique field values to show distribution
         field_values: list[str] = []
         for v in matching[:50]:
-            val = v.get("value", v.get("field", ""))
+            val = v.get("field_value", v.get("value", ""))
             if val and val not in field_values:
                 field_values.append(str(val))
             if len(field_values) >= 10:
@@ -1043,7 +1046,7 @@ def _build_rule_sections(all_violations: list[dict[str, Any]], flagged_version_d
             section_lines.append("Violations:")
             for rv in record_violations:
                 section_lines.append(
-                    f"  - `{rv.get('rule', '')}` on field `{rv.get('field', rv.get('message', ''))}` — value: `{rv.get('value', '(not captured)')}`"
+                    f"  - `{rv.get('rule', '')}` on field `{rv.get('field', '')}` — value: `{rv.get('field_value', rv.get('value', '(not captured)'))}`"
                 )
 
             if parsed_json:

--- a/api/routers/extraction_analysis.py
+++ b/api/routers/extraction_analysis.py
@@ -591,8 +591,19 @@ async def get_violation_detail(
     version: str,
     record_id: str,
     _admin: Annotated[dict[str, Any], Depends(require_admin)],
+    entity_type: Annotated[str | None, Query(pattern=r"^[a-z-]+$")] = None,
 ) -> JSONResponse:
-    """Return all violations for a specific record, plus raw XML and parsed JSON (if available)."""
+    """Return all violations for a specific record, plus raw XML and parsed JSON (if available).
+
+    ``record_id`` alone is NOT a unique key over the version's violations —
+    Discogs record IDs are per-entity-type namespaces, so artist 123, label 123,
+    master 123, and release 123 are distinct records that commonly coexist.
+    Callers that know the entity type (the violations list already does) should
+    pass it to disambiguate; otherwise this deterministically scopes the
+    response to one entity type's violations and files instead of merging
+    violations from every colliding type under one entity's raw data
+    (discogsography-tre5).
+    """
     _validate_version(version)
     _validate_record_id(record_id)
 
@@ -604,13 +615,27 @@ async def get_violation_detail(
     flagged_version_dir = data_root / "flagged" / version
 
     all_violations = await _get_violations(flagged_version_dir)
-    record_violations = [v for v in all_violations if v.get("record_id") == record_id]
+    candidate_violations = [v for v in all_violations if v.get("record_id") == record_id]
 
-    if not record_violations:
+    if not candidate_violations:
         raise HTTPException(status_code=404, detail=f"No violations found for record_id: {record_id!r}")
 
-    # Determine the entity type (use the first match)
-    found_entity_type: str = record_violations[0].get("entity_type", "unknown")
+    if entity_type is not None:
+        record_violations = [v for v in candidate_violations if v.get("entity_type") == entity_type]
+        if not record_violations:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No violations found for record_id {record_id!r} with entity_type {entity_type!r}",
+            )
+        found_entity_type = entity_type
+    else:
+        # No entity_type given: scope to ONE entity type's violations rather than
+        # merging every colliding type together. Deterministic (sorted) choice
+        # of entity type, matching the prior "first match" behavior's
+        # determinism without the cross-type merge.
+        found_entity_type = sorted({v.get("entity_type", "unknown") for v in candidate_violations})[0]
+        record_violations = [v for v in candidate_violations if v.get("entity_type") == found_entity_type]
+
     raw_xml, parsed_json, truncated = await asyncio.to_thread(_load_record_files, flagged_version_dir, found_entity_type, record_id)
 
     return JSONResponse(

--- a/api/routers/insights_compute.py
+++ b/api/routers/insights_compute.py
@@ -26,7 +26,7 @@ from api.queries.insights_neo4j_queries import (
 )
 from api.queries.insights_pg_queries import query_data_completeness
 from api.queries.rarity_queries import fetch_all_rarity_signals
-from api.syncer import DISCOGS_API_BASE, MAX_RATE_LIMIT_RETRIES, _auth_header
+from api.syncer import DISCOGS_API_BASE, MAX_RATE_LIMIT_RETRIES, SYNC_DELAY_SECONDS, _auth_header
 from common import describe_exception
 
 
@@ -70,7 +70,11 @@ router = APIRouter(
     dependencies=[Depends(require_internal_secret)],
 )
 
-_ENRICHMENT_DELAY_SECONDS = 1.0  # 1 req/sec to stay under 60 req/min
+# Reuse api.syncer's rate-limit pacing constant rather than forking a second copy
+# — the two are explicit rate-limit siblings (both share MAX_RATE_LIMIT_RETRIES
+# against the same Discogs 60 req/min budget) and a fork previously let this value
+# drift out of sync with syncer.py's (discogsography-fnhk).
+_ENRICHMENT_DELAY_SECONDS = SYNC_DELAY_SECONDS
 _STALENESS_DAYS = 7
 
 # Hard cap on releases enriched per invocation.

--- a/api/routers/nlq.py
+++ b/api/routers/nlq.py
@@ -76,10 +76,20 @@ async def _extract_user_id(request: Request) -> str | None:
         return None
 
 
-def _cache_key(query: str) -> str:
-    """Build a Redis cache key from a normalized query."""
+def _cache_key(query: str, context: dict[str, Any] | None = None) -> str:
+    """Build a Redis cache key from a normalized query and its entity context.
+
+    The engine now resolves deictic references ("this artist") using
+    ``current_entity_id``/``current_entity_type`` (discogsography-xcsx), so the
+    same query text can produce a different answer depending on which entity is
+    focused. The cache key MUST include that context — keying on query text
+    alone would serve one focused entity's cached answer to a different
+    anonymous user asking the identical question about a different entity.
+    """
     normalized = query.strip().lower()
-    digest = hashlib.sha256(normalized.encode()).hexdigest()[:16]
+    entity_id = (context or {}).get("entity_id") or ""
+    entity_type = (context or {}).get("entity_type") or ""
+    digest = hashlib.sha256(f"{normalized}\x00{entity_type}\x00{entity_id}".encode()).hexdigest()[:16]
     return f"nlq:{digest}"
 
 
@@ -148,7 +158,7 @@ async def nlq_query(request: Request, body: NLQQueryRequest) -> Any:
     # Check Redis cache for public (unauthenticated) queries
     cached_data: dict[str, Any] | None = None
     if user_id is None and _redis is not None:
-        cache_k = _cache_key(body.query)
+        cache_k = _cache_key(body.query, body.context)
         try:
             cached = await _redis.get(cache_k)
             if cached is not None:
@@ -186,7 +196,7 @@ async def nlq_query(request: Request, body: NLQQueryRequest) -> Any:
 
     # Cache public results
     if user_id is None and _redis is not None:
-        cache_k = _cache_key(body.query)
+        cache_k = _cache_key(body.query, body.context)
         try:
             await _redis.setex(cache_k, _nlq_config.cache_ttl, json.dumps(response_data))
         except Exception:
@@ -298,7 +308,7 @@ def _stream_response(
             # at that yield, and a write placed after it would never run.
             # See discogsography-c584.
             if user_id is None and _redis is not None:
-                cache_k = _cache_key(query)
+                cache_k = _cache_key(query, context)
                 try:
                     await _redis.setex(cache_k, _nlq_config.cache_ttl, json.dumps(response_data))
                 except Exception:

--- a/api/routers/nlq.py
+++ b/api/routers/nlq.py
@@ -289,6 +289,21 @@ def _stream_response(
                 "actions": actions_payload,
                 "cached": False,
             }
+
+            # Cache public results — mirrors the non-streaming branch below.
+            # This is the only client the production UI uses (nlq.js always sends
+            # Accept: text/event-stream), so without this write the query cache and
+            # its cached-replay path above are permanently unpopulated. Written
+            # before the "result" yield: a client disconnect raises GeneratorExit
+            # at that yield, and a write placed after it would never run.
+            # See discogsography-c584.
+            if user_id is None and _redis is not None:
+                cache_k = _cache_key(query)
+                try:
+                    await _redis.setex(cache_k, _nlq_config.cache_ttl, json.dumps(response_data))
+                except Exception:
+                    logger.debug("⚠️ NLQ cache write failed", key=cache_k)
+
             yield {"event": "result", "data": json.dumps(response_data)}
         finally:
             # Client disconnect raises GeneratorExit at the current yield; cancel

--- a/api/routers/taste.py
+++ b/api/routers/taste.py
@@ -75,7 +75,16 @@ async def taste_heatmap(
     err = await _check_minimum(_neo4j_driver, user_id)
     if err:
         return err
-    cells, total = await get_taste_heatmap(_neo4j_driver, user_id)
+    try:
+        cells, total = await get_taste_heatmap(_neo4j_driver, user_id)
+    except Neo4jClientError as exc:
+        if "TransactionTimedOut" in str(exc):
+            logger.warning("⏱️ Taste heatmap query timed out", user_id=user_id)
+            return JSONResponse(
+                content={"error": "Taste heatmap query timed out — collection may be too large"},
+                status_code=504,
+            )
+        raise
     resp = HeatmapResponse(
         cells=[HeatmapCell(**c) for c in cells],
         total=total,
@@ -159,12 +168,21 @@ async def taste_card(
     if err:
         return err
 
-    heatmap_result, obscurity_result, drift_result, labels_result = await asyncio.gather(
-        get_taste_heatmap(_neo4j_driver, user_id),
-        get_obscurity_score(_neo4j_driver, user_id),
-        get_taste_drift(_neo4j_driver, user_id),
-        get_top_labels(_neo4j_driver, user_id, limit=5),
-    )
+    try:
+        heatmap_result, obscurity_result, drift_result, labels_result = await asyncio.gather(
+            get_taste_heatmap(_neo4j_driver, user_id),
+            get_obscurity_score(_neo4j_driver, user_id),
+            get_taste_drift(_neo4j_driver, user_id),
+            get_top_labels(_neo4j_driver, user_id, limit=5),
+        )
+    except Neo4jClientError as exc:
+        if "TransactionTimedOut" in str(exc):
+            logger.warning("⏱️ Taste card query timed out", user_id=user_id)
+            return JSONResponse(
+                content={"error": "Taste card query timed out — collection may be too large"},
+                status_code=504,
+            )
+        raise
 
     cells, _total = heatmap_result
     # Aggregate genre counts across all cells (decades) to find the true top genres

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -32,7 +32,7 @@ from common.query_debug import execute_sql, log_cypher_query
 logger = structlog.get_logger(__name__)
 
 DISCOGS_API_BASE = "https://api.discogs.com"
-SYNC_DELAY_SECONDS = 0.5  # 0.5s between requests to stay under 60 req/min
+SYNC_DELAY_SECONDS = 1.0  # 1 req/sec to stay under 60 req/min (discogsography-fnhk)
 PAGE_SIZE = 100
 MAX_RATE_LIMIT_RETRIES = 5
 

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -194,6 +194,14 @@ async def sync_collection(
                         item.get("rating", 0),
                         item.get("date_added"),
                         metadata_json,
+                        # Stamp with the app-host sync_started clock (not PG's NOW()) so
+                        # this write and _reconcile_stale_collection's DELETE cutoff share
+                        # ONE clock source — mirroring the Neo4j half of this same sync,
+                        # which already stamps synced_at=sync_started. A DB-host clock
+                        # lagging the API host would otherwise make NOW() land before the
+                        # cutoff and _reconcile_stale_collection would delete the row this
+                        # sync just wrote (discogsography-vqr0).
+                        sync_started,
                     )
                 )
 
@@ -209,7 +217,7 @@ async def sync_collection(
                             ) VALUES (
                                 %s::uuid, %s, %s, %s,
                                 %s, %s, %s, %s::jsonb, %s,
-                                %s, %s, %s::jsonb, NOW()
+                                %s, %s, %s::jsonb, %s
                             )
                             ON CONFLICT (user_id, release_id, instance_id) DO UPDATE SET
                                 folder_id = EXCLUDED.folder_id,
@@ -221,7 +229,7 @@ async def sync_collection(
                                 rating = EXCLUDED.rating,
                                 date_added = EXCLUDED.date_added,
                                 metadata = COALESCE(EXCLUDED.metadata, user_collections.metadata),
-                                updated_at = NOW()
+                                updated_at = EXCLUDED.updated_at
                         """,
                         batch_params,
                     )
@@ -430,6 +438,9 @@ async def sync_wantlist(
                         item.get("rating", 0),
                         item.get("notes"),
                         item.get("date_added"),
+                        # Same single-clock fix as sync_collection: stamp with the
+                        # app-host sync_started clock, not PG's NOW() (discogsography-vqr0).
+                        sync_started,
                     )
                 )
 
@@ -445,7 +456,7 @@ async def sync_wantlist(
                             ) VALUES (
                                 %s::uuid, %s,
                                 %s, %s, %s, %s,
-                                %s, %s, %s, NOW()
+                                %s, %s, %s, %s
                             )
                             ON CONFLICT (user_id, release_id) DO UPDATE SET
                                 title = EXCLUDED.title,
@@ -455,7 +466,7 @@ async def sync_wantlist(
                                 rating = EXCLUDED.rating,
                                 notes = EXCLUDED.notes,
                                 date_added = EXCLUDED.date_added,
-                                updated_at = NOW()
+                                updated_at = EXCLUDED.updated_at
                         """,
                         batch_params,
                     )

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -461,24 +461,38 @@ class DashboardApp:
                     result = await session.run("CALL dbms.components() YIELD name, versions")
                     await result.single()
 
-                    # Get database size — fall back to basic count if APOC is not installed
+                    # Get database size — fall back to an "unknown" marker if APOC
+                    # is not installed. node_count/rel_count stay None (never a
+                    # fabricated 0) so a fully-populated graph can never render as
+                    # "0 nodes, 0 relationships" — a hard count for an unmeasured
+                    # quantity is indistinguishable from a genuinely empty graph
+                    # and misleads operators into thinking ingestion is broken
+                    # (discogsography-k3vu).
+                    node_count: int | None
+                    rel_count: int | None
                     try:
                         result = await session.run("CALL apoc.meta.stats() YIELD nodeCount, relCount")
                         stats = await result.single()
-                        node_count = stats["nodeCount"] if stats else 0
-                        rel_count = stats["relCount"] if stats else 0
+                        node_count = stats["nodeCount"] if stats else None
+                        rel_count = stats["relCount"] if stats else None
                     except Exception:
                         # APOC not installed — avoid full graph scan which is too
                         # expensive for the 2-second metrics loop on large datasets
-                        node_count = 0
-                        rel_count = 0
+                        node_count = None
+                        rel_count = None
+
+                    size = (
+                        f"{node_count:,} nodes, {rel_count:,} relationships"
+                        if node_count is not None and rel_count is not None
+                        else "unknown (APOC unavailable)"
+                    )
 
                 databases.append(
                     DatabaseInfo(
                         name="Neo4j",
                         status="healthy",
                         connection_count=1,  # Neo4j doesn't expose this easily
-                        size=f"{node_count:,} nodes, {rel_count:,} relationships",
+                        size=size,
                         error=None,
                     )
                 )

--- a/dashboard/static/admin.js
+++ b/dashboard/static/admin.js
@@ -1894,7 +1894,7 @@ class AdminDashboard {
                 chip.className = 'text-xs px-2 py-1 rounded border b-theme t-mid hover:t-high mono';
                 chip.textContent = item.record_id;
                 chip.title = item.reason || '';
-                chip.addEventListener('click', () => this._eaShowRecordDetail(version, item.record_id));
+                chip.addEventListener('click', () => this._eaShowRecordDetail(version, item.record_id, entityType));
                 list.appendChild(chip);
             }
 
@@ -2081,7 +2081,7 @@ class AdminDashboard {
                     const detailBtn = document.createElement('button');
                     detailBtn.className = 'text-[10px] px-2 py-0.5 rounded border b-theme t-dim hover:t-high';
                     detailBtn.textContent = 'View';
-                    detailBtn.addEventListener('click', () => this._eaShowRecordDetail(version, v.record_id));
+                    detailBtn.addEventListener('click', () => this._eaShowRecordDetail(version, v.record_id, v.entity_type));
                     tdDetail.appendChild(detailBtn);
 
                     tr.append(tdId, tdRule, tdSev, tdField, tdValue, tdDetail);
@@ -2110,12 +2110,13 @@ class AdminDashboard {
         }
     }
 
-    async _eaShowRecordDetail(version, recordId) {
+    async _eaShowRecordDetail(version, recordId, entityType) {
         const modal = document.getElementById('ea-modal');
         if (!modal) return;
         try {
+            const params = entityType ? `?entity_type=${encodeURIComponent(entityType)}` : '';
             const resp = await this.authFetch(
-                `/admin/api/extraction-analysis/${encodeURIComponent(version)}/violations/${encodeURIComponent(recordId)}`,
+                `/admin/api/extraction-analysis/${encodeURIComponent(version)}/violations/${encodeURIComponent(recordId)}${params}`,
             );
             if (!resp.ok) return;
             const data = await resp.json();

--- a/dashboard/static/admin.js
+++ b/dashboard/static/admin.js
@@ -2328,7 +2328,7 @@ class AdminDashboard {
                         if (rec.violations && rec.violations.length > 0) {
                             lines.push('**Violations:**');
                             rec.violations.forEach(v => {
-                                lines.push(`- \`${v.rule}\` on field \`${v.message || '(unknown)'}\``);
+                                lines.push(`- \`${v.rule}\` on field \`${v.field || '(unknown)'}\` — value: \`${v.field_value || '(not captured)'}\``);
                             });
                             lines.push('');
                         }

--- a/insights/insights.py
+++ b/insights/insights.py
@@ -250,7 +250,14 @@ async def genre_trends(genre: str = Query(...)) -> JSONResponse:
     if not _pool:
         return JSONResponse(content={"error": "Service not ready"}, status_code=503)
 
-    cache_key = f"insights:genre-trends:{genre.replace(':', '_')}"
+    # No sanitization here on purpose: InsightsCache.versioned_key only strips
+    # the fixed "insights:" literal prefix (removeprefix, not a split), and the
+    # invalidation scan matches the constant glob "insights:g*" — interior
+    # colons in `genre` are harmless. A prior `.replace(':', '_')` was a lossy,
+    # non-injective mapping ("A:B" and "A_B" collided onto one key) that
+    # defended against nothing while corrupting distinct genres' cached
+    # responses (discogsography-qjri).
+    cache_key = f"insights:genre-trends:{genre}"
     # Read the generation BEFORE the DB read — see insights/cache.py.
     generation = await _cache.generation() if _cache else 0
     if _cache:

--- a/tests/api/nlq/test_engine.py
+++ b/tests/api/nlq/test_engine.py
@@ -207,6 +207,52 @@ class TestNLQEngineAuthTools:
         assert "search" in tool_names
 
 
+class TestNLQEngineCurrentEntityContext:
+    """Regression discogsography-xcsx: current_entity_id/current_entity_type were
+    plumbed from the client all the way to NLQContext but never read by the
+    engine — deictic references like "this artist" had no referent."""
+
+    @pytest.mark.asyncio
+    async def test_current_entity_context_injected_into_user_message(self) -> None:
+        config = _make_config()
+        client = _make_client()
+        runner = _make_tool_runner()
+
+        text_response = _make_text_response("Their main collaborators include Jonny Greenwood.")
+        client.messages.create.return_value = text_response
+
+        engine = NLQEngine(config=config, client=client, tool_runner=runner)
+        await engine.run(
+            "Who are this artist's main collaborators?",
+            NLQContext(current_entity_id="Radiohead", current_entity_type="artist"),
+        )
+
+        call_kwargs = client.messages.create.call_args
+        messages = call_kwargs.kwargs.get("messages") if call_kwargs.kwargs else call_kwargs[1].get("messages")
+        user_content = messages[0]["content"]
+        assert "Radiohead" in user_content
+        assert "artist" in user_content
+        assert "Who are this artist's main collaborators?" in user_content
+
+    @pytest.mark.asyncio
+    async def test_no_entity_context_leaves_message_unmodified(self) -> None:
+        """When no entity is focused, the user message must be the bare query —
+        no empty context preamble leaking through."""
+        config = _make_config()
+        client = _make_client()
+        runner = _make_tool_runner()
+
+        text_response = _make_text_response("Radiohead is a British rock band.")
+        client.messages.create.return_value = text_response
+
+        engine = NLQEngine(config=config, client=client, tool_runner=runner)
+        await engine.run("Tell me about Radiohead", NLQContext())
+
+        call_kwargs = client.messages.create.call_args
+        messages = call_kwargs.kwargs.get("messages") if call_kwargs.kwargs else call_kwargs[1].get("messages")
+        assert messages[0]["content"] == "Tell me about Radiohead"
+
+
 class TestNLQEngineGuardrails:
     """Test off-topic guardrails."""
 

--- a/tests/api/nlq/test_nlq_router.py
+++ b/tests/api/nlq/test_nlq_router.py
@@ -174,6 +174,49 @@ class TestNLQQuery:
         assert response.status_code == 200
         mock_redis.setex.assert_called_once()
 
+    def test_cache_key_differs_by_focused_entity_context(self) -> None:
+        """Regression discogsography-xcsx: since the engine now conditions its
+        answer on current_entity_id/current_entity_type, the cache key must
+        include that context — otherwise two anonymous users asking the same
+        query text about different focused entities would collide onto one
+        cache entry and get served each other's answer."""
+        base = nlq_router._cache_key("who are their collaborators?", None)
+        artist_a = nlq_router._cache_key("who are their collaborators?", {"entity_id": "Radiohead", "entity_type": "artist"})
+        artist_b = nlq_router._cache_key("who are their collaborators?", {"entity_id": "Kraftwerk", "entity_type": "artist"})
+
+        assert len({base, artist_a, artist_b}) == 3
+        # Same context must be stable/idempotent.
+        assert nlq_router._cache_key("who are their collaborators?", {"entity_id": "Radiohead", "entity_type": "artist"}) == artist_a
+
+    def test_query_passes_entity_context_to_engine(self, test_client: TestClient) -> None:
+        """The router must forward current_entity_id/current_entity_type from the
+        request body's context into NLQContext so the engine can resolve
+        deictic references."""
+        original_config = nlq_router._nlq_config
+        original_engine = nlq_router._engine
+        original_redis = nlq_router._redis
+        try:
+            nlq_router._nlq_config = MagicMock(is_available=True, max_query_length=500)
+            mock_engine = MagicMock()
+            mock_result = NLQResult(summary="Their collaborators include Jonny Greenwood.", entities=[], tools_used=["search"])
+            mock_engine.run = AsyncMock(return_value=mock_result)
+            nlq_router._engine = mock_engine
+            nlq_router._redis = None
+
+            response = test_client.post(
+                "/api/nlq/query",
+                json={"query": "who are this artist's collaborators?", "context": {"entity_id": "Radiohead", "entity_type": "artist"}},
+            )
+        finally:
+            nlq_router._nlq_config = original_config
+            nlq_router._engine = original_engine
+            nlq_router._redis = original_redis
+
+        assert response.status_code == 200
+        ctx = mock_engine.run.call_args[0][1]
+        assert ctx.current_entity_id == "Radiohead"
+        assert ctx.current_entity_type == "artist"
+
     def test_query_with_auth_token_extracts_user_id(self, test_client: TestClient, auth_headers: dict[str, str]) -> None:
         """When a valid Bearer token is provided, user_id is extracted and passed to engine."""
         original_config = nlq_router._nlq_config

--- a/tests/api/test_extraction_analysis.py
+++ b/tests/api/test_extraction_analysis.py
@@ -498,6 +498,83 @@ class TestViolationDetailEndpoint:
         assert data["raw_xml"] is None
         assert data["parsed_json"] is None
 
+    def test_record_detail_scopes_to_one_entity_type_when_ids_collide(self, test_client: TestClient, tmp_path: Path) -> None:
+        """Regression discogsography-tre5: record_id is a per-entity-type namespace,
+        not a global key — artist 1 and label 1 are distinct records that can both
+        be flagged. Without an entity_type filter, the response must NOT merge
+        violations from both types; it must deterministically pick one and load
+        that entity's files (never a random or cross-type blend)."""
+        import api.routers.extraction_analysis as ea
+
+        _make_flagged_version(tmp_path)  # writes artists/1 with a year-out-of-range violation
+
+        labels_dir = tmp_path / "flagged" / "20260101" / "labels"
+        labels_dir.mkdir(parents=True, exist_ok=True)
+        (labels_dir / "violations.jsonl").write_text(
+            json.dumps({"record_id": "1", "rule": "missing-field", "severity": "error", "field": "name", "field_value": ""}) + "\n"
+        )
+        (labels_dir / "1.xml").write_text("<label><id>1</id></label>")
+        (labels_dir / "1.json").write_text(json.dumps({"id": "1", "kind": "label"}))
+
+        with patch.object(ea, "_discogs_data_root", tmp_path), patch.object(ea, "_musicbrainz_data_root", None):
+            resp = test_client.get(
+                "/api/admin/extraction-analysis/20260101/violations/1",
+                headers=_admin_auth_headers(),
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        # entity_type is "artists" (alphabetically first of {artists, labels}) —
+        # deterministic, matching the prior first-match determinism.
+        assert data["entity_type"] == "artists"
+        # Every violation returned must belong to the SAME entity_type as the
+        # loaded files — no cross-type merge.
+        assert all(v["rule"] == "year-out-of-range" for v in data["violations"])
+        assert not any(v["rule"] == "missing-field" for v in data["violations"])
+        assert "<year>1850</year>" in data["raw_xml"]
+
+    def test_record_detail_entity_type_param_disambiguates_collision(self, test_client: TestClient, tmp_path: Path) -> None:
+        """Regression discogsography-tre5: an explicit entity_type query parameter
+        selects the correct record when IDs collide across entity types."""
+        import api.routers.extraction_analysis as ea
+
+        _make_flagged_version(tmp_path)
+
+        labels_dir = tmp_path / "flagged" / "20260101" / "labels"
+        labels_dir.mkdir(parents=True, exist_ok=True)
+        (labels_dir / "violations.jsonl").write_text(
+            json.dumps({"record_id": "1", "rule": "missing-field", "severity": "error", "field": "name", "field_value": ""}) + "\n"
+        )
+        (labels_dir / "1.xml").write_text("<label><id>1</id></label>")
+        (labels_dir / "1.json").write_text(json.dumps({"id": "1", "kind": "label"}))
+
+        with patch.object(ea, "_discogs_data_root", tmp_path), patch.object(ea, "_musicbrainz_data_root", None):
+            resp = test_client.get(
+                "/api/admin/extraction-analysis/20260101/violations/1?entity_type=labels",
+                headers=_admin_auth_headers(),
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["entity_type"] == "labels"
+        assert all(v["rule"] == "missing-field" for v in data["violations"])
+        assert "<label>" in data["raw_xml"]
+
+    def test_record_detail_entity_type_param_404_when_no_match(self, test_client: TestClient, tmp_path: Path) -> None:
+        """entity_type filter that matches no violation for this record_id is a 404,
+        not a silent fall-through to another entity type's data."""
+        import api.routers.extraction_analysis as ea
+
+        _make_flagged_version(tmp_path)
+
+        with patch.object(ea, "_discogs_data_root", tmp_path), patch.object(ea, "_musicbrainz_data_root", None):
+            resp = test_client.get(
+                "/api/admin/extraction-analysis/20260101/violations/1?entity_type=labels",
+                headers=_admin_auth_headers(),
+            )
+
+        assert resp.status_code == 404
+
 
 # ---------------------------------------------------------------------------
 # Task 5: Parsing Errors endpoint

--- a/tests/api/test_extraction_analysis.py
+++ b/tests/api/test_extraction_analysis.py
@@ -745,6 +745,28 @@ class TestPromptContextEndpoint:
         assert "1" in record_ids
         assert "2" in record_ids
 
+    def test_prompt_context_sample_violations_carry_field_value(self, test_client: TestClient, tmp_path: Path) -> None:
+        """Regression (discogsography-15gn): sample violations expose the extractor's real `field`/`field_value`
+        keys — not a speculative `value`/`message` key that never exists in violations.jsonl."""
+        import api.routers.extraction_analysis as ea
+
+        _make_flagged_version(tmp_path)
+
+        with patch.object(ea, "_discogs_data_root", tmp_path), patch.object(ea, "_musicbrainz_data_root", None):
+            resp = test_client.post(
+                "/api/admin/extraction-analysis/20260101/prompt-context",
+                json={"rules": [{"rule": "year-out-of-range", "entity_type": "artists"}]},
+                headers=_admin_auth_headers(),
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        ctx = data["contexts"][0]
+        record_1 = next(r for r in ctx["sample_records"] if r["record_id"] == "1")
+        violation = record_1["violations"][0]
+        assert violation["field"] == "year"
+        assert violation["field_value"] == "1850"
+
     def test_prompt_context_multiple_rules(self, test_client: TestClient, tmp_path: Path) -> None:
         """Returns separate contexts when multiple rules are selected."""
         import api.routers.extraction_analysis as ea
@@ -888,6 +910,39 @@ class TestGenerateAiPromptEndpoint:
         call_kwargs = mock_client.messages.create.call_args[1]
         assert call_kwargs["model"] == "claude-sonnet-4-20250514"
         assert "year-out-of-range" in call_kwargs["messages"][0]["content"]
+
+    def test_ai_prompt_includes_field_values_not_captured_placeholder(self, test_client: TestClient, tmp_path: Path) -> None:
+        """Regression (discogsography-15gn): the prompt sent to Claude must contain the actual violation
+        values (field_value) rather than the dead '(not captured)' fallback caused by reading a
+        never-populated 'value' key."""
+        import api.routers.extraction_analysis as ea
+
+        _make_flagged_version(tmp_path)
+
+        mock_text_block = MagicMock()
+        mock_text_block.text = "## Root Cause Analysis\nThe year field is out of range."
+        mock_response = MagicMock()
+        mock_response.content = [mock_text_block]
+
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+        with (
+            patch.object(ea, "_discogs_data_root", tmp_path),
+            patch.object(ea, "_musicbrainz_data_root", None),
+            patch.object(ea, "_anthropic_client", mock_client),
+        ):
+            resp = test_client.post(
+                "/api/admin/extraction-analysis/20260101/generate-ai-prompt",
+                json={"rules": [{"rule": "year-out-of-range", "entity_type": "artists"}]},
+                headers=_admin_auth_headers(),
+            )
+
+        assert resp.status_code == 200
+        call_kwargs = mock_client.messages.create.call_args[1]
+        prompt_sent = call_kwargs["messages"][0]["content"]
+        assert "1850" in prompt_sent
+        assert "(not captured)" not in prompt_sent
 
     def test_returns_502_on_anthropic_error(self, test_client: TestClient, tmp_path: Path) -> None:
         """Returns 502 when the Anthropic API call fails."""

--- a/tests/api/test_neo4j_queries.py
+++ b/tests/api/test_neo4j_queries.py
@@ -253,6 +253,29 @@ class TestExploreQueries:
         assert result == record
 
     @pytest.mark.asyncio
+    async def test_explore_artist_alias_count_dedups_across_categories(self) -> None:
+        """Regression (discogsography-1wiu): explore_artist's alias_count badge must
+        use the same cross-category DISTINCT dedup as count_artist_aliases /
+        expand_artist_aliases, not a plain per-category COUNT {} sum."""
+        from api.queries.neo4j_queries import explore_artist
+
+        mock_session = AsyncMock()
+        mock_result = AsyncMock()
+        mock_result.single = AsyncMock(return_value={"id": "1", "name": "Radiohead", "release_count": 10, "label_count": 2, "alias_count": 1})
+        mock_session.run = AsyncMock(return_value=mock_result)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        driver = MagicMock()
+        driver.session = MagicMock(return_value=mock_session)
+
+        await explore_artist(driver, "Radiohead")
+
+        cypher = mock_session.run.call_args[0][0]
+        assert "alias_ids + group_ids + member_ids" in cypher
+        assert "DISTINCT related_id" in cypher
+        assert "COUNT { (a)-[:ALIAS_OF]->(:Artist) }" not in cypher
+
+    @pytest.mark.asyncio
     async def test_explore_artist_not_found(self) -> None:
         from api.queries.neo4j_queries import explore_artist
 
@@ -519,6 +542,24 @@ class TestCountQueries:
 
         driver = _make_driver(single={"total": 1})
         assert await count_artist_aliases(driver, "Radiohead") == 1
+
+    @pytest.mark.asyncio
+    async def test_count_artist_aliases_dedups_across_categories(self) -> None:
+        """Regression (discogsography-1wiu): count_artist_aliases must dedup a node
+        reachable through more than one category (e.g. both ALIAS_OF and MEMBER_OF)
+        the same way expand_artist_aliases's `RETURN DISTINCT item.id` does — a
+        plain per-category sum would double-count it and disagree with the
+        paginated row count."""
+        from api.queries.neo4j_queries import count_artist_aliases
+
+        driver, captured_cypher, _captured_params = _make_capturing_driver(total=1)
+        await count_artist_aliases(driver, "Radiohead")
+        cypher = captured_cypher[0]
+        # Must union the three category id lists and count DISTINCT non-null ids,
+        # not `alias_count + group_count + member_count`.
+        assert "alias_ids + group_ids + member_ids" in cypher
+        assert "DISTINCT related_id" in cypher
+        assert "alias_count + group_count + member_count" not in cypher
 
     @pytest.mark.asyncio
     async def test_count_genre_releases(self) -> None:

--- a/tests/api/test_neo4j_queries.py
+++ b/tests/api/test_neo4j_queries.py
@@ -1392,3 +1392,66 @@ class TestExpandReleasesNullYearOrdering:
         await expand_style_releases(driver, "Art Rock", limit=50, offset=0)
         cypher, _params = calls[0]
         assert "ORDER BY year IS NULL ASC, year DESC" in cypher
+
+
+class TestExpandQueriesHaveUniqueOrderByTiebreaker:
+    """Regression discogsography-ypkc: SKIP/LIMIT pagination requires a TOTAL
+    order to stay stable across separate query executions. Every expand
+    ORDER BY previously sorted only by a non-unique key (release_count, or
+    year for releases) with no tiebreaker, so a tied group's ordering was not
+    guaranteed identical between page executions — rows could duplicate on one
+    page and never appear on any page, even though count_* reported the
+    correct total. expand_artist_aliases (ORDER BY id on unique item.id) was
+    already safe and is intentionally excluded here.
+    """
+
+    def _capture_driver(self) -> tuple[MagicMock, list[tuple[str, Any]]]:
+        calls: list[tuple[str, Any]] = []
+        mock_result = _MockResult(records=[])
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        async def _run_side_effect(cypher: str, params: Any, **_kwargs: Any) -> _MockResult:
+            calls.append((cypher, params))
+            return mock_result
+
+        mock_session.run = AsyncMock(side_effect=_run_side_effect)
+        driver = MagicMock()
+        driver.session = MagicMock(return_value=mock_session)
+        return driver, calls
+
+    @pytest.mark.asyncio
+    async def test_expand_releases_orders_by_id_after_year(self) -> None:
+        from api.queries.neo4j_queries import expand_artist_releases
+
+        driver, calls = self._capture_driver()
+        await expand_artist_releases(driver, "Radiohead", limit=50, offset=0)
+        cypher, _params = calls[0]
+        assert "ORDER BY year IS NULL ASC, year DESC, id" in cypher
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "func_name, entity_arg",
+        [
+            ("expand_artist_labels", "Radiohead"),
+            ("expand_genre_artists", "Rock"),
+            ("expand_genre_labels", "Rock"),
+            ("expand_genre_styles", "Rock"),
+            ("expand_label_artists", "Warp Records"),
+            ("expand_label_genres", "Warp Records"),
+            ("expand_style_artists", "Art Rock"),
+            ("expand_style_labels", "Art Rock"),
+            ("expand_style_genres", "Art Rock"),
+        ],
+    )
+    async def test_aggregate_expand_orders_by_release_count_then_id(self, func_name: str, entity_arg: str) -> None:
+        import api.queries.neo4j_queries as nq
+
+        func = getattr(nq, func_name)
+        driver, calls = self._capture_driver()
+        await func(driver, entity_arg, limit=50, offset=0)
+        cypher, _params = calls[0]
+        assert "ORDER BY release_count DESC, id" in cypher
+        # Guard against regressing to the bare (non-unique) form.
+        assert "ORDER BY release_count DESC\n" not in cypher

--- a/tests/api/test_nlq_sse.py
+++ b/tests/api/test_nlq_sse.py
@@ -174,6 +174,76 @@ async def test_streamed_cached_replay_result_event_carries_actions() -> None:
 
 
 @pytest.mark.asyncio
+async def test_streaming_query_writes_redis_cache_for_anonymous_user() -> None:
+    """Regression discogsography-c584.
+
+    The streaming path is the ONLY path the production Ask UI uses (nlq.js
+    always sends Accept: text/event-stream), but the cache write previously
+    existed only on the non-streaming JSON branch. So the cache — and the
+    cached-replay SSE machinery above — was permanently unpopulated in
+    production and every identical anonymous query re-ran the full engine.
+    """
+    from api.nlq.engine import NLQResult
+    from api.routers import nlq as nlq_router
+
+    engine = MagicMock()
+    engine.run = AsyncMock(
+        return_value=NLQResult(summary="Quincy Jones", entities=[], tools_used=["search"], actions=[]),
+    )
+    nlq_router._engine = engine
+
+    from api.nlq.config import NLQConfig
+
+    mock_redis = AsyncMock()
+    original_redis = nlq_router._redis
+    original_config = nlq_router._nlq_config
+    nlq_router._redis = mock_redis
+    nlq_router._nlq_config = NLQConfig(enabled=True, api_key="k", cache_ttl=3600)
+    try:
+        response = nlq_router._stream_response("who produced Thriller", None, None)
+        events = [event async for event in response.body_iterator]
+    finally:
+        nlq_router._redis = original_redis
+        nlq_router._nlq_config = original_config
+
+    kinds = [e.get("event") for e in events]
+    assert "result" in kinds
+
+    mock_redis.setex.assert_awaited_once()
+    call_args = mock_redis.setex.call_args
+    cache_key, ttl, payload_json = call_args[0]
+    assert cache_key == nlq_router._cache_key("who produced Thriller")
+    assert ttl == 3600
+    payload = json.loads(payload_json)
+    assert payload["summary"] == "Quincy Jones"
+    assert payload["cached"] is False
+
+
+@pytest.mark.asyncio
+async def test_streaming_query_does_not_cache_for_authenticated_user() -> None:
+    """Regression discogsography-c584 — mirror the non-streaming branch's
+    user_id is None guard: authenticated results must never populate the
+    public query cache."""
+    from api.nlq.engine import NLQResult
+    from api.routers import nlq as nlq_router
+
+    engine = MagicMock()
+    engine.run = AsyncMock(return_value=NLQResult(summary="private answer", entities=[], tools_used=[], actions=[]))
+    nlq_router._engine = engine
+
+    mock_redis = AsyncMock()
+    original_redis = nlq_router._redis
+    nlq_router._redis = mock_redis
+    try:
+        response = nlq_router._stream_response("my collection stats", "user-123", None)
+        _ = [event async for event in response.body_iterator]
+    finally:
+        nlq_router._redis = original_redis
+
+    mock_redis.setex.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_streamed_result_matches_non_streaming_body_keys() -> None:
     """The two response modes must expose the same result contract.
 

--- a/tests/api/test_syncer.py
+++ b/tests/api/test_syncer.py
@@ -546,6 +546,61 @@ class TestSyncCollection:
         assert "sync_started" in reconcile_params
 
     @pytest.mark.asyncio
+    async def test_upsert_stamps_updated_at_with_sync_started_not_pg_now(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """Regression discogsography-vqr0: the PG upsert must stamp updated_at with
+        the same app-host sync_started clock the Neo4j half uses for synced_at
+        (and that _reconcile_stale_collection's DELETE cutoff compares against) —
+        not PostgreSQL's own NOW(). A DB-host clock lagging the API host would
+        otherwise make NOW() land before the reconciliation cutoff and delete the
+        row this very sync just wrote.
+        """
+        release = _make_release_item(123)
+        response_data = _make_collection_response([release], page=1, pages=1)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = response_data
+
+        with patch("api.syncer.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await sync_collection(
+                TEST_USER_UUID,
+                TEST_DISCOGS_USERNAME,
+                TEST_CONSUMER_KEY,
+                TEST_CONSUMER_SECRET,
+                TEST_ACCESS_TOKEN,
+                TEST_TOKEN_SECRET,
+                TEST_USER_AGENT,
+                mock_pg_pool,
+                mock_neo4j,
+            )
+
+        # The upsert SQL must not rely on PG's own clock at all.
+        upsert_call = mock_pg_pool._mock_cur.executemany.await_args
+        upsert_sql, upsert_params = upsert_call.args[0], upsert_call.args[1]
+        assert "NOW()" not in upsert_sql
+        upserted_updated_at = upsert_params[0][-1]
+
+        # The Neo4j upsert's synced_at (first session.run call) must be the exact
+        # same value/clock source.
+        upsert_cypher_call = mock_neo4j._mock_session.run.await_args_list[0]
+        neo4j_synced_at = upsert_cypher_call[0][1]["synced_at"]
+        assert upserted_updated_at.isoformat() == neo4j_synced_at
+
+        # And the reconciliation DELETE cutoff (both PG and Neo4j) must be that
+        # exact same sync_started value — one clock, three consumers.
+        pg_delete_call = mock_pg_pool._mock_cur.execute.await_args
+        pg_cutoff = pg_delete_call.args[1][1]
+        assert pg_cutoff == upserted_updated_at
+
+        neo4j_reconcile_call = mock_neo4j._mock_session.run.await_args_list[-1]
+        assert neo4j_reconcile_call[0][1]["sync_started"] == neo4j_synced_at
+
+    @pytest.mark.asyncio
     async def test_no_reconciliation_when_rate_limit_exhausted(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
         """A raised sync (rate limit exhausted) must skip reconciliation entirely
         — deleting rows based on an incomplete fetch would destroy valid data.
@@ -850,6 +905,48 @@ class TestSyncWantlist:
         reconcile_call = mock_neo4j._mock_session.run.await_args_list[-1]
         assert "DELETE wnt" in reconcile_call[0][0]
         assert "WANTS" in reconcile_call[0][0]
+
+    @pytest.mark.asyncio
+    async def test_upsert_stamps_updated_at_with_sync_started_not_pg_now(self, mock_pg_pool: MagicMock, mock_neo4j: MagicMock) -> None:
+        """Regression discogsography-vqr0 — wantlist mirror of the collection fix:
+        the PG upsert must stamp updated_at with the same sync_started clock the
+        Neo4j half uses, not PostgreSQL's own NOW()."""
+        want = _make_want_item(456)
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = _make_wantlist_response([want])
+
+        with patch("api.syncer.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await sync_wantlist(
+                TEST_USER_UUID,
+                TEST_DISCOGS_USERNAME,
+                TEST_CONSUMER_KEY,
+                TEST_CONSUMER_SECRET,
+                TEST_ACCESS_TOKEN,
+                TEST_TOKEN_SECRET,
+                TEST_USER_AGENT,
+                mock_pg_pool,
+                mock_neo4j,
+            )
+
+        upsert_call = mock_pg_pool._mock_cur.executemany.await_args
+        upsert_sql, upsert_params = upsert_call.args[0], upsert_call.args[1]
+        assert "NOW()" not in upsert_sql
+        upserted_updated_at = upsert_params[0][-1]
+
+        upsert_cypher_call = mock_neo4j._mock_session.run.await_args_list[0]
+        neo4j_synced_at = upsert_cypher_call[0][1]["synced_at"]
+        assert upserted_updated_at.isoformat() == neo4j_synced_at
+
+        pg_delete_call = mock_pg_pool._mock_cur.execute.await_args
+        pg_cutoff = pg_delete_call.args[1][1]
+        assert pg_cutoff == upserted_updated_at
 
 
 class TestRunFullSync:

--- a/tests/api/test_syncer.py
+++ b/tests/api/test_syncer.py
@@ -126,6 +126,30 @@ def mock_neo4j() -> MagicMock:
     return driver
 
 
+class TestSyncDelaySeconds:
+    """Regression discogsography-fnhk: SYNC_DELAY_SECONDS must actually respect
+    the Discogs 60 req/min rate limit its comment claims to honor, and must not
+    fork out of sync with its rate-limit sibling in insights_compute.py."""
+
+    def test_sync_delay_seconds_respects_60_req_per_minute(self) -> None:
+        from api.syncer import SYNC_DELAY_SECONDS
+
+        # 0.5s spacing is 2 req/s == 120 req/min — double the Discogs budget.
+        # The pacing interval must keep requests at or under 60/min.
+        assert SYNC_DELAY_SECONDS >= 1.0
+        assert 60 / SYNC_DELAY_SECONDS <= 60
+
+    def test_insights_compute_enrichment_delay_matches_syncer_constant(self) -> None:
+        """insights_compute._ENRICHMENT_DELAY_SECONDS must be the same constant as
+        api.syncer.SYNC_DELAY_SECONDS — not an independently-declared fork that can
+        silently drift (both share MAX_RATE_LIMIT_RETRIES against one Discogs
+        rate-limit budget)."""
+        from api.routers.insights_compute import _ENRICHMENT_DELAY_SECONDS
+        from api.syncer import SYNC_DELAY_SECONDS
+
+        assert _ENRICHMENT_DELAY_SECONDS == SYNC_DELAY_SECONDS
+
+
 class TestAuthHeader:
     """Tests for _auth_header."""
 

--- a/tests/api/test_taste.py
+++ b/tests/api/test_taste.py
@@ -300,6 +300,75 @@ class TestTasteTimeouts:
             resp = test_client.get("/api/user/taste/blindspots", headers=_auth_headers())
         assert resp.status_code == 500
 
+    def test_heatmap_timeout_returns_504(self, test_client: TestClient) -> None:
+        """Regression discogsography-zmko: taste_heatmap was missing the
+        TransactionTimedOut -> 504 guard its siblings (fingerprint, blindspots)
+        have, so a large-collection timeout surfaced as an unhandled 500."""
+        from neo4j.exceptions import ClientError as Neo4jClientError
+
+        exc = Neo4jClientError("TransactionTimedOut: query timed out")
+        with (
+            _patch_min_count(50),
+            patch(
+                "api.routers.taste.get_taste_heatmap",
+                new_callable=AsyncMock,
+                side_effect=exc,
+            ),
+        ):
+            resp = test_client.get("/api/user/taste/heatmap", headers=_auth_headers())
+        assert resp.status_code == 504
+        assert "timed out" in resp.json()["error"]
+
+    def test_heatmap_non_timeout_error_reraises(self, test_client: TestClient) -> None:
+        from neo4j.exceptions import ClientError as Neo4jClientError
+
+        exc = Neo4jClientError("SomeOtherError: something went wrong")
+        with (
+            _patch_min_count(50),
+            patch(
+                "api.routers.taste.get_taste_heatmap",
+                new_callable=AsyncMock,
+                side_effect=exc,
+            ),
+        ):
+            resp = test_client.get("/api/user/taste/heatmap", headers=_auth_headers())
+        assert resp.status_code == 500
+
+    def test_card_timeout_returns_504(self, test_client: TestClient) -> None:
+        """Regression discogsography-zmko: taste_card was missing the
+        TransactionTimedOut -> 504 guard its sibling endpoints have — the exact
+        same asyncio.gather over get_taste_heatmap/get_obscurity_score/
+        get_taste_drift as taste_fingerprint, but unguarded."""
+        from neo4j.exceptions import ClientError as Neo4jClientError
+
+        exc = Neo4jClientError("TransactionTimedOut: query timed out")
+        with (
+            _patch_min_count(50),
+            patch(
+                "api.routers.taste.get_taste_heatmap",
+                new_callable=AsyncMock,
+                side_effect=exc,
+            ),
+        ):
+            resp = test_client.get("/api/user/taste/card", headers=_auth_headers())
+        assert resp.status_code == 504
+        assert "timed out" in resp.json()["error"]
+
+    def test_card_non_timeout_error_reraises(self, test_client: TestClient) -> None:
+        from neo4j.exceptions import ClientError as Neo4jClientError
+
+        exc = Neo4jClientError("SomeOtherError: something went wrong")
+        with (
+            _patch_min_count(50),
+            patch(
+                "api.routers.taste.get_taste_heatmap",
+                new_callable=AsyncMock,
+                side_effect=exc,
+            ),
+        ):
+            resp = test_client.get("/api/user/taste/card", headers=_auth_headers())
+        assert resp.status_code == 500
+
 
 class TestTasteNoAuth:
     def test_heatmap_requires_auth(self, test_client: TestClient) -> None:

--- a/tests/api/test_taste_queries.py
+++ b/tests/api/test_taste_queries.py
@@ -251,6 +251,28 @@ class TestGetObscurityScore:
         # the user owns of the same release.
         assert "WITH DISTINCT u, r" in collectors_cypher
 
+    @pytest.mark.asyncio
+    async def test_total_releases_matches_distinct_release_count_not_instance_count(self) -> None:
+        """Regression discogsography-omrb: total_releases must describe the same
+        distinct-release basis as score/median_collectors, not a separate
+        COLLECTED-edge (instance) count. A user owning 2 physical copies
+        (instance_ids) of a single release must report total_releases=1 —
+        matching the single distinct-release row the score is computed over —
+        not 2."""
+        from api.queries.taste_queries import get_obscurity_score
+
+        # One distinct release row (WITH DISTINCT u, r already collapsed the
+        # user's 2 owned copies of it into 1 row upstream in Cypher).
+        driver = _simple_driver(records=[{"collectors": 0}])
+
+        result = await get_obscurity_score(driver, "user-1")
+
+        assert result["total_releases"] == 1
+        # Exactly one Neo4j round trip — no separate count(r) query that could
+        # disagree with the distinct-release basis of the main query.
+        mock_session = driver.session.return_value
+        assert mock_session.run.await_count == 1
+
 
 # ---------------------------------------------------------------------------
 # get_taste_drift

--- a/tests/dashboard/test_dashboard_app.py
+++ b/tests/dashboard/test_dashboard_app.py
@@ -1151,7 +1151,10 @@ class TestDashboardAppDataCollection:
 
     @pytest.mark.asyncio
     async def test_get_database_info_neo4j_apoc_not_installed(self) -> None:
-        """Test that Neo4j reports 0 counts when APOC is not installed (lines 423-427)."""
+        """Regression discogsography-k3vu: when APOC is unavailable, Neo4j must
+        report an 'unknown' size marker — never a fabricated '0 nodes, 0
+        relationships', which a fully-populated graph cannot be distinguished
+        from and misleads operators into thinking ingestion is broken."""
         mock_config = Mock()
         mock_config.postgres_host = "localhost:5432"
         mock_config.postgres_database = "testdb"
@@ -1189,8 +1192,52 @@ class TestDashboardAppDataCollection:
 
             neo4j_db = next(d for d in databases if d.name == "Neo4j")
             assert neo4j_db.status == "healthy"
-            assert "0 nodes" in neo4j_db.size
-            assert "0 relationships" in neo4j_db.size
+            assert neo4j_db.size == "unknown (APOC unavailable)"
+            assert "0 nodes" not in neo4j_db.size
+            assert "0 relationships" not in neo4j_db.size
+
+    @pytest.mark.asyncio
+    async def test_get_database_info_neo4j_apoc_stats_returns_no_row(self) -> None:
+        """Regression discogsography-k3vu: apoc.meta.stats() succeeding but its
+        single() returning None (e.g. an empty result set) must also report
+        'unknown', not fabricate a 0-count via the `stats["x"] if stats else 0`
+        fallback."""
+        mock_config = Mock()
+        mock_config.postgres_host = "localhost:5432"
+        mock_config.postgres_database = "testdb"
+        mock_config.postgres_username = "test"
+        mock_config.postgres_password = "test"
+
+        with patch("dashboard.dashboard.get_config", return_value=mock_config):
+            app = DashboardApp()
+            app.neo4j_driver = AsyncMock()
+            app.postgres_conn = None
+
+            mock_neo4j_result1 = AsyncMock()
+            mock_neo4j_result1.single = AsyncMock(return_value={"name": "neo4j", "versions": ["5.0"]})
+            mock_neo4j_result1.consume = AsyncMock()
+
+            mock_apoc_result = AsyncMock()
+            mock_apoc_result.single = AsyncMock(return_value=None)
+
+            mock_neo4j_session = AsyncMock()
+
+            async def mock_run(query: str, **_kwargs: object) -> AsyncMock:
+                if "dbms.components" in query:
+                    return mock_neo4j_result1
+                return mock_apoc_result
+
+            mock_neo4j_session.run = mock_run
+            mock_neo4j_session.__aenter__ = AsyncMock(return_value=mock_neo4j_session)
+            mock_neo4j_session.__aexit__ = AsyncMock(return_value=None)
+
+            app.neo4j_driver.session = MagicMock(return_value=mock_neo4j_session)
+
+            databases = await app.get_database_info()
+
+            neo4j_db = next(d for d in databases if d.name == "Neo4j")
+            assert neo4j_db.status == "healthy"
+            assert neo4j_db.size == "unknown (APOC unavailable)"
 
 
 class TestFastAPIEndpoints:

--- a/tests/insights/test_insights.py
+++ b/tests/insights/test_insights.py
@@ -155,6 +155,29 @@ class TestGenreTrendsCacheIntegration:
         assert response.json() == cached
         mock_cache.set.assert_not_called()
 
+    def test_cache_key_does_not_collide_genres_differing_only_by_colon_vs_underscore(
+        self,
+        test_client_with_cache: TestClient,
+        mock_cache: AsyncMock,
+    ) -> None:
+        """Regression discogsography-qjri: a prior `.replace(':', '_')` sanitization
+        was non-injective — genre="A:B" and genre="A_B" both produced cache key
+        "insights:genre-trends:A_B" and were served each other's cached response.
+        The cache key must preserve the raw genre value (interior colons are
+        harmless to InsightsCache.versioned_key, which only strips the fixed
+        "insights:" literal prefix via removeprefix, not a colon split)."""
+        mock_cache.get.return_value = None
+
+        response = test_client_with_cache.get("/api/insights/genre-trends?genre=A:B")
+        assert response.status_code == 200
+        mock_cache.get.assert_called_once_with("insights:genre-trends:A:B", TEST_CACHE_GENERATION)
+
+        mock_cache.reset_mock()
+        mock_cache.get.return_value = None
+        response = test_client_with_cache.get("/api/insights/genre-trends?genre=A_B")
+        assert response.status_code == 200
+        mock_cache.get.assert_called_once_with("insights:genre-trends:A_B", TEST_CACHE_GENERATION)
+
 
 class TestLabelLongevityCacheIntegration:
     def test_cache_miss_queries_pg_and_stores(


### PR DESCRIPTION
Fixes 12 priority-3 API/insights findings from the 2026-08-10 bug hunt (run `wf_646d4b21`), one commit per bead. This is the final batch — with it, all 117 verified findings from the hunt are fixed.

- **discogsography-15gn** — AI prompt builder reads the `field_value`/`field` keys the extractor actually writes (violation values were always blank).
- **discogsography-1wiu** — artist alias/group/member counts dedup across categories, matching what expansion returns.
- **discogsography-c584** — NLQ streaming results are written to the Redis query cache (public-query cache no longer permanently cold).
- **discogsography-fnhk** — SYNC_DELAY_SECONDS honors the Discogs 60 req/min limit.
- **discogsography-qjri** — genre-trends cache keys no longer collide across distinct genres.
- **discogsography-tre5** — get_violation_detail scopes by entity type; no cross-entity merging on shared record_ids.
- **discogsography-vqr0** — sync reconciliation compares app-host timestamps consistently (no DB-vs-app clock skew).
- **discogsography-xcsx** — NLQ resolves "this artist"-style references via the client-plumbed current_entity context.
- **discogsography-zmko** — taste_card/taste_heatmap gain the TransactionTimedOut→504 guard their siblings have.
- **discogsography-k3vu** — dashboard reports Neo4j size as unknown when APOC is unavailable, instead of "0 nodes" as fact.
- **discogsography-omrb** — get_obscurity_score's total_releases matches its distinct-release scoring basis.
- **discogsography-ypkc** — explore expand pagination gains a unique ORDER BY tiebreaker (no duplicated/dropped rows across pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrLwHwMcu3cuQJh8cc1SyW