### PR TITLE
chore: ignore the Beadhive per-session gate lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -358,3 +358,10 @@ perftest-results/
 # Repowise codebase index
 ###
 .repowise/
+
+# Beadhive gate lock — transient, written per-session. Untracked, it makes the
+# working tree dirty, which `bh hive sync` treats as unsafe-to-sync and skips.
+/.beads.gate.lock
+
+# Codex agent state (sibling of .claude/, machine-local)
+/.codex/


### PR DESCRIPTION
`bh hive sync` refuses to sync a hive whose git working tree is dirty. Beadhive writes `.beads.gate.lock` at the repo root every session; because it was untracked and unignored, the tree was *permanently* dirty and this hive was skipped on every sync run.

Verified today: of the four registered hives, `phaze` was the only one that synced — and the only one already carrying this ignore rule (`phaze/.gitignore`). The other three each failed with `dirty branch(es): main`.

It also adds `/.codex/`, which was untracked here for the same reason.

Rule is root-anchored, matching the phaze convention, since bh writes the file at the repo root and nowhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9qDLFXgqBe3JviJS5oLdM