### PR TITLE
docs: explain the insights internal-secret trust model (discogsography-tj89)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -341,6 +341,15 @@ See [MusicBrainz Sync Guide](musicbrainz-sync.md) for operational instructions.
 - Data completeness scores (`/api/insights/data-completeness`)
 - Computation status monitoring (`/api/insights/status`)
 
+**Why insights needs a shared secret** (`INSIGHTS_INTERNAL_SECRET`):
+
+Insights holds no database credentials — it never connects to Neo4j. Every request involving it makes two hops through the API service:
+
+1. **Public hop** — a user calls `/api/insights/*` on the API, which proxies to the insights container.
+2. **Internal hop** — insights computes its analytics by calling back to `/api/internal/insights/*` on the API, which runs the actual Neo4j aggregate queries.
+
+The `internal` prefix on hop 2 is only a URL path: those routes live on the **same listener** as the public API, and the API is the one service intentionally exposed outside the stack. Without a credential, any internet client — or any other container on the compose network — could invoke the internal endpoints directly and run heavy, unauthenticated Neo4j aggregates, bypassing the public API's auth and rate limits. `INSIGHTS_INTERNAL_SECRET` is the service-to-service password that closes this: the API requires it on every `/api/internal/insights/*` call, and insights is the only other holder. Both services must therefore see the **same value** (in production, one Docker secret file mounted into both — see [configuration.md](configuration.md)). Network isolation alone was rejected as the boundary because a single compromised container would otherwise get unrestricted graph access; the shared secret is the defense-in-depth layer, provisioned like every other credential via `scripts/create-secrets.sh`.
+
 **Explore Service** (static frontend):
 
 - Serves the D3.js force-directed graph UI and Plotly.js trends frontend

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -617,6 +617,7 @@ ENCRYPTION_MASTER_KEY="your-master-key-here"
 # as the X-Internal-Secret header; the insights service is configured with the same value.
 # When unset, the router fails closed (rejects every caller). Supply via
 # INSIGHTS_INTERNAL_SECRET_FILE (Docker secret) in production.
+# Full trust-model rationale: architecture.md § "Why insights needs a shared secret".
 INSIGHTS_INTERNAL_SECRET="change-me-in-production"
 
 # Optional — Resend transactional email for password reset notifications
@@ -824,6 +825,7 @@ REDIS_HOST="localhost"                        # Redis hostname for result cachin
 # through the explore proxy, so it is gated by this shared secret (sent as the
 # X-Internal-Secret header). When unset on the API, the router fails closed (rejects all
 # callers); when unset here, the insights service cannot fetch its computation data.
+# Full trust-model rationale: architecture.md § "Why insights needs a shared secret".
 INSIGHTS_INTERNAL_SECRET="change-me-in-production"
 
 # Optional - Scheduler


### PR DESCRIPTION
Documents WHY `INSIGHTS_INTERNAL_SECRET` exists — previously only the WHAT was written down.

- `docs/architecture.md` gains a "Why insights needs a shared secret" subsection under the Insights Service: the two-hop flow (public `/api/insights/*` proxy → insights; insights → `/api/internal/insights/*` callback), why the `internal` prefix on the shared public listener needs a credential, and why network isolation alone was rejected.
- Both `INSIGHTS_INTERNAL_SECRET` entries in `docs/configuration.md` cross-link to that section.

Requested by Robert after the homelab redeploy surfaced the secret requirement ("as long as this is documented i can live with it").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrLwHwMcu3cuQJh8cc1SyW